### PR TITLE
Add customized prefix to look LibCrypto dir.

### DIFF
--- a/cmake/awslc-config.cmake
+++ b/cmake/awslc-config.cmake
@@ -18,7 +18,7 @@
 #
 # If artifact folder is provided:
 #     set(AWSLC_ARTIFACT_FOLDER "xxxx")
-#     find_package(AWS-LC HINTS "hits that can find AWSLC built artifacts")
+#     find_package(AWS-LC HINTS "hints that can find AWSLC built artifacts")
 #     target_link_libraries(project-target LibCrypto::Crypto)
 # else:
 #     find_package(AWS-LC)


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

This PR helps AWS-LC clients find LibCrypto in below situation:
 * A project incorporating AWS-LC may have another LibCrypto (BoringSSL) already built in target directory. To avoid library naming collision, an `awslc` specific folder can be prefixed in built artifacts.

```
Normally, AWS-LC built artifacts includes three dirs:
   {CMAKE_PREFIX_PATH}/bin/
   {CMAKE_PREFIX_PATH}include/
   {CMAKE_PREFIX_PATH}lib/
But, to avoid lib naming collision, a unique folder name can be included:
   {CMAKE_PREFIX_PATH}/{folder name}/bin/
   {CMAKE_PREFIX_PATH}/{folder name}include/
   {CMAKE_PREFIX_PATH}/{folder name}lib/

Usage of this module as follows:

If artifact folder is provided:
    set(AWSLC_ARTIFACT_FOLDER "xxxx")
    find_package(AWS-LC HINTS "hits that can find AWSLC built artifacts")
    target_link_libraries(project-target LibCrypto::Crypto)
else:
    find_package(AWS-LC)
    target_link_libraries(project-target LibCrypto::Crypto)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
