### PR TITLE
Use function reference to get cpu capability vector at the C-level

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_intel.c
+++ b/crypto/fipsmodule/cpucap/cpu_intel.c
@@ -266,10 +266,10 @@ void OPENSSL_cpuid_setup(void) {
     extended_features[0] &= ~(1u << 19);
   }
 
-  OPENSSL_ia32cap_P[0] = edx;
-  OPENSSL_ia32cap_P[1] = ecx;
-  OPENSSL_ia32cap_P[2] = extended_features[0];
-  OPENSSL_ia32cap_P[3] = extended_features[1];
+  OPENSSL_ia32cap_get()[0] = edx;
+  OPENSSL_ia32cap_get()[1] = ecx;
+  OPENSSL_ia32cap_get()[2] = extended_features[0];
+  OPENSSL_ia32cap_get()[3] = extended_features[1];
 
   OPENSSL_cpucap_initialized = 1;
 
@@ -293,10 +293,10 @@ void OPENSSL_cpuid_setup(void) {
   // The first value determines OPENSSL_ia32cap_P[0] and [1]. The second [2]
   // and [3].
 
-  handle_cpu_env(&OPENSSL_ia32cap_P[0], env1);
+  handle_cpu_env(&(OPENSSL_ia32cap_get()[0]), env1);
   env2 = strchr(env1, ':');
   if (env2 != NULL) {
-    handle_cpu_env(&OPENSSL_ia32cap_P[2], env2 + 1);
+    handle_cpu_env(&(OPENSSL_ia32cap_get()[2]), env2 + 1);
   }
 }
 

--- a/crypto/fipsmodule/cpucap/cpu_intel.c
+++ b/crypto/fipsmodule/cpucap/cpu_intel.c
@@ -266,10 +266,10 @@ void OPENSSL_cpuid_setup(void) {
     extended_features[0] &= ~(1u << 19);
   }
 
-  OPENSSL_ia32cap_get()[0] = edx;
-  OPENSSL_ia32cap_get()[1] = ecx;
-  OPENSSL_ia32cap_get()[2] = extended_features[0];
-  OPENSSL_ia32cap_get()[3] = extended_features[1];
+  OPENSSL_ia32cap_P[0] = edx;
+  OPENSSL_ia32cap_P[1] = ecx;
+  OPENSSL_ia32cap_P[2] = extended_features[0];
+  OPENSSL_ia32cap_P[3] = extended_features[1];
 
   OPENSSL_cpucap_initialized = 1;
 
@@ -293,10 +293,10 @@ void OPENSSL_cpuid_setup(void) {
   // The first value determines OPENSSL_ia32cap_P[0] and [1]. The second [2]
   // and [3].
 
-  handle_cpu_env(&(OPENSSL_ia32cap_get()[0]), env1);
+  handle_cpu_env(&OPENSSL_ia32cap_P[0], env1);
   env2 = strchr(env1, ':');
   if (env2 != NULL) {
-    handle_cpu_env(&(OPENSSL_ia32cap_get()[2]), env2 + 1);
+    handle_cpu_env(&OPENSSL_ia32cap_P[2], env2 + 1);
   }
 }
 

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -37,71 +37,82 @@ void OPENSSL_cpuid_setup(void);
 // bits in XCR0, so it is not necessary to check those.
 extern uint32_t OPENSSL_ia32cap_P[4];
 
