### PR TITLE
Fix for bugs in the KEM implementation and SHA3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,7 @@ elseif(MSVC)
               # Disable this because it flags even when there is a default.
       "C4100" # 'exarg' : unreferenced formal parameter
       "C4127" # conditional expression is constant
+      "C4146" # unary minus operator applied to unsigned type, result still unsigned
       "C4200" # nonstandard extension used : zero-sized array in
               # struct/union.
       "C4204" # nonstandard extension used: non-constant aggregate initializer

--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -1832,11 +1832,22 @@ TEST_P(PerKEMTest, Encapsulation) {
   EXPECT_EQ(ct_len, GetParam().ciphertext_len);
   EXPECT_EQ(ss_len, GetParam().shared_secret_len);
 
+  // When only one of |ct| or |ss| is NULL the function fails.
+  ASSERT_FALSE(EVP_PKEY_encapsulate(ctx.get(), ct.data(), &ct_len, nullptr, &ss_len));
+  uint32_t err = ERR_get_error();
+  EXPECT_EQ(ERR_LIB_EVP, ERR_GET_LIB(err));
+  EXPECT_EQ(EVP_R_MISSING_PARAMETERS, ERR_GET_REASON(err));
+
+  ASSERT_FALSE(EVP_PKEY_encapsulate(ctx.get(), nullptr, &ct_len, ss.data(), &ss_len));
+  err = ERR_get_error();
+  EXPECT_EQ(ERR_LIB_EVP, ERR_GET_LIB(err));
+  EXPECT_EQ(EVP_R_MISSING_PARAMETERS, ERR_GET_REASON(err));
+
   // ---- 4. Test calling encapsulate with different lengths ----
   // Set ct length to be less than expected -- should fail.
   ct_len = GetParam().ciphertext_len - 1;
   ASSERT_FALSE(EVP_PKEY_encapsulate(ctx.get(), ct.data(), &ct_len, ss.data(), &ss_len));
-  uint32_t err = ERR_get_error();
+  err = ERR_get_error();
   EXPECT_EQ(ERR_LIB_EVP, ERR_GET_LIB(err));
   EXPECT_EQ(EVP_R_BUFFER_TOO_SMALL, ERR_GET_REASON(err));
 
@@ -2076,6 +2087,24 @@ TEST_P(PerKEMTest, RawKeyOperations) {
   err = ERR_get_error();
   EXPECT_EQ(ERR_LIB_EVP, ERR_GET_LIB(err));
   EXPECT_EQ(EVP_R_BUFFER_TOO_SMALL, ERR_GET_REASON(err));
+
+  //   Missing public/private key.
+  pk_len = GetParam().public_key_len;
+  sk_len = GetParam().secret_key_len;
+  pkey_pk_new.reset(EVP_PKEY_kem_new_raw_public_key(nid, pk.data(), pk_len));
+  pkey_sk_new.reset(EVP_PKEY_kem_new_raw_secret_key(nid, sk.data(), sk_len));
+  ASSERT_TRUE(pkey_pk_new);
+  ASSERT_TRUE(pkey_sk_new);
+
+  ASSERT_FALSE(EVP_PKEY_get_raw_private_key(pkey_pk_new.get(), sk.data(), &sk_len));
+  err = ERR_get_error();
+  EXPECT_EQ(ERR_LIB_EVP, ERR_GET_LIB(err));
+  EXPECT_EQ(EVP_R_NO_KEY_SET, ERR_GET_REASON(err));
+
+  ASSERT_FALSE(EVP_PKEY_get_raw_public_key(pkey_sk_new.get(), pk.data(), &pk_len));
+  err = ERR_get_error();
+  EXPECT_EQ(ERR_LIB_EVP, ERR_GET_LIB(err));
+  EXPECT_EQ(EVP_R_NO_KEY_SET, ERR_GET_REASON(err));
 
   // Failures for new keys from raw data.
   pk_len = GetParam().public_key_len;

--- a/crypto/evp_extra/p_kem_asn1.c
+++ b/crypto/evp_extra/p_kem_asn1.c
@@ -39,6 +39,11 @@ static int kem_get_priv_raw(const EVP_PKEY *pkey, uint8_t *out,
     return 0;
   }
 
+  if (key->secret_key == NULL) {
+    OPENSSL_PUT_ERROR(EVP, EVP_R_NO_KEY_SET);
+    return 0;
+  }
+
   OPENSSL_memcpy(out, key->secret_key, kem->secret_key_len);
   *out_len = kem->secret_key_len;
 
@@ -66,6 +71,11 @@ static int kem_get_pub_raw(const EVP_PKEY *pkey, uint8_t *out,
 
   if (*out_len < kem->public_key_len) {
     OPENSSL_PUT_ERROR(EVP, EVP_R_BUFFER_TOO_SMALL);
+    return 0;
+  }
+
+  if (key->public_key == NULL) {
+    OPENSSL_PUT_ERROR(EVP, EVP_R_NO_KEY_SET);
     return 0;
   }
 

--- a/crypto/fipsmodule/sha/asm/keccak1600-armv8.pl
+++ b/crypto/fipsmodule/sha/asm/keccak1600-armv8.pl
@@ -450,6 +450,8 @@ SHA3_Squeeze:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-48]!
 	add	x29,sp,#0
+	cmp	x2,#0
+	beq	.Lsqueeze_abort
 	stp	x19,x20,[sp,#16]
 	stp	x21,x22,[sp,#32]
 	mov	$A_flat,x0			// put aside arguments
@@ -503,6 +505,7 @@ SHA3_Squeeze:
 .Lsqueeze_done:
 	ldp	x19,x20,[sp,#16]
 	ldp	x21,x22,[sp,#32]
+.Lsqueeze_abort:
 	ldp	x29,x30,[sp],#48
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
@@ -729,6 +732,8 @@ SHA3_Squeeze_cext:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
+	cmp	$len,#0
+	beq	.Lsqueeze_done_ce
 	mov	x9,$ctx
 	mov	x10,$bsz
 .Loop_squeeze_ce:

--- a/crypto/kem/internal.h
+++ b/crypto/kem/internal.h
@@ -49,7 +49,6 @@ struct kem_key_st {
   const KEM *kem;
   uint8_t *public_key;
   uint8_t *secret_key;
-  uint8_t has_secret_key;
 };
 
 KEM_KEY *KEM_KEY_new(void);

--- a/crypto/kem/kem.c
+++ b/crypto/kem/kem.c
@@ -101,7 +101,6 @@ int KEM_KEY_init(KEM_KEY *key, const KEM *kem) {
   key->kem = kem;
   key->public_key = OPENSSL_malloc(kem->public_key_len);
   key->secret_key = OPENSSL_malloc(kem->secret_key_len);
-  key->has_secret_key = 0;
   if (key->public_key == NULL || key->secret_key == NULL) {
     OPENSSL_PUT_ERROR(EVP, ERR_R_MALLOC_FAILURE);
     KEM_KEY_clear(key);
@@ -139,7 +138,6 @@ int KEM_KEY_set_raw_secret_key(KEM_KEY *key, const uint8_t *in) {
     OPENSSL_PUT_ERROR(EVP, ERR_R_MALLOC_FAILURE);
     return 0;
   }
-  key->has_secret_key = 1;
 
   return 1;
 }
@@ -153,7 +151,6 @@ int KEM_KEY_set_raw_key(KEM_KEY *key, const uint8_t *in_public,
     KEM_KEY_clear(key);
     return 0;
   }
-  key->has_secret_key = 1;
 
   return 1;
 }

--- a/crypto/kyber/README.md
+++ b/crypto/kyber/README.md
@@ -21,7 +21,6 @@ The following changes were made to the source code in `pqcrystals_kyber_ref_comm
 * `sha2.h, sha256.c, sha512.c, symmetric-aes.c` are removed because we are using only the SHA3 based Kyber (SHA2 and AES are used in the 90s variants only).
 * `indcpa.c`: call to `randombytes` function is replaced with a call to `pq_custom_randombytes` and the appropriate header file is included (`crypto/rand_extra/pq_custom_randombytes.h`).
 * `kem.c`: calls to `randombytes` function is replaced with calls to `pq_custom_randombytes` and the appropriate header file is included (`crypto/rand_extra/pq_custom_randombytes.h`).
-* `verify.c`: change to fix MSVC compiler warning (see the file for details).
 * `symmetric-shake.c`: unnecessary include of `fips202.h` is removed.
 * `api.h`, `fips202.h`, `params.h`: modified [in this PR](https://github.com/aws/aws-lc/pull/655) to support our [prefixed symbols build](https://github.com/aws/aws-lc/blob/main/BUILDING.md#building-with-prefixed-symbols).
 

--- a/crypto/kyber/pqcrystals_kyber_ref_common/verify.c
+++ b/crypto/kyber/pqcrystals_kyber_ref_common/verify.c
@@ -21,13 +21,7 @@ int verify(const uint8_t *a, const uint8_t *b, size_t len)
   for(i=0;i<len;i++)
     r |= a[i] ^ b[i];
 
-  /*
-   * The original logic: return (-(uint64_t)r) >> 63;
-   * It's been modified to preserve constant time and the intended logic, but
-   * avoids the compiler warning (which turns to an error on in MSVC) for
-   * performing a negation on an unsigned value.
-   */
-  return (-(int16_t)((uint16_t)r & 0x7FFF)) >> 15;
+  return (-(uint64_t)r) >> 63;
 }
 
 /*************************************************

--- a/generated-src/ios-aarch64/crypto/fipsmodule/keccak1600-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/keccak1600-armv8.S
@@ -489,6 +489,8 @@ _SHA3_Squeeze:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-48]!
 	add	x29,sp,#0
+	cmp	x2,#0
+	beq	Lsqueeze_abort
 	stp	x19,x20,[sp,#16]
 	stp	x21,x22,[sp,#32]
 	mov	x19,x0			// put aside arguments
@@ -542,6 +544,7 @@ Lsqueeze_tail:
 Lsqueeze_done:
 	ldp	x19,x20,[sp,#16]
 	ldp	x21,x22,[sp,#32]
+Lsqueeze_abort:
 	ldp	x29,x30,[sp],#48
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
@@ -900,6 +903,8 @@ _SHA3_Squeeze_cext:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
+	cmp	x2,#0
+	beq	Lsqueeze_done_ce
 	mov	x9,x0
 	mov	x10,x3
 Loop_squeeze_ce:

--- a/generated-src/linux-aarch64/crypto/fipsmodule/keccak1600-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/keccak1600-armv8.S
@@ -489,6 +489,8 @@ SHA3_Squeeze:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-48]!
 	add	x29,sp,#0
+	cmp	x2,#0
+	beq	.Lsqueeze_abort
 	stp	x19,x20,[sp,#16]
 	stp	x21,x22,[sp,#32]
 	mov	x19,x0			// put aside arguments
@@ -542,6 +544,7 @@ SHA3_Squeeze:
 .Lsqueeze_done:
 	ldp	x19,x20,[sp,#16]
 	ldp	x21,x22,[sp,#32]
+.Lsqueeze_abort:
 	ldp	x29,x30,[sp],#48
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
@@ -900,6 +903,8 @@ SHA3_Squeeze_cext:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
+	cmp	x2,#0
+	beq	.Lsqueeze_done_ce
 	mov	x9,x0
 	mov	x10,x3
 .Loop_squeeze_ce:

--- a/generated-src/win-aarch64/crypto/fipsmodule/keccak1600-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/keccak1600-armv8.S
@@ -497,6 +497,8 @@ SHA3_Squeeze:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-48]!
 	add	x29,sp,#0
+	cmp	x2,#0
+	beq	Lsqueeze_abort
 	stp	x19,x20,[sp,#16]
 	stp	x21,x22,[sp,#32]
 	mov	x19,x0			// put aside arguments
@@ -550,6 +552,7 @@ Lsqueeze_tail:
 Lsqueeze_done:
 	ldp	x19,x20,[sp,#16]
 	ldp	x21,x22,[sp,#32]
+Lsqueeze_abort:
 	ldp	x29,x30,[sp],#48
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
@@ -916,6 +919,8 @@ SHA3_Squeeze_cext:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
+	cmp	x2,#0
+	beq	Lsqueeze_done_ce
 	mov	x9,x0
 	mov	x10,x3
 Loop_squeeze_ce:

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -710,12 +710,18 @@ OPENSSL_EXPORT int EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **out_pkey);
 //   3. writes the length of |ciphertext| and |shared_secret| to
 //      |ciphertext_len| and |shared_secret_len|.
 //
-// If the given |ciphertext| is NULL it is assumed that the caller is doing
-// a size check: the function will write the size of the ciphertext and the
-// shared secret in |ciphertext_len| and |shared_secret_len| and return 1.
-// If |ciphertext| is non-NULL it is assumed that the caller is performing
-// the actual operation, so it is checked if the lengths of the output buffers,
-// |ciphertext_len| and |shared_secret_len|, are large enough for the KEM.
+// The function requires that output buffers, |ciphertext| and |shared_secret|,
+// be either both NULL or both non-NULL. Otherwise, a failure is returned.
+//
+// If both |ciphertext| and |shared_secret| are NULL it is assumed that
+// the caller is doing a size check: the function will write the size of
+// the ciphertext and the shared secret in |ciphertext_len| and
+// |shared_secret_len| and return successfully.
+//
+// If both |ciphertext| and |shared_secret| are not NULL it is assumed that
+// the caller is performing the actual operation. The function will check
+// additionally if the lengths of the output buffers, |ciphertext_len| and
+// |shared_secret_len|, are large enough for the KEM.
 //
 // NOTE: no allocation is done in the function, the caller is expected to
 // provide large enough |ciphertext| and |shared_secret| buffers.
@@ -735,10 +741,11 @@ OPENSSL_EXPORT int EVP_PKEY_encapsulate(EVP_PKEY_CTX *ctx          /* IN  */,
 //
 // If the given |shared_secret| is NULL it is assumed that the caller is doing
 // a size check: the function will write the size of the shared secret in
-// |shared_secret_len| and return 1.
+// |shared_secret_len| and return successfully.
+//
 // If |shared_secret| is non-NULL it is assumed that the caller is performing
-// the actual operation, so it is checked if the length of the output buffer,
-// |shared_secret_len|, is large enough for the KEM.
+// the actual operation. The functions will check additionally if the length of
+// the output buffer |shared_secret_len| is large enough for the KEM.
 //
 // NOTE: no allocation is done in the function, the caller is expected to
 // provide large enough |shared_secret| buffer.


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 

Cherry-picked three commits from the main branch:
- Revert Kyber verify (#841)
- KEM: fix key retrieval when public/secret key is missing (#855)
- Avoid potential for buffer overflow in SHA3 ARMv8 assembly (#863)

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
