### PR TITLE
Support changing OPENSSL_armcap with environment variable on Apple 64-bit ARM systems

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -377,6 +377,7 @@ if(FIPS_DELOCATE)
 
     fips_shared_support.c
     cpucap/cpucap.c
+    cpucap/cpu_aarch64.c
   )
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
@@ -396,6 +397,7 @@ elseif(FIPS_SHARED)
 
     fips_shared_support.c
     cpucap/cpucap.c
+    cpucap/cpu_aarch64.c
   )
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -377,7 +377,6 @@ if(FIPS_DELOCATE)
 
     fips_shared_support.c
     cpucap/cpucap.c
-    cpucap/cpu_aarch64.c
   )
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 
@@ -397,7 +396,6 @@ elseif(FIPS_SHARED)
 
     fips_shared_support.c
     cpucap/cpucap.c
-    cpucap/cpu_aarch64.c
   )
   target_compile_definitions(fipsmodule PRIVATE BORINGSSL_IMPLEMENTATION)
 

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -71,6 +71,7 @@
 #include "cipher/e_aesccm.c"
 
 #include "cpucap/internal.h"
+#include "cpucap/cpu_aarch64.c"
 #include "cpucap/cpu_aarch64_apple.c"
 #include "cpucap/cpu_aarch64_freebsd.c"
 #include "cpucap/cpu_aarch64_fuchsia.c"

