### PR TITLE
Add SHA3_Squeeze output buffer overflow test

### DIFF
--- a/crypto/fipsmodule/sha/asm/keccak1600-armv8.pl
+++ b/crypto/fipsmodule/sha/asm/keccak1600-armv8.pl
@@ -343,10 +343,10 @@ KeccakF1600:
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
 .size	KeccakF1600,.-KeccakF1600
-.globl	SHA3_Absorb
-.type	SHA3_Absorb,%function
+.globl	SHA3_Absorb_hw
+.type	SHA3_Absorb_hw,%function
 .align	5
-SHA3_Absorb:
+SHA3_Absorb_hw:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-128]!
 	add	x29,sp,#0
@@ -438,15 +438,15 @@ $code.=<<___;
 	ldp	x29,x30,[sp],#128
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
-.size	SHA3_Absorb,.-SHA3_Absorb
+.size	SHA3_Absorb_hw,.-SHA3_Absorb_hw
 ___
 {
 my ($A_flat,$out,$len,$bsz) = map("x$_",(19..22));
 $code.=<<___;
-.globl	SHA3_Squeeze
-.type	SHA3_Squeeze,%function
+.globl	SHA3_Squeeze_hw
+.type	SHA3_Squeeze_hw,%function
 .align	5
-SHA3_Squeeze:
+SHA3_Squeeze_hw:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-48]!
 	add	x29,sp,#0
@@ -509,7 +509,7 @@ SHA3_Squeeze:
 	ldp	x29,x30,[sp],#48
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
-.size	SHA3_Squeeze,.-SHA3_Squeeze
+.size	SHA3_Squeeze_hw,.-SHA3_Squeeze_hw
 ___
 }								}}}
 								{{{

--- a/crypto/fipsmodule/sha/keccak1600.c
+++ b/crypto/fipsmodule/sha/keccak1600.c
@@ -393,4 +393,22 @@ void SHA3_Squeeze(uint64_t A[SHA3_ROWS][SHA3_ROWS], uint8_t *out, size_t len, si
         }
     }
 }
+
+#else
+
+size_t SHA3_Absorb_hw(uint64_t A[SHA3_ROWS][SHA3_ROWS], const uint8_t *inp, size_t len,
+                       size_t r);
+
+size_t SHA3_Absorb(uint64_t A[SHA3_ROWS][SHA3_ROWS], const uint8_t *inp, size_t len,
+                   size_t r) {
+    return SHA3_Absorb_hw(A, inp, len, r);
+}
+
+size_t SHA3_Squeeze_hw(uint64_t A[SHA3_ROWS][SHA3_ROWS], const uint8_t *out, size_t len,
+                        size_t r);
+
+void SHA3_Squeeze(uint64_t A[SHA3_ROWS][SHA3_ROWS], uint8_t *out, size_t len, size_t r) {
+    SHA3_Squeeze_hw(A, out, len, r);
+}
+
 #endif // !KECCAK1600_ASM

--- a/generated-src/ios-aarch64/crypto/fipsmodule/keccak1600-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/keccak1600-armv8.S
@@ -248,11 +248,11 @@ KeccakF1600:
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
 
-.globl	_SHA3_Absorb
-.private_extern	_SHA3_Absorb
+.globl	_SHA3_Absorb_hw
+.private_extern	_SHA3_Absorb_hw
 
 .align	5
-_SHA3_Absorb:
+_SHA3_Absorb_hw:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-128]!
 	add	x29,sp,#0
@@ -481,11 +481,11 @@ Labsorbed:
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
 
-.globl	_SHA3_Squeeze
-.private_extern	_SHA3_Squeeze
+.globl	_SHA3_Squeeze_hw
+.private_extern	_SHA3_Squeeze_hw
 
 .align	5
-_SHA3_Squeeze:
+_SHA3_Squeeze_hw:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-48]!
 	add	x29,sp,#0

--- a/generated-src/linux-aarch64/crypto/fipsmodule/keccak1600-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/keccak1600-armv8.S
@@ -248,11 +248,11 @@ KeccakF1600:
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
 .size	KeccakF1600,.-KeccakF1600
-.globl	SHA3_Absorb
-.hidden	SHA3_Absorb
-.type	SHA3_Absorb,%function
+.globl	SHA3_Absorb_hw
+.hidden	SHA3_Absorb_hw
+.type	SHA3_Absorb_hw,%function
 .align	5
