### PR TITLE
Fips 2021 10 20 1 mu jitter

### DIFF
--- a/third_party/jitterentropy/jitterentropy-base-user.h
+++ b/third_party/jitterentropy/jitterentropy-base-user.h
@@ -113,12 +113,19 @@ static inline void jent_get_nstime(uint64_t *out)
 
 static inline void jent_get_nstime(uint64_t *out)
 {
+#if defined(__MACH__)
+        /*
+         * macOS Apple Silicon
+         */
+        *out = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
+#else
         uint64_t ctr_val;
         /*
          * Use the system counter for aarch64 (64 bit ARM).
          */
         __asm__ volatile("mrs %0, cntvct_el0" : "=r" (ctr_val));
         *out = ctr_val;
+#endif
 }
 
 #else /* (__x86_64__) || (__i386__) || (__aarch64__) */


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-1442

### Description of changes: 
Use `clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);` for Apple Silicon macOS, the previous technique didn't have a high-enough resolution on ARM.

### Call-outs:
The fix in `main` (which removes the `__MACH__` branch) doesn't work in this old FIPS branch. I have no idea why, hopefully just because the version of JitterEntropy is old here.

### Testing:
`ninja run_test` and all is happy in FIPS and non-FIPS mode on Apple Silicon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and  the ISC license.
