### PR TITLE
Release v1.9.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4006,7 +4006,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.8.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.9.0");
 }
 
 #else
@@ -4049,6 +4049,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.8.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.9.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -216,7 +216,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.8.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.9.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Provide a compile option to disable AVX512-specific optimizations ([#945](https://github.com/aws/aws-lc/pull/945))
* aesv8-armx.pl: Avoid buffer overread in AES-XTS decryption  ([#970](https://github.com/aws/aws-lc/pull/970))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
