### PR TITLE
Use build-in string-copy function

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -333,7 +333,7 @@ static int int_x509_param_set1_email(char **pdest, size_t *pdestlen,
       srclen = strlen(src);
     }
 
-    tmp = OPENSSL_memdup(src, srclen);
+    tmp = OPENSSL_strndup(src, srclen);
     if (tmp == NULL) {
       return 0;
     }

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2961,7 +2961,7 @@ OPENSSL_EXPORT int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,
                                                 size_t emaillen);
 
 // X509_VERIFY_PARAM_set1_ip sets the expected IP address to |ip|. |iplen| MUST
-// be set to the length of |email|.
+// be set to the length of |ip|.
 OPENSSL_EXPORT int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
                                              const unsigned char *ip,
                                              size_t iplen);


### PR DESCRIPTION
### Issues:

V946151180

### Description of changes: 

Use build-in memory copy function for a `string` type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
