### PR TITLE
Add -Wmissing-braces to C++ build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,11 @@ if(GCC OR CLANG)
     # and declare that the code is trying to free a stack pointer. GCC 4.1.3 and lower
     # doesn't support this flag and can't use it.
     set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wno-free-nonheap-object")
+    # GCC (from at least 4.8) does not include -Wmissing-braces in -Wall due to Bug 25137.
+    # This warning is turned on everywhere internally however, so we have to define it here
+    # to check that our changes don't break the build.
+    # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25137
+    set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wmissing-braces")
   endif()
 
   # -Wstring-concatenation was added in Clang 12.0.0, which corresponds to

--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -1434,26 +1434,19 @@ TEST(OCSPTest, CertIDDup) {
 
 TEST(OCSPTest, OCSPResponsePrint) {
   static const std::array<std::string, 19> kExpected{
-      "OCSP Response Data:",
-      "    OCSP Response Status: successful (0x0)",
-      "    Response Type: Basic OCSP Response",
-      "    Version: 1 (0x0)",
-      "    Responder Id: C = US, ST = WA, O = s2n, OU = s2n Test OCSP, CN = "
-      "ocsp.s2ntest.com",
-      "    Produced At: May 26 00:23:34 2021 GMT",
-      "    Responses:",
-      "    Certificate ID:",
-      "      Hash Algorithm: sha1",
-      "      Issuer Name Hash: DE7932B3217E48FB4E47AE0B9007A55376AE44CA",
-      "      Issuer Key Hash: 12DF817571CA92D3CE1B2C2B773B9E3377F3F76F",
-      "      Serial Number: 7778",
-      "    Cert Status: good",
-      "    This Update: May 26 00:23:34 2021 GMT",
-      "    Next Update: May 24 00:23:34 2031 GMT",
-      "",
-      "    Response Extensions:",
-      "        OCSP Nonce: ",
-      "            0410AFABD4EC6A172C4A98FB1A6D22FF2928"};
+      {"OCSP Response Data:", "    OCSP Response Status: successful (0x0)",
+       "    Response Type: Basic OCSP Response", "    Version: 1 (0x0)",
+       "    Responder Id: C = US, ST = WA, O = s2n, OU = s2n Test OCSP, CN = "
+       "ocsp.s2ntest.com",
+       "    Produced At: May 26 00:23:34 2021 GMT",
+       "    Responses:", "    Certificate ID:", "      Hash Algorithm: sha1",
+       "      Issuer Name Hash: DE7932B3217E48FB4E47AE0B9007A55376AE44CA",
+       "      Issuer Key Hash: 12DF817571CA92D3CE1B2C2B773B9E3377F3F76F",
+       "      Serial Number: 7778", "    Cert Status: good",
+       "    This Update: May 26 00:23:34 2021 GMT",
+       "    Next Update: May 24 00:23:34 2031 GMT", "",
+       "    Response Extensions:", "        OCSP Nonce: ",
+       "            0410AFABD4EC6A172C4A98FB1A6D22FF2928"}};
 
   std::string respData = GetTestData(
       std::string("crypto/ocsp/test/aws/ocsp_response.der").c_str());
@@ -1479,17 +1472,13 @@ TEST(OCSPTest, OCSPResponsePrint) {
 
 TEST(OCSPTest, OCSPRequestPrint) {
   static const std::array<std::string, 11> kExpected{
-      "OCSP Request Data:",
-      "    Version: 1 (0x0)",
-      "    Requestor List:",
-      "        Certificate ID:",
-      "          Hash Algorithm: sha1",
-      "          Issuer Name Hash: DE7932B3217E48FB4E47AE0B9007A55376AE44CA",
-      "          Issuer Key Hash: 12DF817571CA92D3CE1B2C2B773B9E3377F3F76F",
-      "          Serial Number: 7778",
-      "    Request Extensions:",
-      "        OCSP Nonce: ",
-      "            0410303F128CD824A2B465F4C846882B3E1F"};
+      {"OCSP Request Data:", "    Version: 1 (0x0)", "    Requestor List:",
+       "        Certificate ID:", "          Hash Algorithm: sha1",
+       "          Issuer Name Hash: DE7932B3217E48FB4E47AE0B9007A55376AE44CA",
+       "          Issuer Key Hash: 12DF817571CA92D3CE1B2C2B773B9E3377F3F76F",
+       "          Serial Number: 7778",
+       "    Request Extensions:", "        OCSP Nonce: ",
+       "            0410303F128CD824A2B465F4C846882B3E1F"}};
 
   std::string data =
       GetTestData(std::string("crypto/ocsp/test/aws/ocsp_request.der").c_str());


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
This broke the build during our internal import. I root caused it and discovered it was due to an ancient GCC bug.
I've documented it and we should add it to our build to prevent further import failures.

### Call-outs:
N/A

### Testing:
Turning on the warnings without the test tweak fails the build.
Change also tested in internal build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
