### PR TITLE
Add AES-CCM/ECB/CTR/KW to 'test_fips' tool

### DIFF
--- a/util/fipstools/test_fips.c
+++ b/util/fipstools/test_fips.c
@@ -175,6 +175,16 @@ int main(int argc, char **argv) {
   OPENSSL_cleanse(&aes_key, sizeof(aes_key));
   EVP_AEAD_CTX_zero(&aead_ctx);
 
+  AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key);
+  for (size_t j = 0; j < sizeof(kPlaintext) / 128, j++)
+  {
+    AES_ecb_encrypt(&kPlaintext[j * 128], & output[j * 128], &aes_key, 1);
+  }
+
+  OPENSSL_cleanse(&aes_key, sizeof(aes_key));
+
+
+
   DES_key_schedule des1, des2, des3;
   DES_cblock des_iv;
   DES_set_key(&kDESKey1, &des1);

--- a/util/fipstools/test_fips.c
+++ b/util/fipstools/test_fips.c
@@ -154,8 +154,7 @@ int main(int argc, char **argv) {
 
   /* AES-CCM */
   OPENSSL_memset(nonce, 0, sizeof(nonce));
-  if (!EVP_AEAD_CTX_init(&aead_ctx, EVP_aead_aes_128_ccm_bluetooth(), kAESKey, sizeof(kAESKey), 0, NULL))
-  {
+  if (!EVP_AEAD_CTX_init(&aead_ctx, EVP_aead_aes_128_ccm_bluetooth(), kAESKey, sizeof(kAESKey), 0, NULL)) {
     fprintf(stderr, "EVP_AED_CTX_init for AES-128-CCM failed.\n");
     goto err;
   }
@@ -166,8 +165,7 @@ int main(int argc, char **argv) {
   hexdump(kPlaintext, sizeof(kPlaintext));
   if (!EVP_AEAD_CTX_seal(&aead_ctx, output, &out_len, sizeof(output), nonce,
                         EVP_AEAD_nonce_length(EVP_aead_aes_128_ccm_bluetooth()),
-                        kPlaintext, sizeof(kPlaintext), NULL, 0))
-  {
+                        kPlaintext, sizeof(kPlaintext), NULL, 0)) {
     fprintf(stderr, "EVP_AEAD_CTX_seal for AES-128-CCM failed.\n");
     goto err;
   }
@@ -184,8 +182,7 @@ int main(int argc, char **argv) {
   hexdump(output, out_len);
   if (!EVP_AEAD_CTX_open(&aead_ctx, output, &out_len, sizeof(output), nonce,
                         EVP_AEAD_nonce_length(EVP_aead_aes_128_ccm_bluetooth()),
-                        output, out_len, NULL, 0))
-  {
+                        output, out_len, NULL, 0)) {
     fprintf(stderr, "EVP_AEAD_CTX_open for AES-128-CCM failed.\n");
     goto err;
   }
@@ -198,15 +195,13 @@ int main(int argc, char **argv) {
   /* AES-ECB */
   /* AES-ECB Encryption */
   OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
-  if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0)
-  {
+  if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     fprintf(stderr, "AES_set_encrypt_key failed.\n");
     goto err;
   }
   printf("About to AES-ECB encrypt ");
   hexdump(output, out_len);
-  for (size_t j = 0; j < sizeof(kPlaintext) / 16; j++)
-  {
+  for (size_t j = 0; j < sizeof(kPlaintext) / 16; j++) {
     AES_ecb_encrypt(&kPlaintext[j * 128], & output[j * 128], &aes_key, AES_ENCRYPT);
   }
   printf("  got ");
@@ -220,8 +215,7 @@ int main(int argc, char **argv) {
   }
   printf("About to AES-ECB decrypt ");
   hexdump(output, out_len);
-  for (size_t j = 0; j < out_len / 16; j++)
-  {
+  for (size_t j = 0; j < out_len / 16; j++) {
     AES_ecb_encrypt(&output[j * 128], & output[j * 128], &aes_key, AES_DECRYPT);
   }
   printf("  got ");
@@ -235,8 +229,7 @@ int main(int argc, char **argv) {
   /* AES-CTR */
   /* AES-CTR Encryption */
   OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
-  if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0)
-  {
+  if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     fprintf(stderr, "AES_set_encrypt_key failed.\n");
     goto err;
   }
@@ -258,8 +251,7 @@ int main(int argc, char **argv) {
   OPENSSL_cleanse(&aes_key, sizeof(aes_key));
 
   /* AES-KW Wrap */
-  if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0)
-  {
+  if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     fprintf(stderr, "AES_set_encrypt_key failed.\n");
     goto err;
   }

--- a/util/fipstools/test_fips.c
+++ b/util/fipstools/test_fips.c
@@ -192,6 +192,15 @@ int main(int argc, char **argv) {
 
   OPENSSL_cleanse(&aes_key, sizeof(aes_key));
 
+  if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0)
+  {
+    fprintf(stderr, "AES_set_encrypt_key failed.\n");
+    goto err;
+  }
+  AES_wrap_key(&aes_key, NULL, output, kPlaintext, sizeof(kPlaintext));
+
+  OPENSSL_cleanse(&aes_key, sizeof(aes_key));
+
   DES_key_schedule des1, des2, des3;
   DES_cblock des_iv;
   DES_set_key(&kDESKey1, &des1);

--- a/util/fipstools/test_fips.c
+++ b/util/fipstools/test_fips.c
@@ -120,6 +120,7 @@ int main(int argc, char **argv) {
   }
 
   /* AES-GCM Encryption */
+  memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     printf("AES_set_encrypt_key failed\n");
     goto err;
@@ -136,6 +137,7 @@ int main(int argc, char **argv) {
   hexdump(output, out_len);
 
   /* AES-GCM Decryption */
+  memset(aes_iv, 0, sizeof(aes_iv));
   printf("About to AES-GCM open ");
   hexdump(output, out_len);
   if (!EVP_AEAD_CTX_open(&aead_ctx, output, &out_len, sizeof(output), nonce,
@@ -159,6 +161,7 @@ int main(int argc, char **argv) {
   }
 
   /* AES-CCM Encryption */
+  memset(aes_iv, 0, sizeof(aes_iv));
   printf("About to AES-CCM seal ");
   hexdump(kPlaintext, sizeof(kPlaintext));
   if (!EVP_AEAD_CTX_seal(&aead_ctx, output, &out_len, sizeof(output), nonce,
@@ -172,6 +175,7 @@ int main(int argc, char **argv) {
   hexdump(output, out_len);
 
   /* AES-CCM Decryption */
+  memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_decrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     printf("AES decrypt failed\n");
     goto err;
@@ -193,6 +197,7 @@ int main(int argc, char **argv) {
 
   /* AES-ECB */
   /* AES-ECB Encryption */
+  memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0)
   {
     fprintf(stderr, "AES_set_encrypt_key failed.\n");
@@ -208,6 +213,7 @@ int main(int argc, char **argv) {
   hexdump(output, out_len);
 
   /* AES-ECB Decryption */
+  memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_decrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     printf("AES decrypt failed\n");
     goto err;
@@ -226,7 +232,9 @@ int main(int argc, char **argv) {
   unsigned int num = 0;
   uint8_t ecount_buf[128];
 
+  /* AES-CTR */
   /* AES-CTR Encryption */
+  memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0)
   {
     fprintf(stderr, "AES_set_encrypt_key failed.\n");
@@ -235,6 +243,15 @@ int main(int argc, char **argv) {
   printf("About to AES-CTR Encrypt ");
   hexdump(output, out_len);
   AES_ctr128_encrypt(kPlaintext, output, sizeof(kPlaintext), &aes_key, aes_iv, ecount_buf, &num);
+  printf("  got ");
+  hexdump(output, out_len);
+
+
+  /* AES-CTR Decryption */
+  memset(aes_iv, 0, sizeof(aes_iv));
+  printf("About to AES-CTR Decrypt ");
+  hexdump(output, out_len);
+  AES_ctr128_encrypt(output, output, out_len, &aes_key, aes_iv, ecount_buf, &num);
   printf("  got ");
   hexdump(output, out_len);
 

--- a/util/fipstools/test_fips.c
+++ b/util/fipstools/test_fips.c
@@ -257,7 +257,18 @@ int main(int argc, char **argv) {
   }
   printf("About to AES-KW Wrap ");
   hexdump(output, out_len);
-  AES_wrap_key(&aes_key, NULL, output, kPlaintext, sizeof(kPlaintext));
+  out_len = AES_wrap_key(&aes_key, NULL, output, kPlaintext, sizeof(kPlaintext));
+  printf("  got ");
+  hexdump(output, out_len);
+
+  /* AES-KW Unwrap */
+  if (AES_set_decrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
+    fprintf(stderr, "AES decrypt failed.\n");
+    goto err;
+  }
+  printf("About to AES-KW Unwrap ");
+  hexdump(output, out_len);
+  out_len = AES_unwrap_key(&aes_key, NULL, output, output, out_len);
   printf("  got ");
   hexdump(output, out_len);
 

--- a/util/fipstools/test_fips.c
+++ b/util/fipstools/test_fips.c
@@ -160,7 +160,7 @@ int main(int argc, char **argv) {
 
   /* AES-CCM Encryption */
   printf("About to AES-CCM seal ");
-  hexdump(output, out_len);
+  hexdump(kPlaintext, sizeof(kPlaintext));
   if (!EVP_AEAD_CTX_seal(&aead_ctx, output, &out_len, sizeof(output), nonce,
                         EVP_AEAD_nonce_length(EVP_aead_aes_128_ccm_bluetooth()),
                         kPlaintext, sizeof(kPlaintext), NULL, 0))
@@ -191,6 +191,7 @@ int main(int argc, char **argv) {
   OPENSSL_cleanse(&aes_key, sizeof(aes_key));
   EVP_AEAD_CTX_zero(&aead_ctx);
 
+  /* AES-ECB */
   /* AES-ECB Encryption */
   if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0)
   {
@@ -201,7 +202,21 @@ int main(int argc, char **argv) {
   hexdump(output, out_len);
   for (size_t j = 0; j < sizeof(kPlaintext) / 16; j++)
   {
-    AES_ecb_encrypt(&kPlaintext[j * 128], & output[j * 128], &aes_key, 1);
+    AES_ecb_encrypt(&kPlaintext[j * 128], & output[j * 128], &aes_key, AES_ENCRYPT);
+  }
+  printf("  got ");
+  hexdump(output, out_len);
+
+  /* AES-ECB Decryption */
+  if (AES_set_decrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
+    printf("AES decrypt failed\n");
+    goto err;
+  }
+  printf("About to AES-ECB decrypt ");
+  hexdump(output, out_len);
+  for (size_t j = 0; j < out_len / 16; j++)
+  {
+    AES_ecb_encrypt(&output[j * 128], & output[j * 128], &aes_key, AES_DECRYPT);
   }
   printf("  got ");
   hexdump(output, out_len);

--- a/util/fipstools/test_fips.c
+++ b/util/fipstools/test_fips.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
   uint8_t output[256];
 
   /* AES-CBC Encryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     printf("AES_set_encrypt_key failed\n");
     goto err;
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
   hexdump(output, sizeof(kPlaintext));
 
   /* AES-CBC Decryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_decrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     printf("AES decrypt failed\n");
     goto err;
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
 
   OPENSSL_cleanse(&aes_key, sizeof(aes_key));
 
- /* AES-GCM */
+  /* AES-GCM */
   size_t out_len;
   uint8_t nonce[EVP_AEAD_MAX_NONCE_LENGTH];
   OPENSSL_memset(nonce, 0, sizeof(nonce));
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
   }
 
   /* AES-GCM Encryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     printf("AES_set_encrypt_key failed\n");
     goto err;
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
   hexdump(output, out_len);
 
   /* AES-GCM Decryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   printf("About to AES-GCM open ");
   hexdump(output, out_len);
   if (!EVP_AEAD_CTX_open(&aead_ctx, output, &out_len, sizeof(output), nonce,
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
   }
 
   /* AES-CCM Encryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   printf("About to AES-CCM seal ");
   hexdump(kPlaintext, sizeof(kPlaintext));
   if (!EVP_AEAD_CTX_seal(&aead_ctx, output, &out_len, sizeof(output), nonce,
@@ -175,7 +175,7 @@ int main(int argc, char **argv) {
   hexdump(output, out_len);
 
   /* AES-CCM Decryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_decrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     printf("AES decrypt failed\n");
     goto err;
@@ -197,7 +197,7 @@ int main(int argc, char **argv) {
 
   /* AES-ECB */
   /* AES-ECB Encryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0)
   {
     fprintf(stderr, "AES_set_encrypt_key failed.\n");
@@ -213,7 +213,7 @@ int main(int argc, char **argv) {
   hexdump(output, out_len);
 
   /* AES-ECB Decryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_decrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0) {
     printf("AES decrypt failed\n");
     goto err;
@@ -234,7 +234,7 @@ int main(int argc, char **argv) {
 
   /* AES-CTR */
   /* AES-CTR Encryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   if (AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key) != 0)
   {
     fprintf(stderr, "AES_set_encrypt_key failed.\n");
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
 
 
   /* AES-CTR Decryption */
-  memset(aes_iv, 0, sizeof(aes_iv));
+  OPENSSL_memset(aes_iv, 0, sizeof(aes_iv));
   printf("About to AES-CTR Decrypt ");
   hexdump(output, out_len);
   AES_ctr128_encrypt(output, output, out_len, &aes_key, aes_iv, ecount_buf, &num);

--- a/util/fipstools/test_fips.c
+++ b/util/fipstools/test_fips.c
@@ -176,14 +176,21 @@ int main(int argc, char **argv) {
   EVP_AEAD_CTX_zero(&aead_ctx);
 
   AES_set_encrypt_key(kAESKey, 8 * sizeof(kAESKey), &aes_key);
-  for (size_t j = 0; j < sizeof(kPlaintext) / 128, j++)
+  for (size_t j = 0; j < sizeof(kPlaintext) / 128; j++)
   {
     AES_ecb_encrypt(&kPlaintext[j * 128], & output[j * 128], &aes_key, 1);
   }
 
   OPENSSL_cleanse(&aes_key, sizeof(aes_key));
 
+  memcpy(aes_iv, 0, sizeof(aes_iv));
+  unsigned num = 0;
+  uint8_t ecount_buf[128];
 
+  AES_set_encrypt_key(kPlaintext, 8 * sizeof(kPlaintext), &aes_key);
+  AES_ctr128_encrypt(kPlaintext, output, sizeof(kPlaintext), &aes_key, aes_iv, ecount_buf, &num);
+
+  OPENSSL_cleanse(&aes_key, sizeof(aes_key));
 
   DES_key_schedule des1, des2, des3;
   DES_cblock des_iv;


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1641

### Description of changes: 
AWS-LC currently only tests a few AES functions as a part of its tooling in `test_fips.c`. However, as a part of ATSEC's process, they wish to be able to step into functions for AES-CCM, ECB, CTR, AND KW with a debugger and thus have requested that we add them to our testing script.

In the interest of not having to repeat this patch for future validations, these functions were added to the `test_fips` tool the intention to bring these changes into the main, FIPS 1MU, and FIPS 2022 branches. Additionally, it would likely be prudent to bring the self_checks for the main and FIPS 2022 branches in line with these changes in another PR.

### Call-outs:
N/A

### Testing:
Changes tested by ensuring that all tests still pass and that the output of the `test_fips` tool is as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
