### PR TITLE
Only build acvp/modulewrapper with BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -843,6 +843,8 @@ if(BUILD_TESTING)
     set(MEM_TEST_EXEC mem_test)
     set(MEM_SET_TEST_EXEC mem_set_test)
   endif()
+
+  add_subdirectory(util/fipstools/acvp/modulewrapper)
 endif()
 
 add_subdirectory(crypto)
@@ -851,7 +853,6 @@ if(BUILD_LIBSSL)
   add_subdirectory(tool)
 endif()
 add_subdirectory(util/fipstools)
-add_subdirectory(util/fipstools/acvp/modulewrapper)
 
 if(FUZZ)
   if(LIBFUZZER_FROM_DEPS)

--- a/tests/ci/devicefarm_job.py
+++ b/tests/ci/devicefarm_job.py
@@ -20,7 +20,7 @@ config = {
     "poolArn": DEVICEFARM_DEVICE_POOL,
 }
 
-client = boto3.client('devicefarm')
+client = boto3.client('devicefarm', region_name=AWS_REGION)
 
 unique = config['namePrefix']
 aws_region = config['awsRegion']

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -11,6 +11,9 @@ fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 if [[ ("$(uname -s)" == 'Linux'*) && (("$(uname -p)" == 'x86_64'*) || ("$(uname -p)" == 'aarch64'*)) ]]; then
   echo "Testing AWS-LC static library in FIPS Release mode."
   fips_build_and_test -DCMAKE_BUILD_TYPE=Release
+
+  # These build parameters may be needed by our aws-lc-fips-sys Rust package
+  run_build -DFIPS=1 -DBUILD_LIBSSL=OFF -DBUILD_TESTING=OFF
 fi
 
 # The AL2 version of Clang does not have all of the required artifacts for address sanitizer, see P45594051

--- a/tests/ci/setup.py
+++ b/tests/ci/setup.py
@@ -29,10 +29,11 @@ setuptools.setup(
         # A formatter for Python code.
         "yapf==0.30.0",
         # Introduced by benchmark framework.
-        "boto3==1.18.11",
+        "boto3==1.26.126",
         # Introduced by Android Device Farm CI.
         "requests",
-        "arnparse==0.0.2"
+        "arnparse==0.0.2",
+        "urllib3==1.25.4"
     ],
 
     python_requires=">=3.6",

--- a/util/fipstools/CMakeLists.txt
+++ b/util/fipstools/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(../../include)
 
-if(FIPS)
+if(FIPS AND BUILD_TESTING)
   add_executable(
     test_fips
 


### PR DESCRIPTION
See PR for "main" branch: https://github.com/aws/aws-lc/pull/1012

### Issues:
N/A

### Description of changes: 
* Previously when building for FIPS with both `-DBUILD_LIBSSL=OFF` and `-DBUILD_TESTING=OFF`, CMake produces an error, and the subsequent build attempt fails.
```
> cmake "-DFIPS=1" "-DBUILD_LIBSSL=OFF" "-DBUILD_TESTING=OFF" ../aws-lc
...
-- Configuring done
CMake Error: Cannot determine link language for target "modulewrapper".
CMake Error: CMake can not determine linker language for target: modulewrapper
-- Generating done
-- Build files have been written to: /home/justsmth/repos/AWS-LC-BUILD
```
* Added a build using these flags to the CI.


### Call-outs:
N/A

### Testing:
Successfully built using these flags:
```
> cmake "-DFIPS=1" "-DBUILD_LIBSSL=OFF" "-DBUILD_TESTING=OFF" ../aws-lc
...
-- Found Threads: TRUE  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/justsmth/repos/AWS-LC-BUILD

> make
...
[ 99%] Built target crypto_objects
Scanning dependencies of target fipsmodule
[ 99%] Building C object crypto/fipsmodule/CMakeFiles/fipsmodule.dir/fips_shared_support.c.o
[100%] Building C object crypto/fipsmodule/CMakeFiles/fipsmodule.dir/cpucap/cpucap.c.o
[100%] Built target fipsmodule
Scanning dependencies of target crypto
[100%] Linking C static library libcrypto.a
[100%] Built target crypto

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
