### PR TITLE
Cmake

### DIFF
--- a/cmake/aws-lc-config.cmake
+++ b/cmake/aws-lc-config.cmake
@@ -1,11 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+# Copied from s2n https://github.com/awslabs/s2n/tree/master/cmake/modules
+#
 # - Try to find LibCrypto include dirs and libraries
 #
 # Usage of this module as follows:
 #
 #     find_package(AWS-LC)
+#     target_link_libraries(project-target LibCrypto::Crypto)
 #
 # Variables used by this module, they can change the default behaviour and need
 # to be set before calling find_package:


### PR DESCRIPTION
This change is to add cmake config.

If customers use cmake to build their projects, this cmake config can help find package and add target lib.

Usage:
```
    find_package(AWS-LC)
    target_link_libraries(project-target LibCrypto::Crypto)
```