### PR TITLE
Fix coverage report generation script

### DIFF
--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -386,7 +386,7 @@ func main() {
 				continue
 			}
 
-			if *useValgrind {
+			if *useValgrind || *useCallgrind {
 				if test.SkipValgrind {
 					continue
 				}

--- a/util/generate-asm-lcov.py
+++ b/util/generate-asm-lcov.py
@@ -104,6 +104,7 @@ def generate(data):
   for i in range(len(data)):
     if 'User-annotated source' in data[i] and i < len(data) - 1:
       filename = data[i].split(':', 1)[1].strip()
+      filename = filename.split('\\n')[0]
       res = data[i + 1]
       if filename not in out:
         out[filename] = None
@@ -118,7 +119,7 @@ def output(data):
   """Takes a dictionary |data| of filenames and execution counts and generates
   a LCOV coverage output."""
   out = ''
-  for filename, counts in data.iteritems():
+  for filename, counts in data.items():
     out += 'SF:%s\n' % (os.path.abspath(filename))
     for line, count in enumerate(counts):
       if count != None:
@@ -128,7 +129,7 @@ def output(data):
 
 if __name__ == '__main__':
   if len(sys.argv) != 3:
-    print '%s <Callgrind Folder> <Build Folder>' % (__file__)
+    print('%s <Callgrind Folder> <Build Folder>' % (__file__))
     sys.exit()
 
   cg_folder = sys.argv[1]
@@ -149,4 +150,4 @@ if __name__ == '__main__':
 
   annotated = merge(cg_files, srcs)
   lcov = generate(annotated)
-  print output(lcov)
+  print(output(lcov))

--- a/util/generate-coverage.sh
+++ b/util/generate-coverage.sh
@@ -30,7 +30,7 @@ cd "$BUILD"
 cmake "$SRC" -GNinja -DGCOV=1
 ninja
 
-cp -r "$SRC/crypto" "$SRC/include" "$SRC/ssl" "$SRC/tool" \
+cp -r "$SRC/crypto" "$SRC/include" "$SRC/ssl" "$SRC/tool" "$SRC/third_party" \
   "$BUILD_SRC"
 cp -r "$BUILD"/* "$BUILD_SRC"
 mkdir "$BUILD/callgrind/"
@@ -42,7 +42,12 @@ util/generate-asm-lcov.py "$BUILD/callgrind" "$BUILD" > "$BUILD/asm.info"
 go run "util/all_tests.go" -build-dir "$BUILD"
 
 cd "$SRC/ssl/test/runner"
-go test -shim-path "$BUILD/ssl/test/bssl_shim" -num-workers 1
+go test -shim-path "$BUILD/ssl/test/bssl_shim" -handshaker-path "$BUILD/ssl/test/handshaker" -num-workers 1
+
+## TODO: lcov fails for bcm.c.o with the following error msg.
+## geninfo: ERROR: GCOV failed for /tmp/boringssl.FfIv7q/crypto/fipsmodule/CMakeFiles/fipsmodule.dir/bcm.c.gcda!
+rm "$BUILD/crypto/fipsmodule/CMakeFiles/fipsmodule.dir/bcm.c.gcda"
+rm "$BUILD/crypto/fipsmodule/CMakeFiles/fipsmodule.dir/bcm.c.gcno"
 
 cd "$LCOV"
 lcov -c -d "$BUILD" -b "$BUILD" -o "$BUILD/lcov.info"
@@ -55,4 +60,5 @@ genhtml -p "$BUILD_SRC" "$BUILD/final.info"
 rm -rf "$BUILD"
 rm -rf "$BUILD_SRC"
 
-xdg-open index.html
+# Open webpage on Ubuntu.
+# xdg-open index.html


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1807`

### Description of changes: 
Fix coverage report generation script left by upstream.

### Call-outs:
N/A

### Testing:
Running `/util/generate-coverage.sh coverage` will generate a coverage report.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
