### PR TITLE
Allow RSA keys with d > n to be imported (#844)

### DIFF
--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -967,8 +967,8 @@ TEST(RSATest, CheckKey) {
   ASSERT_TRUE(BN_hex2bn(&rsa->d, kDEuler));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
 
-  // If d is completely out of range but otherwise valid, it is rejected.
-  static const char kDTooLarge[] =
+  // If d is out of range, d > n,  but otherwise valid, it is accepted.
+  static const char kDgtN[] =
       "f2c885128cf04101c283553617c210d8ffd14cde98dc420c3c9892b55606cbedcda24298"
       "7655b3f7b9433c2c316293a1cf1a2b034f197aeec1de8d81a67d94cc902b9fce1712d5a4"
       "9c257ff705725cd77338d23535d3b87c8f4cecc15a6b72641ffd81aea106839d216b5fcd"
@@ -977,18 +977,8 @@ TEST(RSATest, CheckKey) {
       "1601fe843c79cc3efbcb8eafd79262bdd25e2bdf21440f774e26d88ed7df938c5cf6982d"
       "e9fa635b8ca36ce5c5fbd579a53cbb0348ceae752d4bc5621c5acc922ca2082494633337"
       "42e770c1";
-  ASSERT_TRUE(BN_hex2bn(&rsa->d, kDTooLarge));
-  EXPECT_FALSE(RSA_check_key(rsa.get()));
-  ERR_clear_error();
-
-  // Unless, the user explicitly allowed keys with d > n to be parsed.
-  // which is possible only in non-FIPS mode.
-#if !defined(AWSLC_FIPS)
-  allow_rsa_keys_d_gt_n();
-  ASSERT_TRUE(BN_hex2bn(&rsa->d, kDTooLarge));
+  ASSERT_TRUE(BN_hex2bn(&rsa->d, kDgtN));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-#endif
-
   ASSERT_TRUE(BN_hex2bn(&rsa->d, kD));
 
   // CRT value must either all be provided or all missing.
@@ -1417,4 +1407,3 @@ TEST(RSATest, DISABLED_BlindingCacheConcurrency) {
 #endif  // X86_64
 
 #endif  // THREADS
-

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -802,21 +802,6 @@ struct rsa_st {
   unsigned private_key_frozen:1;
 };
 
-#if !defined(AWSLC_FIPS)
-#include <stdbool.h>
-
-// This function is DEPRECATED.
-//
-// Some RSA keys are inappropriately generated -- the private exponent |d|
-// is greater than the modulus |n|. Until such keys are eradicated, we
-// _temporarly_ add a way to relax the requirements for validating RSA keys
-// such that the condition |d < n| can be skipped. This "relaxed" behavior
-// has to be explicitly enabled by the user by calling the function
-// |allow_rsa_keys_d_gt_n()|. The default behavior is still to check
-// if |d < n| and fail if not true.
-OPENSSL_EXPORT void allow_rsa_keys_d_gt_n(void);
-#endif
-
 
 #if defined(__cplusplus)
 }  // extern C


### PR DESCRIPTION
### Issues:
CryptoAlg-1626

### Description of changes: 
Revert 80044b4ca and enable the "relaxed" RSA key import
by default. This will allow parsing RSA keys with d > n.

Previously, we ensured that |key->d| is bounded by |key->n|.
This ensures bounds on |RSA_bits| translate to bounds on
the running time of private key operations.
However, due to some users (V804729436) having to deal with private keys
that are valid but violate this condition we had to remove it.
The main concern for keys that violate the condition (the potential
DoS attack vector) is somewhat alleviated with the hard limit on
the size of RSA keys we allow.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
