### PR TITLE
Add benchmarks for EC_KEY_generate_key(_fips)

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1194,6 +1194,37 @@ static bool SpeedECDHCurve(const std::string &name, int nid,
   return true;
 }
 
+
+static bool SpeedECKeyGenerateKey(bool is_fips, const std::string &name,
+                                      int nid, const std::string &selected) {
+  if (!selected.empty() && name.find(selected) == std::string::npos) {
+    return true;
+  }
+  BM_NAMESPACE::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(nid));
+
+  TimeResults results;
+  if (is_fips) {
+#if !defined(OPENSSL_BENCHMARK)
+    if (!TimeFunction(&results, [&key]() -> bool {
+          return EC_KEY_generate_key_fips(key.get()) == 1;
+        })) {
+      return false;
+    }
+#else
+    return true;
+#endif
+  } else {
+    if (!TimeFunction(&results, [&key]() -> bool {
+          return EC_KEY_generate_key(key.get()) == 1;
+        })) {
+      return false;
+    }
+  }
+  results.Print(is_fips ? name + " with EC_KEY_generate_key_fips"
+                        : name + " with EC_KEY_generate_key");
+  return true;
+}
+
 static bool SpeedECKeyGenCurve(const std::string &name, int nid,
                             const std::string &selected) {
   if (!selected.empty() && name.find(selected) == std::string::npos) {
@@ -1221,7 +1252,7 @@ static bool SpeedECKeyGenCurve(const std::string &name, int nid,
       })) {
       return false;
   }
-  results.Print(name);
+  results.Print(name + " with EVP_PKEY_keygen");
   return true;
 }
 
@@ -1265,6 +1296,19 @@ static bool SpeedECDSACurve(const std::string &name, int nid,
   results.Print(name + " verify");
 
   return true;
+}
+
+static bool SpeedECKeyGenerateKey(bool is_fips, const std::string &selected) {
+  return SpeedECKeyGenerateKey(is_fips, "Generate P-224", NID_secp224r1,
+                               selected) &&
+         SpeedECKeyGenerateKey(is_fips, "Generate P-256",
+                               NID_X9_62_prime256v1, selected) &&
+         SpeedECKeyGenerateKey(is_fips, "Generate P-384", NID_secp384r1,
+                               selected) &&
+         SpeedECKeyGenerateKey(is_fips, "Generate P-521", NID_secp521r1,
+                               selected) &&
+         SpeedECKeyGenerateKey(is_fips, "Generate secp256k1",
+                               NID_secp256k1, selected);
 }
 
 static bool SpeedECDH(const std::string &selected) {
@@ -2298,6 +2342,7 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedECDH(selected) ||
      !SpeedECDSA(selected) ||
      !SpeedECKeyGen(selected) ||
+     !SpeedECKeyGenerateKey(false, selected) ||
 #if !defined(OPENSSL_1_0_BENCHMARK)
      !SpeedECMUL(selected) ||
      // OpenSSL 1.0 doesn't support Scrypt
@@ -2329,6 +2374,7 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedRSAKeyGen(true, selected) ||
      !SpeedHRSS(selected) ||
      !SpeedHash(EVP_blake2b256(), "BLAKE2b-256", selected) ||
+     !SpeedECKeyGenerateKey(true, selected) ||
 #if defined(INTERNAL_TOOL)
      !SpeedHashToCurve(selected) ||
      !SpeedTrustToken("TrustToken-Exp1-Batch1", TRUST_TOKEN_experiment_v1(), 1, selected) ||


### PR DESCRIPTION
### Description of changes: 
While working on https://github.com/aws/aws-lc/pull/957, we noticed that we could use some benchmarks for `EC_KEY_generate_key(_fips)` as well.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
