### PR TITLE
Kyber verify fix

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -709,7 +709,6 @@ if(BUILD_TESTING)
     hmac_extra/hmac_test.cc
     hrss/hrss_test.cc
     impl_dispatch_test.cc
-    kyber/kyber_ref_verify_test.cc
     lhash/lhash_test.cc
     obj/obj_test.cc
     ocsp/ocsp_test.cc

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -709,6 +709,7 @@ if(BUILD_TESTING)
     hmac_extra/hmac_test.cc
     hrss/hrss_test.cc
     impl_dispatch_test.cc
+    kyber/kyber_ref_verify_test.cc
     lhash/lhash_test.cc
     obj/obj_test.cc
     ocsp/ocsp_test.cc

--- a/crypto/kyber/kyber_ref_verify_test.cc
+++ b/crypto/kyber/kyber_ref_verify_test.cc
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+#include <openssl/mem.h>
+
+#define KYBER_K 4 /* Needed for proper macro expansion */
+#include "pqcrystals_kyber_ref_common/verify.h"
+
+/*
+ * This test is needed because the verify function has been modified from the
+ * original Kyber reference code and we want to ensure the proper behavior is
+ * maintained.
+ */
+TEST(KyberRefTest, EVP_PKEY_size) {
+  uint8_t buf_len = 32;
+  uint8_t *buf_a = (uint8_t *)OPENSSL_malloc(buf_len);
+  ASSERT_NE(buf_a, nullptr);
+  uint8_t *buf_b = (uint8_t *)OPENSSL_malloc(buf_len);
+  ASSERT_NE(buf_b, nullptr);
+
+  /* verify should return 0 when the buffers are equal */
+  for (uint8_t i = 0; i < buf_len; i++) {
+    buf_a[i] = i;
+    buf_b[i] = i;
+  }
+  EXPECT_EQ(verify(buf_a, buf_b, buf_len), 0);
+
+  /* verify should return 1 when the buffers differ */
+  for (uint8_t i = 0; i < buf_len; i++) {
+    buf_a[i] = i;
+    buf_b[i] = i+1;
+  }
+  EXPECT_EQ(verify(buf_a, buf_b, buf_len), 1);
+
+  OPENSSL_free(buf_a);
+  OPENSSL_free(buf_b);
+}

--- a/crypto/kyber/kyber_ref_verify_test.cc
+++ b/crypto/kyber/kyber_ref_verify_test.cc
@@ -9,7 +9,7 @@
  * original Kyber reference code and we want to ensure the proper behavior is
  * maintained.
  */
-TEST(KyberRefTest, EVP_PKEY_size) {
+TEST(KyberRefTest, verify) {
   uint8_t buf_len = 32;
   uint8_t *buf_a = (uint8_t *)OPENSSL_malloc(buf_len);
   ASSERT_NE(buf_a, nullptr);

--- a/crypto/kyber/pqcrystals_kyber_ref_common/verify.c
+++ b/crypto/kyber/pqcrystals_kyber_ref_common/verify.c
@@ -27,7 +27,7 @@ int verify(const uint8_t *a, const uint8_t *b, size_t len)
    * avoids the compiler warning (which turns to an error on in MSVC) for
    * performing a negation on an unsigned value.
    */
-  return (-(int16_t)((uint16_t)r & 0x7FFF)) >> 15;
+  return (r + 0xFF) >> 8;
 }
 
 /*************************************************


### PR DESCRIPTION
### Description of changes: 
When Kyber's common reference code was imported, changes were made to the `verify` function to avoid a compiler error that occurs on MSVC. However, the logic was inconsistent with the original reference code. This PR corrects the modification so that it will succeed on all supported compilers and be logically consistent with the original reference code.

### Testing:
A unit test has been added for the verify function to confirm it behaves as intended. This unit test is outside of the existing KEM tests in evp_extra_test.cc because it is Kyber-specific.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
