### PR TITLE
Apply hashstate patch to jitter

### DIFF
--- a/third_party/jitterentropy/jitterentropy-noise.c
+++ b/third_party/jitterentropy/jitterentropy-noise.c
@@ -112,27 +112,28 @@ static void jent_hash_time(struct rand_data *ec, uint64_t time,
 	 * same result.
 	 */
 	for (j = 0; j < hash_loop_cnt; j++) {
-        sha3_update(&ctx, intermediary, sizeof(intermediary));
-        sha3_update(&ctx, (uint8_t *)&ec->rct_count,
-                    sizeof(ec->rct_count));
-        sha3_update(&ctx, (uint8_t *)&ec->apt_cutoff,
-                    sizeof(ec->apt_cutoff));
-        sha3_update(&ctx, (uint8_t *)&ec->apt_observations,
-                    sizeof(ec->apt_observations));
-        sha3_update(&ctx, (uint8_t *)&ec->apt_count,
-                    sizeof(ec->apt_count));
-        sha3_update(&ctx,(uint8_t *) &ec->apt_base,
-                    sizeof(ec->apt_base));
-        sha3_update(&ctx, (uint8_t *)&j, sizeof(uint64_t));
-        sha3_final(&ctx, intermediary);
-    }
-    
-    sha3_update(ec->hash_state, intermediary, sizeof(intermediary));
+		sha3_update(&ctx, intermediary, sizeof(intermediary));
+		sha3_update(&ctx, (uint8_t *)&ec->rct_count,
+		 	sizeof(ec->rct_count));
+		sha3_update(&ctx, (uint8_t *)&ec->apt_cutoff,
+			sizeof(ec->apt_cutoff));
+		sha3_update(&ctx, (uint8_t *)&ec->apt_observations,
+			sizeof(ec->apt_observations));
+		sha3_update(&ctx, (uint8_t *)&ec->apt_count,
+			sizeof(ec->apt_count));
+		sha3_update(&ctx,(uint8_t *) &ec->apt_base,
+			sizeof(ec->apt_base));
+		sha3_update(&ctx, (uint8_t *)&j, sizeof(uint64_t));
+		sha3_final(&ctx, intermediary);
+	}
 
-    if (!stuck)
-        sha3_update(ec->hash_state, (uint8_t *)&time, sizeof(uint64_t));
-    jent_memset_secure(&ctx, SHA_MAX_CTX_SIZE);
-    jent_memset_secure(intermediary, sizeof(intermediary));
+	sha3_update(ec->hash_state, intermediary, sizeof(intermediary));
+
+	if (!stuck) {
+		sha3_update(ec->hash_state, (uint8_t *)&time, sizeof(uint64_t));
+	}
+	jent_memset_secure(&ctx, SHA_MAX_CTX_SIZE);
+	jent_memset_secure(intermediary, sizeof(intermediary));
 }
 
 /**

--- a/third_party/jitterentropy/jitterentropy-noise.h
+++ b/third_party/jitterentropy/jitterentropy-noise.h
@@ -31,6 +31,7 @@ unsigned int jent_measure_jitter(struct rand_data *ec,
 				 uint64_t loop_cnt,
 				 uint64_t *ret_current_delta);
 void jent_random_data(struct rand_data *ec);
+void jent_read_random_block(struct rand_data *ec, char *dst, size_t dst_len);
 
 #ifdef __cplusplus
 }

--- a/third_party/jitterentropy/jitterentropy-sha3.c
+++ b/third_party/jitterentropy/jitterentropy-sha3.c
@@ -19,6 +19,7 @@
  */
 
 #include "jitterentropy-sha3.h"
+#include "jitterentropy-base-user.h"
 
 /***************************************************************************
  * Message Digest Implementation
@@ -379,4 +380,24 @@ int sha3_tester(void)
 	}
 
 	return 0;
+}
+
+int sha3_alloc(void **hash_state)
+{
+	struct sha_ctx *tmp;
+
+	tmp = jent_zalloc(SHA_MAX_CTX_SIZE);
+	if (!tmp)
+		return 1;
+
+	*hash_state = tmp;
+
+	return 0;
+}
+
+void sha3_dealloc(void *hash_state)
+{
+	struct sha_ctx *ctx = (struct sha_ctx *)hash_state;
+
+	jent_zfree(ctx, SHA_MAX_CTX_SIZE);
 }

--- a/third_party/jitterentropy/jitterentropy-sha3.c
+++ b/third_party/jitterentropy/jitterentropy-sha3.c
@@ -19,7 +19,6 @@
  */
 
 #include "jitterentropy-sha3.h"
-#include "jitterentropy-base-user.h"
 
 /***************************************************************************
  * Message Digest Implementation

--- a/third_party/jitterentropy/jitterentropy-sha3.h
+++ b/third_party/jitterentropy/jitterentropy-sha3.h
@@ -52,6 +52,8 @@ struct sha_ctx {
 void sha3_256_init(struct sha_ctx *ctx);
 void sha3_update(struct sha_ctx *ctx, const uint8_t *in, size_t inlen);
 void sha3_final(struct sha_ctx *ctx, uint8_t *digest);
+int sha3_alloc(void **hash_state);
+void sha3_dealloc(void *hash_state);
 int sha3_tester(void);
 
 #ifdef __cplusplus

--- a/third_party/jitterentropy/jitterentropy.h
+++ b/third_party/jitterentropy/jitterentropy.h
@@ -167,7 +167,7 @@ struct rand_data
 	 * of the RNG are marked as SENSITIVE. A user must not
 	 * access that information while the RNG executes its loops to
 	 * calculate the next random value. */
-	uint8_t data[SHA3_256_SIZE_DIGEST]; /* SENSITIVE Actual random number */
+	void *hash_state;		/* SENSITIVE hash state entropy pool */
 	uint64_t prev_time;		/* SENSITIVE Previous time stamp */
 #define DATA_SIZE_BITS (SHA3_256_SIZE_DIGEST_BITS)
 


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-1535

### Description of changes: 
Fix the M1 Jitter build by apply the hashstate patch from upstream Jitter to our copy of jitter. The fips-2021-10-20-1MU branch contains a copy of jitter is somewhere between v3.1.0 (which is on the fips-2021-10-20 branch) and v3.4.0 (which is what is currently on AWS-LC mainline). Those changes were made to take the Windows support from v3.4.0 and back port the changes to v3.1.0.

### Call-outs:
This PR diverges slightly from the upstream patch in one way: our version of jitter on this branch already had the SHA state change from https://github.com/smuellerDD/jitterentropy-library/commit/fee20a0010c25a7120d022b6a0c86f8491a6ac93. This causes the patch to not apply cleanly and needed to be tweaked to handle the difference.

### Testing:
Passes locally on my M1 mac, currently running 1 million test iterations to check stability.

Verified this diff follows the intention of the upstream patch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
