### PR TITLE
Fix aesni-xts-avx512 to support Perl v5.8.8

### DIFF
--- a/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
+++ b/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
@@ -3057,8 +3057,8 @@ ___
 sub evex_byte1 {
   my ($mm, $src1, $dst) = @_;
   # set default to zero
-  $src1 //= 0;
-  $dst //= 0;
+  $src1 = 0 if (!defined($src1));
+  $dst = 0 if (!defined($dst));
 
   my $byte = 0xf0 | $mm;
 


### PR DESCRIPTION
Fixes a build failure seen on the `quay.io/pypa/manylinux1_x86_64` container image as reported by the AWS Common Runtime team.

```
[  2%] Generating aesni-xts-avx512.S
Can't modify division (/) in division (/) at /root/aws-c-auth/build/deps/aws-lc/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl line 3061, near "0;"
  (Might be a runaway multi-line // string starting on line 3060)
Execution of /root/aws-c-auth/build/deps/aws-lc/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl aborted due to compilation errors.
gmake[2]: *** [crypto/fipsmodule/aesni-xts-avx512.S] Error 255
gmake[1]: *** [crypto/fipsmodule/CMakeFiles/fipsmodule.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[  2%] Generating cipher_extra/chacha20_poly1305_x86_64.S
[  3%] Generating cipher_extra/aes128gcmsiv-x86_64.S
[  3%] Generating cipher_extra/aesni-sha1-x86_64.S
[  3%] Generating cipher_extra/aesni-sha256-x86_64.S
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
