### PR TITLE
Supporting functions for OCSP Request

### DIFF
--- a/crypto/ocsp/internal.h
+++ b/crypto/ocsp/internal.h
@@ -72,7 +72,7 @@ struct ocsp_signature_st {
 //       optionalSignature   [0]     EXPLICIT Signature OPTIONAL }
 //
 struct ocsp_request_st {
-    OCSP_REQINFO tbsRequest;
+    OCSP_REQINFO *tbsRequest;
     OCSP_SIGNATURE *optionalSignature;
 };
 

--- a/crypto/ocsp/ocsp_client.c
+++ b/crypto/ocsp/ocsp_client.c
@@ -3,6 +3,23 @@
 
 #include "internal.h"
 
+OCSP_ONEREQ *OCSP_request_add0_id(OCSP_REQUEST *req, OCSP_CERTID *cid)
+{
+    OCSP_ONEREQ *one = OCSP_ONEREQ_new();
+    if (one == NULL) {
+      return NULL;
+    }
+    // Reassign |OCSP_CERTID| allocated by OCSP_ONEREQ_new().
+    OCSP_CERTID_free(one->reqCert);
+    one->reqCert = cid;
+    if (req != NULL &&
+        !sk_OCSP_ONEREQ_push(req->tbsRequest->requestList, one)) {
+      one->reqCert = NULL;  // do not free on error
+      OCSP_ONEREQ_free(one);
+      return NULL;
+    }
+    return one;
+}
 
 int OCSP_response_status(OCSP_RESPONSE *resp) {
   if (resp == NULL){

--- a/crypto/ocsp/ocsp_http.c
+++ b/crypto/ocsp/ocsp_http.c
@@ -107,6 +107,30 @@ int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, OCSP_REQUEST *req)
                             (ASN1_VALUE *)req);
 }
 
+int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,
+                             const char *name, const char *value)
+{
+    if (name == NULL) {
+      return 0;
+    }
+    if (BIO_puts(rctx->mem, name) <= 0) {
+      return 0;
+    }
+    if (value != NULL) {
+        if (BIO_write(rctx->mem, ": ", 2) != 2) {
+          return 0;
+        }
+        if (BIO_puts(rctx->mem, value) <= 0) {
+          return 0;
+        }
+    }
+    if (BIO_write(rctx->mem, "\r\n", 2) != 2) {
+      return 0;
+    }
+    rctx->state = OHS_HTTP_HEADER;
+    return 1;
+}
+
 int OCSP_REQ_CTX_i2d(OCSP_REQ_CTX *rctx, const ASN1_ITEM *it, ASN1_VALUE *val)
 {
     static const char req_hdr[] =

--- a/crypto/ocsp/ocsp_http.c
+++ b/crypto/ocsp/ocsp_http.c
@@ -113,6 +113,9 @@ int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,
     if (name == NULL) {
       return 0;
     }
+    // The following being written conforms to the message-header field
+    // specification in https://www.rfc-editor.org/rfc/rfc2616#section-4.2.
+    // message-header = field-name ":" [ field-value ]
     if (BIO_puts(rctx->mem, name) <= 0) {
       return 0;
     }

--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -798,10 +798,10 @@ TEST(OCSPRequestTest, AddHeader) {
 
   // Ensure additional header contents are written as expected.
   EXPECT_EQ(extended_good_http_request_hdr +
-                std::to_string(ocsp_request_data.size()) + "\r",
+                std::to_string(ocsp_request_data.size()) + "\r\n",
             std::string(reinterpret_cast<const char *>(out),
                         sizeof(extended_good_http_request_hdr) +
-                          std::to_string(ocsp_request_data.size()).size()));
+                          std::to_string(ocsp_request_data.size()).size() + 1));
 }
 
 // Check a |OCSP_CERTID| can be added to an |OCSP_REQUEST| with

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -81,6 +81,20 @@ OPENSSL_EXPORT int OCSP_REQ_CTX_http(OCSP_REQ_CTX *rctx, const char *op,
 // should be sent.
 OPENSSL_EXPORT int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, OCSP_REQUEST *req);
 
+// Adds header name with value "value" to the context rctx. It can be called
+// more than once to add multiple header lines.
+OPENSSL_EXPORT int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,
+                             const char *name, const char *value);
+
+// Add cid to req. Returns the new |OCSP_ONEREQ| pointer allocated on the stack
+// within req. This is useful if we want to add extensions.
+// WARNING: This allocates a new |OCSP_ONEREQ| and assigns the
+// pointer to cid to it. It then adds the newly allocated |OCSP_ONEREQ| to the
+// stack within req. req now takes ownership of cid, and also maintains
+// ownership of the pointer to |OCSP_ONEREQ|.
+OPENSSL_EXPORT OCSP_ONEREQ *OCSP_request_add0_id(OCSP_REQUEST *req,
+                                                 OCSP_CERTID *cid);
+
 // Returns response status from |OCSP_RESPONSE|.
 OPENSSL_EXPORT int OCSP_response_status(OCSP_RESPONSE *resp);
 

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -81,17 +81,17 @@ OPENSSL_EXPORT int OCSP_REQ_CTX_http(OCSP_REQ_CTX *rctx, const char *op,
 // should be sent.
 OPENSSL_EXPORT int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, OCSP_REQUEST *req);
 
-// Adds header name with value "value" to the context rctx. It can be called
+// Adds header name with value |value| to the context |rctx|. It can be called
 // more than once to add multiple header lines.
 OPENSSL_EXPORT int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,
                              const char *name, const char *value);
 
-// Add cid to req. Returns the new |OCSP_ONEREQ| pointer allocated on the stack
-// within req. This is useful if we want to add extensions.
-// WARNING: This allocates a new |OCSP_ONEREQ| and assigns the
-// pointer to cid to it. It then adds the newly allocated |OCSP_ONEREQ| to the
-// stack within req. req now takes ownership of cid, and also maintains
-// ownership of the pointer to |OCSP_ONEREQ|.
+// Add |cid| to |req|. Returns the new |OCSP_ONEREQ| pointer allocated on the
+// stack within |req|. This is useful if we want to add extensions.
+// WARNING: This allocates a new |OCSP_ONEREQ| and assigns the  pointer to |cid|
+// to it. It then adds the newly allocated |OCSP_ONEREQ| to the stack within
+// |req|. |req| now takes ownership of |cid|, and also maintains ownership of
+// the pointer to |OCSP_ONEREQ|.
 OPENSSL_EXPORT OCSP_ONEREQ *OCSP_request_add0_id(OCSP_REQUEST *req,
                                                  OCSP_CERTID *cid);
 


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1536`

### Description of changes: 
Add supporting functions and tests for `OCSPRequest`

Taken from: 
* https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/ocsp/ocsp_ht.c
* https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/ocsp/ocsp_cl.c

### Call-outs:
Code from OpenSSL was cleaned up to adhere to our code styling and library tools, but the actual logic stays the same.

### Testing:
Basic tests to test functions do what they should achieve

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
