### PR TITLE
Remove cruft from generate build script

### DIFF
--- a/util/generate_build_files.py
+++ b/util/generate_build_files.py
@@ -356,7 +356,7 @@ def main():
       'urandom_test': urandom_test_files,
   }
 
-  sorted(WriteAsmFiles(ReadPerlAsmOperations()).items())
+  WriteAsmFiles(ReadPerlAsmOperations())
 
   return 0
 

--- a/util/generate_build_files.py
+++ b/util/generate_build_files.py
@@ -208,7 +208,6 @@ def ArchForAsmFilename(filename):
 def WriteAsmFiles(perlasms):
   """Generates asm files from perlasm directives for each supported OS x
   platform combination."""
-  asmfiles = {}
 
   for osarch in OS_ARCH_COMBOS:
     (osname, arch, perlasm_style, extra_args, asm_ext) = osarch
@@ -224,15 +223,6 @@ def WriteAsmFiles(perlasms):
       if arch in ArchForAsmFilename(filename):
         PerlAsm(os.path.join(DEST_DIR, output), perlasm['input'], perlasm_style,
                 perlasm['extra_args'] + extra_args)
-        asmfiles.setdefault(key, []).append(output)
-
-  for (key, non_perl_asm_files) in NON_PERL_FILES.items():
-    asmfiles.setdefault(key, []).extend(non_perl_asm_files)
-
-  for files in asmfiles.values():
-    files.sort()
-
-  return asmfiles
 
 
 def ExtractVariablesFromCMakeFile(cmakefile):
@@ -366,7 +356,7 @@ def main():
       'urandom_test': urandom_test_files,
   }
 
-  asm_outputs = sorted(WriteAsmFiles(ReadPerlAsmOperations()).items())
+  sorted(WriteAsmFiles(ReadPerlAsmOperations()).items())
 
   return 0
 

--- a/util/generate_build_files.py
+++ b/util/generate_build_files.py
@@ -14,8 +14,6 @@
 # OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-"""Enumerates source files for consumption by various build systems."""
-
 import io
 import optparse
 import os
@@ -52,53 +50,6 @@ def FindCMakeFiles(directory):
 
   return cmakefiles
 
-def OnlyFIPSFragments(path, dent, is_dir):
-  return is_dir or (path.startswith(
-      os.path.join(SRC_DIR, 'crypto', 'fipsmodule', '')) and
-      NoTests(path, dent, is_dir))
-
-def NoTestsNorFIPSFragments(path, dent, is_dir):
-  return (NoTests(path, dent, is_dir) and
-      (is_dir or not OnlyFIPSFragments(path, dent, is_dir)))
-
-def NoTests(path, dent, is_dir):
-  """Filter function that can be passed to FindCFiles in order to remove test
-  sources."""
-  if is_dir:
-    return dent != 'test'
-  return 'test.' not in dent
-
-
-def OnlyTests(path, dent, is_dir):
-  """Filter function that can be passed to FindCFiles in order to remove
-  non-test sources."""
-  if is_dir:
-    return dent != 'test'
-  return '_test.' in dent
-
-
-def AllFiles(path, dent, is_dir):
-  """Filter function that can be passed to FindCFiles in order to include all
-  sources."""
-  return True
-
-
-def NoTestRunnerFiles(path, dent, is_dir):
-  """Filter function that can be passed to FindCFiles or FindHeaderFiles in
-  order to exclude test runner files."""
-  # NOTE(martinkr): This prevents .h/.cc files in src/ssl/test/runner, which
-  # are in their own subpackage, from being included in boringssl/BUILD files.
-  return not is_dir or dent != 'runner'
-
-
-def NotGTestSupport(path, dent, is_dir):
-  return 'gtest' not in dent and 'abi_test' not in dent
-
-
-def SSLHeaderFiles(path, dent, is_dir):
-  return dent in ['ssl.h', 'tls1.h', 'ssl23.h', 'ssl3.h', 'dtls1.h', 'srtp.h']
-
-
 def FindCFiles(directory, filter_func):
   """Recurses through directory and returns a list of paths to all the C source
   files that pass filter_func."""
@@ -118,27 +69,6 @@ def FindCFiles(directory, filter_func):
 
   cfiles.sort()
   return cfiles
