### PR TITLE
Fix RelWithDebInfo with FIPS build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,14 +442,13 @@ elseif(MSVC)
   set(CMAKE_C_FLAGS   "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
   set(CMAKE_CXX_FLAGS "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
 
-  # If we're in RelWithDebInfo then we want to override the default flag it sets to be the same as regular release, then add flags to generate .pdb files.
-  # This fixes the problem we run into with RelWithDebInfo and FIPS mode on Windows where 
-  if(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo")
-    message("Overriding default RelWithDebInfo flags with Release flags")
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELEASE}")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBOINFO "${CMAKE_CXX_FLAGS_RELEASE}")
+  # If we're using MSVC on Windows then we want the '-g' debug flag with '/Zi', which accomplishes the same thing but in a manner that is compatible with VS.
+  # This also fixes the problem we run into with Debug/RelWithDebInfo and FIPS mode on Windows where the FIPS module wouldn't span the expected symbol.
+  if(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" OR CMAKE_BUILD_TYPE_LOWER MATCHES "debug")
+    message(STATUS "Replacing default -g flag for ${CMAKE_BUILD_TYPE} with /Zi")
+    string(REPLACE "-g" "/Zi" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    string(REPLACE "-g" "/Zi" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,9 +442,10 @@ elseif(MSVC)
   set(CMAKE_C_FLAGS   "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
   set(CMAKE_CXX_FLAGS "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
 
-  # If we're using MSVC on Windows then we want to replace the '-g' debug flag with '/Zi', which accomplishes the same thing but in a manner that is compatible with VS.
+  # If we're using MSVC on Windows in FIPS mode with RelWithDebInfo then we want to replace the '-g' debug flag with '/Zi'.
+  # The '/Zi' flag accomplishes the same thing as '-g', but in a manner that is compatible with MSVC.
   # This also fixes the problem we run into with RelWithDebInfo and FIPS mode on Windows where the FIPS module wouldn't span the expected symbol.
-  if(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo")
+  if(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" AND FIPS)
     message(STATUS "Replacing default -g flag for ${CMAKE_BUILD_TYPE} with /Zi")
     string(REPLACE "-g" "/Zi" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
     string(REPLACE "-g" "/Zi" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,7 +443,7 @@ elseif(MSVC)
   set(CMAKE_CXX_FLAGS "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
   # We want to enable debug compiler and linker flags to obtain debug symbols
   # This isn't the same as setting CMAKE_BUILD_TYPE=Debug/RelWithDebInfo, but instead generates .pdb files that allow debugging of release code.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
+  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,12 +446,13 @@ elseif(MSVC)
   # The '/Zi' flag accomplishes the same thing as '-g', but in a manner that is compatible with MSVC.
   # This also fixes the problem we run into with RelWithDebInfo and FIPS mode on Windows where the FIPS module wouldn't span the expected symbol.
   if(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" AND FIPS)
-    message(STATUS "Replacing default -g flag for ${CMAKE_BUILD_TYPE} with /Zi")
-    string(REPLACE "-g" "/Zi" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
-    string(REPLACE "-g" "/Zi" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+    # We want to replace the default /debug flag with /DEBUG:FULL, to explicitly make sure that .PDBs can be used on other machines than where it's built.
+    string(REPLACE "/debug" "/DEBUG:FULL" CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO}")
+    string(REPLACE "/debug" "/DEBUG:FULL" CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO}")
 
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
+    # We also want to reenable optimizations as /debug turns it off by default.
+    set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /OPT:REF,ICF,LBR")
+    set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /OPT:REF,ICF,LBR")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,11 +441,18 @@ elseif(MSVC)
                             ${MSVC_LEVEL4_WARNINGS_LIST})
   set(CMAKE_C_FLAGS   "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
   set(CMAKE_CXX_FLAGS "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
-  # We want to enable debug compiler and linker flags to obtain debug symbols
-  # This isn't the same as setting CMAKE_BUILD_TYPE=Debug/RelWithDebInfo, but instead generates .pdb files that allow debugging of release code.
-  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
+
+  # If we're in RelWithDebInfo then we want to override the default flag it sets to be the same as regular release, then add flags to generate .pdb files.
+  # This fixes the problem we run into with RelWithDebInfo and FIPS mode on Windows where 
+  if(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo")
+    message("Overriding default RelWithDebInfo flags with Release flags")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELEASE}")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBOINFO "${CMAKE_CXX_FLAGS_RELEASE}")
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
+  endif()
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,11 @@ elseif(MSVC)
                             ${MSVC_LEVEL4_WARNINGS_LIST})
   set(CMAKE_C_FLAGS   "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
   set(CMAKE_CXX_FLAGS "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
+  # We want to enable debug compiler and linker flags to obtain debug symbols
+  # This isn't the same as setting CMAKE_BUILD_TYPE=Debug/RelWithDebInfo, but instead generates .pdb files that allow debugging of release code.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,12 +442,12 @@ elseif(MSVC)
   set(CMAKE_C_FLAGS   "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
   set(CMAKE_CXX_FLAGS "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
 
-  # If we're using MSVC on Windows then we want the '-g' debug flag with '/Zi', which accomplishes the same thing but in a manner that is compatible with VS.
-  # This also fixes the problem we run into with Debug/RelWithDebInfo and FIPS mode on Windows where the FIPS module wouldn't span the expected symbol.
-  if(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" OR CMAKE_BUILD_TYPE_LOWER MATCHES "debug")
+  # If we're using MSVC on Windows then we want to replace the '-g' debug flag with '/Zi', which accomplishes the same thing but in a manner that is compatible with VS.
+  # This also fixes the problem we run into with RelWithDebInfo and FIPS mode on Windows where the FIPS module wouldn't span the expected symbol.
+  if(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo")
     message(STATUS "Replacing default -g flag for ${CMAKE_BUILD_TYPE} with /Zi")
-    string(REPLACE "-g" "/Zi" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-    string(REPLACE "-g" "/Zi" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(REPLACE "-g" "/Zi" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+    string(REPLACE "-g" "/Zi" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG:FULL /OPT:REF,ICF,LBR")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,15 +442,15 @@ elseif(MSVC)
   set(CMAKE_C_FLAGS   "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
   set(CMAKE_CXX_FLAGS "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
 
-  # If we're using MSVC on Windows in FIPS mode with RelWithDebInfo then we want to replace the '-g' debug flag with '/Zi'.
-  # The '/Zi' flag accomplishes the same thing as '-g', but in a manner that is compatible with MSVC.
-  # This also fixes the problem we run into with RelWithDebInfo and FIPS mode on Windows where the FIPS module wouldn't span the expected symbol.
+  # If we're using MSVC on Windows in FIPS mode with RelWithDebInfo then we want to override some of the default RelWithDebInfo flags.
+  # This fixes the problem we run into with RelWithDebInfo and FIPS mode on Windows where the FIPS module wouldn't span the expected symbol.
   if(CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" AND FIPS)
-    # We want to replace the default /debug flag with /DEBUG:FULL, to explicitly make sure that .PDBs can be used on other machines than where it's built.
+    # /Zi requires the /debug flag for executables/libraries that we want .pdb files for.
+    # We want to replace the default /debug flag with /DEBUG:FULL, to explicitly make sure that the .pdb files can be used on machines other than one on which it's built.
     string(REPLACE "/debug" "/DEBUG:FULL" CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO}")
     string(REPLACE "/debug" "/DEBUG:FULL" CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO}")
 
-    # We also want to reenable optimizations as /debug turns it off by default.
+    # The /debug flag also turns off the /OPT linker flag so we want to turn them back on across the board.
     set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /OPT:REF,ICF,LBR")
     set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /OPT:REF,ICF,LBR")
   endif()

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -755,6 +755,10 @@ install(TARGETS crypto
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
+if(MSVC AND CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" AND FIPS)
+  install (FILES $<TARGET_FILE_DIR:crypto>/crypto.pdb DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
 configure_file("cmake/crypto-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/crypto-config.cmake"
     @ONLY)

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -79,6 +79,10 @@ install(TARGETS ssl
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
+if(MSVC AND CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" AND FIPS)
+  install(FILES $<TARGET_FILE_DIR:ssl>/ssl.pdb DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
 configure_file("cmake/ssl-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/ssl-config.cmake"
     @ONLY)

--- a/tests/ci/run_windows_tests.bat
+++ b/tests/ci/run_windows_tests.bat
@@ -21,10 +21,12 @@ call :build_and_test Release "-DOPENSSL_NO_ASM=1" || goto error
 set PATH=%BUILD_DIR%;%BUILD_DIR%\crypto;%BUILD_DIR%\ssl;%PATH%
 call :build_and_test Release "-DBUILD_SHARED_LIBS=1" || goto error
 call :build_and_test Release "-DBUILD_SHARED_LIBS=1 -DFIPS=1" || goto error
+@rem For FIPS on Windows we also have a RelWithDebInfo build to generate debug symbols.
+call :build_and_test RelWithDebInfo "-DBUILD_SHARED_LIBS=1 -DFIPS=1" || goto error
 
 goto :EOF
 
-@rem %1 is the build type Release/Debug
+@rem %1 is the build type (e.g. Release/Debug)
 @rem %2 is the additional full CMake args
 :build_and_test
 @echo on

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -46,6 +46,10 @@ endif()
 install(TARGETS bssl
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+if(MSVC AND CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" AND FIPS)
+  install (FILES $<TARGET_FILE_DIR:bssl>/bssl.pdb DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
 function(build_benchmark target_name install_path)
   find_library(libcrypto-${target_name} crypto PATHS ${install_path}/lib/ ${install_path}/lib64/ NO_DEFAULT_PATH)
   message(STATUS "Building ${target_name} benchmark using header files from ${install_path}/include and libcrypto from ${libcrypto-${target_name}}.")


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Currently AWS-LC's `RelWithDebInfo` build type fails when the library is being built in FIPS mode on Windows. This is unfortunate because ATSEC needs to be able to debug the library as a part of their process. This build fixes the `RelWithDebInfo` build on Windows and outputs `.pdb` files to facilitate debugging in Visual Studio.

### Call-outs:
This change replaces the `-g` flag with `/Zi` when running with MSVC in `RelWithDebugInfo` mode, which is used by Visual Studio to produce debug symbols.


### Testing:
Changes tested by ensuring the build now successfully produces debug files with the appropriate flags and that it is able to be used in the Visual Studio debugger. Also checked for any performance degradations (there were none) and ensured that no other flags were enabled that would make `RelWithDebInfo` not a "Release build with debug information".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
