### PR TITLE
Define OPENSSL_NO_ASM macro if processor is unknown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,6 +691,7 @@ elseif (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "riscv64")
   set(ARCH "riscv64")
 else()
   message(STATUS "Unknown processor found. Using generic implementations. Processor:" ${CMAKE_SYSTEM_PROCESSOR})
+  add_definitions(-DOPENSSL_NO_ASM)
   set(ARCH "generic")
 endif()
 


### PR DESCRIPTION
While trying to compile https://github.com/aws/aws-iot-device-sdk-cpp-v2 using yocto sdk for the Raspberry Pi 3, I got a number of undefined symbols at the linker stage.

This is due to `CMakeLists.txt` setting the `ARCH` variable (although it is already set to `arm` in my case) to `generic` because `CMAKE_SYSTEM_PROCESSOR` is set to `cortexa7t2hf-neon-vfpv4-hudl`.
If the processor is unknown then we cannot use ASM implementations. Thus, we must define the `OPENSSL_NO_ASM` macro to avoid errors at the linker stage.

### Issues:

No issues.

### Description of changes: 

Define `OPENSSL_NO_ASM` macro if processor is unknown.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:

No testing apart from building the project.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
