### PR TITLE
Add missing APIs to better support Bind

### DIFF
--- a/crypto/fipsmodule/bn/internal.h
+++ b/crypto/fipsmodule/bn/internal.h
@@ -217,6 +217,10 @@ extern "C" {
 #define Hw(t) ((BN_ULONG)((t) >> BN_BITS2))
 #endif
 
+#define BN_GENCB_UNSET 0
+#define BN_GENCB_NEW_STYLE 1
+#define BN_GENCB_OLD_STYLE 2
+
 // bn_minimal_width returns the minimal value of |bn->top| which fits the
 // value of |bn|.
 int bn_minimal_width(const BIGNUM *bn);

--- a/crypto/fipsmodule/dh/dh.c
+++ b/crypto/fipsmodule/dh/dh.c
@@ -129,6 +129,11 @@ void DH_get0_key(const DH *dh, const BIGNUM **out_pub_key,
   }
 }
 
+void DH_clear_flags(DH *dh, int flags) {
+  (void) dh;
+  (void) flags;
+}
+
 int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key) {
   if (pub_key != NULL) {
     BN_free(dh->pub_key);

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -689,7 +689,9 @@ OPENSSL_EXPORT BN_GENCB *BN_GENCB_new(void);
 OPENSSL_EXPORT void BN_GENCB_free(BN_GENCB *callback);
 
 // BN_GENCB_set configures |callback| to call |f| and sets |callback->arg| to
-// |arg|. Only one callback can be configured in a |BN_GENCB|, calling
+// |arg|. |BN_GENCB_set| is recommended over |BN_GENCB_set_old| as |BN_GENCB_set|
+// accepts callbacks that return a result and have a strong type for the
+// |BN_GENCB|. Only one callback can be configured in a |BN_GENCB|, calling
 // |BN_GENCB_set| or |BN_GENCB_set_old| multiple times will overwrite the
 // callback.
 OPENSSL_EXPORT void BN_GENCB_set(BN_GENCB *callback,

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -159,6 +159,9 @@ OPENSSL_EXPORT int ENGINE_register_all_complete(void);
 // OPENSSL_load_builtin_modules does nothing.
 OPENSSL_EXPORT void OPENSSL_load_builtin_modules(void);
 
+// AWS-LC does not support custom flags when initializing the library, these
+// values are included to simplify building other software that expects them.
+
 #define OPENSSL_INIT_NO_LOAD_CRYPTO_STRINGS 0
 #define OPENSSL_INIT_LOAD_CRYPTO_STRINGS 0
 #define OPENSSL_INIT_ADD_ALL_CIPHERS 0
@@ -167,6 +170,7 @@ OPENSSL_EXPORT void OPENSSL_load_builtin_modules(void);
 #define OPENSSL_INIT_NO_ADD_ALL_DIGESTS 0
 #define OPENSSL_INIT_LOAD_CONFIG 0
 #define OPENSSL_INIT_NO_LOAD_CONFIG 0
+#define OPENSSL_INIT_ENGINE_ALL_BUILTIN 0
 
 // OPENSSL_init_crypto calls |CRYPTO_library_init| and returns one.
 OPENSSL_EXPORT int OPENSSL_init_crypto(uint64_t opts,

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -337,6 +337,17 @@ OPENSSL_EXPORT int DH_compute_key(uint8_t *out, const BIGNUM *peers_key,
 // This function has been deprecated with no replacement.
 OPENSSL_EXPORT DH *DH_get_2048_256(void);
 
+// DH_clear_flags does nothing and is included to simplify compiling code that
+// expects it.
+OPENSSL_EXPORT void DH_clear_flags(DH *dh, int flags);
+
+// DH_FLAG_CACHE_MONT_P is not supported by AWS-LC and is included to simplify
+// compiling code that expects it. This flag controls if the DH APIs should
+// cache the montgomery form of the prime to speed up multiplication at the cost
+// of increasing memory storage. AWS-LC always does this and does not support
+// turning this option off.
+#define DH_FLAG_CACHE_MONT_P 0
+
 
 #if defined(__cplusplus)
 }  // extern C


### PR DESCRIPTION
### Description of changes: 
* BN_GENCB_set_old sets old style callbacks on BN_GENCB
* DH_clear_flags which is a no op
* Define but don't support DH_FLAG_CACHE_MONT_P, AWS-LC always uses montgomery multiplication for DH

### Call-outs:
I considered using the existing [callback_wrapper](https://github.com/aws/aws-lc/blob/main/crypto/decrepit/dh/dh_decrepit.c#L57-L68) pattern used in DH_generate_parameters. However, that function can keep the `wrapped_callback` on the stack and not worry about memory management. For this use case users can call `BN_GENCB_set_old` directly. This would require allocating  `wrapped_callback` on the heap, but they don't expect to have to clean up any memory, and BN_GENCB_free wouldn't be able to tell what if anything it has to free. 

Therefore, using a union and `type` in bn_gencb_st seemed like the easiest path forward. All of this is internal implementation details we could change if we need to simplify/reduce the size of `bn_gencb_st`.

### Testing:
Added a new unit test that ensures the expected callback is called. This PR does not add all the required changes for Bind so I haven't added an integration test that attempts to build Bind with AWS-LC yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
