### PR TITLE
Less computationally intensive finite field Diffie Hellman parameter checks

### DIFF
--- a/crypto/dh_extra/dh_test.cc
+++ b/crypto/dh_extra/dh_test.cc
@@ -80,8 +80,14 @@ TEST(DHTest, Basic) {
   ASSERT_TRUE(a);
   ASSERT_TRUE(DH_generate_parameters_ex(a.get(), 64, DH_GENERATOR_5, nullptr));
 
-  int check_result;
+  int check_result = 0;
   ASSERT_TRUE(DH_check(a.get(), &check_result));
+  EXPECT_FALSE(check_result & DH_CHECK_P_NOT_PRIME);
+  EXPECT_FALSE(check_result & DH_CHECK_P_NOT_SAFE_PRIME);
+  EXPECT_FALSE(check_result & DH_CHECK_UNABLE_TO_CHECK_GENERATOR);
+  EXPECT_FALSE(check_result & DH_CHECK_NOT_SUITABLE_GENERATOR);
+  check_result = 0;
+  ASSERT_TRUE(DH_check_trusted(a.get(), &check_result));
   EXPECT_FALSE(check_result & DH_CHECK_P_NOT_PRIME);
   EXPECT_FALSE(check_result & DH_CHECK_P_NOT_SAFE_PRIME);
   EXPECT_FALSE(check_result & DH_CHECK_UNABLE_TO_CHECK_GENERATOR);

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -740,6 +740,13 @@ OPENSSL_EXPORT int BN_generate_prime_ex(BIGNUM *ret, int bits, int safe,
 // https://eprint.iacr.org/2018/749. (1/4)^64 = 2^{-128}.)
 #define BN_prime_checks_for_validation 64
 
+// Same as |BN_prime_checks_for_validation| for the case where the consumer
+// trusts that DH parameters are from a trusted source.
+// It gives a false positive rate of at most 2^{-64}. (The worst case
+// false positive rate for a single iteration is 1/4 per
+// https://eprint.iacr.org/2018/749. (1/4)^32 = 2^{-64}.)
+#define BN_prime_checks_for_validation_DH_trusted 32
+
 // BN_prime_checks_for_generation can be used as the |checks| argument to the
 // primality testing functions when generating random primes. It gives a false
 // positive rate at most the security level of the corresponding RSA key size.

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -256,11 +256,13 @@ OPENSSL_EXPORT unsigned DH_num_bits(const DH *dh);
 // Note: these checks may be quite computationally expensive.
 OPENSSL_EXPORT int DH_check(const DH *dh, int *out_flags);
 
-// Use |DH_check|.
-//
 // DH_check_trusted is the same as |DH_check| but for the case where the
-// consumer explicitly trusts the DH parameters. This will not work in cases
-// where an actor can maliciously choose DH parameters.
+// consumer explicitly trusts the DH parameters |dh|. This will not work in
+// cases where the input can be adversarially chosen. So, unless you know
+// better, always use |DH_check|. |DH_check_trusted| is less computationally
+// intensive than |DH_check|.
+//
+// Note: Use |DH_check|!
 OPENSSL_EXPORT int DH_check_trusted(const DH *dh, int *out_flags);
 
 #define DH_CHECK_PUBKEY_TOO_SMALL 0x1

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -256,6 +256,13 @@ OPENSSL_EXPORT unsigned DH_num_bits(const DH *dh);
 // Note: these checks may be quite computationally expensive.
 OPENSSL_EXPORT int DH_check(const DH *dh, int *out_flags);
 
+// Use |DH_check|.
+//
+// DH_check_trusted is the same as |DH_check| but for the case where the
+// consumer explicitly trusts the DH parameters. This will not work in cases
+// where an actor can maliciously choose DH parameters.
+OPENSSL_EXPORT int DH_check_trusted(const DH *dh, int *out_flags);
+
 #define DH_CHECK_PUBKEY_TOO_SMALL 0x1
 #define DH_CHECK_PUBKEY_TOO_LARGE 0x2
 #define DH_CHECK_PUBKEY_INVALID 0x4

--- a/tool/bssl_bm.h
+++ b/tool/bssl_bm.h
@@ -11,6 +11,7 @@
 #include "openssl/ctrdrbg.h"
 #include <openssl/curve25519.h>
 #include <openssl/crypto.h>
+#include <openssl/dh.h>
 #include <openssl/digest.h>
 #include <openssl/err.h>
 #include <openssl/ec.h>

--- a/tool/ossl_bm.h
+++ b/tool/ossl_bm.h
@@ -7,6 +7,7 @@
 #include <openssl/aes.h>
 #include <openssl/bn.h>
 #include <openssl/crypto.h>
+#include <openssl/dh.h>
 #include <openssl/ec.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/tool/ossl_bm.h
+++ b/tool/ossl_bm.h
@@ -54,6 +54,7 @@ template <typename T> struct Deleter {
 } // namespace internal
 template <typename T> using UniquePtr = std::unique_ptr<T, internal::Deleter<T>>;
 
+OSSL_MAKE_DELETER(DH, DH_free)
 OSSL_MAKE_DELETER(RSA, RSA_free)
 OSSL_MAKE_DELETER(BIGNUM, BN_free)
 OSSL_MAKE_DELETER(EC_KEY, EC_KEY_free)

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2011,6 +2011,7 @@ static bool SpeedDHcheck(size_t prime_bit_length) {
 
   results.PrintWithPrimes("DH check(s)", prime_bit_length);
 
+#if !defined(OPENSSL_BENCHMARK)
   if (!TimeFunction(&results, [&dh_params]() -> bool {
         int result = 0;
         if (DH_check_trusted(dh_params.get(), &result) != 1) {
@@ -2022,6 +2023,8 @@ static bool SpeedDHcheck(size_t prime_bit_length) {
   }
 
   results.PrintWithPrimes("DH trusted check(s)", prime_bit_length);
+#endif
+
   return true;
 }
 

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2010,6 +2010,18 @@ static bool SpeedDHcheck(size_t prime_bit_length) {
   }
 
   results.PrintWithPrimes("DH check(s)", prime_bit_length);
+
+  if (!TimeFunction(&results, [&dh_params]() -> bool {
+        int result = 0;
+        if (DH_check_trusted(dh_params.get(), &result) != 1) {
+          return false;
+        }
+        return true;
+      })) {
+    return false;
+  }
+
+  results.PrintWithPrimes("DH trusted check(s)", prime_bit_length);
   return true;
 }
 

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -204,7 +204,8 @@ static uint64_t time_now() {
 }
 #endif
 
-static uint64_t g_timeout_seconds = 1;
+#define TIMEOUT_SECONDS_DEFAULT 1
+static uint64_t g_timeout_seconds = TIMEOUT_SECONDS_DEFAULT;
 static std::vector<size_t> g_chunk_lengths = {16, 256, 1350, 8192, 16384};
 static std::vector<size_t> g_prime_bit_lengths = {2048, 3072};
 
@@ -2013,12 +2014,14 @@ static bool SpeedDHcheck(size_t prime_bit_length) {
 }
 
 static bool SpeedDHcheck(std::string selected) {
-  if (!selected.empty() && selected.find("dhcheck") == std::string::npos) {
+  // Don't run this by default because it's so slow.
+  if (selected != "dhcheck") {
     return true;
   }
 
-  if (!g_print_json) {
-    printf("DH check speed test is very slow. Speed test works best with higher timeouts.\n");
+  uint64_t maybe_reset_timeout = g_timeout_seconds;
+  if (g_timeout_seconds == TIMEOUT_SECONDS_DEFAULT) {
+    g_timeout_seconds = 10;
   }
 
   for (size_t prime_bit_length : g_prime_bit_lengths) {
@@ -2026,6 +2029,8 @@ static bool SpeedDHcheck(std::string selected) {
       return false;
     }
   }
+
+  g_timeout_seconds = maybe_reset_timeout;
 
   return true;
 }

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1988,7 +1988,7 @@ static bool SpeedJitter(std::string selected) {
 static bool SpeedDHcheck(size_t prime_bit_length) {
 
   TimeResults results;
-  bssl::UniquePtr<DH> dh_params(DH_new());
+  BM_NAMESPACE::UniquePtr<DH> dh_params(DH_new());
   if (dh_params == nullptr) {
     return false;
   }
@@ -2310,7 +2310,8 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedScrypt(selected) ||
 #endif
      !SpeedRSA(selected) ||
-     !SpeedRSAKeyGen(false, selected)
+     !SpeedRSAKeyGen(false, selected) ||
+     !SpeedDHcheck(selected)
 #if !defined(OPENSSL_BENCHMARK)
      ||
      !SpeedKEM(selected) ||
@@ -2347,9 +2348,8 @@ bool Speed(const std::vector<std::string> &args) {
      !SpeedPKCS8(selected) ||
 #endif
      !SpeedBase64(selected) ||
-     !SpeedSipHash(selected) ||
+     !SpeedSipHash(selected)
 #endif
-     !SpeedDHcheck(selected)
      ) {
     return false;
   }


### PR DESCRIPTION
### Issues:

D71483351

### Description of changes: 

This is mostly a proposal for now...

`DH_check()` is about 2x more computationally expensive than the proposed version in this PR `DH_check_trusted()`. This might be unexpected by application consumers.

`DH_check_trusted()` uses `BN_prime_checks_for_validation_DH_trusted = 32` number of Miller-Rabin iterations instead of `BN_prime_checks_for_validation = 64` for `DH_check()`. This doesn't work in cases where the input can be chosen adversarially. One can generate composite integers that can pass a rather surprisingly high number of Miller-Rabin iterations with high likelihood. Obviously, this doesn't apply if you trust your parameters and are willing to do that risk analysis.

`DH_check()` is considered the secure default, and is the baseline performance.

Gonna rebase on https://github.com/aws/aws-lc/pull/982 eventually.

### Call-outs:

The computational intensive `DH_check()` can be particularly annoying for TLS applications, since they might need to load DH parameters they explicitly trust, but will have to swallow the 2x cost. This is exacerbated by the cost not being 2x 1-digit ms, but rather 2x 1-digit second (depending on the prime size). Actually applying the attack vector explained above is rather difficult in TLS as well. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
