### PR TITLE
Add checks to ensure that OPENSSL_ia32cap is not in the fips module

### DIFF
--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -70,6 +70,7 @@
 #include "cipher/e_aes.c"
 #include "cipher/e_aesccm.c"
 
+#include "cpucap/internal.h"
 #include "cpucap/cpu_aarch64_apple.c"
 #include "cpucap/cpu_aarch64_freebsd.c"
 #include "cpucap/cpu_aarch64_fuchsia.c"
@@ -155,12 +156,6 @@ extern const uint8_t BORINGSSL_bcm_text_hash[];
 #if defined(BORINGSSL_SHARED_LIBRARY)
 extern const uint8_t BORINGSSL_bcm_rodata_start[];
 extern const uint8_t BORINGSSL_bcm_rodata_end[];
-#endif
-
-// We need to get OPENSSL_ia32cap_P from cpucap.c without including the file
-// However, OPENSSL_ia32cap is only defined for x86 processors
-#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
-extern uint32_t OPENSSL_ia32cap_P[4];
 #endif
 
 // assert_within is used to sanity check that certain symbols are within the
@@ -274,6 +269,8 @@ int BORINGSSL_integrity_test(void) {
   assert_not_within(start, CRYPTO_chacha_20, end);
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
   assert_not_within(start, OPENSSL_ia32cap_P, end);
+#elif defined(OPENSSL_AARCH64)
+  assert_not_within(start, &OPENSSL_armcap_P, end);
 #endif  
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
@@ -290,6 +287,8 @@ int BORINGSSL_integrity_test(void) {
   assert_within(rodata_start, kPKCS1SigPrefixes, rodata_end);
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
   assert_not_within(rodata_start, OPENSSL_ia32cap_P, rodata_end);
+#elif defined(OPENSSL_AARCH64)
+  assert_not_within(rodata_start, &OPENSSL_armcap_P, rodata_end);
 #endif
 
   // Per FIPS 140-3 we have to perform the CAST of the HMAC used for integrity

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -160,7 +160,7 @@ extern const uint8_t BORINGSSL_bcm_rodata_end[];
 // We need to get OPENSSL_ia32cap_P from cpucap.c without including the file
 // However, OPENSSL_ia32cap is only defined for x86 processors
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
-extern const uint32_t OPENSSL_ia32cap_P[];
+extern uint32_t OPENSSL_ia32cap_P[4];
 #endif
 
 // assert_within is used to sanity check that certain symbols are within the

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -157,6 +157,12 @@ extern const uint8_t BORINGSSL_bcm_rodata_start[];
 extern const uint8_t BORINGSSL_bcm_rodata_end[];
 #endif
 
+// We need to get OPENSSL_ia32cap_P from cpucap.c without including the file
+// However, OPENSSL_ia32cap is only defined for x86 processors
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
+extern const OPENSSL_ia32cap_P[];
+#endif
+
 // assert_within is used to sanity check that certain symbols are within the
 // bounds of the integrity check. It checks that start <= symbol < end and
 // aborts otherwise.
@@ -266,7 +272,9 @@ int BORINGSSL_integrity_test(void) {
   assert_within(start, EVP_AEAD_CTX_seal, end);
   assert_not_within(start, OPENSSL_cleanse, end);
   assert_not_within(start, CRYPTO_chacha_20, end);
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
   assert_not_within(start, OPENSSL_ia32cap_P, end);
+#endif  
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
   const uint8_t *const rodata_start = BORINGSSL_bcm_rodata_start;
@@ -280,7 +288,9 @@ int BORINGSSL_integrity_test(void) {
   assert_within(rodata_start, kPrimes, rodata_end);
   assert_within(rodata_start, kP256Params, rodata_end);
   assert_within(rodata_start, kPKCS1SigPrefixes, rodata_end);
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
   assert_not_within(rodata_start, OPENSSL_ia32cap_P, rodata_end);
+#endif
 
   // Per FIPS 140-3 we have to perform the CAST of the HMAC used for integrity
   // check before the integrity check itself. So we first call

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -266,6 +266,7 @@ int BORINGSSL_integrity_test(void) {
   assert_within(start, EVP_AEAD_CTX_seal, end);
   assert_not_within(start, OPENSSL_cleanse, end);
   assert_not_within(start, CRYPTO_chacha_20, end);
+  assert_not_within(start, OPENSSL_ia32cap_P, end);
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
   const uint8_t *const rodata_start = BORINGSSL_bcm_rodata_start;
@@ -279,6 +280,7 @@ int BORINGSSL_integrity_test(void) {
   assert_within(rodata_start, kPrimes, rodata_end);
   assert_within(rodata_start, kP256Params, rodata_end);
   assert_within(rodata_start, kPKCS1SigPrefixes, rodata_end);
+  assert_not_within(rodata_start, OPENSSL_ia32cap_P, rodata_end);
 
   // Per FIPS 140-3 we have to perform the CAST of the HMAC used for integrity
   // check before the integrity check itself. So we first call

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -160,7 +160,7 @@ extern const uint8_t BORINGSSL_bcm_rodata_end[];
 // We need to get OPENSSL_ia32cap_P from cpucap.c without including the file
 // However, OPENSSL_ia32cap is only defined for x86 processors
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
-extern const OPENSSL_ia32cap_P[];
+extern const uint32_t OPENSSL_ia32cap_P[];
 #endif
 
 // assert_within is used to sanity check that certain symbols are within the

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -28,6 +28,12 @@
     "target_arch": "arm"
   },
   {
+    "comment": "Test OPENSSL_ia32cap on crypto_test for x86, as urandom_test is disabled for shared builds on x86",
+    "cmd": ["crypto/crypto_test"],
+    "env": ["OPENSSL_ia32cap=0:0"],
+    "target_arch": "x86"
+  },
+  {
     "cmd": ["crypto/urandom_test"],
     "skip_valgrind": true
   },

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -29,7 +29,7 @@
   },
   {
     "comment": "Test OPENSSL_ia32cap on crypto_test for x86, as urandom_test is disabled for shared builds on x86",
-    "cmd": ["crypto/crypto_test"],
+    "cmd": ["crypto/crypto_test", "--gtest_filter=Crypto.OnDemandIntegrityTest"],
     "env": ["OPENSSL_ia32cap=0:0"],
     "target_arch": "x86"
   },


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving,
explain why this change is necessary.

AWS-LC currently does not explicitly check that `OPENSSL_ia32cap`is not in the fips module during it's integrity check. Additionally, it only runs the urandom test - always returns success on x86 shared builds - with the environment variable set. This has proven to be a problem as outlined in the description for PR https://github.com/aws/aws-lc/pull/878.

As such, this PR adds checks to the integrity check and also tests `crypto_test` with the variable set in order to ensure that any change that accidentally adds OPENSSL_ia32cap back into the fips module is caught in the future.

### Call-outs:
N/A

### Testing:
Built locally on Windows x86 and MacOS arm to ensure that the tests run as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