-
-
-def FindHeaderFiles(directory, filter_func):
-  """Recurses through directory and returns a list of paths to all the header files that pass filter_func."""
-  hfiles = []
-
-  for (path, dirnames, filenames) in os.walk(directory):
-    for filename in filenames:
-      if not filename.endswith('.h'):
-        continue
-      if not filter_func(path, filename, False):
-        continue
-      hfiles.append(os.path.join(path, filename))
-
-      for (i, dirname) in enumerate(dirnames):
-        if not filter_func(path, dirname, True):
-          del dirnames[i]
-
-  hfiles.sort()
-  return hfiles
-
 
 def ExtractPerlAsmFromCMakeFile(cmakefile):
   """Parses the contents of the CMakeLists.txt file passed as an argument and
@@ -162,7 +92,6 @@ def ExtractPerlAsmFromCMakeFile(cmakefile):
       })
 
   return perlasms
-
 
 def ReadPerlAsmOperations():
   """Returns a list of all perlasm() directives found in CMake config files in
@@ -224,7 +153,6 @@ def WriteAsmFiles(perlasms):
         PerlAsm(os.path.join(DEST_DIR, output), perlasm['input'], perlasm_style,
                 perlasm['extra_args'] + extra_args)
 
-
 def ExtractVariablesFromCMakeFile(cmakefile):
   """Parses the contents of the CMakeLists.txt file passed as an argument and
   returns a dictionary of exported source lists."""
@@ -253,20 +181,8 @@ def ExtractVariablesFromCMakeFile(cmakefile):
     raise ValueError('Unfinished set command')
   return variables
 
-
 def main():
   cmake = ExtractVariablesFromCMakeFile(os.path.join(SRC_DIR, 'sources.cmake'))
-  crypto_c_files = (FindCFiles(os.path.join(SRC_DIR, 'crypto'), NoTestsNorFIPSFragments) +
-                    FindCFiles(os.path.join(SRC_DIR, 'third_party', 'fiat'), NoTestsNorFIPSFragments))
-  fips_fragments = FindCFiles(os.path.join(SRC_DIR, 'crypto', 'fipsmodule'), OnlyFIPSFragments)
-  ssl_source_files = FindCFiles(os.path.join(SRC_DIR, 'ssl'), NoTests)
-  tool_c_files = FindCFiles(os.path.join(SRC_DIR, 'tool'), NoTests)
-  tool_h_files = FindHeaderFiles(os.path.join(SRC_DIR, 'tool'), AllFiles)
-
-  # BCM shared library C files
-  bcm_crypto_c_files = [
-      os.path.join(SRC_DIR, 'crypto', 'fipsmodule', 'bcm.c')
-  ]
 
   # Generate err_data.c
   if not os.path.isdir(DEST_DIR):
@@ -277,97 +193,24 @@ def main():
                           cwd=os.path.join(SRC_DIR, 'crypto', 'err'),
                           stdout=err_data)
 
-  crypto_c_files.append('err_data.c')
-  crypto_c_files.sort()
-
-  test_support_c_files = FindCFiles(os.path.join(SRC_DIR, 'crypto', 'test'),
-                                    NotGTestSupport)
-  test_support_h_files = (
-      FindHeaderFiles(os.path.join(SRC_DIR, 'crypto', 'test'), AllFiles) +
-      FindHeaderFiles(os.path.join(SRC_DIR, 'ssl', 'test'), NoTestRunnerFiles))
-
-  crypto_test_files = []
-
   # Generate crypto_test_data.cc
   with open(os.path.join(DEST_DIR, 'crypto_test_data.cc'), 'w+') as out:
     subprocess.check_call(
         ['go', 'run', 'util/embed_test_data.go'] + cmake['CRYPTO_TEST_DATA'],
         cwd=SRC_DIR,
         stdout=out)
