### PR TITLE
Support older versions of AWS-LC that still need SHA3 turned on

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2004,6 +2004,11 @@ static const argument_t kArguments[] = {
 };
 
 bool Speed(const std::vector<std::string> &args) {
+#if defined(OPENSSL_IS_AWSLC)
+  // For mainline AWS-LC this is a no-op, however if speed.cc built with an old
+  // branch of AWS-LC SHA3 might be disabled by default and fail the benchmark.
+  EVP_MD_unstable_sha3_enable(true);
+#endif
   std::map<std::string, std::string> args_map;
   if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
     PrintUsage(kArguments);


### PR DESCRIPTION
### Description of changes: 
The canary currently fails to run the new benchmark code with the old 2022 branch which still has SHA3 off by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
