### PR TITLE
Add support for OCSP_REQUEST_print and OCSP_RESPONSE_print

### DIFF
--- a/crypto/ocsp/ocsp_print.c
+++ b/crypto/ocsp/ocsp_print.c
@@ -8,8 +8,24 @@
  */
 
 #include <openssl/ocsp.h>
+#include <openssl/pem.h>
 
 #include "internal.h"
+
+static int ocsp_certid_print(BIO *bp, OCSP_CERTID *certid, int indent) {
+  BIO_printf(bp, "%*sCertificate ID:\n", indent, "");
+  indent += 2;
+  BIO_printf(bp, "%*sHash Algorithm: ", indent, "");
+  i2a_ASN1_OBJECT(bp, certid->hashAlgorithm->algorithm);
+  BIO_printf(bp, "\n%*sIssuer Name Hash: ", indent, "");
+  i2a_ASN1_STRING(bp, certid->issuerNameHash, 0);
+  BIO_printf(bp, "\n%*sIssuer Key Hash: ", indent, "");
+  i2a_ASN1_STRING(bp, certid->issuerKeyHash, 0);
+  BIO_printf(bp, "\n%*sSerial Number: ", indent, "");
+  i2a_ASN1_INTEGER(bp, certid->serialNumber);
+  BIO_printf(bp, "\n");
+  return 1;
+}
 
 typedef struct {
   long t;
@@ -61,4 +77,191 @@ const char *OCSP_crl_reason_str(long s) {
       {OCSP_REVOKED_STATUS_AACOMPROMISE, "aACompromise"}};
   size_t tbl_size = (sizeof(reason_tbl) / sizeof((reason_tbl)[0]));
   return do_table2string(s, reason_tbl, tbl_size);
+}
+
+int OCSP_REQUEST_print(BIO *bp, OCSP_REQUEST *req, unsigned long flags) {
+  long l;
+  OCSP_CERTID *cid = NULL;
+  OCSP_ONEREQ *one = NULL;
+  OCSP_REQINFO *inf = req->tbsRequest;
+  OCSP_SIGNATURE *sig = req->optionalSignature;
+
+  if (BIO_write(bp, "OCSP Request Data:\n", 19) <= 0) {
+    goto err;
+  }
+  l = ASN1_INTEGER_get(inf->version);
+  if (BIO_printf(bp, "    Version: %ld (0x%ld)", l + 1, l) <= 0) {
+    goto err;
+  }
+  if (inf->requestorName != NULL) {
+    if (BIO_write(bp, "\n    Requestor Name: ", 21) <= 0) {
+      goto err;
+    }
+    GENERAL_NAME_print(bp, inf->requestorName);
+  }
+  if (BIO_write(bp, "\n    Requestor List:\n", 21) <= 0) {
+    goto err;
+  }
+  for (size_t i = 0; i < sk_OCSP_ONEREQ_num(inf->requestList); i++) {
+    one = sk_OCSP_ONEREQ_value(inf->requestList, i);
+    cid = one->reqCert;
+    ocsp_certid_print(bp, cid, 8);
+    if (!X509V3_extensions_print(bp, "Request Single Extensions",
+                                 one->singleRequestExtensions, flags, 8)) {
+      goto err;
+    }
+  }
+  if (!X509V3_extensions_print(bp, "Request Extensions", inf->requestExtensions,
+                               flags, 4)) {
+    goto err;
+  }
+  if (sig != NULL) {
+    X509_signature_print(bp, sig->signatureAlgorithm, sig->signature);
+    for (size_t i = 0; i < sk_X509_num(sig->certs); i++) {
+      X509_print(bp, sk_X509_value(sig->certs, i));
+      PEM_write_bio_X509(bp, sk_X509_value(sig->certs, i));
+    }
+  }
+  return 1;
+err:
+  return 0;
+}
+
+int OCSP_RESPONSE_print(BIO *bp, OCSP_RESPONSE *resp, unsigned long flags) {
+  int ret = 0;
+  long l;
+  OCSP_CERTID *cid = NULL;
+  OCSP_BASICRESP *br = NULL;
+  OCSP_RESPID *rid = NULL;
+  OCSP_RESPDATA *rd = NULL;
+  OCSP_CERTSTATUS *cst = NULL;
+  OCSP_REVOKEDINFO *rev = NULL;
+  OCSP_SINGLERESP *single = NULL;
+  OCSP_RESPBYTES *rb = resp->responseBytes;
+
+  if (BIO_puts(bp, "OCSP Response Data:\n") <= 0) {
+    goto err;
+  }
+  l = ASN1_ENUMERATED_get(resp->responseStatus);
+  if (BIO_printf(bp, "    OCSP Response Status: %s (0x%ld)\n",
+                 OCSP_response_status_str(l), l) <= 0) {
+    goto err;
+  }
+  if (rb == NULL) {
+    return 1;
+  }
+  if (BIO_puts(bp, "    Response Type: ") <= 0) {
+    goto err;
+  }
+  if (i2a_ASN1_OBJECT(bp, rb->responseType) <= 0) {
+    goto err;
+  }
+  if (OBJ_obj2nid(rb->responseType) != NID_id_pkix_OCSP_basic) {
+    BIO_puts(bp, " (unknown response type)\n");
+    return 1;
+  }
+
+  if ((br = OCSP_response_get1_basic(resp)) == NULL) {
+    goto err;
+  }
+  rd = br->tbsResponseData;
+  l = ASN1_INTEGER_get(rd->version);
+  if (BIO_printf(bp, "\n    Version: %ld (0x%ld)\n", l + 1, l) <= 0) {
+    goto err;
+  }
+  if (BIO_puts(bp, "    Responder Id: ") <= 0) {
+    goto err;
+  }
+
+  rid = rd->responderId;
+  switch (rid->type) {
+    case V_OCSP_RESPID_NAME:
+      X509_NAME_print_ex(bp, rid->value.byName, 0, XN_FLAG_ONELINE);
+      break;
+    case V_OCSP_RESPID_KEY:
+      i2a_ASN1_STRING(bp, rid->value.byKey, 0);
+      break;
+  }
+
+  if (BIO_printf(bp, "\n    Produced At: ") <= 0) {
+    goto err;
+  }
+  if (!ASN1_GENERALIZEDTIME_print(bp, rd->producedAt)) {
+    goto err;
+  }
+  if (BIO_printf(bp, "\n    Responses:\n") <= 0) {
+    goto err;
+  }
+  for (size_t i = 0; i < sk_OCSP_SINGLERESP_num(rd->responses); i++) {
+    if (!sk_OCSP_SINGLERESP_value(rd->responses, i)) {
+      continue;
+    }
+    single = sk_OCSP_SINGLERESP_value(rd->responses, i);
+    cid = single->certId;
+    if (ocsp_certid_print(bp, cid, 4) <= 0) {
+      goto err;
+    }
+    cst = single->certStatus;
+    if (BIO_printf(bp, "    Cert Status: %s",
+                   OCSP_cert_status_str(cst->type)) <= 0) {
+      goto err;
+    }
+    if (cst->type == V_OCSP_CERTSTATUS_REVOKED) {
+      rev = cst->value.revoked;
+      if (BIO_printf(bp, "\n    Revocation Time: ") <= 0) {
+        goto err;
+      }
+      if (!ASN1_GENERALIZEDTIME_print(bp, rev->revocationTime)) {
+        goto err;
+      }
+      if (rev->revocationReason) {
+        l = ASN1_ENUMERATED_get(rev->revocationReason);
+        if (BIO_printf(bp, "\n    Revocation Reason: %s (0x%ld)",
+                       OCSP_crl_reason_str(l), l) <= 0) {
+          goto err;
+        }
+      }
+    }
+    if (BIO_printf(bp, "\n    This Update: ") <= 0) {
+      goto err;
+    }
+    if (!ASN1_GENERALIZEDTIME_print(bp, single->thisUpdate)) {
+      goto err;
+    }
+    if (single->nextUpdate) {
+      if (BIO_printf(bp, "\n    Next Update: ") <= 0) {
+        goto err;
+      }
+      if (!ASN1_GENERALIZEDTIME_print(bp, single->nextUpdate)) {
+        goto err;
+      }
+    }
+    if (BIO_write(bp, "\n", 1) <= 0) {
+      goto err;
+    }
+    if (!X509V3_extensions_print(bp, "Response Single Extensions",
+                                 single->singleExtensions, flags, 8)) {
+      goto err;
+    }
+    if (BIO_write(bp, "\n", 1) <= 0) {
+      goto err;
+    }
+  }
+  if (!X509V3_extensions_print(bp, "Response Extensions",
+                               rd->responseExtensions, flags, 4)) {
+    goto err;
+  }
+  if (X509_signature_print(bp, br->signatureAlgorithm, br->signature) <= 0) {
+    goto err;
+  }
+
+  for (size_t i = 0; i < sk_X509_num(br->certs); i++) {
+    X509_print(bp, sk_X509_value(br->certs, i));
+    PEM_write_bio_X509(bp, sk_X509_value(br->certs, i));
+  }
+
+  ret = 1;
+err:
+  OCSP_BASICRESP_free(br);
+  return ret;
 }

