### PR TITLE
Fixed typo and libcrypto naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AWS Lib Crypto (aws-lc) Public Preview
+# AWS libcrypto (aws-lc) Public Preview
 
-AWS Lib Crypto (aws-lc) is a cryptographic library originally forked from BoringSSL and is designed to cater to AWS's needs.  This library will be supported and ehnanced by crypto experts within Amazon.  
+AWS libcrypto (aws-lc) is a cryptographic library originally forked from BoringSSL and is designed to cater to AWS's needs.  This library will be supported and enhanced by cryptography experts within Amazon.
 
 ## Quickstart for Ubuntu
 1. Setup required dependencies


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 

Fixed typo and clarified "crypto" as "cryptography".

It is standard to use the spelling "libcrypto" not "Lib Crypto".

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
