### PR TITLE
Cherry pick recent CMake changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -786,6 +786,9 @@ if(BUILD_TESTING)
   # Add minimal googletest targets. The provided one has many side-effects, and
   # googletest has a very straightforward build.
   add_library(boringssl_gtest third_party/googletest/src/gtest-all.cc)
+  if(USE_CUSTOM_LIBCXX)
+    target_link_libraries(boringssl_gtest libcxx)
+  endif()
   if(BUILD_SHARED_LIBS)
     # This is needed for the Windows build to correctly annotate GTest's API with __declspec(dllexport)
     target_compile_options(boringssl_gtest PRIVATE -DGTEST_CREATE_SHARED_LIBRARY=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -795,9 +795,11 @@ if(BUILD_TESTING)
     # This is needed for the Windows build to correctly annotate GTest's API with __declspec(dllexport)
     target_compile_options(boringssl_gtest PRIVATE -DGTEST_CREATE_SHARED_LIBRARY=1)
   endif()
-  target_include_directories(boringssl_gtest PRIVATE third_party/googletest)
-
-  include_directories(third_party/googletest/include)
+  target_include_directories(
+    boringssl_gtest
+    PUBLIC third_party/googletest/include
+    PRIVATE third_party/googletest
+  )
 
   # Declare a dummy target to build all unit tests. Test targets should inject
   # themselves as dependencies next to the target definition.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,6 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
   set(GCC 1)
 endif()
 
-# This is a dummy target which all other targets depend on (manually - see other
-# CMakeLists.txt files). This gives us a hook to add any targets which need to
-# run before all other targets.
-add_custom_target(global_target)
-
 if (UNIX AND NOT APPLE)
   include(GNUInstallDirs)
 elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
@@ -157,7 +152,6 @@ if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
     COMMAND sed -i.bak '/ bignum_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/boringssl_prefix_symbols_nasm.inc
     DEPENDS util/make_prefix_headers.go
             ${BORINGSSL_PREFIX_SYMBOLS_PATH})
-
   # add_dependencies needs a target, not a file, so we add an intermediate
   # target.
   add_custom_target(
@@ -165,7 +159,6 @@ if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
     DEPENDS symbol_prefix_include/boringssl_prefix_symbols.h
             symbol_prefix_include/boringssl_prefix_symbols_asm.h
             symbol_prefix_include/boringssl_prefix_symbols_nasm.inc)
-  add_dependencies(global_target boringssl_prefix_symbols)
 elseif(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_HEADERS)
 
   if(IS_ABSOLUTE ${BORINGSSL_PREFIX_HEADERS})
@@ -179,6 +172,8 @@ elseif(BORINGSSL_PREFIX OR BORINGSSL_PREFIX_SYMBOLS)
   message(FATAL_ERROR "Must specify both or neither of BORINGSSL_PREFIX and BORINGSSL_PREFIX_SYMBOLS")
 elseif((BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS) AND NOT GO_EXECUTABLE)
   message(FATAL_ERROR "Must have Go installed when using BORINGSSL_PREFIX and BORINGSSL_PREFIX_SYMBOLS")
+else()
+  add_custom_target(boringssl_prefix_symbols)
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -623,9 +623,9 @@ if(BUILD_TESTING)
 
   macro(add_test_executable executable_name test_file)
     message(STATUS "Generating test executable ${executable_name}.")
-    add_executable(${executable_name} ${test_file} $<TARGET_OBJECTS:boringssl_gtest_main>)
+    add_executable(${executable_name} ${test_file})
     target_compile_definitions(${executable_name} PRIVATE BORINGSSL_IMPLEMENTATION)
-    target_link_libraries(${executable_name} test_support_lib boringssl_gtest crypto)
+    target_link_libraries(${executable_name} test_support_lib boringssl_gtest_main crypto)
     add_dependencies(all_tests ${executable_name})
   endmacro()
 
@@ -733,11 +733,9 @@ if(BUILD_TESTING)
     decrepit/ripemd/ripemd_test.cc
 
     $<TARGET_OBJECTS:crypto_test_data>
-    $<TARGET_OBJECTS:boringssl_gtest_main>
-
   )
 
