### PR TITLE
Add Missing Windows FIPS Segment Markers

### DIFF
--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -30,7 +30,8 @@
 #if defined(BORINGSSL_FIPS) && defined(OPENSSL_WINDOWS)
 #pragma code_seg(".fipstx$b")
 #pragma data_seg(".fipsda$b")
-#pragma const_seg(".fipsda$b")
+#pragma const_seg(".fipsco$b")
+#pragma bss_seg(".fipsbs$b")
 #endif
 
 #include <openssl/digest.h>

--- a/crypto/fipsmodule/fips_shared_library_marker.c
+++ b/crypto/fipsmodule/fips_shared_library_marker.c
@@ -21,7 +21,8 @@
 #if defined(_MSC_VER)
 #pragma code_seg(".fipstx$a")
 #pragma data_seg(".fipsda$a")
-#pragma const_seg(".fipsda$a")
+#pragma const_seg(".fipsco$a")
+#pragma bss_seg(".fipsbs$a")
 #endif
 
 // Dummy but not empty function and array to avoid the compiler completely
@@ -36,7 +37,8 @@ const uint8_t BORINGSSL_bcm_rodata_start[16] =
 #if defined(_MSC_VER)
 #pragma code_seg(".fipstx$z")
 #pragma data_seg(".fipsda$z")
-#pragma const_seg(".fipsda$z")
+#pragma const_seg(".fipsco$z")
+#pragma bss_seg(".fipsbs$z")
 #endif
 
 // Dummy but not empty function and array to avoid the compiler completely


### PR DESCRIPTION
### Description of changes: 
For it's Windows FIPS build, AWS-LC currently does not specify bss segment markers, and also sets the const segment to use the same markers as the data segment. This is a problem as that means that data that can change may end up in the constant section and vice versa. This PR fixes this by creating dedicated markers for the const and bss segments.

### Call-outs:
N/A

### Testing:
Built and tested on Windows platform to ensure that the changes work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
