### PR TITLE
Modifing two out of date references to master

### DIFF
--- a/cmake/awslc-config.cmake
+++ b/cmake/awslc-config.cmake
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copied from s2n https://github.com/awslabs/s2n/tree/master/cmake/modules
+# Copied from s2n https://github.com/awslabs/s2n/tree/main/cmake/modules
 #
 # - Try to find LibCrypto include dirs and libraries
 #

--- a/tests/ci/docker_images/windows/README.md
+++ b/tests/ci/docker_images/windows/README.md
@@ -26,7 +26,7 @@ You can test the images by running `docker run -it vs2015` or `docker run -it
 vs2017`. To emulate a CodeBuild run locally execute the following inside one of
 the docker images :
 ```
-$ git clone https://github.com/awslabs/aws-lc.git -b master --depth 1
+$ git clone https://github.com/awslabs/aws-lc.git -b main --depth 1
 $ cd aws-lc
 # Depending on the docker image run:
 $ .\tests\ci\run_windows_tests.bat "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64


### PR DESCRIPTION
*Issue # 544*

Changing the default branch from master -> main, as seen below.  I also updated the default branch in Github and setup the branch protection to point to main.    

//Verify that head is pointed to master before change
daryma@YYZ16-CG9433T67 MINGW64 /c/code/aws-lc (main)
$ git branch -r
  origin/HEAD -> origin/master
  origin/master

//Verify that head is pointed to main after change.
daryma@YYZ16-CG9433T67 MINGW64 /c/code/aws-lc (main)
$ git branch -r
  origin/HEAD -> origin/main
  origin/main


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