-  target_link_libraries(${CRYPTO_TEST_EXEC} test_support_lib boringssl_gtest crypto)
+  target_link_libraries(${CRYPTO_TEST_EXEC} test_support_lib boringssl_gtest_main crypto)
   if(WIN32)
     target_link_libraries(${CRYPTO_TEST_EXEC} ws2_32)
   endif()

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -504,7 +504,7 @@ add_library(
 target_compile_definitions(crypto_objects PRIVATE BORINGSSL_IMPLEMENTATION)
 
 # For the prefix build, the object files need the prefix header files to build.
-add_dependencies(crypto_objects global_target)
+add_dependencies(crypto_objects boringssl_prefix_symbols)
 
 function(build_libcrypto name module_source)
   if(FIPS)
@@ -512,8 +512,6 @@ function(build_libcrypto name module_source)
   else()
     add_library(${name} $<TARGET_OBJECTS:crypto_objects> ${CRYPTO_FIPS_OBJECTS} ${module_source})
   endif()
-
-  add_dependencies(${name}  global_target)
 
   if(FIPS_DELOCATE OR FIPS_SHARED)
     add_dependencies(${name} bcm_o_target)
@@ -627,7 +625,6 @@ if(BUILD_TESTING)
     message(STATUS "Generating test executable ${executable_name}.")
     add_executable(${executable_name} ${test_file} $<TARGET_OBJECTS:boringssl_gtest_main>)
     target_compile_definitions(${executable_name} PRIVATE BORINGSSL_IMPLEMENTATION)
-    add_dependencies(${executable_name} global_target)
     target_link_libraries(${executable_name} test_support_lib boringssl_gtest crypto)
     add_dependencies(all_tests ${executable_name})
   endmacro()
@@ -643,7 +640,6 @@ if(BUILD_TESTING)
   # it does.
   add_executable(
     ${RANDOM_TEST_EXEC}
-
     fipsmodule/rand/urandom_test.cc
   )
 
@@ -656,7 +652,6 @@ if(BUILD_TESTING)
 
   target_link_libraries(${RANDOM_TEST_EXEC} test_support_lib boringssl_gtest crypto)
 
-  add_dependencies(${RANDOM_TEST_EXEC} global_target)
   add_dependencies(all_tests ${RANDOM_TEST_EXEC})
 
   add_executable(
@@ -741,8 +736,6 @@ if(BUILD_TESTING)
     $<TARGET_OBJECTS:boringssl_gtest_main>
 
   )
-
-  add_dependencies(${CRYPTO_TEST_EXEC} global_target)
 
   target_link_libraries(${CRYPTO_TEST_EXEC} test_support_lib boringssl_gtest crypto)
   if(WIN32)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(../include)
-
 if(NOT OPENSSL_NO_ASM)
   if(UNIX)
     if(ARCH STREQUAL "aarch64")
@@ -502,6 +500,7 @@ add_library(
 )
 
 target_compile_definitions(crypto_objects PRIVATE BORINGSSL_IMPLEMENTATION)
+target_include_directories(crypto_objects PRIVATE ../include)
 
 # For the prefix build, the object files need the prefix header files to build.
 add_dependencies(crypto_objects boringssl_prefix_symbols)
@@ -553,6 +552,8 @@ if(FIPS_SHARED)
       generated_fips_shared_support.c
       ${PROJECT_SOURCE_DIR}/crypto/fipsmodule/cpucap/cpucap.c
     )
+    target_include_directories(generated_fipsmodule PRIVATE ../include)
+
     build_libcrypto(crypto $<TARGET_OBJECTS:generated_fipsmodule>)
   else()
     # On Apple and Linux platforms inject_hash.go can parse libcrypto and inject

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -291,7 +291,7 @@ if(FIPS_DELOCATE)
     set(BCM_ASM_PROCESSED_SOURCES ${BCM_ASM_SOURCES})
   endif()
 
-  add_dependencies(bcm_c_generated_asm global_target)
+  add_dependencies(bcm_c_generated_asm boringssl_prefix_symbols)
 
   set_target_properties(bcm_c_generated_asm PROPERTIES COMPILE_OPTIONS "-S")
   set_target_properties(bcm_c_generated_asm PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -313,7 +313,7 @@ if(FIPS_DELOCATE)
   )
   target_compile_definitions(bcm_hashunset PRIVATE BORINGSSL_IMPLEMENTATION)
 
-  add_dependencies(bcm_hashunset global_target)
+  add_dependencies(bcm_hashunset boringssl_prefix_symbols)
 
   set_target_properties(bcm_hashunset PROPERTIES POSITION_INDEPENDENT_CODE ON)
   set_target_properties(bcm_hashunset PROPERTIES LINKER_LANGUAGE C)
@@ -343,7 +343,7 @@ if(FIPS_DELOCATE)
   )
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
-  add_dependencies(fipsmodule global_target)
+  add_dependencies(fipsmodule boringssl_prefix_symbols)
 
   set_target_properties(fipsmodule PROPERTIES LINKER_LANGUAGE C)
 elseif(FIPS_SHARED)
