### PR TITLE
Release v1.8.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -3964,7 +3964,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.7.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.8.0");
 }
 
 #else
@@ -4007,6 +4007,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.7.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.8.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -216,7 +216,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.7.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.8.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
* Improves support for OpenSSH ([#894](https://github.com/aws/aws-lc/pull/894))
* **Bug fix**: Added back `ASN1_STRING_clear_free` which was incorrectly removed in `v1.7.0`. ([#936](https://github.com/aws/aws-lc/pull/936))
* **Bug fix**: `BORINGSSL_function_hit` array size did not match updated header definition ([#934](https://github.com/aws/aws-lc/pull/934))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
