### PR TITLE
Reference OPENSSL_ia32cap_P at x86 machine code level through a unique symbol instead of a common offset symbol avoiding add instruction

### DIFF
--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -1539,12 +1539,14 @@ Args:
 				}
 
 				if symbol == "OPENSSL_ia32cap_P" {
+
 					uniqueSymbol := newCpuCapUniqueSymbol(len(d.cpuCapUniqueSymbols), targetReg)
 					wrappers = append(wrappers, func(k func()) {
 						d.output.WriteString("\tjmp\t" + uniqueSymbol.getIntelSymbol() + "\n")
 						d.output.WriteString(uniqueSymbol.getIntelSymbolReturn() + ":\n")
 					})
 					d.cpuCapUniqueSymbols = append(d.cpuCapUniqueSymbols, uniqueSymbol)
+
 				} else if useGOT {
 					wrappers = append(wrappers, d.loadFromGOT(d.output, targetReg, symbol, section, redzoneCleared))
 				} else {
@@ -1965,6 +1967,8 @@ func transform(w stringWriter, inputs []inputFile) error {
 		w.WriteString("\tleaq OPENSSL_ia32cap_P(%rip), %rax\n")
 		w.WriteString("\tret\n")
 
+		// This is a fixed order iteration. such that we can soundly write tests
+		// for this in /testdata.
 		for _, uniqueSymbol := range d.cpuCapUniqueSymbols {
 			w.WriteString(".type " + uniqueSymbol.getIntelSymbol() + ", @function\n")
 			w.WriteString(uniqueSymbol.getIntelSymbol() + ":\n")

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -1239,18 +1239,6 @@ func (d *delocation) loadFromGOT(w stringWriter, destination, symbol, section st
 	}
 }
 
-func saveFlags(w stringWriter, redzoneCleared bool) wrapperFunc {
-	return func(k func()) {
-		if !redzoneCleared {
-			w.WriteString("\tleaq -128(%rsp), %rsp\n") // Clear the red zone.
-			defer w.WriteString("\tleaq 128(%rsp), %rsp\n")
-		}
-		w.WriteString("\tpushfq\n")
-		k()
-		w.WriteString("\tpopfq\n")
-	}
-}
-
 func saveRegister(w stringWriter, avoidRegs []string) (wrapperFunc, string) {
 	candidates := []string{"%rax", "%rbx", "%rcx", "%rdx"}
 

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -1968,7 +1968,7 @@ func transform(w stringWriter, inputs []inputFile) error {
 		w.WriteString("\tleaq OPENSSL_ia32cap_P(%rip), %rax\n")
 		w.WriteString("\tret\n")
 
-		// Luckily, this is a fixed order iteration. So, that we can write
+		// Luckily, this is a fixed order iteration. So, we can write
 		// deterministic tests for this in /testdata.
 		for _, uniqueSymbol := range d.cpuCapUniqueSymbols {
 			w.WriteString(".type " + uniqueSymbol.getIntelSymbol() + ", @function\n")

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -65,22 +65,22 @@ type cpuCapUniqueSymbol struct {
 	suffixUniqueness string
 }
 
-const cpuCapIntelSymbolPrefix = "LOPENSSL_ia32cap_P_"
+const cpuCapx86SymbolPrefix = "LOPENSSL_ia32cap_P_"
 
-func (uniqueSymbol cpuCapUniqueSymbol) getIntelSymbol() string {
-	return cpuCapIntelSymbolPrefix + uniqueSymbol.registerName + uniqueSymbol.suffixUniqueness
+func (uniqueSymbol cpuCapUniqueSymbol) getx86Symbol() string {
+	return cpuCapx86SymbolPrefix + uniqueSymbol.registerName + uniqueSymbol.suffixUniqueness
 }
 
-func (uniqueSymbol cpuCapUniqueSymbol) getIntelSymbolReturn() string {
-	return uniqueSymbol.getIntelSymbol() + "_return"
+func (uniqueSymbol cpuCapUniqueSymbol) getx86SymbolReturn() string {
+	return uniqueSymbol.getx86Symbol() + "_return"
 }
 
 // uniqueness must be a globally unique integer value.
 func newCpuCapUniqueSymbol(uniqueness int, registerName string) *cpuCapUniqueSymbol {
-    uniqueSymbol := new(cpuCapUniqueSymbol)
-    uniqueSymbol.registerName = strings.Trim(registerName, "%") // should work with both AT&T and Intel syntax.
-    uniqueSymbol.suffixUniqueness = strconv.Itoa(uniqueness)
-    return uniqueSymbol
+	return &cpuCapUniqueSymbol{
+	    registerName: strings.Trim(registerName, "%"), // should work with both AT&T and Intel syntax.
+	    suffixUniqueness: strconv.Itoa(uniqueness),
+	}
 }
 
 // delocation holds the state needed during a delocation operation.
@@ -1387,8 +1387,8 @@ Args:
 
 				uniqueSymbol := newCpuCapUniqueSymbol(len(d.cpuCapUniqueSymbols), reg)
 				wrappers = append(wrappers, func(k func()) {
-					d.output.WriteString("\tjmp\t" + uniqueSymbol.getIntelSymbol() + "\n")
-					d.output.WriteString(uniqueSymbol.getIntelSymbolReturn() + ":\n")
+					d.output.WriteString("\tjmp\t" + uniqueSymbol.getx86Symbol() + "\n")
+					d.output.WriteString(uniqueSymbol.getx86SymbolReturn() + ":\n")
 				})
 				d.cpuCapUniqueSymbols = append(d.cpuCapUniqueSymbols, uniqueSymbol)
 
@@ -1543,8 +1543,8 @@ Args:
 
 					uniqueSymbol := newCpuCapUniqueSymbol(len(d.cpuCapUniqueSymbols), targetReg)
 					wrappers = append(wrappers, func(k func()) {
-						d.output.WriteString("\tjmp\t" + uniqueSymbol.getIntelSymbol() + "\n")
-						d.output.WriteString(uniqueSymbol.getIntelSymbolReturn() + ":\n")
+						d.output.WriteString("\tjmp\t" + uniqueSymbol.getx86Symbol() + "\n")
+						d.output.WriteString(uniqueSymbol.getx86SymbolReturn() + ":\n")
 					})
 					d.cpuCapUniqueSymbols = append(d.cpuCapUniqueSymbols, uniqueSymbol)
 
@@ -1971,10 +1971,10 @@ func transform(w stringWriter, inputs []inputFile) error {
 		// Luckily, this is a fixed order iteration. So, we can write
 		// deterministic tests for this in /testdata.
 		for _, uniqueSymbol := range d.cpuCapUniqueSymbols {
-			w.WriteString(".type " + uniqueSymbol.getIntelSymbol() + ", @function\n")
-			w.WriteString(uniqueSymbol.getIntelSymbol() + ":\n")
+			w.WriteString(".type " + uniqueSymbol.getx86Symbol() + ", @function\n")
+			w.WriteString(uniqueSymbol.getx86Symbol() + ":\n")
 			w.WriteString("\tleaq OPENSSL_ia32cap_P(%rip), %" + uniqueSymbol.registerName + "\n")
-			w.WriteString("\tjmp " + uniqueSymbol.getIntelSymbolReturn() + "\n")
+			w.WriteString("\tjmp " + uniqueSymbol.getx86SymbolReturn() + "\n")
 		}
 
 		if d.gotDeltaNeeded {

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -59,6 +59,7 @@ const (
 	aarch64
 )
 
+// represents a unique symbol for an occurrence of OPENSSL_ia32cap_P.
 type cpuCapUniqueSymbol struct {
 	registerName string
 	suffixUniqueness string
@@ -71,13 +72,13 @@ func (uniqueSymbol cpuCapUniqueSymbol) getIntelSymbol() string {
 }
 
 func (uniqueSymbol cpuCapUniqueSymbol) getIntelSymbolReturn() string {
-	return cpuCapIntelSymbolPrefix + uniqueSymbol.registerName + uniqueSymbol.suffixUniqueness + "_return"
+	return uniqueSymbol.getIntelSymbol() + "_return"
 }
 
-// uniqueness must be a globally unique integer value
+// uniqueness must be a globally unique integer value.
 func newCpuCapUniqueSymbol(uniqueness int, registerName string) *cpuCapUniqueSymbol {
     uniqueSymbol := new(cpuCapUniqueSymbol)
-    uniqueSymbol.registerName = strings.Trim(registerName, "%") // should work with both AT&T and Intel syntax
+    uniqueSymbol.registerName = strings.Trim(registerName, "%") // should work with both AT&T and Intel syntax.
     uniqueSymbol.suffixUniqueness = strconv.Itoa(uniqueness)
     return uniqueSymbol
 }
@@ -93,7 +94,7 @@ type delocation struct {
 	symbols map[string]struct{}
 	// localEntrySymbols is the set of symbols with .localentry directives.
 	localEntrySymbols map[string]struct{}
-	// cpuCapUniqueSymbols represents the set of unique references for each
+	// cpuCapUniqueSymbols represents the set of unique symbols for each
 	// discovered occurrence of OPENSSL_ia32cap_P.
 	cpuCapUniqueSymbols []*cpuCapUniqueSymbol
 	// redirectors maps from out-call symbol name to the name of a
@@ -1967,8 +1968,8 @@ func transform(w stringWriter, inputs []inputFile) error {
 		w.WriteString("\tleaq OPENSSL_ia32cap_P(%rip), %rax\n")
 		w.WriteString("\tret\n")
 
-		// This is a fixed order iteration. such that we can soundly write tests
-		// for this in /testdata.
+		// Luckily, this is a fixed order iteration. So, that we can write
+		// deterministic tests for this in /testdata.
 		for _, uniqueSymbol := range d.cpuCapUniqueSymbols {
 			w.WriteString(".type " + uniqueSymbol.getIntelSymbol() + ", @function\n")
 			w.WriteString(uniqueSymbol.getIntelSymbol() + ":\n")

--- a/util/fipstools/delocate/testdata/generic-FileDirectives/out.s
+++ b/util/fipstools/delocate/testdata/generic-FileDirectives/out.s
@@ -17,11 +17,6 @@ BORINGSSL_bcm_text_end:
 OPENSSL_ia32cap_get:
 	leaq OPENSSL_ia32cap_P(%rip), %rax
 	ret
-.extern OPENSSL_ia32cap_P
-.type OPENSSL_ia32cap_addr_delta, @object
-.size OPENSSL_ia32cap_addr_delta, 8
-OPENSSL_ia32cap_addr_delta:
-.quad OPENSSL_ia32cap_P-OPENSSL_ia32cap_addr_delta
 .type BORINGSSL_bcm_text_hash, @object
 .size BORINGSSL_bcm_text_hash, 32
 BORINGSSL_bcm_text_hash:

--- a/util/fipstools/delocate/testdata/x86_64-BSS/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-BSS/out.s
@@ -71,11 +71,6 @@ z_bss_get:
 OPENSSL_ia32cap_get:
 	leaq OPENSSL_ia32cap_P(%rip), %rax
 	ret
-.extern OPENSSL_ia32cap_P
-.type OPENSSL_ia32cap_addr_delta, @object
-.size OPENSSL_ia32cap_addr_delta, 8
-OPENSSL_ia32cap_addr_delta:
-.quad OPENSSL_ia32cap_P-OPENSSL_ia32cap_addr_delta
 .type BORINGSSL_bcm_text_hash, @object
 .size BORINGSSL_bcm_text_hash, 32
 BORINGSSL_bcm_text_hash:

--- a/util/fipstools/delocate/testdata/x86_64-Basic/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-Basic/out.s
@@ -65,11 +65,6 @@ BORINGSSL_bcm_text_end:
 OPENSSL_ia32cap_get:
 	leaq OPENSSL_ia32cap_P(%rip), %rax
 	ret
-.extern OPENSSL_ia32cap_P
-.type OPENSSL_ia32cap_addr_delta, @object
-.size OPENSSL_ia32cap_addr_delta, 8
-OPENSSL_ia32cap_addr_delta:
-.quad OPENSSL_ia32cap_P-OPENSSL_ia32cap_addr_delta
 .type BORINGSSL_bcm_text_hash, @object
 .size BORINGSSL_bcm_text_hash, 32
 BORINGSSL_bcm_text_hash:

--- a/util/fipstools/delocate/testdata/x86_64-GOTRewrite/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-GOTRewrite/out.s
@@ -9,30 +9,20 @@ foo:
 bar:
 	# leaq of OPENSSL_ia32cap_P is supported.
 # WAS leaq OPENSSL_ia32cap_P(%rip), %r11
-	leaq -128(%rsp), %rsp
-	pushfq
-	leaq	OPENSSL_ia32cap_addr_delta(%rip), %r11
-	addq	(%r11), %r11
-	popfq
-	leaq 128(%rsp), %rsp
+	jmp	LOPENSSL_ia32cap_P_r110
+LOPENSSL_ia32cap_P_r110_return:
 
 	# As is the equivalent GOTPCREL movq.
 # WAS movq OPENSSL_ia32cap_P@GOTPCREL(%rip), %r12
-	leaq -128(%rsp), %rsp
-	pushfq
-	leaq	OPENSSL_ia32cap_addr_delta(%rip), %r12
-	addq	(%r12), %r12
-	popfq
-	leaq 128(%rsp), %rsp
+	jmp	LOPENSSL_ia32cap_P_r121
+LOPENSSL_ia32cap_P_r121_return:
 
 	# And a non-movq instruction via the GOT.
 # WAS orq OPENSSL_ia32cap_P@GOTPCREL(%rip), %r12
 	leaq -128(%rsp), %rsp
 	pushq %rax
-	pushfq
-	leaq	OPENSSL_ia32cap_addr_delta(%rip), %rax
-	addq	(%rax), %rax
-	popfq
+	jmp	LOPENSSL_ia32cap_P_rax2
+LOPENSSL_ia32cap_P_rax2_return:
 	orq %rax, %r12
 	popq %rax
 	leaq 128(%rsp), %rsp
@@ -41,10 +31,8 @@ bar:
 # WAS orq OPENSSL_ia32cap_P@GOTPCREL(%rip), %rax
 	leaq -128(%rsp), %rsp
 	pushq %rbx
-	pushfq
-	leaq	OPENSSL_ia32cap_addr_delta(%rip), %rbx
-	addq	(%rbx), %rbx
-	popfq
+	jmp	LOPENSSL_ia32cap_P_rbx3
+LOPENSSL_ia32cap_P_rbx3_return:
 	orq %rbx, %rax
 	popq %rbx
 	leaq 128(%rsp), %rsp
@@ -297,11 +285,22 @@ stderr_GOTPCREL_external:
 OPENSSL_ia32cap_get:
 	leaq OPENSSL_ia32cap_P(%rip), %rax
 	ret
-.extern OPENSSL_ia32cap_P
-.type OPENSSL_ia32cap_addr_delta, @object
-.size OPENSSL_ia32cap_addr_delta, 8
-OPENSSL_ia32cap_addr_delta:
-.quad OPENSSL_ia32cap_P-OPENSSL_ia32cap_addr_delta
+.type LOPENSSL_ia32cap_P_r110, @function
+LOPENSSL_ia32cap_P_r110:
+	leaq OPENSSL_ia32cap_P(%rip), %r11
+	jmp LOPENSSL_ia32cap_P_r110_return
+.type LOPENSSL_ia32cap_P_r121, @function
+LOPENSSL_ia32cap_P_r121:
+	leaq OPENSSL_ia32cap_P(%rip), %r12
+	jmp LOPENSSL_ia32cap_P_r121_return
+.type LOPENSSL_ia32cap_P_rax2, @function
+LOPENSSL_ia32cap_P_rax2:
+	leaq OPENSSL_ia32cap_P(%rip), %rax
+	jmp LOPENSSL_ia32cap_P_rax2_return
+.type LOPENSSL_ia32cap_P_rbx3, @function
+LOPENSSL_ia32cap_P_rbx3:
+	leaq OPENSSL_ia32cap_P(%rip), %rbx
+	jmp LOPENSSL_ia32cap_P_rbx3_return
 .type BORINGSSL_bcm_text_hash, @object
 .size BORINGSSL_bcm_text_hash, 32
 BORINGSSL_bcm_text_hash:

--- a/util/fipstools/delocate/testdata/x86_64-LabelRewrite/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-LabelRewrite/out.s
@@ -107,11 +107,6 @@ bcm_redirector_memcpy:
 OPENSSL_ia32cap_get:
 	leaq OPENSSL_ia32cap_P(%rip), %rax
 	ret
-.extern OPENSSL_ia32cap_P
-.type OPENSSL_ia32cap_addr_delta, @object
-.size OPENSSL_ia32cap_addr_delta, 8
-OPENSSL_ia32cap_addr_delta:
-.quad OPENSSL_ia32cap_P-OPENSSL_ia32cap_addr_delta
 .type BORINGSSL_bcm_text_hash, @object
 .size BORINGSSL_bcm_text_hash, 32
 BORINGSSL_bcm_text_hash:

--- a/util/fipstools/delocate/testdata/x86_64-LargeMemory/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-LargeMemory/out.s
@@ -47,11 +47,6 @@ BORINGSSL_bcm_text_end:
 OPENSSL_ia32cap_get:
 	leaq OPENSSL_ia32cap_P(%rip), %rax
 	ret
-.extern OPENSSL_ia32cap_P
-.type OPENSSL_ia32cap_addr_delta, @object
-.size OPENSSL_ia32cap_addr_delta, 8
-OPENSSL_ia32cap_addr_delta:
-.quad OPENSSL_ia32cap_P-OPENSSL_ia32cap_addr_delta
 .Lboringssl_got_delta:
 	.quad _GLOBAL_OFFSET_TABLE_-.Lboringssl_got_delta
 .Lboringssl_got_h:

--- a/util/fipstools/delocate/testdata/x86_64-Sections/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-Sections/out.s
@@ -53,11 +53,6 @@ BORINGSSL_bcm_text_end:
 OPENSSL_ia32cap_get:
 	leaq OPENSSL_ia32cap_P(%rip), %rax
 	ret
-.extern OPENSSL_ia32cap_P
-.type OPENSSL_ia32cap_addr_delta, @object
-.size OPENSSL_ia32cap_addr_delta, 8
-OPENSSL_ia32cap_addr_delta:
-.quad OPENSSL_ia32cap_P-OPENSSL_ia32cap_addr_delta
 .type BORINGSSL_bcm_text_hash, @object
 .size BORINGSSL_bcm_text_hash, 32
 BORINGSSL_bcm_text_hash:

--- a/util/fipstools/delocate/testdata/x86_64-ThreeArg/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-ThreeArg/out.s
@@ -40,11 +40,6 @@ BORINGSSL_bcm_text_end:
 OPENSSL_ia32cap_get:
 	leaq OPENSSL_ia32cap_P(%rip), %rax
 	ret
-.extern OPENSSL_ia32cap_P
-.type OPENSSL_ia32cap_addr_delta, @object
-.size OPENSSL_ia32cap_addr_delta, 8
-OPENSSL_ia32cap_addr_delta:
-.quad OPENSSL_ia32cap_P-OPENSSL_ia32cap_addr_delta
 .type BORINGSSL_bcm_text_hash, @object
 .size BORINGSSL_bcm_text_hash, 32
 BORINGSSL_bcm_text_hash:


### PR DESCRIPTION
### Issues:

CryptoAlg-1577

### Description of changes: 

See [#856](https://github.com/aws/aws-lc/pull/856) for background and description of issue resolved in this PR.

This is the second PR out of two PRs that bridge the performance gap.

See ticket for performance comparisons.

The first PR took care of the C-level. But the machine-optimised algorithm implementation sometimes directly dereference `OPENSSL_ia32cap_P`. These also need to be fixed-up. As before, we can't just add a call instruction to `OPENSSL_ia32cap_get` because it would compromise soundness/correctness.

Recall, that the issue was the `add` instruction. Instead of injecting that instruction, we instead do the following for each occurrence of `OPENSSL_ia32cap_P` discovered in the textual assembly:
* Define a new unique symbol. Uniquness is ensured using both the original (not true in all cases, but see "call outs") register name and a unique global counter. Bit redundant using both, but makes it easier to read IMO.
* Under the new unique symbol, copy the address of `OPENSSL_ia32cap_P` into the original register. This will probably spawn a relocation, but this is fine, because we put this new unique symbol outside the FIPS module scope in `.text`. Putting it here also means that we know the address relative to RIP.
* To jump back to the original execution point, we inject a "return" symbol/label where `OPENSSL_ia32cap_P` was discovered. 

Examplewise, we have something looking like the following.
Original:
```
    mov OPENSSL_ia32cap_P(%RIP), %rax
```
Transformed into:
```
    jmp OPENSSL_ia32cap_P_rax0
OPENSSL_ia32cap_P_rax0_return:

"after fips scope"

OPENSSL_ia32cap_P_rax0:
    lea OPENSSL_ia32cap_P(%RIP), %rax
    jmp OPENSSL_ia32cap_P_rax0_return
```

Note, we need a new symbol for each occurrence of `OPENSSL_ia32cap_P` to ensure we can jump back to the correct place.

### Call-outs:

The original destination register is not always used. The reason is that the delocator script fix-up other things that switches out the original register. For example, for the `instrCombine` type instructions, [we switch register](https://github.com/aws/aws-lc/blob/main/util/fipstools/delocate/delocate.go#L1456-L1466), using [an ordered list of possible new registers](https://github.com/aws/aws-lc/blob/main/util/fipstools/delocate/delocate.go#L1220).

We use this ordered list in the tests to correctly predict the output.  For example, the **4th** occurrence of `OPENSSL_ia32cap_P`
```
orq OPENSSL_ia32cap_P@GOTPCREL(%rip), %rax
```
does **NOT** result in the following code output
```
	jmp	LOPENSSL_ia32cap_P_rax3
LOPENSSL_ia32cap_P_rax2_return:

"after fips scope"

.type LOPENSSL_ia32cap_P_rax3, @function
LOPENSSL_ia32cap_P_rax3:
	leaq OPENSSL_ia32cap_P(%rip), %rax
	jmp LOPENSSL_ia32cap_P_rax3_return
```
because of the `orq` instruction. **Instead**, the `rbx` register is used, producing
```
	jmp	LOPENSSL_ia32cap_P_rbx3
LOPENSSL_ia32cap_P_rbx3_return:

"after fips scope"
.type LOPENSSL_ia32cap_P_rbx3, @function
LOPENSSL_ia32cap_P_rbx3:
	leaq OPENSSL_ia32cap_P(%rip), %rbx
	jmp LOPENSSL_ia32cap_P_rbx3_return
```

### Testing:

Ran the delocator test script `delocate_script.go` from the delocate folder:
```
$ go test
PASS
ok      boringssl.googlesource.com/boringssl/util/fipstools/delocate    0.011s
```

Although, I had to "fix" a small regression like this:
```
diff --git a/util/fipstools/delocate/delocate.go b/util/fipstools/delocate/delocate.go
index df2ebbe3a..98499dbcd 100644
--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -1431,7 +1431,8 @@ Args:
 
                                classification := classifyInstruction(instructionName, argNodes)
                                if classification != instrThreeArg && classification != instrCompare && i != 0 {
-                                       return nil, fmt.Errorf("GOT access must be source operand, %w", classification)
+                                       //return nil, fmt.Errorf("GOT access must be source operand, %w", classification)
+                                       return nil, nil
                                }
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
