### PR TITLE
Add support for SSL_(read/peek/write)_ex

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -374,7 +374,7 @@ OPENSSL_EXPORT int SSL_read(SSL *ssl, void *buf, int num);
 
 // SSL_read_ex reads up to |num| bytes from |ssl| into |buf|. It is similar to
 // |SSL_read|, but instead of returning the number of bytes read, it returns
-// 1 on success or 0 for failure. The number bytes actually read is stored in
+// 1 on success or 0 for failure. The number of bytes actually read is stored in
 // |read_bytes|.
 //
 // This is only maintained for OpenSSL compatibility. Use |SSL_read| instead.
@@ -386,7 +386,7 @@ OPENSSL_EXPORT int SSL_peek(SSL *ssl, void *buf, int num);
 
 // SSL_peek_ex reads up to |num| bytes from |ssl| into |buf|. It is similar to
 // |SSL_peek|, but instead of returning the number of bytes read, it returns
-// 1 on success or 0 for failure. The number bytes actually read is stored in
+// 1 on success or 0 for failure. The number of bytes actually read is stored in
 // |read_bytes|.
 //
 // This is only maintained for OpenSSL compatibility. Use |SSL_peek| instead.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -372,8 +372,26 @@ OPENSSL_EXPORT int SSL_accept(SSL *ssl);
 // https://crbug.com/466303.
 OPENSSL_EXPORT int SSL_read(SSL *ssl, void *buf, int num);
 
+// SSL_read_ex reads up to |num| bytes from |ssl| into |buf|. It is similar to
+// |SSL_read|, but instead of returning the number of bytes read, it returns
+// 1 on success or 0 for failure. The number bytes actually read is stored in
+// |read_bytes|.
+//
+// This is only maintained for OpenSSL compatibility. Use |SSL_read| instead.
+OPENSSL_EXPORT int SSL_read_ex(SSL *ssl, void *buf, size_t num,
+                               size_t *read_bytes);
+
 // SSL_peek behaves like |SSL_read| but does not consume any bytes returned.
 OPENSSL_EXPORT int SSL_peek(SSL *ssl, void *buf, int num);
+
+// SSL_peek_ex reads up to |num| bytes from |ssl| into |buf|. It is similar to
+// |SSL_peek|, but instead of returning the number of bytes read, it returns
+// 1 on success or 0 for failure. The number bytes actually read is stored in
+// |read_bytes|.
+//
+// This is only maintained for OpenSSL compatibility. Use |SSL_peek| instead.
+OPENSSL_EXPORT int SSL_peek_ex(SSL *ssl, void *buf, size_t num,
+                               size_t *read_bytes);
 
 // SSL_pending returns the number of buffered, decrypted bytes available for
 // read in |ssl|. It does not read from the transport.
@@ -427,6 +445,15 @@ OPENSSL_EXPORT int SSL_has_pending(const SSL *ssl);
 // TODO(davidben): Ensure 0 is only returned on transport EOF.
 // https://crbug.com/466303.
 OPENSSL_EXPORT int SSL_write(SSL *ssl, const void *buf, int num);
+
+// SSL_write_ex writes up to |num| bytes from |buf| into |ssl|. It is similar to
+// |SSL_write|, but instead of returning the number of bytes written, it returns
+// 1 on success or 0 for failure. The number bytes actually written is stored in
+// |written|.
+//
+// This is only maintained for OpenSSL compatibility. Use |SSL_write| instead.
+OPENSSL_EXPORT int SSL_write_ex(SSL *s, const void *buf, size_t num,
+                                size_t *written);
 
 // SSL_KEY_UPDATE_REQUESTED indicates that the peer should reply to a KeyUpdate
 // message with its own, thus updating traffic secrets for both directions on

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1006,6 +1006,15 @@ static int ssl_read_impl(SSL *ssl) {
   return 1;
 }
 
+int SSL_read_ex(SSL *ssl, void *buf, size_t num, size_t *read_bytes) {
+  int ret = SSL_read(ssl, buf, (int)num);
+  if (ret <= 0) {
+    return 0;
+  }
+  *read_bytes = ret;
+  return 1;
+}
+
 int SSL_read(SSL *ssl, void *buf, int num) {
   int ret = SSL_peek(ssl, buf, num);
   if (ret <= 0) {
@@ -1038,6 +1047,15 @@ int SSL_peek(SSL *ssl, void *buf, int num) {
       std::min(ssl->s3->pending_app_data.size(), static_cast<size_t>(num));
   OPENSSL_memcpy(buf, ssl->s3->pending_app_data.data(), todo);
   return static_cast<int>(todo);
+}
+
+int SSL_peek_ex(SSL *ssl, void *buf, size_t num, size_t *read_bytes) {
+  int ret = SSL_peek(ssl, buf, (int)num);
+  if (ret <= 0) {
+    return 0;
+  }
+  *read_bytes = ret;
+  return 1;
 }
 
 int SSL_write(SSL *ssl, const void *buf, int num) {
@@ -1079,6 +1097,15 @@ int SSL_write(SSL *ssl, const void *buf, int num) {
                       static_cast<size_t>(num)));
   } while (needs_handshake);
   return ret <= 0 ? ret : static_cast<int>(bytes_written);
+}
+
+int SSL_write_ex(SSL *ssl, const void *buf, size_t num, size_t *written) {
+  int ret = SSL_write(ssl, buf, (int)num);
+  if (ret <= 0) {
+    return 0;
+  }
+  *written = ret;
+  return 1;
 }
 
 int SSL_key_update(SSL *ssl, int request_type) {

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -5564,9 +5564,9 @@ TEST_P(SSLVersionTest, SSLPendingEx) {
   EXPECT_EQ(0, SSL_has_pending(client_.get()));
 
   size_t buf_len;
-  ASSERT_TRUE(SSL_write_ex(server_.get(), "hello", 5, &buf_len));
+  ASSERT_EQ(1, SSL_write_ex(server_.get(), "hello", 5, &buf_len));
   ASSERT_EQ(buf_len, (size_t)5);
-  ASSERT_TRUE(SSL_write_ex(server_.get(), "world", 5, &buf_len));
+  ASSERT_EQ(1, SSL_write_ex(server_.get(), "world", 5, &buf_len));
   ASSERT_EQ(buf_len, (size_t)5);
 
   EXPECT_EQ(0, SSL_pending(client_.get()));


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1852`

### Description of changes: 
mySQL consumes the `SSL_(read/peek/write)_ex` family of APIs from OpenSSL1.1.1. These are similar to the existing `SSL_(read/peek/write)` APIs in AWS-LC, but have slightly different expected parameters and function signatures.
Since these have the same underlying operations, I just wrapped `SSL_*_ex` around it's respective `SSL_*` operation.

* More information can be found in OpenSSL's documentation here: https://www.openssl.org/docs/man1.1.1/man3/SSL_read_ex.html

### Call-outs:
N/A

### Testing:
I extended an existing test suite that was testing the `SSL_pending` and `SSL_(read/peek/write)`, and created one that used `SSL_(read/peek/write)_ex` instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
