### PR TITLE
Change the Jitter entropy recovery mechanism

### DIFF
--- a/crypto/fipsmodule/rand/cpu_jitter_test.cc
+++ b/crypto/fipsmodule/rand/cpu_jitter_test.cc
@@ -57,6 +57,12 @@ TEST(CPUJitterEntropyTest, Basic) {
   EXPECT_NE(jitter_ec.instance, nullptr);
   EXPECT_EQ(jitter_ec.instance->osr, osr);
 
+  // Test drawing entropy from the Jitter object that was reset.
+  EXPECT_EQ(jent_read_entropy(jitter_ec.instance,
+                              (char*) data0, data_len), data_len);
+  EXPECT_EQ(jent_read_entropy_safe(&jitter_ec.instance,
+                                   (char*) data1, data_len), data_len);
+
   // Verify that the Jitter library version is v3.4.0.
   unsigned int jitter_version = 3040000;
   EXPECT_EQ(jitter_version, jent_version());

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -129,6 +129,10 @@ OPENSSL_INLINE int have_fast_rdrand(void) {
 #define MAX_BACKOFF_RETRIES 9
 OPENSSL_EXPORT void HAZMAT_set_urandom_test_mode_for_testing(void);
 
+#if defined(BORINGSSL_FIPS)
+#define JITTER_MAX_NUM_TRIES (3)
+#endif
+
 #if defined(__cplusplus)
 }  // extern C
 #endif

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -238,6 +238,13 @@ static void CRYPTO_get_fips_seed(uint8_t *out_entropy, size_t out_entropy_len,
                           out_entropy_len) == (ssize_t) out_entropy_len) {
         break;
     }
+    // If Jitter entropy failed to produce entropy we need to reset it.
+    jent_entropy_collector_free(state->jitter_ec);
+    state->jitter_ec = NULL;
+    jent_entropy_collector_alloc(0, JENT_FORCE_FIPS);
+    if (state->jitter_ec == NULL) {
+      abort();
+    }
   }
 
   if (num_tries == max_num_tries) {

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -240,7 +240,7 @@ static void CRYPTO_get_fips_seed(uint8_t *out_entropy, size_t out_entropy_len,
     // If Jitter entropy failed to produce entropy we need to reset it.
     jent_entropy_collector_free(state->jitter_ec);
     state->jitter_ec = NULL;
-    jent_entropy_collector_alloc(0, JENT_FORCE_FIPS);
+    state->jitter_ec = jent_entropy_collector_alloc(0, JENT_FORCE_FIPS);
     if (state->jitter_ec == NULL) {
       abort();
     }

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -230,8 +230,7 @@ static void CRYPTO_get_fips_seed(uint8_t *out_entropy, size_t out_entropy_len,
   // |jent_read_entropy| has a false positive health test failure rate of 2^-22.
   // To avoid aborting so frequently, we retry 3 times.
   size_t num_tries;
-  const size_t max_num_tries = 3;
-  for (num_tries = 0; num_tries < max_num_tries; num_tries++) {
+  for (num_tries = 1; num_tries <= JITTER_MAX_NUM_TRIES; num_tries++) {
     // Try to generate the required number of bytes with Jitter.
     // If successful break out from the loop, otherwise try again.
     if (jent_read_entropy(state->jitter_ec, (char *) out_entropy,
@@ -247,7 +246,7 @@ static void CRYPTO_get_fips_seed(uint8_t *out_entropy, size_t out_entropy_len,
     }
   }
 
-  if (num_tries == max_num_tries) {
+  if (num_tries > JITTER_MAX_NUM_TRIES) {
     abort();
   }
 


### PR DESCRIPTION
Previously, we were calling the |jent_entropy_read_safe| Jitter function to get entropy. This function has a built-in recover mechanism where if the source fails to produce entropy then the function changes some parameters and tries again. Due to FIPS rules, this is not possible any more. We change the call to |jent_entropy_read| instead and handle the potential failure in the AWS-LC part of the module by retrying three times (note that in this case the same entropy source parameters do not change).

### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
