### PR TITLE
Add Stale Issue GitHub Workflow

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -1,0 +1,45 @@
+name: "Close stale issues"
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+      - uses: aws-actions/stale-issue-cleanup@v3
+        with:
+          # Setting messages to an empty string will cause the automation to skip
+          # that category
+          ancient-issue-message: This issue has not received attention in 1 year. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
+          stale-issue-message: This issue has not received a response in 1 week. If you want to keep this issue open, please just leave a comment below and auto-close will be canceled.
+          stale-pr-message: This pull request hasn’t been active in longer than a week, add a comment or an upvote to prevent automatic closure, or if the pull request is already closed, please feel free to open a new one.
+
+          # These labels are required
+          stale-issue-label: closing-soon
+          exempt-issue-label: automation-exempt
+          stale-pr-label: no-pr-activity
+          exempt-pr-labels: automation-exempt
+          response-requested-label: response-requested
+
+          # Don't set closed-for-staleness label to skip closing very old issues
+          # regardless of label
+          closed-for-staleness-label: closed-for-staleness
+
+          # Issue timing
+          days-before-stale: 7
+          days-before-close: 7
+          days-before-ancient: 365
+
+          # If you don't want to mark a issue as being ancient based on a
+          # threshold of "upvotes", you can set this here. An "upvote" is
+          # the total number of +1, heart, hooray, and rocket reactions
+          # on an issue.
+          minimum-upvotes-to-exempt: 1
+
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # loglevel: DEBUG
+          # Set dry-run to true to not perform label or close actions.


### PR DESCRIPTION
### Description of changes: 
Adds the [aws-actions/stale-issue-cleanup](https://github.com/aws-actions/stale-issue-cleanup) GitHub Action to cleanup stale issues or pull requests.

It is currently configured to do the following:
* An issue or pull request is created to the repository.
* If the last comment on the issue/pr is over 4 days old then the issue/pr is marked as stale with the `closing-soon`/`no-pr-activity` labels.
  * `response-request` can be applied to an issue/pr to indicate that a response is requested. If present the label application time is used for determining whether the issue is stale (labelTime + 4 days). If a comment is provided the label is removed automatically.
* `automation-exempt` can be applied to disable automatic closure of an issue or pull request.
* If an issue/pr has been marked with the associated stale label for over 3 days will be closed an marked with the `closed-for-staleness` label.

Total time from last comment, being marked as stale, to being closed would be 7 days.

### Call-outs:
Added the following labels:
* `response-request` - Apply to an issue or pull request to mark that it is waiting for a response.
* `closing-soon` - Automatically applied to an issue after it has had no replies after four days.
* `no-pr-activity` - Automatically applied to a pull request after it has had no activity after four days.
* `automation-exempt` - May be applied to an issue or pr to disable the auto-closure.
* `closed-for-staleness` - Automatically to an issue or pull request after it is closed for being stale for 3 days.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
