### PR TITLE
Reapply "Remove support for "old-style" X509V3_EXT_METHODs"

### DIFF
--- a/crypto/x509v3/v3_lib.c
+++ b/crypto/x509v3/v3_lib.c
@@ -57,6 +57,7 @@
  */
 /* X509 v3 extension utilities */
 
+#include <assert.h>
 #include <stdio.h>
 
 #include <openssl/conf.h>
@@ -76,6 +77,9 @@ static int ext_stack_cmp(const X509V3_EXT_METHOD *const *a,
 }
 
 int X509V3_EXT_add(X509V3_EXT_METHOD *ext) {
+  // We only support |ASN1_ITEM|-based extensions.
+  assert(ext->it != NULL);
+
   // TODO(davidben): This should be locked. Also check for duplicates.
   if (!ext_list && !(ext_list = sk_X509V3_EXT_METHOD_new(ext_stack_cmp))) {
     return 0;
@@ -132,15 +136,7 @@ int X509V3_EXT_free(int nid, void *ext_data) {
     return 0;
   }
 
-  if (ext_method->it != NULL) {
-    ASN1_item_free(ext_data, ASN1_ITEM_ptr(ext_method->it));
-  } else if (ext_method->ext_free != NULL) {
-    ext_method->ext_free(ext_data);
-  } else {
-    OPENSSL_PUT_ERROR(X509V3, X509V3_R_CANNOT_FIND_FREE_FUNCTION);
-    return 0;
-  }
-
+  ASN1_item_free(ext_data, ASN1_ITEM_ptr(ext_method->it));
   return 1;
 }
 
@@ -180,23 +176,14 @@ void *X509V3_EXT_d2i(const X509_EXTENSION *ext) {
     return NULL;
   }
   p = ext->value->data;
-  void *ret;
-  if (method->it) {
-    ret =
-        ASN1_item_d2i(NULL, &p, ext->value->length, ASN1_ITEM_ptr(method->it));
-  } else {
-    ret = method->d2i(NULL, &p, ext->value->length);
-  }
+  void *ret =
+      ASN1_item_d2i(NULL, &p, ext->value->length, ASN1_ITEM_ptr(method->it));
   if (ret == NULL) {
     return NULL;
   }
   // Check for trailing data.
   if (p != ext->value->data + ext->value->length) {
-    if (method->it) {
-      ASN1_item_free(ret, ASN1_ITEM_ptr(method->it));
-    } else {
-      method->ext_free(ret);
-    }
+    ASN1_item_free(ret, ASN1_ITEM_ptr(method->it));
     OPENSSL_PUT_ERROR(X509V3, X509V3_R_TRAILING_DATA_IN_EXTENSION);
     return NULL;
   }

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -104,9 +104,13 @@ typedef void *(*X509V3_EXT_R2I)(const X509V3_EXT_METHOD *method,
 struct v3_ext_method {
   int ext_nid;
   int ext_flags;
-  // If this is set the following four fields are ignored
+
+  // it determines how values of this extension are allocated, released, parsed,
+  // and marshalled. This must be non-NULL.
   ASN1_ITEM_EXP *it;
-  // Old style ASN1 calls
+
+  // The following functions are ignored in favor of |it|. They are retained in
+  // the struct only for source compatibility with existing struct definitions.
   X509V3_EXT_NEW ext_new;
   X509V3_EXT_FREE ext_free;
   X509V3_EXT_D2I d2i;
@@ -662,8 +666,55 @@ OPENSSL_EXPORT ASN1_INTEGER *s2i_ASN1_INTEGER(const X509V3_EXT_METHOD *meth,
                                               const char *value);
 OPENSSL_EXPORT char *i2s_ASN1_ENUMERATED(const X509V3_EXT_METHOD *meth,
                                          const ASN1_ENUMERATED *aint);
+
+// X509V3_EXT_add registers |ext| as a custom extension for the extension type
+// |ext->ext_nid|. |ext| must be valid for the remainder of the address space's
+// lifetime. It returns one on success and zero on error.
+//
+// WARNING: This function modifies global state. If other code in the same
+// address space also registers an extension with type |ext->ext_nid|, the two
+// registrations will conflict. Which registration takes effect is undefined. If
+// the two registrations use incompatible in-memory representations, code
+// expecting the other registration will then cast a type to the wrong type,
+// resulting in a potentially exploitable memory error. This conflict can also
+// occur if BoringSSL later adds support for |ext->ext_nid|, with a different
+// in-memory representation than the one expected by |ext|.
+//
+// This function, additionally, is not thread-safe and cannot be called
+// concurrently with any other BoringSSL function.
+//
+// As a result, it is impossible to safely use this function. Registering a
+// custom extension has no impact on certificate verification so, instead,
+// callers should simply handle the custom extension with the byte-based
+// |X509_EXTENSION| APIs directly. Registering |ext| with the library has little
+// practical value.
 OPENSSL_EXPORT int X509V3_EXT_add(X509V3_EXT_METHOD *ext);
+
+// X509V3_EXT_add_list calls |X509V3_EXT_add| on |&extlist[0]|, |&extlist[1]|,
+// and so on, until some |extlist[i]->ext_nid| is -1. It returns one on success
+// and zero on error.
+//
+// WARNING: Do not use this function. See |X509V3_EXT_add|.
+OPENSSL_EXPORT int X509V3_EXT_add_list(X509V3_EXT_METHOD *extlist);
+
+// X509V3_EXT_add_alias registers a custom extension with NID |nid_to|. The
+// corresponding ASN.1 type is copied from |nid_from|. It returns one on success
+// and zero on error.
+//
+// WARNING: Do not use this function. See |X509V3_EXT_add|.
 OPENSSL_EXPORT int X509V3_EXT_add_alias(int nid_to, int nid_from);
+
+// X509V3_EXT_cleanup removes all custom extensions registered with
+// |X509V3_EXT_add*|.
+//
+// WARNING: This function modifies global state and will impact custom
+// extensions registered by any code in the same address space. It,
+// additionally, is not thread-safe and cannot be called concurrently with any
+// other BoringSSL function.
+//
+// Instead of calling this function, allow memory from custom extensions to be
+// released on process exit, along with other global program state.
+OPENSSL_EXPORT void X509V3_EXT_cleanup(void);
 
 OPENSSL_EXPORT const X509V3_EXT_METHOD *X509V3_EXT_get(
     const X509_EXTENSION *ext);

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -111,6 +111,13 @@ struct v3_ext_method {
 
   // The following functions are ignored in favor of |it|. They are retained in
   // the struct only for source compatibility with existing struct definitions.
+  //
+  // Only OCSP nonce extensions currently rely on these functions with AWS-LC.
+  // This is to maintain backwards compatibility with how OCSP nonce extensions
+  // are handled in OpenSSL. This can't be easily removed because OpenSSL
+  // considers the OCSP nonce to be "special".
+  // |X509V3_EXT_add| enforces |it| to be non-NULL, so external users are not
+  // allowed to use the following functions.
   X509V3_EXT_NEW ext_new;
   X509V3_EXT_FREE ext_free;
   X509V3_EXT_D2I d2i;


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1906`

### Description of changes: 
This reapplies the commit that was reverted in https://github.com/aws/aws-lc/pull/1054. OCSP nonce extensions can't migrate directly to the "new-style" X509V3_EXT_METHODs, so there's still some code we have to keep around.
On the bright side, we can still enforce the new `ext->it` non-NULL requirement in `X509V3_EXT_add`  for external users. Not all of the code is used for OCSP nonce extensions, so I've kept most of the optimizations from the BoringSSL commit. Only the code necessary for OCSP is left.

### Call-outs:
Only the code in `crypto/x509v3/v3_conf.c` and `crypto/x509v3/v3_prn.c` was reverted back to the "old-style". 
Observable in this commit: https://github.com/aws/aws-lc/commit/3c1f8ade0df8cb5556480441919a455a807bb6e5

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
