### PR TITLE
Align OCSP behavior with OpenSSL for nginx

### DIFF
--- a/crypto/ocsp/ocsp_verify.c
+++ b/crypto/ocsp/ocsp_verify.c
@@ -9,7 +9,6 @@
 // https://datatracker.ietf.org/doc/html/rfc6960#section-4.2.2.3
 static X509 *ocsp_find_signer_sk(STACK_OF(X509) *certs, OCSP_RESPID *id) {
   if (certs == NULL || id == NULL) {
-    OPENSSL_PUT_ERROR(OCSP, ERR_R_PASSED_NULL_PARAMETER);
     return NULL;
   }
 
@@ -54,7 +53,7 @@ static int ocsp_find_signer(X509 **psigner, OCSP_BASICRESP *bs,
   signer = ocsp_find_signer_sk(certs, rid);
   if (signer != NULL) {
     *psigner = signer;
-    return 1;
+    return 2;
   }
 
   // look in certs stack the responder may have included in |OCSP_BASICRESP|,
@@ -337,44 +336,47 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs, X509_STORE *st,
     OPENSSL_PUT_ERROR(OCSP, OCSP_R_SIGNER_CERTIFICATE_NOT_FOUND);
     goto end;
   }
+  if ((ret == 2) && IS_OCSP_FLAG_SET(flags, OCSP_TRUSTOTHER)) {
+      flags |= OCSP_NOVERIFY;
+  }
 
   // Check if public key in signer matches key in |OCSP_BASICRESP|.
   ret = ocsp_verify_key(bs, signer);
   if (ret <= 0) {
     goto end;
   }
+  if (!IS_OCSP_FLAG_SET(flags, OCSP_NOVERIFY)) {
+      // Verify signer and if valid, check the certificate chain.
+      ret = ocsp_setup_untrusted(bs, certs, &untrusted, flags);
+      if (ret <= 0) {
+          goto end;
+      }
+      ret = ocsp_verify_signer(signer, st, untrusted, &chain);
+      if (ret <= 0) {
+          goto end;
+      }
 
-  // Verify signer and if valid, check the certificate chain.
-  ret = ocsp_setup_untrusted(bs, certs, &untrusted, flags);
-  if (ret <= 0) {
-    goto end;
+      // At this point we have a valid certificate chain, need to verify it
+      // against the OCSP issuer criteria.
+      ret = ocsp_check_issuer(bs, chain);
+
+      // If a certificate chain is not verifiable against the OCSP issuer
+      // criteria, we try to check for explicit trust.
+      if (ret == 0) {
+          // Easy case: explicitly trusted. Get root CA and check for explicit
+          // trust.
+          if (IS_OCSP_FLAG_SET(flags, OCSP_NOEXPLICIT)) {
+              goto end;
+          }
+          X509 *root_cert = sk_X509_value(chain, sk_X509_num(chain) - 1);
+          if (X509_check_trust(root_cert, NID_OCSP_sign, 0) != X509_TRUST_TRUSTED) {
+              OPENSSL_PUT_ERROR(OCSP, OCSP_R_ROOT_CA_NOT_TRUSTED);
+              ret = 0;
+              goto end;
+          }
+          ret = 1;
+      }
   }
-  ret = ocsp_verify_signer(signer, st, untrusted, &chain);
-  if (ret <= 0) {
-    goto end;
-  }
-
-  // At this point we have a valid certificate chain, need to verify it
-  // against the OCSP issuer criteria.
-  ret = ocsp_check_issuer(bs, chain);
-
-  // If a certificate chain is not verifiable against the OCSP issuer
-  // criteria, we try to check for explicit trust.
-  if (ret == 0) {
-    // Easy case: explicitly trusted. Get root CA and check for explicit
-    // trust.
-    if (IS_OCSP_FLAG_SET(flags, OCSP_NOEXPLICIT)) {
-      goto end;
-    }
-    X509 *root_cert = sk_X509_value(chain, sk_X509_num(chain) - 1);
-    if (X509_check_trust(root_cert, NID_OCSP_sign, 0) != X509_TRUST_TRUSTED) {
-      OPENSSL_PUT_ERROR(OCSP, OCSP_R_ROOT_CA_NOT_TRUSTED);
-      ret = 0;
-      goto end;
-    }
-    ret = 1;
-  }
-
 
 end:
   sk_X509_pop_free(chain, X509_free);

--- a/crypto/ocsp/ocsp_verify.c
+++ b/crypto/ocsp/ocsp_verify.c
@@ -4,6 +4,10 @@
 #include <string.h>
 #include "internal.h"
 
+#define SIGNER_IN_CERTSTACK 2
+#define SIGNER_IN_BASICRESP 1
+#define SIGNER_NOT_FOUND 0
+
 // Set up |X509_STORE_CTX| to verify signer and returns cert chain if verify is
 // OK. A |OCSP_RESPID| can be identified either by name or its keyhash.
 // https://datatracker.ietf.org/doc/html/rfc6960#section-4.2.2.3
@@ -53,20 +57,20 @@ static int ocsp_find_signer(X509 **psigner, OCSP_BASICRESP *bs,
   signer = ocsp_find_signer_sk(certs, rid);
   if (signer != NULL) {
     *psigner = signer;
-    return 2;
+    return SIGNER_IN_CERTSTACK;
   }
 
   // look in certs stack the responder may have included in |OCSP_BASICRESP|,
-  // unless the flags contain OCSP_NOINTERN.
+  // unless the flags contain |OCSP_NOINTERN|.
   signer = ocsp_find_signer_sk(bs->certs, rid);
-  if (!IS_OCSP_FLAG_SET(flags, OCSP_NOINTERN) && signer) {
+  if (signer != NULL && !IS_OCSP_FLAG_SET(flags, OCSP_NOINTERN)) {
     *psigner = signer;
-    return 1;
+    return SIGNER_IN_BASICRESP;
   }
   // Maybe lookup from store if by subject name.
 
   *psigner = NULL;
-  return 0;
+  return SIGNER_NOT_FOUND;
 }
 
 // check if public key in signer matches key in |OCSP_BASICRESP|.
@@ -332,12 +336,13 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs, X509_STORE *st,
 
   // Look for signer certificate.
   int ret = ocsp_find_signer(&signer, bs, certs, flags);
-  if (ret <= 0) {
+  if (ret <= SIGNER_NOT_FOUND) {
     OPENSSL_PUT_ERROR(OCSP, OCSP_R_SIGNER_CERTIFICATE_NOT_FOUND);
     goto end;
   }
-  if ((ret == 2) && IS_OCSP_FLAG_SET(flags, OCSP_TRUSTOTHER)) {
-      flags |= OCSP_NOVERIFY;
+  if ((ret == SIGNER_IN_CERTSTACK) &&
+      IS_OCSP_FLAG_SET(flags, OCSP_TRUSTOTHER)) {
+    flags |= OCSP_NOVERIFY;
   }
 
   // Check if public key in signer matches key in |OCSP_BASICRESP|.
@@ -346,36 +351,36 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs, X509_STORE *st,
     goto end;
   }
   if (!IS_OCSP_FLAG_SET(flags, OCSP_NOVERIFY)) {
-      // Verify signer and if valid, check the certificate chain.
-      ret = ocsp_setup_untrusted(bs, certs, &untrusted, flags);
-      if (ret <= 0) {
-          goto end;
-      }
-      ret = ocsp_verify_signer(signer, st, untrusted, &chain);
-      if (ret <= 0) {
-          goto end;
-      }
+    // Verify signer and if valid, check the certificate chain.
+    ret = ocsp_setup_untrusted(bs, certs, &untrusted, flags);
+    if (ret <= 0) {
+      goto end;
+    }
+    ret = ocsp_verify_signer(signer, st, untrusted, &chain);
+    if (ret <= 0) {
+      goto end;
+    }
 
-      // At this point we have a valid certificate chain, need to verify it
-      // against the OCSP issuer criteria.
-      ret = ocsp_check_issuer(bs, chain);
+    // At this point we have a valid certificate chain, need to verify it
+    // against the OCSP issuer criteria.
+    ret = ocsp_check_issuer(bs, chain);
 
-      // If a certificate chain is not verifiable against the OCSP issuer
-      // criteria, we try to check for explicit trust.
-      if (ret == 0) {
-          // Easy case: explicitly trusted. Get root CA and check for explicit
-          // trust.
-          if (IS_OCSP_FLAG_SET(flags, OCSP_NOEXPLICIT)) {
-              goto end;
-          }
-          X509 *root_cert = sk_X509_value(chain, sk_X509_num(chain) - 1);
-          if (X509_check_trust(root_cert, NID_OCSP_sign, 0) != X509_TRUST_TRUSTED) {
-              OPENSSL_PUT_ERROR(OCSP, OCSP_R_ROOT_CA_NOT_TRUSTED);
-              ret = 0;
-              goto end;
-          }
-          ret = 1;
+    // If a certificate chain is not verifiable against the OCSP issuer
+    // criteria, we try to check for explicit trust.
+    if (ret == 0) {
+      // Easy case: explicitly trusted. Get root CA and check for explicit
+      // trust.
+      if (IS_OCSP_FLAG_SET(flags, OCSP_NOEXPLICIT)) {
+        goto end;
       }
+      X509 *root_cert = sk_X509_value(chain, sk_X509_num(chain) - 1);
+      if (X509_check_trust(root_cert, NID_OCSP_sign, 0) != X509_TRUST_TRUSTED) {
+        OPENSSL_PUT_ERROR(OCSP, OCSP_R_ROOT_CA_NOT_TRUSTED);
+        ret = 0;
+        goto end;
+      }
+      ret = 1;
+    }
   }
 
 end:

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -27,26 +27,25 @@ extern "C" {
 #define OCSP_NOCERTS 0x1
 // OCSP_NOINTERN is for |OCSP_basic_verify|. Searches for certificates the
 // responder may have included in |bs| will be done, unless the flags contain
-// OCSP_NOINTERN.
+// |OCSP_NOINTERN|.
 #define OCSP_NOINTERN 0x2
 // OCSP_NOCHAIN is for |OCSP_basic_verify|. All certificates in |certs| and in
 // |bs| are considered as untrusted certificates for the construction of the
 // validation path for the signer certificate unless the OCSP_NOCHAIN flag is
 // set.
 #define OCSP_NOCHAIN 0x8
-// OCSP_NOVERIFY is for |OCSP_basic_verify|. This is a no-op flag in AWS-LC.
-// When setting this flag in OpenSSL, the |OCSP_BASICRESP|'s signature will
-// still be verified, but setting this flag skips verifying the signer's
-// certificate.
-#define OCSP_NOVERIFY 0
+// OCSP_NOVERIFY is for |OCSP_basic_verify|. When setting this flag, the
+// |OCSP_BASICRESP|'s signature will still be verified, but setting this flag
+// skips additionally verifying the signer's certificate.
+#define OCSP_NOVERIFY 0x10
 // OCSP_NOEXPLICIT is for |OCSP_basic_verify|. We will check for explicit trust
 // for OCSP signing in the root CA certificate, unless the flags contain
 // OCSP_NOEXPLICIT.
 #define OCSP_NOEXPLICIT 0x20
-// OCSP_TRUSTOTHER is for |OCSP_basic_verify|. This is a no-op flag in AWS-LC.
-// When setting this flag in OpenSSL, if the reponse signer's cert is one of
-// those in the |certs| stack then it is implicitly trusted.
-#define OCSP_TRUSTOTHER 0
+// OCSP_TRUSTOTHER is for |OCSP_basic_verify|. When setting this flag in OpenSSL,
+// if the reponse signer's cert is one of those in the |certs| stack then it is
+// implicitly trusted.
+#define OCSP_TRUSTOTHER 0x200
 
 typedef struct ocsp_cert_id_st OCSP_CERTID;
 typedef struct ocsp_one_request_st OCSP_ONEREQ;

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -25,25 +25,25 @@ extern "C" {
 // OCSP_NOCERTS is for |OCSP_request_sign| if no certificates are included
 // in the |OCSP_REQUEST|. Certificates are optional.
 #define OCSP_NOCERTS 0x1
-// OCSP_NOINTERN is for |OCSP_basic_verify|. Searches for certificates the
-// responder may have included in |bs| will be done, unless the flags contain
-// |OCSP_NOINTERN|.
+// OCSP_NOINTERN is for |OCSP_basic_verify|. Certificates included within |bs|
+// by the responder will be searched for the signer certificate, unless the
+// |OCSP_NOINTERN| flag is set.
 #define OCSP_NOINTERN 0x2
 // OCSP_NOCHAIN is for |OCSP_basic_verify|. All certificates in |certs| and in
 // |bs| are considered as untrusted certificates for the construction of the
-// validation path for the signer certificate unless the OCSP_NOCHAIN flag is
+// validation path for the signer certificate unless the |OCSP_NOCHAIN| flag is
 // set.
 #define OCSP_NOCHAIN 0x8
 // OCSP_NOVERIFY is for |OCSP_basic_verify|. When setting this flag, the
-// |OCSP_BASICRESP|'s signature will still be verified, but setting this flag
-// skips additionally verifying the signer's certificate.
+// |OCSP_BASICRESP|'s signature will still be verified, but skips additionally
+// verifying the signer's certificate.
 #define OCSP_NOVERIFY 0x10
 // OCSP_NOEXPLICIT is for |OCSP_basic_verify|. We will check for explicit trust
 // for OCSP signing in the root CA certificate, unless the flags contain
-// OCSP_NOEXPLICIT.
+// |OCSP_NOEXPLICIT|.
 #define OCSP_NOEXPLICIT 0x20
-// OCSP_TRUSTOTHER is for |OCSP_basic_verify|. When setting this flag in OpenSSL,
-// if the reponse signer's cert is one of those in the |certs| stack then it is
+// OCSP_TRUSTOTHER is for |OCSP_basic_verify|. When this flag is set, if the
+// response signer's cert is one of those in the |certs| stack then it is
 // implicitly trusted.
 #define OCSP_TRUSTOTHER 0x200
 

--- a/sources.cmake
+++ b/sources.cmake
@@ -111,6 +111,7 @@ set(
   crypto/ocsp/test/aws/ocsp_response_sigrequired.der
   crypto/ocsp/test/aws/ocsp_response_unauthorized.der
   crypto/ocsp/test/aws/ca_cert.pem
+  crypto/ocsp/test/aws/ocsp_expired_cert.pem
   crypto/ocsp/test/aws/server_cert.pem
   crypto/ocsp/test/aws/server_ecdsa_cert.pem
   crypto/ocsp/test/aws/server_ecdsa_key.pem


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1849`

### Description of changes: 
Asides from the behavior fixed in https://github.com/aws/aws-lc/pull/1074, there was some slight OCSP errors when building with nginx's OCSP stapling tests. There are still a couple of tests failing due to us missing multiple certs support, but this should resolve all other issues with us failing the test.
* https://github.com/nginx/nginx-tests/blob/master/ssl_stapling.t

1. The NULL check in `ocsp_find_signer_sk` static function was a bit too pedantic, so I relaxed it. It's possible for the OCSP Basic response to be missing a cert stack, so we shouldn't be throwing an error on the stack if that happens.
2. Implemented functionality for the two OCSP flags, `OCSP_NOVERIFY` and `OCSP_TRUSTOTHER`

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
