### PR TITLE
Build flag AWS_LC_INTERNAL_IGNORE_BN_SET_FLAGS

### DIFF
--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -1036,8 +1036,14 @@ OPENSSL_EXPORT unsigned BN_num_bits_word(BN_ULONG l);
 
 #define BN_FLG_MALLOCED 0x01
 #define BN_FLG_STATIC_DATA 0x02
+
+#ifdef AWS_LC_INTERNAL_IGNORE_BN_SET_FLAGS
+#define BN_set_flags(x, y) /* Ignored */
+#define BN_FLG_CONSTTIME 0x04
+#endif /* AWS_LC_INTERNAL_IGNORE_BN_SET_FLAGS */
+
 // |BN_FLG_CONSTTIME| has been removed and intentionally omitted so code relying
-// on it will not compile. Consumers outside BoringSSL should use the
+// on it will not compile unless the flag above is set. Consumers should use the
 // higher-level cryptographic algorithms exposed by other modules. Consumers
 // within the library should call the appropriate timing-sensitive algorithm
 // directly.


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Added flag allowing library consumers to indicate that calls to `BN_set_flags` can be ignored.

### Call-outs:
* openssh still has logic that uses `BN_set_flags`.  A [recent change to openssh](https://github.com/openssh/openssh-portable/commit/3c527d55f906e6970d17c4cab6db90ae9e013235) similar to this one allows it to more easily compile against BoringSSL.

### Testing:
* With this change and the one for [PR 894](https://github.com/aws/aws-lc/pull/894), I built and tested OpenSSH-8.9p1 (with PKCS11 disabled) against AWS-LC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
