### PR TITLE
Save leaf certificate in SSL early to avoid losing external data

### DIFF
--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2605,14 +2605,13 @@ struct SSL_X509_METHOD {
   void (*cert_clear)(CERT *cert);
   // cert_free frees all X509-related state.
   void (*cert_free)(CERT *cert);
-  // cert_flush_cached_chain drops any cached |X509|-based certificate chain
-  // from |cert|.
   // cert_dup duplicates any needed fields from |cert| to |new_cert|.
   void (*cert_dup)(CERT *new_cert, const CERT *cert);
-  void (*cert_flush_cached_chain)(CERT *cert);
-  // cert_flush_cached_chain drops any cached |X509|-based leaf certificate
+  // cert_flush_cached_chain drops any cached |X509|-based certificate chain
   // from |cert|.
-  void (*cert_flush_cached_leaf)(CERT *cert);
+  void (*cert_flush_cached_chain)(CERT *cert);
+  // cert_flush_leaf drops the |X509|-based leaf certificate from |cert|.
+  void (*cert_flush_leaf)(CERT *cert);
 
   // session_cache_objects fills out |sess->x509_peer| and |sess->x509_chain|
   // from |sess->certs| and erases |sess->x509_chain_without_leaf|. It returns

--- a/ssl/ssl_cert.cc
+++ b/ssl/ssl_cert.cc
@@ -161,6 +161,11 @@ UniquePtr<CERT> ssl_cert_dup(CERT *cert) {
     }
   }
 
+  if (cert->x509_leaf != nullptr) {
+    X509_up_ref(cert->x509_leaf);
+    ret->x509_leaf = cert->x509_leaf;
+  }
+
   ret->privatekey = UpRef(cert->privatekey);
   ret->key_method = cert->key_method;
 
@@ -315,8 +320,6 @@ bool ssl_set_cert(CERT *cert, UniquePtr<CRYPTO_BUFFER> buffer) {
     case leaf_cert_and_privkey_ok:
       break;
   }
-
-  cert->x509_method->cert_flush_cached_leaf(cert);
 
   if (cert->chain != nullptr) {
     CRYPTO_BUFFER_free(sk_CRYPTO_BUFFER_value(cert->chain.get(), 0));

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -4848,7 +4848,7 @@ TEST(SSLTest, GetCertificateASN1) {
   bssl::UniquePtr<X509> cert = GetTestCertificate();
   ASSERT_TRUE(cert);
 
-  // Concert cert to ASN1 to pass in.
+  // Convert cert to ASN1 to pass in.
   uint8_t *der = nullptr;
   size_t der_len = i2d_X509(cert.get(), &der);
   bssl::UniquePtr<uint8_t> free_der(der);

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -234,7 +234,7 @@ static bool ssl_cert_set_chain(CERT *cert, STACK_OF(X509) *chain) {
   return true;
 }
 
-static void ssl_crypto_x509_cert_flush_cached_leaf(CERT *cert) {
+static void ssl_crypto_x509_cert_flush_leaf(CERT *cert) {
   X509_free(cert->x509_leaf);
   cert->x509_leaf = nullptr;
 }
@@ -260,7 +260,7 @@ static bool ssl_crypto_x509_check_client_CA_list(
 }
 
 static void ssl_crypto_x509_cert_clear(CERT *cert) {
-  ssl_crypto_x509_cert_flush_cached_leaf(cert);
+  ssl_crypto_x509_cert_flush_leaf(cert);
   ssl_crypto_x509_cert_flush_cached_chain(cert);
 
   X509_free(cert->x509_stash);
@@ -526,7 +526,7 @@ const SSL_X509_METHOD ssl_crypto_x509_method = {
   ssl_crypto_x509_cert_free,
   ssl_crypto_x509_cert_dup,
   ssl_crypto_x509_cert_flush_cached_chain,
-  ssl_crypto_x509_cert_flush_cached_leaf,
+  ssl_crypto_x509_cert_flush_leaf,
   ssl_crypto_x509_session_cache_objects,
   ssl_crypto_x509_session_dup,
   ssl_crypto_x509_session_clear,
@@ -758,6 +758,12 @@ static int ssl_use_certificate(CERT *cert, X509 *x) {
     return 0;
   }
 
+  // We set the |x509_leaf| here to prevent any external data set from being
+  // lost. The rest of the chain still uses |CRYPTO_BUFFER|s.
+  X509_free(cert->x509_leaf);
+  X509_up_ref(x);
+  cert->x509_leaf = x;
+
   UniquePtr<CRYPTO_BUFFER> buffer = x509_to_buffer(x);
   if (!buffer) {
     return 0;
@@ -779,29 +785,9 @@ int SSL_CTX_use_certificate(SSL_CTX *ctx, X509 *x) {
   return ssl_use_certificate(ctx->cert.get(), x);
 }
 
-// ssl_cert_cache_leaf_cert sets |cert->x509_leaf|, if currently NULL, from the
-// first element of |cert->chain|.
-static int ssl_cert_cache_leaf_cert(CERT *cert) {
-  assert(cert->x509_method);
-
-  if (cert->x509_leaf != NULL ||
-      cert->chain == NULL) {
-    return 1;
-  }
-
-  CRYPTO_BUFFER *leaf = sk_CRYPTO_BUFFER_value(cert->chain.get(), 0);
-  if (!leaf) {
-    return 1;
-  }
-
-  cert->x509_leaf = X509_parse_from_buffer(leaf);
-  return cert->x509_leaf != NULL;
-}
-
 static X509 *ssl_cert_get0_leaf(CERT *cert) {
-  if (cert->x509_leaf == NULL &&
-      !ssl_cert_cache_leaf_cert(cert)) {
-    return NULL;
+  if (cert->x509_leaf == nullptr) {
+    return nullptr;
   }
 
   return cert->x509_leaf;

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -786,10 +786,6 @@ int SSL_CTX_use_certificate(SSL_CTX *ctx, X509 *x) {
 }
 
 static X509 *ssl_cert_get0_leaf(CERT *cert) {
-  if (cert->x509_leaf == nullptr) {
-    return nullptr;
-  }
-
   return cert->x509_leaf;
 }
 


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1935`

### Description of changes: 
This reverts some of the changes done in https://github.com/aws/aws-lc/commit/3a2b47ab5be5c75edacb8cdc246dc2dc8fb2c0cd. 
AWS-LC/BoringSSL also allows external data to be associated with the X509 structures with the same APIs. However, our SSL connections don't directly save the X509 certificate as a structure within `SSL_CTX`. We "fold" the certificate and convert it into a binary blob to maintain within `SSL_CTX`. The certificate is not parsed back into an `X509` until the user asks for it.
This creates issues when the user attempts to associate data with the certificate with `X509_set_ex_data` and passes the certificate into `SSL_CTX`. The data usually associated is not ASN.1 code, thus non-parsable, and the associated data gets lost during the translation to pure bytes. This creates issues with codebases like nginx, who was associating their own OCSP stapling data structures with X509 structures in SSL_CTX.
* https://github.com/nginx/nginx/blob/6bdfd58f2660c394306ef34fe825d2f02f5ba813/src/event/ngx_event_openssl_stapling.c#L223-L241

I've changed this to cache the leaf certificate early, so that the external data is kept for that cert. The same behavior is kept for the rest of the change. This keeps the changes needed contained and avoids an entire restructure of the use of `CRYPTO_BUFFER` in `CERT`.


### Call-outs:
This lets us pass more ssl_stapling in nginx. There are some more subtle OCSP changes required, but I'll open another PR for that.

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
