### PR TITLE
Add `KemKeyShare` to libssl

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2366,6 +2366,11 @@ OPENSSL_EXPORT int SSL_set1_curves_list(SSL *ssl, const char *curves);
 #define SSL_CURVE_X25519 29
 #define SSL_CURVE_CECPQ2 16696
 
+// PQ and hybrid group IDs are not yet standardized. Current IDs are driven by
+// community consensus and are defined at
+// https://github.com/open-quantum-safe/openssl/blob/OQS-OpenSSL_1_1_1-stable/oqs-template/oqs-kem-info.md
+#define SSL_CURVE_KYBER512_R3 0x023A
+
 // SSL_get_curve_id returns the ID of the curve used by |ssl|'s most recently
 // completed handshake or 0 if not applicable.
 //

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -1084,8 +1084,9 @@ class SSLKeyShare {
   HAS_VIRTUAL_DESTRUCTOR
 
   // Create returns a SSLKeyShare instance for use with group |group_id| or
-  // nullptr on error.
-  static UniquePtr<SSLKeyShare> Create(uint16_t group_id);
+  // nullptr on error. Marked with OPENSSL_EXPORT to make it available for
+  // unit tests.
+  OPENSSL_EXPORT static UniquePtr<SSLKeyShare> Create(uint16_t group_id);
 
   // Create deserializes an SSLKeyShare instance previously serialized by
   // |Serialize|.
@@ -1136,6 +1137,12 @@ struct NamedGroup {
 
 // NamedGroups returns all supported groups.
 Span<const NamedGroup> NamedGroups();
+
+// PQGroups returns all supported post-quantum groups. A post-quantum
+// group may be a hybrid group containing at least one PQ
+// component (e.g. SECP256R1_KYBER512_R3) or a standalone PQ group
+// (e.g. KYBER512_R3).
+Span<const uint16_t> PQGroups();
 
 // ssl_nid_to_group_id looks up the group corresponding to |nid|. On success, it
 // sets |*out_group_id| to the group ID and returns true. Otherwise, it returns


### PR DESCRIPTION
### Description of changes: 
This is the first of several PRs to add PQ/hybrid functionality to `libssl`. This PR adds:
* A new key share type: `KemKeyShare`. This handles the keygen/encapsulation/decapsulation flow for PQ KEMs in TLS 1.3. For the foreseeable future, `KemKeyShare` will not be available to negotiate on its own - it will be used only as part of a hybrid key share. In a future PR, an additional type, `HybridKeyShare`, will be added. `HybridKeyShare` will implement the generalized hybrid concept, allowing the hybrid combination of any other key share types. (In particular, we will be interested in combining an `ECKeyShare` with a `KemKeyShare`.)

### Call-outs:
[`NamedGroups`](https://github.com/aws/aws-lc/blob/6dcb1c327d4e9023855b92d6f7eb8e2c54e5616f/ssl/ssl_key_share.cc#L302-L315) defines which groups are made available for TLS negotiation. Since we are not adding anything to that, the `KemKeyShare` functionality is effectively feature-guarded from general use.

### Testing:
* Unit tests for `KemKeyShare` have been added. 
* Interoperability and integration tests will be added in future PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