--- a/crypto/fipsmodule/cpucap/cpu_aarch64.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64.c
@@ -26,7 +26,8 @@ void handle_cpu_env(uint32_t *out, const char *in) {
 
   // Detect if the user is trying to use the environment variable to set
   // a capability that is _not_ available on the CPU:
-  // If the runtime capability check (e.g via getauxval() on Linux) returned a non-zero hwcap in `armcap` (out)
+  // If the runtime capability check (e.g via getauxval() on Linux)
+  // returned a non-zero hwcap in `armcap` (out)
   // and a bit set in the requested `v` is not set in `armcap`,
   // abort instead of crashing later.
   // The case of invert cannot enable an unexisting capability;

--- a/crypto/fipsmodule/cpucap/cpu_aarch64.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64.c
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+#if defined(OPENSSL_AARCH64) && !defined(OPENSSL_STATIC_ARMCAP)
+
 #include "cpu_aarch64.h"
 
 void handle_cpu_env(uint32_t *out, const char *in) {
@@ -45,3 +47,5 @@ void handle_cpu_env(uint32_t *out, const char *in) {
     out[0] = v;
   }
 }
+
+#endif // OPENSSL_AARCH64 && !OPENSSL_STATIC_ARMCAP

--- a/crypto/fipsmodule/cpucap/cpu_aarch64.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64.c
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include "cpu_aarch64.h"
+
+void handle_cpu_env(uint32_t *out, const char *in) {
+  const int invert = in[0] == '~';
+  const int or = in[0] == '|';
+  const int skip_first_byte = invert || or;
+  const int hex = in[skip_first_byte] == '0' && in[skip_first_byte+1] == 'x';
+  uint32_t armcap = out[0];
+
+  int sscanf_result;
+  uint32_t v;
+  if (hex) {
+    sscanf_result = sscanf(in + skip_first_byte + 2, "%" PRIx32, &v);
+  } else {
+    sscanf_result = sscanf(in + skip_first_byte, "%" PRIu32, &v);
+  }
+
+  if (!sscanf_result) {
+    return;
+  }
+
+  // Detect if the user is trying to use the environment variable to set
+  // a capability that is _not_ available on the CPU:
+  // If getauxval() returned a non-zero hwcap in `armcap` (out)
+  // and a bit set in the requested `v` is not set in `armcap`,
+  // abort instead of crashing later.
+  // The case of invert cannot enable an unexisting capability;
+  // it can only disable an existing one.
+  if (!invert && armcap && (~armcap & v))
+  {
+    fprintf(stderr,
+            "Fatal Error: HW capability found: 0x%02X, but HW capability requested: 0x%02X.\n",
+            armcap, v);
+    exit(1);
+  }
+
+  if (invert) {
+    out[0] &= ~v;
+  } else if (or) {
+    out[0] |= v;
+  } else {
+    out[0] = v;
+  }
+}

--- a/crypto/fipsmodule/cpucap/cpu_aarch64.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64.c
@@ -26,7 +26,7 @@ void handle_cpu_env(uint32_t *out, const char *in) {
 
   // Detect if the user is trying to use the environment variable to set
   // a capability that is _not_ available on the CPU:
-  // If getauxval() returned a non-zero hwcap in `armcap` (out)
+  // If the runtime capability check (e.g via getauxval() on Linux) returned a non-zero hwcap in `armcap` (out)
   // and a bit set in the requested `v` is not set in `armcap`,
   // abort instead of crashing later.
   // The case of invert cannot enable an unexisting capability;

--- a/crypto/fipsmodule/cpucap/cpu_aarch64.h
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64.h
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#ifndef OPENSSL_HEADER_CPUCAP_CPU_AARCH64_H
+#define OPENSSL_HEADER_CPUCAP_CPU_AARCH64_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <inttypes.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// cpu_aarch64 contains common functions used across multiple cpu_aarch64_* files
+
+// handle_cpu_env applies the value from |in| to the CPUID values in |out[0]|.
+// See the comment in |OPENSSL_cpuid_setup| about this.
+void handle_cpu_env(uint32_t *out, const char *in);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // OPENSSL_HEADER_CPUCAP_CPU_AARCH64_H

--- a/crypto/fipsmodule/cpucap/cpu_aarch64.h
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64.h
@@ -14,11 +14,15 @@ extern "C" {
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(OPENSSL_AARCH64) && !defined(OPENSSL_STATIC_ARMCAP)
+
 // cpu_aarch64 contains common functions used across multiple cpu_aarch64_* files
 
 // handle_cpu_env applies the value from |in| to the CPUID values in |out[0]|.
 // See the comment in |OPENSSL_cpuid_setup| about this.
 void handle_cpu_env(uint32_t *out, const char *in);
+
+#endif // OPENSSL_AARCH64 && !OPENSSL_STATIC_ARMCAP
 
 #if defined(__cplusplus)
 }

--- a/crypto/fipsmodule/cpucap/cpu_aarch64_apple.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_apple.c
@@ -13,7 +13,6 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 
 #include "internal.h"
-#include "cpu_aarch64.h"
 
 #if defined(OPENSSL_AARCH64) && defined(OPENSSL_APPLE) && \
     !defined(OPENSSL_STATIC_ARMCAP)
@@ -23,6 +22,7 @@
 
 #include <openssl/arm_arch.h>
 
+#include "cpu_aarch64.h"
 
 extern uint32_t OPENSSL_armcap_P;
 extern uint8_t OPENSSL_cpucap_initialized;

--- a/crypto/fipsmodule/cpucap/cpu_aarch64_apple.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_apple.c
@@ -67,6 +67,51 @@ static int is_brand(const char *in_str) {
   return 1;
 }
 
+// handle_cpu_env applies the value from |in| to the CPUID values in |out[0]|.
+// See the comment in |OPENSSL_cpuid_setup| about this.
+static void handle_cpu_env(uint32_t *out, const char *in) {
+  const int invert = in[0] == '~';
+  const int or = in[0] == '|';
+  const int skip_first_byte = invert || or;
+  const int hex = in[skip_first_byte] == '0' && in[skip_first_byte+1] == 'x';
+  uint32_t armcap = out[0];
+
+  int sscanf_result;
+  uint32_t v;
+  if (hex) {
+    sscanf_result = sscanf(in + skip_first_byte + 2, "%" PRIx32, &v);
+  } else {
+    sscanf_result = sscanf(in + skip_first_byte, "%" PRIu32, &v);
+  }
+
+  if (!sscanf_result) {
+    return;
+  }
+
+  // Detect if the user is trying to use the environment variable to set
+  // a capability that is _not_ available on the CPU:
+  // If getauxval() returned a non-zero hwcap in `armcap` (out)
+  // and a bit set in the requested `v` is not set in `armcap`,
+  // abort instead of crashing later.
+  // The case of invert cannot enable an unexisting capability;
+  // it can only disable an existing one.
+  if (!invert && armcap && (~armcap & v))
+  {
+    fprintf(stderr,
+            "Fatal Error: HW capability found: 0x%02X, but HW capability requested: 0x%02X.\n",
+            armcap, v);
+    exit(1);
+  }
+
+  if (invert) {
+    out[0] &= ~v;
+  } else if (or) {
+    out[0] |= v;
+  } else {
+    out[0] = v;
+  }
+}
+
 void OPENSSL_cpuid_setup(void) {
   // Apple ARM64 platforms have NEON and cryptography extensions available
   // statically, so we do not need to query them. In particular, there sometimes
@@ -96,6 +141,21 @@ void OPENSSL_cpuid_setup(void) {
 
   if (is_brand("Apple M1")) {
     OPENSSL_armcap_P |= ARMV8_APPLE_M1;
+  }
+
+  // OPENSSL_armcap is a 32-bit, unsigned value which may start with "0x" to
+  // indicate a hex value. Prior to the 32-bit value, a '~' or '|' may be given.
+  //
+  // If the '~' prefix is present:
+  //   the value is inverted and ANDed with the probed CPUID result
+  // If the '|' prefix is present:
+  //   the value is ORed with the probed CPUID result
+  // Otherwise:
+  //   the value is taken as the result of the CPUID
+  const char *env;
+  env = getenv("OPENSSL_armcap");
+  if (env != NULL) {
+    handle_cpu_env(&OPENSSL_armcap_P, env);
   }
 
   OPENSSL_cpucap_initialized = 1;

--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -13,7 +13,6 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 
 #include "internal.h"
-#include "cpu_aarch64.h"
 
 #if defined(OPENSSL_AARCH64) && defined(OPENSSL_LINUX) && \
     !defined(OPENSSL_STATIC_ARMCAP)
@@ -26,6 +25,7 @@
 
 #include <openssl/arm_arch.h>
 
+#include "cpu_aarch64.h"
 
 extern uint32_t OPENSSL_armcap_P;
 extern uint8_t OPENSSL_cpucap_initialized;

--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -13,6 +13,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 
 #include "internal.h"
+#include "cpu_aarch64.h"
 
 #if defined(OPENSSL_AARCH64) && defined(OPENSSL_LINUX) && \
     !defined(OPENSSL_STATIC_ARMCAP)
@@ -22,11 +23,6 @@
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
-#include <inttypes.h>
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include <openssl/arm_arch.h>
 
@@ -38,51 +34,6 @@ static uint64_t armv8_cpuid_probe(void) {
   uint64_t val;
   __asm__ volatile("mrs %0, MIDR_EL1" : "=r" (val));
   return val;
-}
-
-// handle_cpu_env applies the value from |in| to the CPUID values in |out[0]|.
-// See the comment in |OPENSSL_cpuid_setup| about this.
-static void handle_cpu_env(uint32_t *out, const char *in) {
-  const int invert = in[0] == '~';
-  const int or = in[0] == '|';
-  const int skip_first_byte = invert || or;
-  const int hex = in[skip_first_byte] == '0' && in[skip_first_byte+1] == 'x';
-  uint32_t armcap = out[0];
-
-  int sscanf_result;
-  uint32_t v;
-  if (hex) {
-    sscanf_result = sscanf(in + skip_first_byte + 2, "%" PRIx32, &v);
-  } else {
-    sscanf_result = sscanf(in + skip_first_byte, "%" PRIu32, &v);
-  }
-
-  if (!sscanf_result) {
-    return;
-  }
-
-  // Detect if the user is trying to use the environment variable to set
-  // a capability that is _not_ available on the CPU:
-  // If getauxval() returned a non-zero hwcap in `armcap` (out)
-  // and a bit set in the requested `v` is not set in `armcap`,
-  // abort instead of crashing later.
-  // The case of invert cannot enable an unexisting capability;
-  // it can only disable an existing one.
-  if (!invert && armcap && (~armcap & v))
-  {
-    fprintf(stderr,
-            "Fatal Error: HW capability found: 0x%02X, but HW capability requested: 0x%02X.\n",
-            armcap, v);
-    exit(1);
-  }
-
-  if (invert) {
-    out[0] &= ~v;
-  } else if (or) {
-    out[0] |= v;
-  } else {
-    out[0] = v;
-  }
 }
 
 void OPENSSL_cpuid_setup(void) {

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -167,33 +167,15 @@ extern uint32_t OPENSSL_armcap_P;
 // |CRYPTO_is_ARMv8_AES_capable| and |CRYPTO_is_ARMv8_PMULL_capable|
 // for checking the support for AES and PMULL instructions, respectively.
 OPENSSL_INLINE int CRYPTO_is_NEON_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP_NEON)
-  return 1;
-#elif defined(OPENSSL_STATIC_ARMCAP)
-  return 0;
-#else
   return (OPENSSL_armcap_P & ARMV7_NEON) != 0;
-#endif
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_AES_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP_AES)
-  return 1;
-#elif defined(OPENSSL_STATIC_ARMCAP)
-  return 0;
-#else
   return (OPENSSL_armcap_P & ARMV8_AES) != 0;
-#endif
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_PMULL_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP_PMULL)
-  return 1;
-#elif defined(OPENSSL_STATIC_ARMCAP)
-  return 0;
-#else
   return (OPENSSL_armcap_P & ARMV8_PMULL) != 0;
-#endif
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_GCM_8x_capable(void) {

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -179,22 +179,14 @@ OPENSSL_INLINE int CRYPTO_is_ARMv8_PMULL_capable(void) {
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_GCM_8x_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP)
-  return 0;
-#else
   return ((OPENSSL_armcap_P & ARMV8_SHA3) != 0 &&
           ((OPENSSL_armcap_P & ARMV8_NEOVERSE_V1) != 0 ||
            (OPENSSL_armcap_P & ARMV8_APPLE_M1) != 0));
-#endif
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_wide_multiplier_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP)
-  return 0;
-#else
   return (OPENSSL_armcap_P & ARMV8_NEOVERSE_V1) != 0 ||
            (OPENSSL_armcap_P & ARMV8_APPLE_M1) != 0;
-#endif
 }
 
 #endif  // OPENSSL_ARM || OPENSSL_AARCH64

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -167,7 +167,7 @@ extern uint32_t OPENSSL_armcap_P;
 // |CRYPTO_is_ARMv8_AES_capable| and |CRYPTO_is_ARMv8_PMULL_capable|
 // for checking the support for AES and PMULL instructions, respectively.
 OPENSSL_INLINE int CRYPTO_is_NEON_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP_NEON) || defined(__ARM_NEON)
