### PR TITLE
Add support for X509_get0_pubkey

### DIFF
--- a/crypto/x509/internal.h
+++ b/crypto/x509/internal.h
@@ -365,6 +365,11 @@ ASN1_TYPE *ASN1_generate_v3(const char *str, const X509V3_CTX *cnf);
 
 int X509_CERT_AUX_print(BIO *bp, X509_CERT_AUX *x, int indent);
 
+// X509_PUBKEY_get0 decodes the public key in |key| and returns an |EVP_PKEY|
+// on success, or NULL on error. It is similar to |X509_PUBKEY_get|, but it
+// directly returns the reference to |pkey| of |key|. This means that the
+// caller must not free the result after use.
+EVP_PKEY *X509_PUBKEY_get0(X509_PUBKEY *key);
 
 // RSA-PSS functions.
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -233,6 +233,13 @@ X509 *X509_find_by_subject(const STACK_OF(X509) *sk, X509_NAME *name) {
   return NULL;
 }
 
+EVP_PKEY *X509_get0_pubkey(const X509 *x) {
+    if ((x == NULL) || (x->cert_info == NULL)) {
+        return NULL;
+    }
+    return (X509_PUBKEY_get0(x->cert_info->key));
+}
+
 EVP_PKEY *X509_get_pubkey(X509 *x) {
   if ((x == NULL) || (x->cert_info == NULL)) {
     return NULL;

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -6173,3 +6173,20 @@ TEST(X509Test, SortRDN) {
       0x02, 0x41, 0x42};
   EXPECT_EQ(Bytes(kExpected), Bytes(der, der_len));
 }
+
+TEST(X509Test, TestDecode) {
+  bssl::UniquePtr<X509> cert(CertFromPEM(kExamplePSSCert));
+  ASSERT_TRUE(cert);
+
+  // |X509_get0_pubkey| directly returns a reference to the decoded |pkey|, so
+  // it can't be freed.
+  EVP_PKEY *pkey1 = X509_get0_pubkey(cert.get());
+  ASSERT_TRUE(pkey1);
+  ASSERT_TRUE(X509_verify(cert.get(), pkey1));
+
+  // |X509_get_pubkey| returns the decoded |pkey| with its reference count
+  // updated, so we must free it.
+  bssl::UniquePtr<EVP_PKEY> pkey2(X509_get_pubkey(cert.get()));
+  ASSERT_TRUE(pkey2);
+  ASSERT_TRUE(X509_verify(cert.get(), pkey2.get()));
+}

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -193,6 +193,13 @@ OPENSSL_EXPORT X509_NAME *X509_get_subject_name(const X509 *x509);
 // object.
 OPENSSL_EXPORT X509_PUBKEY *X509_get_X509_PUBKEY(const X509 *x509);
 
+// X509_get0_pubkey returns |x509|'s public key as an |EVP_PKEY|, or NULL if the
+// public key was unsupported or could not be decoded. It is similar to
+// |X509_get_pubkey|, but it does not increment the reference count of the
+// returned |EVP_PKEY|. This means that the caller must not free the result after
+// use.
+OPENSSL_EXPORT EVP_PKEY *X509_get0_pubkey(const X509 *x);
+
 // X509_get_pubkey returns |x509|'s public key as an |EVP_PKEY|, or NULL if the
 // public key was unsupported or could not be decoded. This function returns a
 // reference to the |EVP_PKEY|. The caller must release the result with


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1725`

### Description of changes: 
mySQL consumes the `X509_get0_pubkey` API when building with OpenSSL1.1.1/AWS-LC, and uses the `X509_get_pubkey` when built with OpenSSL1.0.2. `X509_get0_pubkey` seems to have been added in OpenSSL1.1.1 and is very similar to `X509_get_pubkey` (which exists in AWS-LC).

`X509_get_pubkey` attempts to decode the public key for certificate x. If successful it returns the public key as an `EVP_PKEY pointer` with its reference count incremented: this means the returned key must be freed up after use. `X509_get0_pubkey` is similar except it does not increment the reference count of the returned `EVP_PKEY` so it must not be freed up after use.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
