### PR TITLE
Bump AWSLC_VERSION_NUMBER_STRING to 1.10.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4006,7 +4006,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.9.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.10.0");
 }
 
 #else
@@ -4049,6 +4049,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.9.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.10.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -216,7 +216,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.9.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.10.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Update minor release number. [Looking at the 72 commits since the v1.9.0 release](https://github.com/aws/aws-lc/compare/v1.9.0...main) there are new APIs/Functioanlity (e.g. Dilithium, s2n-bignum runtime check) but the changes are all backward compatible. 

### Testing:
Test pass locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
