### PR TITLE
Check HWCAP_CPUID before reading MIDR_EL1 on aarch64

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -97,6 +97,7 @@ void OPENSSL_cpuid_setup(void) {
   static const unsigned long kSHA256 = 1 << 6;
   static const unsigned long kSHA512 = 1 << 21;
   static const unsigned long kSHA3 = 1 << 17;
+  static const unsigned long kCPUID = 1 << 11;
 
   uint64_t OPENSSL_arm_midr = 0;
 
@@ -127,11 +128,13 @@ void OPENSSL_cpuid_setup(void) {
     OPENSSL_armcap_P |= ARMV8_SHA3;
   }
 
-  // Check if the CPU model is Neoverse V1,
-  // which has a wide crypto/SIMD pipeline.
-  OPENSSL_arm_midr = armv8_cpuid_probe();
-  if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V1)) {
-    OPENSSL_armcap_P |= ARMV8_NEOVERSE_V1;
+  if (hwcap & kCPUID) {
+    // Check if the CPU model is Neoverse V1,
+    // which has a wide crypto/SIMD pipeline.
+    OPENSSL_arm_midr = armv8_cpuid_probe();
+    if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V1)) {
+      OPENSSL_armcap_P |= ARMV8_NEOVERSE_V1;
+    }
   }
 
   // OPENSSL_armcap is a 32-bit, unsigned value which may start with "0x" to


### PR DESCRIPTION
Valgrind does not support emulating the MIDR_EL1 aarch64 system register, and will crash if an attempt is made to read it.

The fix is to simply check HWCAP_CPUID before reading MIDR_EL1.

### Description of changes: 

On aarch64 AWS-LC will read from the [MIDR_EL1](https://developer.arm.com/documentation/ddi0601/2020-12/AArch64-Registers/MIDR-EL1--Main-ID-Register) system register without first checking [HWCAP](https://docs.kernel.org/arm64/elf_hwcaps.html) for the [HWCAP_CPUID](https://docs.kernel.org/arm64/elf_hwcaps.html#the-hwcaps-exposed-in-at-hwcap) flag.

Unfortunately Valgrind does not currently support emulating the `MIDR_EL1` register. As such it would crash when it attempts to read from it. If Valgrind ever adds support for that register this code won't need to be modified.

### Testing:

I ran unit tests as outlined in `BUILDING.md`.

```
mkdir -p build
cd build
rm -rf
cmake3 ..
make -j
cd ..
go run util/all_tests.go
cd ssl/test/runner
go test
cd ../../..
```

I also ran Valgrind on 3rd party code which has AWS-LC as a dependency and was previously failing because of this issue.

Before modifying AWS-LC I first created a minimal replicable test of this issue:

```
#include <iostream>
#include <cstdint>
#include <asm/hwcap.h>
#include <sys/auxv.h>

static uint64_t armv8_cpuid_probe() {
  uint64_t val;
  __asm__ volatile("mrs %0, MIDR_EL1" : "=r" (val));
  return val;
}

int main() {
  uint32_t hwcap = getauxval(AT_HWCAP);
  std::cout << "hwcap = " << hwcap << "\n";
  std::cout << "HWCAP_CPUID = " << HWCAP_CPUID << "\n";
  uint32_t has_cpu_id = hwcap & HWCAP_CPUID;
  std::cout << "hwcap & HWCAP_CPUID = " << has_cpu_id << "\n";
  if (has_cpu_id) {
    std::cout << "armv8_cpuid_probe = " << armv8_cpuid_probe() << "\n";
  }
  return 0;
}
```

When run normally it had the following output on my aarch64 machine:

```
hwcap = 269590527
HWCAP_CPUID = 2048
has_cpu_id = 2048
armv8_cpuid_probe = 1094701249
```

When run under Valgrind 3.20 it had the following output:

```
hwcap = 507
HWCAP_CPUID = 2048
has_cpu_id = 0
```

Without the if statement checking `has_cpu_id` Valgrind had with the following output:

```
hwcap = 507
HWCAP_CPUID = 2048
has_cpu_id = 0
ARM64 front end: branch_etc
disInstr(arm64): unhandled instruction 0xD5380000
disInstr(arm64): 1101'0101 0011'1000 0000'0000 0000'0000
==13175== valgrind: Unrecognised instruction at address 0x400968.
...
```