### PR TITLE
Revert Kyber verify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,7 @@ elseif(MSVC)
               # Disable this because it flags even when there is a default.
       "C4100" # 'exarg' : unreferenced formal parameter
       "C4127" # conditional expression is constant
+      "C4146" # unary minus operator applied to unsigned type, result still unsigned
       "C4200" # nonstandard extension used : zero-sized array in
               # struct/union.
       "C4204" # nonstandard extension used: non-constant aggregate initializer

--- a/crypto/kyber/README.md
+++ b/crypto/kyber/README.md
@@ -21,7 +21,6 @@ The following changes were made to the source code in `pqcrystals_kyber_ref_comm
 * `sha2.h, sha256.c, sha512.c, symmetric-aes.c` are removed because we are using only the SHA3 based Kyber (SHA2 and AES are used in the 90s variants only).
 * `indcpa.c`: call to `randombytes` function is replaced with a call to `pq_custom_randombytes` and the appropriate header file is included (`crypto/rand_extra/pq_custom_randombytes.h`).
 * `kem.c`: calls to `randombytes` function is replaced with calls to `pq_custom_randombytes` and the appropriate header file is included (`crypto/rand_extra/pq_custom_randombytes.h`).
-* `verify.c`: change to fix MSVC compiler warning (see the file for details).
 * `symmetric-shake.c`: unnecessary include of `fips202.h` is removed.
 * `api.h`, `fips202.h`, `params.h`: modified [in this PR](https://github.com/aws/aws-lc/pull/655) to support our [prefixed symbols build](https://github.com/aws/aws-lc/blob/main/BUILDING.md#building-with-prefixed-symbols).
 

--- a/crypto/kyber/pqcrystals_kyber_ref_common/verify.c
+++ b/crypto/kyber/pqcrystals_kyber_ref_common/verify.c
@@ -21,13 +21,7 @@ int verify(const uint8_t *a, const uint8_t *b, size_t len)
   for(i=0;i<len;i++)
     r |= a[i] ^ b[i];
 
-  /*
-   * The original logic: return (-(uint64_t)r) >> 63;
-   * It's been modified to preserve constant time and the intended logic, but
-   * avoids the compiler warning (which turns to an error on in MSVC) for
-   * performing a negation on an unsigned value.
-   */
-  return (-(int16_t)((uint16_t)r & 0x7FFF)) >> 15;
+  return (-(uint64_t)r) >> 63;
 }
 
 /*************************************************


### PR DESCRIPTION
### Description of changes: 
When Kyber's common reference code was imported, changes were made to the `verify` function to avoid a compiler warning that occurs on MSVC. However, the logic was inconsistent with the original reference code. This PR reverts the modification back to be consistent with [the original reference code](https://github.com/pq-crystals/kyber/blob/master/ref/verify.c#L24).

### Testing:
All existing unit tests have been run and are passing. This is expected to fail the MSVC CI test as written. The suppressed warnings list will be updated once I get the warning ID.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
