### PR TITLE
Add CMake config to install headers, libraries, and binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,19 @@ enable_language(CXX)
 # run before all other targets.
 add_custom_target(global_target)
 
+if (UNIX AND NOT APPLE)
+  include(GNUInstallDirs)
+elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR "lib")
+  set(CMAKE_INSTALL_INCLUDEDIR "include")
+  set(CMAKE_INSTALL_BINDIR "bin")
+endif()
+
+install(DIRECTORY include/openssl
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        COMPONENT Development
+)
+
 if(ANDROID)
   # Android-NDK CMake files reconfigure the path and so Go and Perl won't be
   # found. However, ninja will still find them in $PATH if we just name them.
@@ -621,3 +634,4 @@ add_custom_target(
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     DEPENDS all_tests bssl_shim handshaker
     ${MAYBE_USES_TERMINAL})
+

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -555,3 +555,10 @@ if(WIN32)
   target_link_libraries(crypto_test ws2_32)
 endif()
 add_dependencies(all_tests crypto_test)
+
+install(TARGETS crypto
+        EXPORT crypto-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -62,3 +62,10 @@ if(WIN32)
   target_link_libraries(ssl_test ws2_32)
 endif()
 add_dependencies(all_tests ssl_test)
+
+install(TARGETS ssl
+        EXPORT ssl-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -32,3 +32,10 @@ else()
     target_link_libraries(bssl ssl crypto)
   endif()
 endif()
+
+install(TARGETS bssl
+        EXPORT bssl-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
This adds config to install AWS-LC in a common way. A follow up change could add the CMake targets to help consumers who use CMake FindPackage.
```
$ ls
aws-lc  build  install

$ cmake aws-lc -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=install
...

$ ninja -C build install
...

$ ls install/
bin  include  lib

$ ls install/bin/
bssl

$ ls install/include/
openssl

$ ls install/include/openssl/
aead.h      base.h      buffer.h      conf.h        digest.h  ecdh.h     hkdf.h          md5.h      opensslconf.h  pkcs8.h     rsa.h        ssl.h          type_check.h
aes.h       base64.h    bytestring.h  cpu.h         dsa.h     ecdsa.h    hmac.h          mem.h      opensslv.h     poly1305.h  safestack.h  ssl3.h         x509.h
arm_arch.h  bio.h       cast.h        crypto.h      dtls1.h   engine.h   hrss.h          nid.h      ossl_typ.h     pool.h      sha.h        stack.h        x509_vfy.h
asn1.h      blowfish.h  chacha.h      curve25519.h  e_os2.h   err.h      is_boringssl.h  obj.h      pem.h          rand.h      siphash.h    thread.h       x509v3.h
asn1_mac.h  bn.h        cipher.h      des.h         ec.h      evp.h      lhash.h         obj_mac.h  pkcs12.h       rc4.h       span.h       tls1.h
asn1t.h     buf.h       cmac.h        dh.h          ec_key.h  ex_data.h  md4.h           objects.h  pkcs7.h        ripemd.h    srtp.h       trust_token.h

$ ls install/lib/
libcrypto.a  libssl.a
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
