### PR TITLE
Zeroize data immediately after use for FIPS

### DIFF
--- a/crypto/fipsmodule/digest/internal.h
+++ b/crypto/fipsmodule/digest/internal.h
@@ -63,6 +63,7 @@
 extern "C" {
 #endif
 
+#define EVP_MAX_MD_BLOCK_SIZE_BYTES  (EVP_MAX_MD_BLOCK_SIZE / 8)
 
 struct env_md_st {
   // type contains a NID identifing the digest function. (For example,

--- a/crypto/fipsmodule/ecdsa/ecdsa.c
+++ b/crypto/fipsmodule/ecdsa/ecdsa.c
@@ -341,6 +341,7 @@ ECDSA_SIG *ECDSA_do_sign(const uint8_t *digest, size_t digest_len,
   for (;;) {
     EC_SCALAR k;
     if (!ec_random_nonzero_scalar(group, &k, additional_data)) {
+      OPENSSL_cleanse(&k, sizeof(EC_SCALAR));
       return NULL;
     }
 
@@ -348,6 +349,7 @@ ECDSA_SIG *ECDSA_do_sign(const uint8_t *digest, size_t digest_len,
     ECDSA_SIG *sig =
         ecdsa_sign_impl(group, &retry, priv_key, &k, digest, digest_len);
     if (sig != NULL || !retry) {
+      OPENSSL_cleanse(&k, sizeof(EC_SCALAR));
       return sig;
     }
   }

--- a/crypto/fipsmodule/hmac/hmac.c
+++ b/crypto/fipsmodule/hmac/hmac.c
@@ -319,6 +319,8 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, size_t key_len,
 
   result = 1;
 end:
+  OPENSSL_cleanse(pad, EVP_MAX_MD_BLOCK_SIZE / 8);
+  OPENSSL_cleanse(key_block, EVP_MAX_MD_BLOCK_SIZE / 8);
   FIPS_service_indicator_unlock_state();
   if (result != 1) {
     // We're in some error state, so return our context to a known and well defined zero state.

--- a/crypto/fipsmodule/hmac/hmac.c
+++ b/crypto/fipsmodule/hmac/hmac.c
@@ -286,8 +286,8 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, size_t key_len,
   FIPS_service_indicator_lock_state();
   int result = 0;
 
-  uint64_t pad[EVP_MAX_MD_BLOCK_SIZE / 8] = {0};
-  uint64_t key_block[EVP_MAX_MD_BLOCK_SIZE / 8] = {0};
+  uint64_t pad[EVP_MAX_MD_BLOCK_SIZE_BYTES] = {0};
+  uint64_t key_block[EVP_MAX_MD_BLOCK_SIZE_BYTES] = {0};
   if (block_size < key_len) {
     // Long keys are hashed.
     if (!methods->init(&ctx->md_ctx) ||
@@ -319,8 +319,8 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, size_t key_len,
 
   result = 1;
 end:
-  OPENSSL_cleanse(pad, EVP_MAX_MD_BLOCK_SIZE / 8);
-  OPENSSL_cleanse(key_block, EVP_MAX_MD_BLOCK_SIZE / 8);
+  OPENSSL_cleanse(pad, EVP_MAX_MD_BLOCK_SIZE_BYTES);
+  OPENSSL_cleanse(key_block, EVP_MAX_MD_BLOCK_SIZE_BYTES);
   FIPS_service_indicator_unlock_state();
   if (result != 1) {
     // We're in some error state, so return our context to a known and well defined zero state.


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1720`

### Description of changes: 
Zeroize HMAC padding and key block data immediately after use. Also add zeroization of k in ECDSA. This is for FIPS.

### Call-outs:
Benchmarking results are in the internal SIM. No noticeable regressions were found.

### Testing:
Original HMAC tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
