### PR TITLE
Measure entire X25519 work for easy comparison with ECDH

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1314,6 +1314,24 @@ static bool Speed25519(const std::string &selected) {
 
   results.Print("Curve25519 arbitrary point multiplication");
 
+  if (!TimeFunction(&results, []() -> bool {
+        uint8_t out_base[32], in_base[32];
+        BM_memset(in_base, 0, sizeof(in_base));
+        X25519_public_from_private(out_base, in_base);
+
+        uint8_t out[32], in1[32], in2[32];
+        BM_memset(in1, 0, sizeof(in1));
+        BM_memset(in2, 0, sizeof(in2));
+        in1[0] = 1;
+        in2[0] = 9;
+        return X25519(out, in1, in2) == 1;
+      })) {
+    fprintf(stderr, "X25519 (base-point + arbitrary point multiplication) failed.\n");
+    return false;
+  }
+
+  results.Print("X25519 (base-point + arbitrary point multiplication)");
+
   return true;
 }
 

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1326,11 +1326,11 @@ static bool Speed25519(const std::string &selected) {
         in2[0] = 9;
         return X25519(out, in1, in2) == 1;
       })) {
-    fprintf(stderr, "X25519 (base-point + arbitrary point multiplication) failed.\n");
+    fprintf(stderr, "ECDH X25519 failed.\n");
     return false;
   }
 
-  results.Print("X25519 (base-point + arbitrary point multiplication)");
+  results.Print("ECDH X25519");
 
   return true;
 }


### PR DESCRIPTION
### Issues:

Related: CryptoAlg-1587

### Description of changes: 

For e.g. TLS, the entire flow is really "public key" generation and computation of the shared secret. For X25519, the AWS-LC functions doing that are: `X25519_public_from_private()` and `X25519()`. Where the latter also includes the randomness generation work.

ATM, we only repot these individually. But to make comparison with e.g. `bssl speed -filter ECDH` easy, we should output the performance of the entire flow as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