--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -1384,15 +1384,15 @@ TEST(OCSPTest, CertIDDup) {
 
 TEST(OCSPTest, OCSPResponsePrint) {
   static const std::array<std::string, 18> kExpected{
-      "OCSP Response Data:",      "    OCSP Response Status:",
-      "    Response Type:",       "    Version:",
-      "    Responder Id:",        "    Produced At:",
-      "    Responses:",           "    Certificate ID:",
-      "      Hash Algorithm:",    "      Issuer Name Hash:",
-      "      Issuer Key Hash:",   "      Serial Number:",
-      "    Cert Status:",         "    This Update:",
-      "    Next Update:",         "",
-      "    Response Extensions:", "        OCSP Nonce:"};
+      "OCSP Response Data",      "    OCSP Response Status",
+      "    Response Type",       "    Version",
+      "    Responder Id",        "    Produced At",
+      "    Responses",           "    Certificate ID",
+      "      Hash Algorithm",    "      Issuer Name Hash",
+      "      Issuer Key Hash",   "      Serial Number",
+      "    Cert Status",         "    This Update",
+      "    Next Update",         "",
+      "    Response Extensions", "        OCSP Nonce"};
 
   std::string respData = GetTestData(
       std::string("crypto/ocsp/test/aws/ocsp_response.der").c_str());
@@ -1412,19 +1412,21 @@ TEST(OCSPTest, OCSPResponsePrint) {
   std::string line;
   for (const auto &expected : kExpected) {
     std::getline(iss, line);
-    EXPECT_EQ(OPENSSL_memcmp(line.c_str(), expected.c_str(),
-                             strlen(expected.c_str())),
-              0);
+    // Each line has a colon before the expected label.
+    std::istringstream line_stream(line);
+    std::string parsed_line;
+    std::getline(line_stream, parsed_line, ':');
+    EXPECT_EQ(parsed_line, expected);
   }
 }
 
 TEST(OCSPTest, OCSPRequestPrint) {
-  static const std::array<std::string, 10> kExpected2{
-      "OCSP Request Data:",         "    Version:",
-      "    Requestor List:",        "        Certificate ID:",
-      "          Hash Algorithm:",  "          Issuer Name Hash:",
-      "          Issuer Key Hash:", "          Serial Number:",
-      "    Request Extensions:",    "        OCSP Nonce: "};
+  static const std::array<std::string, 10> kExpected{
+      "OCSP Request Data",         "    Version",
+      "    Requestor List",        "        Certificate ID",
+      "          Hash Algorithm",  "          Issuer Name Hash",
+      "          Issuer Key Hash", "          Serial Number",
+      "    Request Extensions",    "        OCSP Nonce"};
 
   std::string data =
       GetTestData(std::string("crypto/ocsp/test/aws/ocsp_request.der").c_str());
@@ -1442,10 +1444,12 @@ TEST(OCSPTest, OCSPRequestPrint) {
   // the expected format.
   std::istringstream iss((std::string((char *)out, outlen)));
   std::string line;
-  for (const auto &expected : kExpected2) {
+  for (const auto &expected : kExpected) {
     std::getline(iss, line);
-    EXPECT_EQ(OPENSSL_memcmp(line.c_str(), expected.c_str(),
-                             strlen(expected.c_str())),
-              0);
+    // Each line has a colon before the expected label.
+    std::istringstream line_stream(line);
+    std::string parsed_line;
+    std::getline(line_stream, parsed_line, ':');
+    EXPECT_EQ(parsed_line, expected);
   }
 }

--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -1383,16 +1383,26 @@ TEST(OCSPTest, CertIDDup) {
 }
 
 TEST(OCSPTest, OCSPResponsePrint) {
-  static const std::array<std::string, 18> kExpected{
-      "OCSP Response Data",      "    OCSP Response Status",
-      "    Response Type",       "    Version",
-      "    Responder Id",        "    Produced At",
-      "    Responses",           "    Certificate ID",
-      "      Hash Algorithm",    "      Issuer Name Hash",
-      "      Issuer Key Hash",   "      Serial Number",
-      "    Cert Status",         "    This Update",
-      "    Next Update",         "",
-      "    Response Extensions", "        OCSP Nonce"};
+  static const std::array<std::string, 19> kExpected{
+      "OCSP Response Data:",
+      "    OCSP Response Status: successful (0x0)",
+      "    Response Type: Basic OCSP Response",
+      "    Version: 1 (0x0)",
+      "    Responder Id: C = US, ST = WA, O = s2n, OU = s2n Test OCSP, CN = ocsp.s2ntest.com",
+      "    Produced At: May 26 00:23:34 2021 GMT",
+      "    Responses:",
+      "    Certificate ID:",
+      "      Hash Algorithm: sha1",
+      "      Issuer Name Hash: DE7932B3217E48FB4E47AE0B9007A55376AE44CA",
+      "      Issuer Key Hash: 12DF817571CA92D3CE1B2C2B773B9E3377F3F76F",
+      "      Serial Number: 7778",
+      "    Cert Status: good",
+      "    This Update: May 26 00:23:34 2021 GMT",
+      "    Next Update: May 24 00:23:34 2031 GMT",
+      "",
+      "    Response Extensions:",
+      "        OCSP Nonce: ",
+      "            0410AFABD4EC6A172C4A98FB1A6D22FF2928"};
 
   std::string respData = GetTestData(
       std::string("crypto/ocsp/test/aws/ocsp_response.der").c_str());
@@ -1412,21 +1422,23 @@ TEST(OCSPTest, OCSPResponsePrint) {
   std::string line;
   for (const auto &expected : kExpected) {
     std::getline(iss, line);
-    // Each line has a colon before the expected label.
-    std::istringstream line_stream(line);
-    std::string parsed_line;
-    std::getline(line_stream, parsed_line, ':');
-    EXPECT_EQ(parsed_line, expected);
+    EXPECT_EQ(line, expected);
   }
 }
 
 TEST(OCSPTest, OCSPRequestPrint) {
-  static const std::array<std::string, 10> kExpected{
-      "OCSP Request Data",         "    Version",
-      "    Requestor List",        "        Certificate ID",
-      "          Hash Algorithm",  "          Issuer Name Hash",
-      "          Issuer Key Hash", "          Serial Number",
-      "    Request Extensions",    "        OCSP Nonce"};
+  static const std::array<std::string, 11> kExpected{
+      "OCSP Request Data:",
+      "    Version: 1 (0x0)",
+      "    Requestor List:",
+      "        Certificate ID:",
+      "          Hash Algorithm: sha1",
+      "          Issuer Name Hash: DE7932B3217E48FB4E47AE0B9007A55376AE44CA",
+      "          Issuer Key Hash: 12DF817571CA92D3CE1B2C2B773B9E3377F3F76F",
+      "          Serial Number: 7778",
+      "    Request Extensions:",
+      "        OCSP Nonce: ",
+      "            0410303F128CD824A2B465F4C846882B3E1F"};
 
   std::string data =
       GetTestData(std::string("crypto/ocsp/test/aws/ocsp_request.der").c_str());
@@ -1446,10 +1458,6 @@ TEST(OCSPTest, OCSPRequestPrint) {
   std::string line;
   for (const auto &expected : kExpected) {
     std::getline(iss, line);
-    // Each line has a colon before the expected label.
-    std::istringstream line_stream(line);
-    std::string parsed_line;
-    std::getline(line_stream, parsed_line, ':');
-    EXPECT_EQ(parsed_line, expected);
+    EXPECT_EQ(line, expected);
   }
 }

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -356,6 +356,20 @@ OPENSSL_EXPORT const char *OCSP_cert_status_str(long status_code);
 // if an OCSP response is revoked.
 OPENSSL_EXPORT const char *OCSP_crl_reason_str(long status_code);
 
+// OCSP_REQUEST_print prints the contents of an OCSP request to |bp|. |flags| is
+// used to configure printing of the |req|'s extensions (See
+// |X509V3_extensions_print| for more information).
+// This is typically used for debugging or diagnostic purposes.
+OPENSSL_EXPORT int OCSP_REQUEST_print(BIO *bp, OCSP_REQUEST *req,
+                                      unsigned long flags);
+
+// OCSP_RESPONSE_print prints the contents of an OCSP response to |bp|. |flags|
+// is used to configure printing of the |resp|'s extensions (See
+// |X509V3_extensions_print| for more information).
+// This is typically used for debugging or diagnostic purposes.
+OPENSSL_EXPORT int OCSP_RESPONSE_print(BIO *bp, OCSP_RESPONSE *resp,
+                                       unsigned long flags);
+
 
 #if defined(__cplusplus)
 }  // extern C


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1564`

### Description of changes: 
Once https://github.com/aws/aws-lc/pull/901 is merged in, these should be the only OCSP functions left we'll need to support for the time being.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
