### PR TITLE
Add service indicator check for 0 <= slen <= hlen

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -225,9 +225,6 @@ static void evp_md_ctx_verify_service_indicator(const EVP_MD_CTX *ctx,
     if (!EVP_PKEY_CTX_get_rsa_padding(pctx, &padding)) {
       goto err;
     }
-    // The approved RSA key sizes for signing are 2048, 3072 and 4096 bits.
-    // Note: |EVP_PKEY_size| returns the size in bytes.
-    size_t pkey_size = EVP_PKEY_size(ctx->pctx->pkey);
 
     if (padding == RSA_PKCS1_PSS_PADDING) {
       int salt_len;
@@ -235,23 +232,21 @@ static void evp_md_ctx_verify_service_indicator(const EVP_MD_CTX *ctx,
       const EVP_MD *mgf1_md;
       if (!EVP_PKEY_CTX_get_rsa_pss_saltlen(pctx, &salt_len) ||
           !EVP_PKEY_CTX_get_rsa_mgf1_md(pctx, &mgf1_md) ||
+          (salt_len != RSA_PSS_SALTLEN_DIGEST &&
+           (salt_len > hash_len || salt_len < 0)) ||
           EVP_MD_type(mgf1_md) != md_type) {
-        goto err;
-      }
-      // RSA_PSS_SALTLEN_DIGEST (-1) has the special meaning of "sLen ==
-      // hLen", other values need additional checks.
-      // FIPS 186-4, Section 5.5, requires that if the RSA key size is 1024
-      // bits (128 bytes) and the hash function output block is 512 bits
-      // (64 bytes), then the length of the salt shall be "0 <= sLen <=
-      // hLen-2". Otherwise it requires that the salt length used in PSS
-      // satisfies "0 <= sLen <= hLen".
-      if (salt_len != RSA_PSS_SALTLEN_DIGEST &&
-          ((pkey_size == 128 && hash_len == 64 &&
-            (salt_len > hash_len - 2 || salt_len < 0)) ||
-           (salt_len > hash_len || salt_len < 0))) {
+        // Cases with non-standard padding functions are excluded.
+        // FIPS 186-4, Section 5.5, requires that the salt length used in PSS
+        // satisfies "0 <= sLen <= hLen". RSA_PSS_SALTLEN_DIGEST (-1) has the
+        // special meaning of "sLen == hLen", other values need additional
+        // checks.
         goto err;
       }
     }
+
+    // The approved RSA key sizes for signing are 2048, 3072 and 4096 bits.
+    // Note: |EVP_PKEY_size| returns the size in bytes.
+    size_t pkey_size = EVP_PKEY_size(ctx->pctx->pkey);
 
     // Check if the MD type and the RSA key size are approved.
     if (md_ok(md_type) &&


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1753`

### Description of changes: 
 FIPS 186-4, Section 5.5, requires that if the RSA key size is 1024  bits (128 bytes) and the hash function output block is 512 bits (64 bytes), then the length of the salt shall be "0 <= sLen <= hLen-2". Otherwise it requires that the salt length used in PSS satisfies "0 <= sLen <= hLen".
* https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf

### Call-outs:
Adding the check directly into the digest signing will create backwards incompatibility. We've gotten approval from our FIPS vendor to add this check in the service indicator instead. OpenSSL follows the same concept by marking a new default option in their "provider" APIs (their version of the service indicator).
* https://github.com/openssl/openssl/commit/6c73ca4a2f4ea71f4a880670624e7b2fdb6f32da

### Testing:
Adjust test that was failing to use a value larger than `hlen` instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
