### PR TITLE
Fix two trailing new-lines in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,7 @@ Resolves #ISSUE-NUMBER1
 Addresses #ISSUE-NUMBER2
 
 ### Description of changes: 
-Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving,
-explain why this change is necessary.
+Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.
 
 ### Call-outs:
 Point out areas that need special attention or support during the review process. Discuss architecture or design changes.
@@ -12,5 +11,4 @@ Point out areas that need special attention or support during the review process
 ### Testing:
 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
 
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
-the ISC license.
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.


### PR DESCRIPTION
### Description of changes: 

After: https://raw.githubusercontent.com/torben-hansen/aws-lc/68c4238166ccea9844e7c9720651b3d493ede7f1/.github/PULL_REQUEST_TEMPLATE.md
before: https://raw.githubusercontent.com/aws/aws-lc/main/.github/PULL_REQUEST_TEMPLATE.md

One appeared as below:

> Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, **trailing new-line**
explain why this change is necessary.


Another one appeared in the license text as this:

>By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and **trailing new-line**
the ISC license.

### Testing:

No code harmed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