-SHA3_Absorb:
+SHA3_Absorb_hw:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-128]!
 	add	x29,sp,#0
@@ -480,12 +480,12 @@ SHA3_Absorb:
 	ldp	x29,x30,[sp],#128
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
-.size	SHA3_Absorb,.-SHA3_Absorb
-.globl	SHA3_Squeeze
-.hidden	SHA3_Squeeze
-.type	SHA3_Squeeze,%function
+.size	SHA3_Absorb_hw,.-SHA3_Absorb_hw
+.globl	SHA3_Squeeze_hw
+.hidden	SHA3_Squeeze_hw
+.type	SHA3_Squeeze_hw,%function
 .align	5
-SHA3_Squeeze:
+SHA3_Squeeze_hw:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-48]!
 	add	x29,sp,#0
@@ -548,7 +548,7 @@ SHA3_Squeeze:
 	ldp	x29,x30,[sp],#48
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
-.size	SHA3_Squeeze,.-SHA3_Squeeze
+.size	SHA3_Squeeze_hw,.-SHA3_Squeeze_hw
 .type	KeccakF1600_ce,%function
 .align	5
 KeccakF1600_ce:

--- a/generated-src/win-aarch64/crypto/fipsmodule/keccak1600-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/keccak1600-armv8.S
@@ -252,13 +252,13 @@ KeccakF1600:
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
 
-.globl	SHA3_Absorb
+.globl	SHA3_Absorb_hw
 
-.def SHA3_Absorb
+.def SHA3_Absorb_hw
    .type 32
 .endef
 .align	5
-SHA3_Absorb:
+SHA3_Absorb_hw:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-128]!
 	add	x29,sp,#0
@@ -487,13 +487,13 @@ Labsorbed:
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
 
-.globl	SHA3_Squeeze
+.globl	SHA3_Squeeze_hw
 
-.def SHA3_Squeeze
+.def SHA3_Squeeze_hw
    .type 32
 .endef
 .align	5
-SHA3_Squeeze:
+SHA3_Squeeze_hw:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-48]!
 	add	x29,sp,#0


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-1671

# Notes

# Add SHA3_Squeeze output buffer overflow test

The idea behind this new test draws from [stack canaries](https://en.wikipedia.org/wiki/Buffer_overflow_protection#Canaries). Basically, we append a segment of memory with well-known contents to our output buffer, failing the test if that canary value changes after the call to SHA3_Squeeze. This methodology isn't perfect, as it won't detect cases where the function overwrites the canary segment with that same canary value (`0xff` in this case). If we wanted to improve this, we might fill the canary with random data, however the static value is enough to catch the motivating overflow in testing.

#  Wrap SHA3 ARMv8 ASM optimizations in C function

Interestingly, we [mark all ARM assembly `.globl`s as `.hidden`](https://github.com/aws/aws-lc/commit/3ab3e3db6e5e060612d9f2172aa0efa3ff8f55a3), making it impossible to directly unit-test symbols defined only in ARM assembly on ARM platforms. To work around this, for each exported SHA3 function that also has an ASM implementation, we rename that implementation with a `_asm` suffix and wrap it with the exported C function.

# Testing

Manually testing on a c7g.xlarge (Graviton 3 ARMv8), I reverted the buffer overflow fix e1065a0 and confirmed that the test fails:

```
[ec2-user@ip-172-31-93-239 aws-lc]$ git log --oneline HEAD^..HEAD
18c024362 (HEAD -> main) Revert "Avoid potential for buffer overflow in SHA3 ARMv8 assembly (#863)"

[ec2-user@ip-172-31-93-239 aws-lc]$ cmake-build.sh && ./build/crypto/crypto_test --gtest_filter=KeccakInternalTest.SqueezeOutputBufferOverflow
...
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from KeccakInternalTest
[ RUN      ] KeccakInternalTest.SqueezeOutputBufferOverflow
/home/ec2-user/aws-lc/crypto/fipsmodule/sha/sha3_test.cc:228: Failure
Value of: std::equal(out.end() - canary.size(), out.end(), canary.begin()) == true
  Actual: false
Expected: true
[  FAILED  ] KeccakInternalTest.SqueezeOutputBufferOverflow (0 ms)
[----------] 1 test from KeccakInternalTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] KeccakInternalTest.SqueezeOutputBufferOverflow

 1 FAILED TEST
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
