### PR TITLE
Add AES CTR benchmark

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -458,7 +458,7 @@ static bool SpeedRSAKeyGen(bool is_fips, const std::string &selected) {
 
 static bool SpeedAESGenericChunk(const EVP_CIPHER *cipher, std::string name,
                              size_t chunk_byte_len, size_t ad_len, bool encrypt) {
-  int len;
+  int len, result;
   int* len_ptr = &len;
   const size_t key_len = EVP_CIPHER_key_length(cipher);
   static const unsigned kAlignment = 16;
@@ -496,8 +496,8 @@ static bool SpeedAESGenericChunk(const EVP_CIPHER *cipher, std::string name,
       ERR_print_errors_fp(stderr);
       return false;
     }
-    if (!TimeFunction(&encryptResults, [&ctx, chunk_byte_len, plaintext, ciphertext, len_ptr, tag, &nonce, &ad, ad_len, &isGCM]() -> bool {
-      int result =  EVP_EncryptInit_ex(ctx.get(), NULL, NULL, NULL, nonce.get());
+    if (!TimeFunction(&encryptResults, [&ctx, chunk_byte_len, plaintext, ciphertext, len_ptr, tag, &nonce, &ad, ad_len, &isGCM, &result]() -> bool {
+      result = EVP_EncryptInit_ex(ctx.get(), NULL, NULL, NULL, nonce.get());
       if (isGCM) {
         result &= EVP_EncryptUpdate(ctx.get(), NULL, len_ptr, ad.get(), ad_len);
       }
@@ -516,8 +516,8 @@ static bool SpeedAESGenericChunk(const EVP_CIPHER *cipher, std::string name,
     encryptResults.PrintWithBytes(encryptName, chunk_byte_len);
   }
   else {
-    int result =  EVP_EncryptInit_ex(ctx.get(), cipher, NULL, key.get(), nonce.get());
-    if(isGCM){
+    result =  EVP_EncryptInit_ex(ctx.get(), cipher, NULL, key.get(), nonce.get());
+    if (isGCM) {
       result &= EVP_EncryptUpdate(ctx.get(), NULL, len_ptr, ad.get(), ad_len);
     }
     result &= EVP_EncryptUpdate(ctx.get(), ciphertext, len_ptr, plaintext, chunk_byte_len);
@@ -539,8 +539,8 @@ static bool SpeedAESGenericChunk(const EVP_CIPHER *cipher, std::string name,
       ERR_print_errors_fp(stderr);
       return false;
     }
-    if (!TimeFunction(&decryptResults, [&ctx, chunk_byte_len, plaintext, ciphertext, len_ptr, tag, &nonce, &ad, ad_len, &isGCM]() -> bool {
-      int result = EVP_DecryptInit_ex(ctx.get(), NULL, NULL, NULL, nonce.get());
+    if (!TimeFunction(&decryptResults, [&ctx, chunk_byte_len, plaintext, ciphertext, len_ptr, tag, &nonce, &ad, ad_len, &isGCM, &result]() -> bool {
+      result = EVP_DecryptInit_ex(ctx.get(), NULL, NULL, NULL, nonce.get());
       if(isGCM) {
         result &= EVP_DecryptUpdate(ctx.get(), NULL, len_ptr, ad.get(), ad_len);
       }


### PR DESCRIPTION
### Description of changes: 
Refactor our EVP AES GCM benchmark to support both GCM and CTR mode benchmarking. 

### Call-outs:
In the AES CTR mode benchmark I do not increment the counter. I think this is a more fair comparison with the AES GCM benchmark because it also reuses the IV. In theory we could add a separate benchmark that just increments the counter, or just generates new GCM IVs.

### Testing:
On an m1 mac:
```
./tool/bssl speed -filter EVP-AES-128-GCM
Did 7354000 EVP-AES-128-GCM encrypt init operations in 1000010us (7353926.5 ops/sec)
Did 20196500 EVP-AES-128-GCM encrypt (16 bytes) operations in 1000001us (20196479.8 ops/sec): 323.1 MB/s
Did 12446000 EVP-AES-128-GCM encrypt (256 bytes) operations in 1000045us (12445440.0 ops/sec): 3186.0 MB/s
Did 4585500 EVP-AES-128-GCM encrypt (1350 bytes) operations in 1000025us (4585385.4 ops/sec): 6190.3 MB/s
Did 1010000 EVP-AES-128-GCM encrypt (8192 bytes) operations in 1000781us (1009211.8 ops/sec): 8267.5 MB/s
Did 518000 EVP-AES-128-GCM encrypt (16384 bytes) operations in 1000289us (517850.3 ops/sec): 8484.5 MB/s
Did 7509500 EVP-AES-128-GCM decrypt init operations in 1000016us (7509379.8 ops/sec)
Did 18962250 EVP-AES-128-GCM decrypt (16 bytes) operations in 1000013us (18962003.5 ops/sec): 303.4 MB/s
Did 11958250 EVP-AES-128-GCM decrypt (256 bytes) operations in 1000006us (11958178.3 ops/sec): 3061.3 MB/s
Did 4510500 EVP-AES-128-GCM decrypt (1350 bytes) operations in 1000037us (4510333.1 ops/sec): 6088.9 MB/s
Did 1010000 EVP-AES-128-GCM decrypt (8192 bytes) operations in 1000668us (1009325.8 ops/sec): 8268.4 MB/s
Did 520000 EVP-AES-128-GCM decrypt (16384 bytes) operations in 1000141us (519926.7 ops/sec): 8518.5 MB/s
./tool/bssl speed -filter EVP-AES-128-CTR
Did 14075750 EVP-AES-128-CTR encrypt init operations in 1000014us (14075552.9 ops/sec)
Did 28601250 EVP-AES-128-CTR encrypt (16 bytes) operations in 1000005us (28601107.0 ops/sec): 457.6 MB/s
Did 27356500 EVP-AES-128-CTR encrypt (256 bytes) operations in 1000004us (27356390.6 ops/sec): 7003.2 MB/s
Did 7686000 EVP-AES-128-CTR encrypt (1350 bytes) operations in 1000064us (7685508.1 ops/sec): 10375.4 MB/s
Did 1465000 EVP-AES-128-CTR encrypt (8192 bytes) operations in 1000442us (1464352.8 ops/sec): 11996.0 MB/s
Did 742000 EVP-AES-128-CTR encrypt (16384 bytes) operations in 1000856us (741365.4 ops/sec): 12146.5 MB/s
Did 13870750 EVP-AES-128-CTR decrypt init operations in 1000016us (13870528.1 ops/sec)
Did 26890000 EVP-AES-128-CTR decrypt (16 bytes) operations in 1000003us (26889919.3 ops/sec): 430.2 MB/s
Did 25867250 EVP-AES-128-CTR decrypt (256 bytes) operations in 1000009us (25867017.2 ops/sec): 6622.0 MB/s
Did 7615500 EVP-AES-128-CTR decrypt (1350 bytes) operations in 1000008us (7615439.1 ops/sec): 10280.8 MB/s
Did 1459750 EVP-AES-128-CTR decrypt (8192 bytes) operations in 1000111us (1459588.0 ops/sec): 11956.9 MB/s
Did 741000 EVP-AES-128-CTR decrypt (16384 bytes) operations in 1000875us (740352.2 ops/sec): 12129.9 MB/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
