### PR TITLE
Add option to disable the reference to getauxval.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,6 +499,15 @@ endif()
 
 if(FIPS)
   add_definitions(-DBORINGSSL_FIPS)
+  # DISABLE_GETAUXVAL builds the object file - bcm.o(the fips module) without
+  # the reference to `getauxval` on the Linux platforms(e.g. AL2 and Ubuntu 20.04).
+  # The `bcm.o` will be used later in another build on old Linux platforms where glibc
+  # prior to 2.16 does not have `getauxval` and `sys/auxv.h`.
+  # Warn: DISABLE_GETAUXVAL is currently only tested in the `shared` build on `x86_64`.
+  if(DISABLE_GETAUXVAL)
+    message(STATUS "NO_GETAUXVAL is enabled.")
+    add_definitions(-DNO_GETAUXVAL)
+  endif()
   if(FIPS_BREAK_TEST)
     add_definitions("-DBORINGSSL_FIPS_BREAK_${FIPS_BREAK_TEST}=1")
   endif()

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -45,7 +45,8 @@
 #include <sys/system_properties.h>
 #endif
 
-#if !defined(OPENSSL_ANDROID)
+// NO_GETAUXVAL is used to disable the reference to 'getauxval'.
+#if !defined(OPENSSL_ANDROID) && !defined(NO_GETAUXVAL)
 #define OPENSSL_HAS_GETAUXVAL
 #endif
 // glibc prior to 2.16 does not have getauxval and sys/auxv.h. Android has some

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -4,6 +4,11 @@
 
 source tests/ci/common_posix_setup.sh
 
+if [[ ("$(uname -p)" == 'x86_64'*) ]]; then
+  echo "Testing AWS-LC in FIPS Release and DISABLE_GETAUXVAL mode."
+  fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DDISABLE_GETAUXVAL=1
+fi
+
 echo "Testing AWS-LC in FIPS Debug mode."
 fips_build_and_test
 


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-800

### Description of changes: 
This PR adds option to disable the reference to `getauxval`. 

### Call-outs:
* Vendor affirm support is currently planed to cover only `shared` build on `x86_64`.

### Testing:
* Added new build dimension to `tests/ci/run_fips_tests.sh`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
