### PR TITLE
Allow keys without e in RSA_set0_key

### DIFF
--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -37,10 +37,6 @@
 // Various pre-computed constants.
 #include "./curve25519_tables.h"
 
-#if defined(OPENSSL_NO_ASM)
-#define FIAT_25519_NO_ASM
-#endif
-
 #if defined(BORINGSSL_CURVE25519_64BIT)
 #include "../../third_party/fiat/curve25519_64.h"
 #else

--- a/crypto/fipsmodule/bn/exponentiation.c
+++ b/crypto/fipsmodule/bn/exponentiation.c
@@ -851,7 +851,11 @@ static int copy_from_prebuf(BIGNUM *b, int top, const BN_ULONG *table, int idx,
   OPENSSL_memset(b->d, 0, sizeof(BN_ULONG) * top);
   const int width = 1 << window;
   for (int i = 0; i < width; i++, table += top) {
-    BN_ULONG mask = constant_time_eq_int(i, idx);
+    // Use a value barrier to prevent Clang from adding a branch when |i != idx|
+    // and making this copy not constant time. Clang is still allowed to learn
+    // that |mask| is constant across the inner loop, so this won't inhibit any
+    // vectorization it might do.
+    BN_ULONG mask = value_barrier_w(constant_time_eq_int(i, idx));
     for (int j = 0; j < top; j++) {
       b->d[j] |= table[j] & mask;
     }

--- a/crypto/fipsmodule/ec/p256.c
+++ b/crypto/fipsmodule/ec/p256.c
@@ -31,10 +31,6 @@
 #include "../delocate.h"
 #include "./internal.h"
 
-#if defined(OPENSSL_NO_ASM)
-#define FIAT_P256_NO_ASM
-#endif
-
 #if defined(BORINGSSL_HAS_UINT128)
 #define BORINGSSL_NISTP256_64BIT 1
 #include "../../../third_party/fiat/p256_64.h"

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -230,7 +230,7 @@ void RSA_get0_crt_params(const RSA *rsa, const BIGNUM **out_dmp1,
 
 int RSA_set0_key(RSA *rsa, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
   if ((rsa->n == NULL && n == NULL) ||
-      (rsa->e == NULL && e == NULL)) {
+      (rsa->e == NULL && e == NULL && rsa->d == NULL && d == NULL)) {
     return 0;
   }
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -282,7 +282,7 @@ typedef uint32_t crypto_word_t;
 // always has the same output for a given input. This allows it to eliminate
 // dead code, move computations across loops, and vectorize.
 static inline crypto_word_t value_barrier_w(crypto_word_t a) {
-#if !defined(OPENSSL_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
+#if defined(__GNUC__) || defined(__clang__)
   __asm__("" : "+r"(a) : /* no inputs */);
 #endif
   return a;
@@ -290,7 +290,7 @@ static inline crypto_word_t value_barrier_w(crypto_word_t a) {
 
 // value_barrier_u32 behaves like |value_barrier_w| but takes a |uint32_t|.
 static inline uint32_t value_barrier_u32(uint32_t a) {
-#if !defined(OPENSSL_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
+#if defined(__GNUC__) || defined(__clang__)
   __asm__("" : "+r"(a) : /* no inputs */);
 #endif
   return a;
@@ -298,7 +298,7 @@ static inline uint32_t value_barrier_u32(uint32_t a) {
 
 // value_barrier_u64 behaves like |value_barrier_w| but takes a |uint64_t|.
 static inline uint64_t value_barrier_u64(uint64_t a) {
-#if !defined(OPENSSL_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
+#if defined(__GNUC__) || defined(__clang__)
   __asm__("" : "+r"(a) : /* no inputs */);
 #endif
   return a;

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -152,8 +152,10 @@ OPENSSL_EXPORT void RSA_get0_crt_params(const RSA *rsa, const BIGNUM **out_dmp1,
 // |n|, |e|, and |d| respectively, if non-NULL. On success, it takes ownership
 // of each argument and returns one. Otherwise, it returns zero.
 //
-// |d| may be NULL, but |n| and |e| must either be non-NULL or already
-// configured on |rsa|.
+// For a public key, |d| may be NULL, but |n| and |e| must either be non-NULL
+// or already configured on |rsa|. For a private key, |e| may be NULL, but |n|
+// and |d| must either be non-NULL or already configured on |rsa|. Private keys
+// missing |e| are often used by the JCA.
 //
 // It is an error to call this function after |rsa| has been used for a
 // cryptographic operation. Construct a new |RSA| object instead.


### PR DESCRIPTION
### Description of changes: 
Cherry pick the RSA_set0_key change and value_barrier_w change from main.

### Call-outs:
We only need this pr or https://github.com/aws/aws-lc/pull/822 (which includes everything from main). This change has the minimal set of changes to pass the CI and include the e change.

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
