### PR TITLE
Add DH_check support to perf tool

### DIFF
--- a/tool/bssl_bm.h
+++ b/tool/bssl_bm.h
@@ -11,6 +11,7 @@
 #include "openssl/ctrdrbg.h"
 #include <openssl/curve25519.h>
 #include <openssl/crypto.h>
+#include <openssl/dh.h>
 #include <openssl/digest.h>
 #include <openssl/err.h>
 #include <openssl/ec.h>

--- a/tool/ossl_bm.h
+++ b/tool/ossl_bm.h
@@ -7,6 +7,7 @@
 #include <openssl/aes.h>
 #include <openssl/bn.h>
 #include <openssl/crypto.h>
+#include <openssl/dh.h>
 #include <openssl/ec.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/tool/ossl_bm.h
+++ b/tool/ossl_bm.h
@@ -54,6 +54,7 @@ template <typename T> struct Deleter {
 } // namespace internal
 template <typename T> using UniquePtr = std::unique_ptr<T, internal::Deleter<T>>;
 
+OSSL_MAKE_DELETER(DH, DH_free)
 OSSL_MAKE_DELETER(RSA, RSA_free)
 OSSL_MAKE_DELETER(BIGNUM, BN_free)
 OSSL_MAKE_DELETER(EC_KEY, EC_KEY_free)

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -204,7 +204,8 @@ static uint64_t time_now() {
 }
 #endif
 
-static uint64_t g_timeout_seconds = 1;
+#define TIMEOUT_SECONDS_DEFAULT 1
+static uint64_t g_timeout_seconds = TIMEOUT_SECONDS_DEFAULT;
 static std::vector<size_t> g_chunk_lengths = {16, 256, 1350, 8192, 16384};
 static std::vector<size_t> g_prime_bit_lengths = {2048, 3072};
 
@@ -2013,12 +2014,14 @@ static bool SpeedDHcheck(size_t prime_bit_length) {
 }
 
 static bool SpeedDHcheck(std::string selected) {
-  if (!selected.empty() && selected.find("dhcheck") == std::string::npos) {
+  // Don't run this by default because it's so slow.
+  if (selected != "dhcheck") {
     return true;
   }
 
-  if (!g_print_json) {
-    printf("DH check speed test is very slow. Speed test works best with higher timeouts.\n");
+  uint64_t maybe_reset_timeout = g_timeout_seconds;
+  if (g_timeout_seconds == TIMEOUT_SECONDS_DEFAULT) {
+    g_timeout_seconds = 10;
   }
 
   for (size_t prime_bit_length : g_prime_bit_lengths) {
@@ -2026,6 +2029,8 @@ static bool SpeedDHcheck(std::string selected) {
       return false;
     }
   }
+
+  g_timeout_seconds = maybe_reset_timeout;
 
   return true;
 }

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1988,7 +1988,7 @@ static bool SpeedJitter(std::string selected) {
 static bool SpeedDHcheck(size_t prime_bit_length) {
 
   TimeResults results;
-  bssl::UniquePtr<DH> dh_params(DH_new());
+  BM_NAMESPACE::UniquePtr<DH> dh_params(DH_new());
   if (dh_params == nullptr) {
     return false;
   }
@@ -2310,7 +2310,8 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedScrypt(selected) ||
 #endif
      !SpeedRSA(selected) ||
-     !SpeedRSAKeyGen(false, selected)
+     !SpeedRSAKeyGen(false, selected) ||
+     !SpeedDHcheck(selected)
 #if !defined(OPENSSL_BENCHMARK)
      ||
      !SpeedKEM(selected) ||
@@ -2347,9 +2348,8 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedPKCS8(selected) ||
 #endif
      !SpeedBase64(selected) ||
-     !SpeedSipHash(selected) ||
+     !SpeedSipHash(selected)
 #endif
-     !SpeedDHcheck(selected)
      ) {
     return false;
   }


### PR DESCRIPTION
### Description of changes: 

Makes it possible to measure performance of the function `DH_check()`.

### Call-outs:

Generating DH parameters for higher bit sizes gets pretty slow.

### Testing:

```
$ ./tool/bssl speed -filter dhcheck -timeout 10 -primes 2048,4096
DH check speed test is very slow. Speed test works best with higher timeouts.
Did 16 DH check(s) (2048 bits) operations in 10164348us (1.574 ops/sec)
Did 3 DH check(s) (4096 bits) operations in 15465898us (0.194 ops/sec)

$ ./tool/bssl speed -filter dhcheck -timeout 2 -primes 1024 -json
[
{"description": "DH check(s)", "numCalls": 20, "microseconds": 2045047, "primeSizePerCall": 1024}
]
```

**Checking new `-chuncks` and `-primes` parsing**

```
$ ./tool/bssl speed -filter EVP-AES-128-GCM -chunks 20,50,56
Did 5489000 EVP-AES-128-GCM encrypt init operations in 1000135us (5488259.1 ops/sec)
Did 10318000 EVP-AES-128-GCM encrypt (20 bytes) operations in 1000012us (10317876.2 ops/sec): 206.4 MB/s
Did 9833000 EVP-AES-128-GCM encrypt (50 bytes) operations in 1000011us (9832891.8 ops/sec): 491.6 MB/s
Did 9841000 EVP-AES-128-GCM encrypt (56 bytes) operations in 1000018us (9840822.9 ops/sec): 551.1 MB/s
Did 5481000 EVP-AES-128-GCM decrypt init operations in 1000071us (5480610.9 ops/sec)
Did 10456000 EVP-AES-128-GCM decrypt (20 bytes) operations in 1000013us (10455864.1 ops/sec): 209.1 MB/s
Did 10318500 EVP-AES-128-GCM decrypt (50 bytes) operations in 1000013us (10318365.9 ops/sec): 515.9 MB/s
Did 10318500 EVP-AES-128-GCM decrypt (56 bytes) operations in 1000007us (10318427.8 ops/sec): 577.8 MB/s


$ ./tool/bssl speed -filter EVP-AES-128-GCM -chunks 20,50,56
Did 5487000 EVP-AES-128-GCM encrypt init operations in 1000077us (5486577.5 ops/sec)
Did 10589000 EVP-AES-128-GCM encrypt (20 bytes) operations in 1000083us (10588121.2 ops/sec): 211.8 MB/s
Did 10230000 EVP-AES-128-GCM encrypt (50 bytes) operations in 1000024us (10229754.5 ops/sec): 511.5 MB/s
Did 10228250 EVP-AES-128-GCM encrypt (56 bytes) operations in 1000001us (10228239.8 ops/sec): 572.8 MB/s
Did 5497250 EVP-AES-128-GCM decrypt init operations in 1000019us (5497145.6 ops/sec)
Did 11285000 EVP-AES-128-GCM decrypt (20 bytes) operations in 1000073us (11284176.3 ops/sec): 225.7 MB/s
Did 11094000 EVP-AES-128-GCM decrypt (50 bytes) operations in 1000021us (11093767.0 ops/sec): 554.7 MB/s
Did 11095000 EVP-AES-128-GCM decrypt (56 bytes) operations in 1000021us (11094767.0 ops/sec): 621.3 MB/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
