### PR TITLE
Revert back to using bssl

### DIFF
--- a/tests/ci/run_analytics.sh
+++ b/tests/ci/run_analytics.sh
@@ -84,7 +84,7 @@ function run_build_and_collect_metrics {
 
   libcrypto_size=$(size "${BUILD_ROOT}/crypto/libcrypto.${lib_extension}")
   libssl_size=$(size "${BUILD_ROOT}/ssl/libssl.${lib_extension}")
-  tool_size=$(size "${BUILD_ROOT}/tool/awslc")
+  tool_size=$(size "${BUILD_ROOT}/tool/bssl")
   put_metric --metric-name LibCryptoSize --value "$libcrypto_size" --unit Bytes --dimensions "${size_common_dimensions}"
   put_metric --metric-name LibSSLSize --value "$libssl_size" --unit Bytes --dimensions "${size_common_dimensions}"
   put_metric --metric-name ToolSize --value "$tool_size" --unit Bytes --dimensions "${size_common_dimensions}"

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(
-  awslc
+  bssl
 
   args.cc
   ciphers.cc
@@ -20,40 +20,35 @@ add_executable(
   transport_common.cc
 )
 
-target_include_directories(awslc PUBLIC ../include)
-target_compile_options(awslc PUBLIC -DINTERNAL_TOOL)
+target_include_directories(bssl PUBLIC ../include)
+target_compile_options(bssl PUBLIC -DINTERNAL_TOOL)
 
-add_custom_target(link_bssl ALL
-        COMMAND ${CMAKE_COMMAND} -E create_symlink awslc bssl)
-add_dependencies(link_bssl global_target)
-add_dependencies(awslc link_bssl)
+add_dependencies(bssl global_target)
 
 if(WIN32)
-  target_link_libraries(awslc ws2_32)
+  target_link_libraries(bssl ws2_32)
 endif()
 
 if(APPLE OR WIN32 OR ANDROID)
-  target_link_libraries(awslc ssl crypto)
+  target_link_libraries(bssl ssl crypto)
   set(LIBRT_FLAG "")
 else()
   find_library(FOUND_LIBRT rt)
   if(FOUND_LIBRT)
-    target_link_libraries(awslc ssl crypto -lrt)
+    target_link_libraries(bssl ssl crypto -lrt)
     set(LIBRT_FLAG "-lrt")
   else()
-    target_link_libraries(awslc ssl crypto)
+    target_link_libraries(bssl ssl crypto)
     set(LIBRT_FLAG "")
   endif()
 endif()
 
-install(TARGETS awslc
+install(TARGETS bssl
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
-install(CODE "execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink \${CMAKE_INSTALL_PREFIX}/bin/awslc \${CMAKE_INSTALL_PREFIX}/bin/bssl )")
-
 
 if(MSVC AND CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" AND FIPS)
-  install (FILES $<TARGET_FILE_DIR:awslc>/awslc.pdb DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install (FILES $<TARGET_FILE_DIR:bssl>/bssl.pdb DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 function(build_benchmark target_name install_path)


### PR DESCRIPTION
### Issues:
Resolves `P84022616`

### Description of changes: 
Internal imports are finding broken symlinks. CMake doesn't seem to support relative path symlinks, so directly removing it and using `awslc` from now should resolve our issues. 

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
