### PR TITLE
Update size of BORINGSSL_function_hit to account for new aes_gcm_encrypt_avx512

### DIFF
--- a/crypto/fipsmodule/cpucap/cpucap.c
+++ b/crypto/fipsmodule/cpucap/cpucap.c
@@ -79,7 +79,7 @@ HIDDEN uint32_t OPENSSL_armcap_P = 0;
 
 #if defined(BORINGSSL_DISPATCH_TEST)
 // This value must be explicitly initialized to zero. See similar comment above.
-HIDDEN uint8_t BORINGSSL_function_hit[7] = {0};
+HIDDEN uint8_t BORINGSSL_function_hit[8] = {0};
 #endif
 
 // This variable is used only for testing purposes to ensure that the library


### PR DESCRIPTION
### Description of changes: 
https://github.com/aws/aws-lc/pull/692 added aes_gcm_encrypt_avx512 to the flags and updated the external declaration in the [header file](https://github.com/aws/aws-lc/blame/main/crypto/internal.h#L1023-L1024), but the actual size of BORINGSSL_function_hit is still only 7. 

Working on an unrelated change locally with GCC 11.3.0 caught this:
```
workplace/oss/aws-lc/crypto/fipsmodule/cpucap/cpucap.c:76:16: error: conflicting types for ‘BORINGSSL_function_hit’; have ‘uint8_t[7]’ {aka ‘unsigned char[7]’}
   76 | HIDDEN uint8_t BORINGSSL_function_hit[7] = {0};
      |                ^~~~~~~~~~~~~~~~~~~~~~
In file included from workplace/oss/aws-lc/crypto/fipsmodule/cpucap/cpucap.c:13:
workplace/oss/aws-lc/crypto/fipsmodule/cpucap/../../internal.h:1044:16: note: previous declaration of ‘BORINGSSL_function_hit’ with type ‘uint8_t[8]’ {aka ‘unsigned char[8]’}
 1044 | extern uint8_t BORINGSSL_function_hit[8];
      |                ^~~~~~~~~~~~~~~~~~~~~~

```

### Testing:
Built locally, not sure why our CI didn't catch this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