-  crypto_test_files += ['crypto_test_data.cc']
-
-  crypto_test_files += FindCFiles(os.path.join(SRC_DIR, 'crypto'), OnlyTests)
-  crypto_test_files += [
-      os.path.join(SRC_DIR, 'crypto/test/abi_test.cc'),
-      os.path.join(SRC_DIR, 'crypto/test/file_test_gtest.cc'),
-      os.path.join(SRC_DIR, 'crypto/test/gtest_main.cc'),
-  ]
-  # urandom_test.cc is in a separate binary so that it can be test PRNG
-  # initialisation.
-  crypto_test_files = [
-      file for file in crypto_test_files
-      if not file.endswith('/urandom_test.cc')
-  ]
-  crypto_test_files.sort()
-
-  ssl_test_files = FindCFiles(os.path.join(SRC_DIR, 'ssl'), OnlyTests)
-  ssl_test_files += [
-      os.path.join(SRC_DIR, 'crypto/test/abi_test.cc'),
-      os.path.join(SRC_DIR, 'crypto/test/gtest_main.cc'),
-  ]
-  ssl_test_files.sort()
-
-  urandom_test_files = [
-      os.path.join(SRC_DIR, "crypto/fipsmodule/rand/urandom_test.cc"),
-  ]
-
-  fuzz_c_files = FindCFiles(os.path.join(SRC_DIR, 'fuzz'), NoTests)
-
-  ssl_h_files = FindHeaderFiles(os.path.join(SRC_DIR, 'include', 'openssl'),
-                                SSLHeaderFiles)
-
-  def NotSSLHeaderFiles(path, filename, is_dir):
-    return not SSLHeaderFiles(path, filename, is_dir)
-  crypto_h_files = FindHeaderFiles(os.path.join(SRC_DIR, 'include', 'openssl'),
-                                   NotSSLHeaderFiles)
-
-  ssl_internal_h_files = FindHeaderFiles(os.path.join(SRC_DIR, 'ssl'), NoTests)
-  crypto_internal_h_files = (
-      FindHeaderFiles(os.path.join(SRC_DIR, 'crypto'), NoTests) +
-      FindHeaderFiles(os.path.join(SRC_DIR, 'third_party', 'fiat'), NoTests))
-
-  files = {
-      'bcm_crypto': bcm_crypto_c_files,
-      'crypto': crypto_c_files,
-      'crypto_headers': crypto_h_files,
-      'crypto_internal_headers': crypto_internal_h_files,
-      'crypto_test': crypto_test_files,
-      'crypto_test_data': sorted(os.path.join(SRC_DIR, x) for x in cmake['CRYPTO_TEST_DATA']),
-      'fips_fragments': fips_fragments,
-      'fuzz': fuzz_c_files,
-      'ssl': ssl_source_files,
-      'ssl_headers': ssl_h_files,
-      'ssl_internal_headers': ssl_internal_h_files,
-      'ssl_test': ssl_test_files,
-      'tool': tool_c_files,
-      'tool_headers': tool_h_files,
-      'test_support': test_support_c_files,
-      'test_support_headers': test_support_h_files,
-      'urandom_test': urandom_test_files,
-  }
 
   WriteAsmFiles(ReadPerlAsmOperations())
 
   return 0
 
-
 if __name__ == '__main__':
   usage = '''%prog
 
-  This script generates intermediate build files for CMake builds without the need
-  to install Go or Perl as a dependency. These files are output to the |generated-src|
-  directory and are used by the top-level CMakeLists.txt for AWS-LC if these depedencies
-  are not found.
+  This script generates intermediate build files for CMake builds without the
+  need to install Go or Perl as a dependency. These files are output to the
+  |generated-src| directory and are used by the top-level CMakeLists.txt if
+  either Go or Perl are not found.
   '''
 
   parser = optparse.OptionParser(usage=usage)
@@ -375,17 +218,5 @@ if __name__ == '__main__':
 
   SRC_DIR = os.getcwd()
   DEST_DIR = os.path.relpath('generated-src', os.getcwd())
-
-  # NON_PERL_FILES enumerates assembly files that are not processed by the
-  # perlasm system.
-  NON_PERL_FILES = {
-      ('linux', 'arm'): [
-          os.path.relpath(os.path.join(SRC_DIR, "crypto/curve25519/asm/x25519-asm-arm.S"), DEST_DIR),
-          os.path.relpath(os.path.join(SRC_DIR, "crypto/poly1305/asm/poly1305_asm_arm.S"), DEST_DIR),
-      ],
-      ('linux', 'x86_64'): [
-          os.path.relpath(os.path.join(SRC_DIR, "crypto/hrss/asm/poly_rq_mul.S"), DEST_DIR),
-      ],
-  }
 
   sys.exit(main())


### PR DESCRIPTION
### Description of changes: 

Removes 50% of the code from `generate_build_files.py` which are never used. Probably a remnant from years ago when first changing this script to feed AWS-LC needs.

Consuming Perl-generated machine implementations and Go generated files are done by cmake scripts.

### Testing:

#### First check script generates the same folder

```
$ cp -r generated-src/ ../generated_source
$ rm -rf ./generated-src
$ python3 util/generate_build_files.py 
$ diff -rq generated-src/ ../generated_source/
<empty>
$ git diff
<empty>
```

#### Check build without Perl

```
$ cmake3 -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(pwd)/../awslc-install -DBUILD_SHARED_LIBS=OFF -DDISABLE_PERL=ON .. 
$ ninja-build run_tests

[...]

All tests passed!
```

#### Check build without Go

```
$ cmake3 -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(pwd)/../awslc-install -DBUILD_SHARED_LIBS=OFF -DDISABLE_GO=ON .. 
$ ninja-build
$ ./crypto/crypto_test

[...]

[  PASSED  ] 1421 tests.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
