### PR TITLE
Stringify enum to pretty-print errors

### DIFF
--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -1099,6 +1099,7 @@ Args:
 
 type instructionType int
 
+// also update stringifier when making changes to this enum.
 const (
 	instrPush instructionType = iota
 	instrMove
@@ -1120,6 +1121,13 @@ const (
 	instrCompare
 	instrOther
 )
+
+func (index instructionType) String() string {
+	return [...]string{"instrPush", "instrMove", "instrTransformingMove",
+		"instrJump", "instrConditionalMove", "instrCombine",
+		"instrMemoryVectorCombine", "instrThreeArg",
+		"instrCompare", "instrOther"}[index]
+}
 
 func classifyInstruction(instr string, args []*node32) instructionType {
 	switch instr {
@@ -1419,7 +1427,7 @@ Args:
 
 				classification := classifyInstruction(instructionName, argNodes)
 				if classification != instrThreeArg && classification != instrCompare && i != 0 {
-					return nil, fmt.Errorf("GOT access must be source operand, %w", classification)
+					return nil, fmt.Errorf("GOT access must be source operand, %s", classification)
 				}
 
 				// Reduce the instruction to movq symbol@GOTPCREL, targetReg.


### PR DESCRIPTION
### Description of changes: 

Executing `go test` (which executes `delocate.go` tests), results in:
```
$ go test
# boringssl.googlesource.com/boringssl/util/fipstools/delocate
./delocate.go:1422:18: fmt.Errorf format %s has arg classification of wrong type boringssl.googlesource.com/boringssl/util/fipstools/delocate.instructionType
FAIL    boringssl.googlesource.com/boringssl/util/fipstools/delocate [build failed]
```

The enum type `instructionType` doesn't have an unwrap. I believe. In fact, not entirely sure how `Errorf` translates `%w` and it's argument. Instead, just stringify the enum type `instructionType` and pass that up the stack to pretty-print.

After these changes, we get:
```
$ go test
PASS
ok      boringssl.googlesource.com/boringssl/util/fipstools/delocate    0.011s
```

### Testing:

Modelled `delocate.go` call stack for the error as an attempt to verify changes work as intended: https://go.dev/play/p/zCkaM6RN8Fq.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
