### PR TITLE
Add OSSL_HANDSHAKE_STATE enum for OpenSSL compatability

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -4508,9 +4508,10 @@ OPENSSL_EXPORT int SSL_was_key_usage_invalid(const SSL *ssl);
 #define SSL_ST_RENEGOTIATE (0x04 | SSL_ST_INIT)
 #define SSL_ST_BEFORE (0x05 | SSL_ST_INIT)
 
-// TLS_ST_* are aliases for |SSL_ST_*| for OpenSSL 1.1.0 compatibility.
-#define TLS_ST_OK SSL_ST_OK
-#define TLS_ST_BEFORE SSL_ST_BEFORE
+// OSSL_HANDSHAKE_STATE enumerates possible TLS states returned from
+// |SSL_get_state| and |SSL_state|. TLS_ST_* are aliases for |SSL_ST_*| for
+// OpenSSL 1.1.0 compatibility.
+typedef enum {TLS_ST_OK = SSL_ST_OK, TLS_ST_BEFORE = SSL_ST_INIT} OSSL_HANDSHAKE_STATE;
 
 // SSL_CB_* are possible values for the |type| parameter in the info
 // callback and the bitmasks that make them up.

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -4653,6 +4653,17 @@ TEST_P(SSLVersionTest, GetServerName) {
                SSL_get_servername(server_.get(), TLSEXT_NAMETYPE_host_name));
 }
 
+TEST_P(SSLVersionTest, GetState) {
+  ClientConfig config;
+  ASSERT_TRUE(Connect(config));
+  int server_state = SSL_get_state(server_.get());
+  EXPECT_EQ(server_state, TLS_ST_OK);
+  EXPECT_EQ(server_state, SSL_ST_OK);
+  int client_state = SSL_state(client_.get());
+  EXPECT_EQ(client_state, TLS_ST_OK);
+  EXPECT_EQ(client_state, SSL_ST_OK);
+}
+
 // Test that session cache mode bits are honored in the client session callback.
 TEST_P(SSLVersionTest, ClientSessionCacheMode) {
   SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_OFF);


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1875

### Description of changes: 
[OpenSSL uses this enum](https://github.com/openssl/openssl/blob/674b61ebd982d6a6564ac1f90d8cde22371564bc/include/openssl/ssl.h.in#L1011-L1066) for possible states returned from `SSL_get_state`.

### Call-outs:
[AWS-LC can only return these two values](https://github.com/aws/aws-lc/blob/main/ssl/ssl_lib.cc#L2585-L2587) so I only included them in this enum. 

### Testing:
Added a simple test that checks both states match.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
