### PR TITLE
Add Jitter speed test for FIPS build

### DIFF
--- a/tool/bssl_bm.h
+++ b/tool/bssl_bm.h
@@ -8,6 +8,7 @@
 #include <openssl/aes.h>
 #include <openssl/base64.h>
 #include <openssl/bn.h>
+#include "openssl/ctrdrbg.h"
 #include <openssl/curve25519.h>
 #include <openssl/crypto.h>
 #include <openssl/digest.h>
@@ -29,6 +30,7 @@
 #if defined(INTERNAL_TOOL)
 #include <../crypto/ec_extra/internal.h>
 #include <../crypto/trust_token/internal.h>
+#include "../third_party/jitterentropy/jitterentropy.h"
 #endif
 
 #define BM_NAMESPACE bssl


### PR DESCRIPTION
### Description of changes: 
Add an AWS-LC FIPS specific benchmark for Jitter.
Sample output:
```
./tool/bssl speed -filter Jitter -chunks 10,20,40,80,160
Did 198 Jitter (10 bytes) operations in 1043768us (189.7 ops/sec): 0.0 MB/s
Did 209 Jitter (20 bytes) operations in 1094657us (190.9 ops/sec): 0.0 MB/s
Did 99 Jitter (40 bytes) operations in 1037250us (95.4 ops/sec): 0.0 MB/s
Did 66 Jitter (80 bytes) operations in 1036942us (63.6 ops/sec): 0.0 MB/s
Did 39 Jitter (160 bytes) operations in 1022004us (38.2 ops/sec): 0.0 MB/s
./tool/bssl speed -filter Jitter -chunks 10,20,40,80,160 -json
[
{"description": "Jitter", "numCalls": 195, "microseconds": 1036469, "bytesPerCall": 10},
{"description": "Jitter", "numCalls": 190, "microseconds": 1018698, "bytesPerCall": 20},
{"description": "Jitter", "numCalls": 99, "microseconds": 1042746, "bytesPerCall": 40},
{"description": "Jitter", "numCalls": 66, "microseconds": 1044551, "bytesPerCall": 80},
{"description": "Jitter", "numCalls": 39, "microseconds": 1019696, "bytesPerCall": 160}
]
```

### Call-outs:
Jitter is so slow MB/s doesn't make a lot of sense, I thought about updating it to be smart and print in B/s, KB/s, or MB/s. But I was afraid that might break other tooling that expects MB/s.

### Testing:
Built and ran locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