+#if defined(OPENSSL_STATIC_ARMCAP_NEON)
   return 1;
 #elif defined(OPENSSL_STATIC_ARMCAP)
   return 0;
@@ -177,7 +177,7 @@ OPENSSL_INLINE int CRYPTO_is_NEON_capable(void) {
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_AES_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP_AES) || defined(__ARM_FEATURE_AES)
+#if defined(OPENSSL_STATIC_ARMCAP_AES)
   return 1;
 #elif defined(OPENSSL_STATIC_ARMCAP)
   return 0;
@@ -187,7 +187,7 @@ OPENSSL_INLINE int CRYPTO_is_ARMv8_AES_capable(void) {
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_PMULL_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP_PMULL) || defined(__ARM_FEATURE_AES)
+#if defined(OPENSSL_STATIC_ARMCAP_PMULL)
   return 1;
 #elif defined(OPENSSL_STATIC_ARMCAP)
   return 0;


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-1873

### Description of changes: 
AWS-LC currently uses a static ARM capabilities variable for 64 bit ARM Apple devices, as we know that certain hardware features are always present on them. This change gives Apple ARM users an option to define at runtime the CPU capabilities through an environment variable to determine whether to run the hardware vs. non-hardware implementation of an algorithm is used.

### Call-outs:
Refactored `handle_cpu_env()` function in `cpu_aarch64_linux.c` to a general `cpu_aarch64.c` file to avoid duplicating the code in `cpu_aarch64_apple.c`. Modified CMakeFIle accordingly.

### Testing:
Tests pass locally, confirmed that non-hardware APIs are used when `OPENSSL_armcap=0:0` and that the correct hardware APIs are used when it is left unset. Behavior for testing this already exists in `all_tests.json`, used by `all_tests.go`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