+#if defined(BORINGSSL_FIPS) && !defined(BORINGSSL_SHARED_LIBRARY)
+// The FIPS module, as a static library, requires an out-of-line version of
+// |OPENSSL_ia32cap_get| so accesses can be rewritten by delocate. Mark the
+// function const so multiple accesses can be optimized together.
+const uint32_t *OPENSSL_ia32cap_get(void) __attribute__((const));
+#else
+OPENSSL_INLINE const uint32_t *OPENSSL_ia32cap_get(void) {
+  return OPENSSL_ia32cap_P;
+}
+#endif
+
 // See Intel manual, volume 2A, table 3-11.
 
 OPENSSL_INLINE int CRYPTO_is_FXSR_capable(void) {
-  return (OPENSSL_ia32cap_P[0] & (1 << 24)) != 0;
+  return (OPENSSL_ia32cap_get()[0] & (1 << 24)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_intel_cpu(void) {
   // The reserved bit 30 is used to indicate an Intel CPU.
-  return (OPENSSL_ia32cap_P[0] & (1 << 30)) != 0;
+  return (OPENSSL_ia32cap_get()[0] & (1 << 30)) != 0;
 }
 
 // See Intel manual, volume 2A, table 3-10.
 
 OPENSSL_INLINE int CRYPTO_is_PCLMUL_capable(void) {
-  return (OPENSSL_ia32cap_P[1] & (1 << 1)) != 0;
+  return (OPENSSL_ia32cap_get()[1] & (1 << 1)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_SSSE3_capable(void) {
-  return (OPENSSL_ia32cap_P[1] & (1 << 9)) != 0;
+  return (OPENSSL_ia32cap_get()[1] & (1 << 9)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_SSE4_1_capable(void) {
-  return (OPENSSL_ia32cap_P[1] & (1 << 19)) != 0;
+  return (OPENSSL_ia32cap_get()[1] & (1 << 19)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_MOVBE_capable(void) {
-  return (OPENSSL_ia32cap_P[1] & (1 << 22)) != 0;
+  return (OPENSSL_ia32cap_get()[1] & (1 << 22)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_AESNI_capable(void) {
-  return (OPENSSL_ia32cap_P[1] & (1 << 25)) != 0;
+  return (OPENSSL_ia32cap_get()[1] & (1 << 25)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_AVX_capable(void) {
-  return (OPENSSL_ia32cap_P[1] & (1 << 28)) != 0;
+  return (OPENSSL_ia32cap_get()[1] & (1 << 28)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_RDRAND_capable(void) {
-  return (OPENSSL_ia32cap_P[1] & (1u << 30)) != 0;
+  return (OPENSSL_ia32cap_get()[1] & (1u << 30)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_AMD_XOP_support(void) {
-  return (OPENSSL_ia32cap_P[1] & (1 << 11)) != 0;
+  return (OPENSSL_ia32cap_get()[1] & (1 << 11)) != 0;
 }
 
 // See Intel manual, volume 2A, table 3-8.
 
 OPENSSL_INLINE int CRYPTO_is_BMI1_capable(void) {
-  return (OPENSSL_ia32cap_P[2] & (1 << 3)) != 0;
+  return (OPENSSL_ia32cap_get()[2] & (1 << 3)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_AVX2_capable(void) {
-  return (OPENSSL_ia32cap_P[2] & (1 << 5)) != 0;
+  return (OPENSSL_ia32cap_get()[2] & (1 << 5)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_BMI2_capable(void) {
-  return (OPENSSL_ia32cap_P[2] & (1 << 8)) != 0;
+  return (OPENSSL_ia32cap_get()[2] & (1 << 8)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_ADX_capable(void) {
-  return (OPENSSL_ia32cap_P[2] & (1 << 19)) != 0;
+  return (OPENSSL_ia32cap_get()[2] & (1 << 19)) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_SHAEXT_capable(void) {
-  return (OPENSSL_ia32cap_P[2] & (1 << 29)) != 0;
+  return (OPENSSL_ia32cap_get()[2] & (1 << 29)) != 0;
 }
 
 #endif  // OPENSSL_X86 || OPENSSL_X86_64

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -77,8 +77,8 @@ static const p384_felem p384_felem_one = {
 // every x86 CPU so we have to check if they are available and in case
 // they are not we fallback to slightly slower but generic implementation.
 static inline uint8_t p384_use_s2n_bignum_alt(void) {
-  return ((OPENSSL_ia32cap_P[2] & (1u <<  8)) == 0) || // bmi2
-         ((OPENSSL_ia32cap_P[2] & (1u << 19)) == 0);   // adx
+  return ((OPENSSL_ia32cap_get[2] & (1u <<  8)) == 0) || // bmi2
+         ((OPENSSL_ia32cap_get[2] & (1u << 19)) == 0);   // adx
 }
 #else
 // On aarch64 platforms s2n-bignum has two implementations of certain

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -77,8 +77,8 @@ static const p384_felem p384_felem_one = {
 // every x86 CPU so we have to check if they are available and in case
 // they are not we fallback to slightly slower but generic implementation.
 static inline uint8_t p384_use_s2n_bignum_alt(void) {
-  return ((OPENSSL_ia32cap_get[2] & (1u <<  8)) == 0) || // bmi2
-         ((OPENSSL_ia32cap_get[2] & (1u << 19)) == 0);   // adx
+  return ((OPENSSL_ia32cap_get()[2] & (1u <<  8)) == 0) || // bmi2
+         ((OPENSSL_ia32cap_get()[2] & (1u << 19)) == 0);   // adx
 }
 #else
 // On aarch64 platforms s2n-bignum has two implementations of certain

--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -80,8 +80,8 @@ static const p521_limb_t p521_felem_p[P521_NLIMBS] = {
 // every x86 CPU so we have to check if they are available and in case
 // they are not we fallback to slightly slower but generic implementation.
 static inline uint8_t p521_use_s2n_bignum_alt(void) {
-  return ((OPENSSL_ia32cap_get[2] & (1u <<  8)) == 0) || // bmi2
-         ((OPENSSL_ia32cap_get[2] & (1u << 19)) == 0);   // adx
+  return ((OPENSSL_ia32cap_get()[2] & (1u <<  8)) == 0) || // bmi2
+         ((OPENSSL_ia32cap_get()[2] & (1u << 19)) == 0);   // adx
 }
 #else
 // On aarch64 platforms s2n-bignum has two implementations of certain

--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -80,8 +80,8 @@ static const p521_limb_t p521_felem_p[P521_NLIMBS] = {
 // every x86 CPU so we have to check if they are available and in case
 // they are not we fallback to slightly slower but generic implementation.
 static inline uint8_t p521_use_s2n_bignum_alt(void) {
-  return ((OPENSSL_ia32cap_P[2] & (1u <<  8)) == 0) || // bmi2
-         ((OPENSSL_ia32cap_P[2] & (1u << 19)) == 0);   // adx
+  return ((OPENSSL_ia32cap_get[2] & (1u <<  8)) == 0) || // bmi2
+         ((OPENSSL_ia32cap_get[2] & (1u << 19)) == 0);   // adx
 }
 #else
 // On aarch64 platforms s2n-bignum has two implementations of certain


### PR DESCRIPTION
### Issues:

CryptoAlg-1577

### Description of changes:

The goal of this PR is to close a performance gap between FIPS static and FIPS shared build. The latter is more performant in some cases.

#### Background

`OPENSSL_ia32cap_P` is a global, initialised, mutable variable. And hence, will typically go to `.bss`.  However, the location of the `.bss` segment is not known before program load-time. Hence, dereferences of `OPENSSL_ia32cap_P` in code must be filled in by the loader. This modifies `.text` before it's mapped into memory, in turn, would make any hash over (part of) `.text` unpredictable. This is bad for FIPS, which requires a deterministic hash over part of `.text` to implement the integrity check.

All of this is already known though and there already exist an implement solution! We are only concerned about the static FIPS build. The shared build uses a different technique that doesn't require in-line modifications of textural assembly code, and therefore is not subject to the same performance degradation explained below.

The FIPS static build fix-up dereferences of `OPENSSL_ia32cap_P` in a pretty straightforward way:
* [First add a "trampoline" label](https://github.com/aws/aws-lc/blob/main/util/fipstools/delocate/delocate.go#L1948-L1952) `OPENSSL_ia32cap_addr_delta` storing an offset to `OPENSSL_ia32cap_P`.
* Replace dereferences of `OPENSSL_ia32cap_P` by [first loading the address of](https://github.com/aws/aws-lc/blob/main/util/fipstools/delocate/delocate.go#L1372) `OPENSSL_ia32cap_addr_delta` (which is known relative to `RIP`, and then [add the offset stored](https://github.com/aws/aws-lc/blob/main/util/fipstools/delocate/delocate.go#L1373) under that label.

Note, that the latter step requires an addition. The addition might modify carry-flags. This is problematic, because the in-line modification of the assembly performed by the delocator script is not really context-aware. It just simply uses the destination register. But injecting an instruction that potentially modifies the carry-flag could break soundness/correctness because the subsequent assembly code was not written with this in mind.

Therefore, the delocator script push the cpu flags onto the stack and pops them after the injected code: https://github.com/aws/aws-lc/blob/main/util/fipstools/delocate/delocate.go#L1367-L1369. This restores the carry-flag state to what it was before the injected code ensuring soundness/correctness.

Now to the actual issue: It was found that this push/pop of carry-flags introduced a small latency, that when accumulated affects performance. For example, `AES-256-XTS init and encrypt (256 bytes)` can perform `4706548` invocations per second for the fips static build, but `6735574` invocations per second for the fips shared build (c6i.4xlarge); in other words, fips shared build does `~43%`  more invocations per second than the fips static build. Performance differences can be seen for various other algorithms e.g. `P384` ops, `SHA-256`, `AEAD-AES-128-GCM`, etc.

#### Solution

This is the first PR out of two PRs that bridge the performance gap.

This PR use a function reference instead of directly dereferences the global variable at the C-level. Some instances of dereferencing the variable directly were added in https://github.com/aws/aws-lc/pull/330/files, removing the function reference. Others seem to just have been dereferencing the global variable always. Make this consistent and only use the functional reference at the C-level. This avoids the push/pop of the carry-flags. And performance benchmark shows that this recovers some of the performance gap.

Next PR will tackle the assembly level code, which can't directly use the functional reference: again because the delocator script is not context-aware, so adding a function call, will modify state that later assembly code has not been written to account for. For example, the assembly code might use registers that the function call by definition assumes are callee owned.

See CryptoAlg-1577 for performance gain information.

### Testing:

CI passes over all relevant compilers for fips build. CryptoAlg-1577 has information on benchmarks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
