### PR TITLE
Heap-allocate Dilithium keypair members

### DIFF
--- a/crypto/evp_extra/internal.h
+++ b/crypto/evp_extra/internal.h
@@ -4,6 +4,8 @@
 #include <openssl/base.h>
 #include "../fipsmodule/evp/internal.h"
 
+#include "../dilithium/sig_dilithium.h"
+
 typedef struct {
   // key is the concatenation of the private seed and public key. It is stored
   // as a single 64-bit array to allow passing to |ED25519_sign|. If
@@ -26,9 +28,8 @@ typedef struct {
 #ifdef ENABLE_DILITHIUM
 
 typedef struct {
-  uint8_t pub[1952];
-  uint8_t priv[4000];
-  char has_private;
+  uint8_t *pub;
+  uint8_t *priv;
 } DILITHIUM3_KEY;
 
 #endif


### PR DESCRIPTION
# Notes

Dilithium `EVP_PKEY` structs can have:

1. both public and private keys (from key generation)
1. only public key (from deserialization)
1. only private key (from deserialization)

Dilithium keys are also very large, so it's preferable to allocate these
keys on the heap as needed to save potentially unused stack space.


# Issues

Resolves V845897935

# Testing

- CI checks
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
