### PR TITLE
Fixed use of wrong conditional statement

### DIFF
--- a/patches/0002-cmake-install-config.patch
+++ b/patches/0002-cmake-install-config.patch
@@ -8,7 +8,7 @@ Index: aws-lc/third_party/boringssl/CMakeLists.txt
  
 +if(UNIX AND NOT APPLE)
 +    include(GNUInstallDirs)
-+elseif()
++else()
 +    set(CMAKE_INSTALL_LIBDIR "lib")
 +    set(CMAKE_INSTALL_INCLUDEDIR "include")
 +    set(CMAKE_INSTALL_BINDIR "bin")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Changed conditional statement type from `elseif` to `else`. The missing condition in the `elseif` statement type defaults to false and, hence, the commands under the `elseif` was not executing on OSX breaking the build.

Updated the guilty git patch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
