### PR TITLE
Unit test mode

### DIFF
--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -21,6 +21,26 @@
 #include "internal.h"
 
 
+struct test_st {
+  char test_mode;
+};
+static struct test_st test_state = { AWS_LC_TEST_MODE_NOT_ENABLED };
+
+int AWS_LC_TEST_get_test_mode(void) {
+  return test_state.test_mode;
+}
+
+void AWS_LC_TEST_ensure_test_mode_enabled(void) {
+  if (AWS_LC_TEST_get_test_mode() != AWS_LC_TEST_MODE_ENABLED) {
+    abort();
+  }
+}
+
+void AWS_LC_TEST_enable_test_mode(void) {
+  test_state.test_mode = AWS_LC_TEST_MODE_ENABLED;
+}
+
+
 OPENSSL_STATIC_ASSERT(sizeof(ossl_ssize_t) == sizeof(size_t),
               ossl_ssize_t_should_be_the_same_size_as_size_t)
 

--- a/crypto/fipsmodule/rand/fork_detect.c
+++ b/crypto/fipsmodule/rand/fork_detect.c
@@ -152,6 +152,7 @@ uint64_t CRYPTO_get_fork_generation(void) {
 }
 
 void CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing(void) {
+  AWS_LC_TEST_ensure_test_mode_enabled();
   *g_ignore_madv_wipeonfork_bss_get() = 1;
 }
 

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -34,6 +34,8 @@
 #include "fork_detect.h"
 #include "getrandom_fillin.h"
 
+#include "../../test/gtest_main.h"
+
 #if !defined(PTRACE_O_EXITKILL)
 #define PTRACE_O_EXITKILL (1 << 20)
 #endif
@@ -542,6 +544,7 @@ TEST(URandomTest, Test) {
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  bssl::SetupGoogleTest();
 
   if (getenv("BORINGSSL_IGNORE_MADV_WIPEONFORK")) {
     CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing();

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -118,6 +118,9 @@
 #include <assert.h>
 #include <string.h>
 
+#define AWS_LC_TEST_MODE_NOT_ENABLED 0
+#define AWS_LC_TEST_MODE_ENABLED 1
+
 #if defined(BORINGSSL_CONSTANT_TIME_VALIDATION)
 #include <valgrind/memcheck.h>
 #endif
@@ -155,6 +158,18 @@ OPENSSL_MSVC_PRAGMA(warning(pop))
 #if defined(__cplusplus)
 extern "C" {
 #endif
+
+// AWS_LC_TEST_get_test_mode returns the current test mode state.
+int AWS_LC_TEST_get_test_mode(void);
+
+// AWS_LC_TEST_ensure_test_mode_enabled verifies that test mode is enabled. If
+// test mode is not enabled, it aborts.
+void AWS_LC_TEST_ensure_test_mode_enabled(void);
+
+// AWS_LC_TEST_enable_test_mode is used to put libcrypto and libssl into
+// "test mode". Currently, this is only used to ensure that testing-only
+// functions are only called in test mode.
+OPENSSL_EXPORT void AWS_LC_TEST_enable_test_mode(void);
 
 #if (!defined(_MSC_VER) || defined(__clang__)) && defined(OPENSSL_64_BIT)
 #define BORINGSSL_HAS_UINT128

--- a/crypto/test/gtest_main.cc
+++ b/crypto/test/gtest_main.cc
@@ -28,6 +28,8 @@ int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   bssl::SetupGoogleTest();
 
+  AWS_LC_TEST_enable_test_mode();
+
   bool unwind_tests = true;
   for (int i = 1; i < argc; i++) {
 #if !defined(OPENSSL_WINDOWS)

--- a/crypto/test/gtest_main.cc
+++ b/crypto/test/gtest_main.cc
@@ -28,8 +28,6 @@ int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   bssl::SetupGoogleTest();
 
-  AWS_LC_TEST_enable_test_mode();
-
   bool unwind_tests = true;
   for (int i = 1; i < argc; i++) {
 #if !defined(OPENSSL_WINDOWS)

--- a/crypto/test/gtest_main.h
+++ b/crypto/test/gtest_main.h
@@ -55,6 +55,7 @@ class ErrorTestEventListener : public testing::EmptyTestEventListener {
 // testing::InitGoogleTest has been called and before RUN_ALL_TESTS.
 inline void SetupGoogleTest() {
   CRYPTO_library_init();
+  AWS_LC_TEST_enable_test_mode();
 
 #if defined(OPENSSL_WINDOWS)
   // Initialize Winsock.


### PR DESCRIPTION
### Description of changes: 

Adds a test mode that is entered when running unit tests. This will allow exported test-only functions to verify that it's only executed during testing.

In the future the test object `test_st` can be used to enable more granular tests e.g. test counting.

### Testing:

Verified behaviour of `CRYPTO_fork_detect_ignore_madv_wipeonfork_for_testing` through test fixture `ForkDetect.Test`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
