### PR TITLE
add support for SSL_get_key_update_type and SSL_KEY_UPDATE_NONE

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -476,13 +476,12 @@ OPENSSL_EXPORT int SSL_write_ex(SSL *s, const void *buf, size_t num,
 // requires that |ssl| have completed a TLS >= 1.3 handshake. It returns one on
 // success or zero on error.
 //
-// If the updatetype parameter is set to |SSL_KEY_UPDATE_NOT_REQUESTED|, then
-// the sending keys for this connection will be updated and the peer will be
-// informed of the change.
-// If the updatetype parameter is set to |SSL_KEY_UPDATE_REQUESTED|, then the
-// sending keys for this connection will be updated and the peer will be
-// informed of the change along with a request for the peer to additionally
-// update its sending keys.
+// If |request_type| is set to |SSL_KEY_UPDATE_NOT_REQUESTED|, then the sending
+// keys for this connection will be updated and the peer will be informed of the
+// change.
+// If |request_type| is set to |SSL_KEY_UPDATE_REQUESTED|, then the sending keys
+// for this connection will be updated and the peer will be informed of the change
+// along with a request for the peer to additionally update its sending keys.
 // RFC: https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.3
 //
 // Note that this function does not _send_ the message itself. The next call to
@@ -494,7 +493,7 @@ OPENSSL_EXPORT int SSL_key_update(SSL *ssl, int request_type);
 // SSL_get_key_update_type returns the state of the pending key operation in
 // |ssl|. The type of pending key operation will be either
 // |SSL_KEY_UPDATE_REQUESTED| or |SSL_KEY_UPDATE_NOT_REQUESTED| if there is one,
-// and |SSL_KEY_UPDATE_NONE| if otherwise. This can be used to indicate whether
+// and |SSL_KEY_UPDATE_NONE| otherwise. This can be used to indicate whether
 // a key update operation has been scheduled but not yet performed.
 OPENSSL_EXPORT int SSL_get_key_update_type(const SSL *ssl);
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -464,16 +464,29 @@ OPENSSL_EXPORT int SSL_write_ex(SSL *s, const void *buf, size_t num,
 // it's own KeyUpdate message.
 #define SSL_KEY_UPDATE_NOT_REQUESTED 0
 
+// SSL_KEY_UPDATE_NONE should not be set by the user and is only used to
+// indicate that there is a pending key operation. OpenSSL indicates that -1 is
+// used, so that it will be an invalid value for the on-the-wire protocol.
+#define SSL_KEY_UPDATE_NONE -1
+
 // SSL_key_update queues a TLS 1.3 KeyUpdate message to be sent on |ssl|
-// if one is not already queued. The |request_type| argument must one of the
-// |SSL_KEY_UPDATE_*| values. This function requires that |ssl| have completed a
-// TLS >= 1.3 handshake. It returns one on success or zero on error.
+// if one is not already queued. The |request_type| argument must be either be
+// |SSL_KEY_UPDATE_REQUESTED| or |SSL_KEY_UPDATE_NOT_REQUESTED|. This function
+// requires that |ssl| have completed a TLS >= 1.3 handshake. It returns one on
+// success or zero on error.
 //
 // Note that this function does not _send_ the message itself. The next call to
 // |SSL_write| will cause the message to be sent. |SSL_write| may be called with
 // a zero length to flush a KeyUpdate message when no application data is
 // pending.
 OPENSSL_EXPORT int SSL_key_update(SSL *ssl, int request_type);
+
+// SSL_get_key_update_type returns the internal |key_update_pending| status of
+// |ssl| and can be used to indicate whether a key update operation has been
+// scheduled but not yet performed. It will be of the values
+// |SSL_KEY_UPDATE_REQUESTED| or |SSL_KEY_UPDATE_NOT_REQUESTED| if there is one,
+// and |SSL_KEY_UPDATE_NONE| if otherwise.
+OPENSSL_EXPORT int SSL_get_key_update_type(const SSL *ssl);
 
 // SSL_shutdown shuts down |ssl|. It runs in two stages. First, it sends
 // close_notify and returns zero or one on success or -1 on failure. Zero

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2719,6 +2719,12 @@ struct SSL3_STATE {
   // needs re-doing when in SSL_accept or SSL_connect
   int rwstate = SSL_ERROR_NONE;
 
+  // key_update_pending will be either |SSL_KEY_UPDATE_REQUESTED| or
+  // |SSL_KEY_UPDATE_NOT_REQUESTED| if we have a KeyUpdate acknowledgment
+  // outstanding. |SSL_KEY_UPDATE_NONE| indicates that no KeyUpdates
+  // acknowledgements are pending.
+  int key_update_pending = SSL_KEY_UPDATE_NONE;
+
   enum ssl_encryption_level_t read_level = ssl_encryption_initial;
   enum ssl_encryption_level_t write_level = ssl_encryption_initial;
 
@@ -2772,10 +2778,6 @@ struct SSL3_STATE {
   // channel_id_valid is true if, on the server, the client has negotiated a
   // Channel ID and the |channel_id| field is filled in.
   bool channel_id_valid : 1;
-
-  // key_update_pending is true if we have a KeyUpdate acknowledgment
-  // outstanding.
-  bool key_update_pending : 1;
 
   // early_data_accepted is true if early data was accepted by the server.
   bool early_data_accepted : 1;

--- a/ssl/s3_lib.cc
+++ b/ssl/s3_lib.cc
@@ -174,7 +174,6 @@ SSL3_STATE::SSL3_STATE()
       delegated_credential_used(false),
       send_connection_binding(false),
       channel_id_valid(false),
-      key_update_pending(false),
       early_data_accepted(false),
       alert_dispatch(false),
       renegotiate_pending(false),

--- a/ssl/s3_pkt.cc
+++ b/ssl/s3_pkt.cc
@@ -290,7 +290,7 @@ static int do_tls_write(SSL *ssl, size_t *out_bytes_written, uint8_t type,
 
   // Now that we've made progress on the connection, uncork KeyUpdate
   // acknowledgments.
-  ssl->s3->key_update_pending = false;
+  ssl->s3->key_update_pending = SSL_KEY_UPDATE_NONE;
 
   // Flush the write buffer.
   ret = ssl_write_buffer_flush(ssl);

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1131,7 +1131,7 @@ int SSL_key_update(SSL *ssl, int request_type) {
     return 0;
   }
 
-  if (!ssl->s3->key_update_pending &&
+  if (ssl->s3->key_update_pending == SSL_KEY_UPDATE_NONE &&
       !tls13_add_key_update(ssl, request_type)) {
     return 0;
   }
@@ -1750,6 +1750,10 @@ int SSL_check_private_key(const SSL *ssl) {
 
 long SSL_get_default_timeout(const SSL *ssl) {
   return SSL_DEFAULT_SESSION_TIMEOUT;
+}
+
+int SSL_get_key_update_type(const SSL *ssl) {
+  return ssl->s3->key_update_pending;
 }
 
 int SSL_renegotiate(SSL *ssl) {

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -6235,6 +6235,9 @@ TEST(SSLTest, SSLGetKeyUpdate) {
   ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx.get(),
                                      server_ctx.get()));
 
+  // Initial state should be |SSL_KEY_UPDATE_NONE|.
+  EXPECT_EQ(SSL_get_key_update_type(client.get()), SSL_KEY_UPDATE_NONE);
+
   // Test setting |SSL_key_update| with |SSL_KEY_UPDATE_REQUESTED|.
   EXPECT_TRUE(SSL_key_update(client.get(), SSL_KEY_UPDATE_REQUESTED));
   // |SSL_get_key_update_type| is used to determine whether a key update


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1851`

### Description of changes: 
mySQL consumes `SSL_get_key_update_type` along with `SSL_KEY_UPDATE_NONE` when building with OpenSSL1.1.1.  OpenSSL indicates that: 
> SSL_get_key_update_type() can be used to determine whether a key update operation has been scheduled but not yet performed. The type of the pending key update operation will be returned if there is one, or SSL_KEY_UPDATE_NONE otherwise.

AWS-LC does have existing related symbols (`SSL_key_update` and `SSL_KEY_UPDATE_(NOT_)REQUESTED`) and a `key_update_pending` boolean in the underlying SSL3 structure which may seem to be reusable in this case.
However, in OpenSSL, `SSL_get_key_update_type` has 3 possible values (`SSL_KEY_UPDATE_REQUESTED`, `SSL_KEY_UPDATE_NOT_REQUESTED`, `SSL_KEY_UPDATE_NONE`). We could return `SSL_KEY_UPDATE_NONE` when `key_update_pending` is false in AWS-LC, but we wouldn't be able to easily differentiate between `SSL_KEY_UPDATE_REQUESTED/NOT_REQUESTED` because both values are setting `key_pending` to true.
The way to work around this was to change `key_update_pending` into an `int`, so that it can maintain the 3 possible states that OpenSSL has.

* https://www.openssl.org/docs/man1.1.1/man3/SSL_get_key_update_type.html
* https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/include/openssl/ssl.h#L972-L977
* https://github.com/mysql/mysql-server/commit/98fa0818c8de42f8a26ba87b0f40f72ef75f6e57#diff-dec17245c4a9e498e6656bd12b5f8cb435bfba5a4dbc482913cbe03cc54ef324R195-R215

### Call-outs:
Above

### Testing:
New Unit Test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
