### PR TITLE
Bump AWS-LC API version

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -208,7 +208,7 @@ extern "C" {
 // against multiple revisions of BoringSSL at the same time. It is not
 // recommended to do so for longer than is necessary.
 
-#define AWSLC_API_VERSION 20
+#define AWSLC_API_VERSION 21
 
 // This string tracks the most current production release version on Github
 // https://github.com/aws/aws-lc/releases.


### PR DESCRIPTION
### Issues:
Addresses [aws/s2n-tls #3902](https://github.com/aws/s2n-tls/issues/3902)

# Notes

This commit increments AWS-LC's API version in light of the new KEM API.

s2n-tls recently had to [remove a feature check](https://github.com/aws/s2n-tls/pull/3901/files) due to it failing against older versions of AWS-LC (specifically, v1.3.0). The feature check relied on the new Kyber KEM API being present, and checked for it if AWS-LC API version >= 20. However, there are many AWS-LC versions at APIv20 without the KEM API. So, we bump the API version here and will re-instate the check in s2n-tls checking for API version >= 21.

# Testing

- CI checks

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
