### PR TITLE
Ensure CodeBuild always has GOPROXY set via buildspec.

### DIFF
--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -43,6 +43,14 @@ $ docker build -t ubuntu-18.04:base -f tests/ci/docker_images/linux-x86/ubuntu-1
 For more examples, see `build_images.sh` script in directories corresponding
 to different platforms (linux-x86, linux-aarch, windows, rust).
 
+### Issues with proxy.golang.org when running images locally
+
+If you are having issues contacting `proxy.golang.org` try running the image
+with the `GOPROXY=direct`. For example:
+```bash
+docker run -e GOPROXY=direct -v `pwd`:`pwd` -w `pwd` -it ubuntu-20.04:clang-9x
+```
+
 ## Test locations
 
 ### Unit tests

--- a/tests/ci/codebuild/android/run_android_fips_shared.yml
+++ b/tests/ci/codebuild/android/run_android_fips_shared.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/android/run_android_fips_static.yml
+++ b/tests/ci/codebuild/android/run_android_fips_static.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/android/run_android_shared_debug.yml
+++ b/tests/ci/codebuild/android/run_android_shared_debug.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/android/run_android_shared_release.yml
+++ b/tests/ci/codebuild/android/run_android_shared_release.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/android/run_android_static_debug.yml
+++ b/tests/ci/codebuild/android/run_android_static_debug.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/android/run_android_static_release.yml
+++ b/tests/ci/codebuild/android/run_android_static_release.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/common/run_analytics.yml
+++ b/tests/ci/codebuild/common/run_analytics.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/common/run_ssl_runner_valgrind_tests.yml
+++ b/tests/ci/codebuild/common/run_ssl_runner_valgrind_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/common/run_valgrind_tests.yml
+++ b/tests/ci/codebuild/common/run_valgrind_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-aarch/docker-img-build.yml
+++ b/tests/ci/codebuild/linux-aarch/docker-img-build.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   install:
     commands:

--- a/tests/ci/codebuild/linux-aarch/run_fips_tests.yml
+++ b/tests/ci/codebuild/linux-aarch/run_fips_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-aarch/run_minimal_tests.yml
+++ b/tests/ci/codebuild/linux-aarch/run_minimal_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-aarch/run_posix_tests.yml
+++ b/tests/ci/codebuild/linux-aarch/run_posix_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-aarch/run_prefix_tests.yml
+++ b/tests/ci/codebuild/linux-aarch/run_prefix_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-aarch/run_sanitizer_tests.yml
+++ b/tests/ci/codebuild/linux-aarch/run_sanitizer_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-aarch/run_ssl_asan_tests.yml
+++ b/tests/ci/codebuild/linux-aarch/run_ssl_asan_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_intel-sde.yml
+++ b/tests/ci/codebuild/linux-x86/amazonlinux-2_gcc-7x_intel-sde.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/docker-img-build.yml
+++ b/tests/ci/codebuild/linux-x86/docker-img-build.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   install:
     commands:

--- a/tests/ci/codebuild/linux-x86/fedora-31_clang-9x.yml
+++ b/tests/ci/codebuild/linux-x86/fedora-31_clang-9x.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/install_shared_and_static.yml
+++ b/tests/ci/codebuild/linux-x86/install_shared_and_static.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/linux-x86/openssh_integration.yml
+++ b/tests/ci/codebuild/linux-x86/openssh_integration.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/linux-x86/postgres_integration.yml
+++ b/tests/ci/codebuild/linux-x86/postgres_integration.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   install:
     run-as: root

--- a/tests/ci/codebuild/linux-x86/pre-push.yml
+++ b/tests/ci/codebuild/linux-x86/pre-push.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_bm_build_test.yml
+++ b/tests/ci/codebuild/linux-x86/run_bm_build_test.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_bm_framework.yml
+++ b/tests/ci/codebuild/linux-x86/run_bm_framework.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_cryptofuzz.yml
+++ b/tests/ci/codebuild/linux-x86/run_cryptofuzz.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_fips_tests.yml
+++ b/tests/ci/codebuild/linux-x86/run_fips_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_fuzz_tests.yml
+++ b/tests/ci/codebuild/linux-x86/run_fuzz_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_legacy_build.yml
+++ b/tests/ci/codebuild/linux-x86/run_legacy_build.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_minimal_tests.yml
+++ b/tests/ci/codebuild/linux-x86/run_minimal_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_posix_tests.yml
+++ b/tests/ci/codebuild/linux-x86/run_posix_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_prefix_tests.yml
+++ b/tests/ci/codebuild/linux-x86/run_prefix_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/run_sanitizer_tests.yml
+++ b/tests/ci/codebuild/linux-x86/run_sanitizer_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/linux-x86/s2n_integration.yml
+++ b/tests/ci/codebuild/linux-x86/s2n_integration.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/linux-x86/ubuntu-20.04_clang-10x_formal-verification.yml
+++ b/tests/ci/codebuild/linux-x86/ubuntu-20.04_clang-10x_formal-verification.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   pre_build:
     commands:

--- a/tests/ci/codebuild/macos-aarch/run_m1_tests.yml
+++ b/tests/ci/codebuild/macos-aarch/run_m1_tests.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/windows-x86/windows-msvc2015.yml
+++ b/tests/ci/codebuild/windows-x86/windows-msvc2015.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/codebuild/windows-x86/windows-msvc2017.yml
+++ b/tests/ci/codebuild/windows-x86/windows-msvc2017.yml
@@ -3,6 +3,10 @@
 
 version: 0.2
 
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
 phases:
   build:
     commands:

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -1,9 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
-# If having trouble reaching proxy.golang.org, uncomment the following:
-#go env -w GOPROXY=direct
-
 if [ -v CODEBUILD_SRC_DIR ]; then
   SRC_ROOT="$CODEBUILD_SRC_DIR"
 else

--- a/tests/ci/docker_images/dependencies/install_common_dependencies.sh
+++ b/tests/ci/docker_images/dependencies/install_common_dependencies.sh
@@ -17,5 +17,4 @@ mv go/* "$GOROOT"
 rm $GO_ARCHIVE
 # Common Go configuration
 go env -w GO111MODULE=on
-go env -w GOPROXY=https://proxy.golang.org,direct
 go env -w GOFLAGS=-buildvcs=false

--- a/tests/ci/run_openssh_integration.sh
+++ b/tests/ci/run_openssh_integration.sh
@@ -44,7 +44,6 @@ pushd "${SCRATCH_FOLDER}"
 # Test helper functions.
 
 function aws_lc_build() {
-  export GOPROXY=direct
   ${CMAKE_COMMAND} "${AWS_LC_DIR}" -GNinja "-B${AWS_LC_BUILD_FOLDER}" "-DCMAKE_INSTALL_PREFIX=${AWS_LC_INSTALL_FOLDER}" "$@"
   ${NINJA_COMMAND} -C "${AWS_LC_BUILD_FOLDER}" install
   ls -R "${AWS_LC_INSTALL_FOLDER}"


### PR DESCRIPTION
### Description of changes: 
* Ensure GOPROXY is always set in codebuild containers via buildspec file. (AmazonLinux patches the Go compiler to use direct by default, so we want to force proxy usage here).
* Removed hard-coded values from bash scripts
* Add guidance to CI README.md for local docker usage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