@@ -361,7 +361,7 @@ elseif(FIPS_SHARED)
   )
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
-  add_dependencies(fipsmodule global_target)
+  add_dependencies(fipsmodule boringssl_prefix_symbols)
 
   add_library(
     bcm_library
@@ -375,7 +375,7 @@ elseif(FIPS_SHARED)
   target_compile_definitions(bcm_library PRIVATE BORINGSSL_IMPLEMENTATION)
   target_include_directories(bcm_library PRIVATE ../../include)
 
-  add_dependencies(bcm_library global_target)
+  add_dependencies(bcm_library boringssl_prefix_symbols)
   if (APPLE)
     set(BCM_NAME bcm.o)
     # The linker on macOS doesn't have the ability to process linker scripts,
@@ -469,5 +469,5 @@ else()
   )
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
-  add_dependencies(fipsmodule global_target)
+  add_dependencies(fipsmodule boringssl_prefix_symbols)
 endif()

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(../../include)
-
 if(ANDROID)
   # Since "--Wa,--noexecstack" is not used during the preprocessor step of Android (because assembler is not invoked),
   # Clang reports that argument as unused. We remove the flag only for the FIPS build of Android.
@@ -292,7 +290,7 @@ if(FIPS_DELOCATE)
   endif()
 
   add_dependencies(bcm_c_generated_asm boringssl_prefix_symbols)
-
+  target_include_directories(bcm_c_generated_asm PRIVATE ../../include)
   set_target_properties(bcm_c_generated_asm PROPERTIES COMPILE_OPTIONS "-S")
   set_target_properties(bcm_c_generated_asm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
@@ -344,6 +342,7 @@ if(FIPS_DELOCATE)
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(fipsmodule boringssl_prefix_symbols)
+  target_include_directories(fipsmodule PRIVATE ../../include)
 
   set_target_properties(fipsmodule PROPERTIES LINKER_LANGUAGE C)
 elseif(FIPS_SHARED)
@@ -362,6 +361,7 @@ elseif(FIPS_SHARED)
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(fipsmodule boringssl_prefix_symbols)
+  target_include_directories(fipsmodule PRIVATE ../../include)
 
   add_library(
     bcm_library
@@ -376,6 +376,7 @@ elseif(FIPS_SHARED)
   target_include_directories(bcm_library PRIVATE ../../include)
 
   add_dependencies(bcm_library boringssl_prefix_symbols)
+  target_include_directories(bcm_library PRIVATE ../../include)
   if (APPLE)
     set(BCM_NAME bcm.o)
     # The linker on macOS doesn't have the ability to process linker scripts,
@@ -470,4 +471,5 @@ else()
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(fipsmodule boringssl_prefix_symbols)
+  target_include_directories(fipsmodule PRIVATE ../../include)
 endif()

--- a/crypto/test/CMakeLists.txt
+++ b/crypto/test/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 if(WIN32)
   target_link_libraries(test_support_lib dbghelp)
 endif()
+target_link_libraries(test_support_lib boringssl_gtest crypto)
 add_dependencies(test_support_lib global_target)
 
 add_library(
@@ -29,3 +30,4 @@ add_library(
 )
 
 add_dependencies(boringssl_gtest_main global_target)
+target_link_libraries(boringssl_gtest_main boringssl_gtest crypto test_support_lib)

--- a/crypto/test/CMakeLists.txt
+++ b/crypto/test/CMakeLists.txt
@@ -19,7 +19,6 @@ if(WIN32)
   target_link_libraries(test_support_lib dbghelp)
 endif()
 target_link_libraries(test_support_lib boringssl_gtest crypto)
-add_dependencies(test_support_lib global_target)
 
 add_library(
   boringssl_gtest_main
@@ -28,6 +27,4 @@ add_library(
 
   gtest_main.cc
 )
-
-add_dependencies(boringssl_gtest_main global_target)
 target_link_libraries(boringssl_gtest_main boringssl_gtest crypto test_support_lib)

--- a/crypto/test/CMakeLists.txt
+++ b/crypto/test/CMakeLists.txt
@@ -20,11 +20,5 @@ if(WIN32)
 endif()
 target_link_libraries(test_support_lib boringssl_gtest crypto)
 
-add_library(
-  boringssl_gtest_main
-
-  OBJECT
-
-  gtest_main.cc
-)
+add_library(boringssl_gtest_main STATIC gtest_main.cc)
 target_link_libraries(boringssl_gtest_main boringssl_gtest crypto test_support_lib)

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,9 +1,6 @@
-include_directories(../include)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-prototypes")
-
 macro(fuzzer name)
   add_executable(${name} ${name}.cc)
+  target_compile_options(${name} PRIVATE "-Wno-missing-prototypes")
   target_link_libraries(${name} crypto ${ARGN})
   if(LIBFUZZER_FROM_DEPS)
     set_target_properties(${name} PROPERTIES LINK_FLAGS "-fsanitize=fuzzer-no-link")

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -4,7 +4,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-prototypes")
 
 macro(fuzzer name)
   add_executable(${name} ${name}.cc)
-  add_dependencies(${name} global_target)
   target_link_libraries(${name} crypto ${ARGN})
   if(LIBFUZZER_FROM_DEPS)
     set_target_properties(${name} PROPERTIES LINK_FLAGS "-fsanitize=fuzzer-no-link")

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(../include)
-
 add_library(
   ssl
 

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -58,11 +58,9 @@ if(BUILD_TESTING)
     span_test.cc
     ssl_test.cc
     ssl_c_test.c
+ )
 
-    $<TARGET_OBJECTS:boringssl_gtest_main>
-  )
-
-  target_link_libraries(${SSL_TEST_EXEC} test_support_lib boringssl_gtest ssl crypto)
+  target_link_libraries(${SSL_TEST_EXEC} test_support_lib boringssl_gtest_main ssl crypto)
   if(WIN32)
     target_link_libraries(${SSL_TEST_EXEC} ws2_32)
   endif()

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -44,7 +44,6 @@ add_library(
   ssl_decrepit.c
 )
 target_compile_definitions(ssl PRIVATE BORINGSSL_IMPLEMENTATION)
-add_dependencies(ssl global_target)
 
 target_link_libraries(ssl crypto)
 
@@ -62,8 +61,6 @@ if(BUILD_TESTING)
 
     $<TARGET_OBJECTS:boringssl_gtest_main>
   )
-
-  add_dependencies(${SSL_TEST_EXEC} global_target)
 
   target_link_libraries(${SSL_TEST_EXEC} test_support_lib boringssl_gtest ssl crypto)
   if(WIN32)

--- a/ssl/test/CMakeLists.txt
+++ b/ssl/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(../../include)
-
 add_executable(
   bssl_shim
 

--- a/ssl/test/CMakeLists.txt
+++ b/ssl/test/CMakeLists.txt
@@ -14,8 +14,6 @@ add_executable(
   test_state.cc
 )
 
-add_dependencies(bssl_shim global_target)
-
 target_link_libraries(bssl_shim test_support_lib ssl crypto)
 if(WIN32)
   target_link_libraries(bssl_shim ws2_32)
@@ -34,8 +32,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     test_config.cc
     test_state.cc
   )
-
-  add_dependencies(handshaker global_target)
 
   target_link_libraries(handshaker test_support_lib ssl crypto)
 else()

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -23,8 +23,6 @@ add_executable(
 target_include_directories(bssl PUBLIC ../include)
 target_compile_options(bssl PUBLIC -DINTERNAL_TOOL)
 
-add_dependencies(bssl global_target)
-
 if(WIN32)
   target_link_libraries(bssl ws2_32)
 endif()

--- a/util/fipstools/CMakeLists.txt
+++ b/util/fipstools/CMakeLists.txt
@@ -6,7 +6,5 @@ if(FIPS)
 
     test_fips.c
   )
-
-  add_dependencies(test_fips global_target)
   target_link_libraries(test_fips crypto)
 endif()

--- a/util/fipstools/CMakeLists.txt
+++ b/util/fipstools/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(../../include)
-
 if(FIPS)
   add_executable(
     test_fips

--- a/util/fipstools/acvp/modulewrapper/CMakeLists.txt
+++ b/util/fipstools/acvp/modulewrapper/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(../../../../include)
-
 if(FIPS)
   add_executable(
     modulewrapper

--- a/util/fipstools/acvp/modulewrapper/CMakeLists.txt
+++ b/util/fipstools/acvp/modulewrapper/CMakeLists.txt
@@ -7,8 +7,5 @@ if(FIPS)
     main.cc
     modulewrapper.cc
   )
-
-  add_dependencies(modulewrapper global_target)
-
   target_link_libraries(modulewrapper crypto)
 endif()


### PR DESCRIPTION
### Description of changes: 
While working on this fix it became apparent that these 4 changes were required to be merged at one time. "Make boringssl_gtest_main a STATIC library" is needed to fix an issue with old CMake versions in "Clean up test_support_lib and GTest dependencies slightly" and the same for removing the global target.

I think this will fix the missing CMake dependency that is causing my issue in https://github.com/aws/aws-lc/pull/920.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
