### PR TITLE
Release v1.12.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4036,7 +4036,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.11.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.12.0");
 }
 
 #else
@@ -4079,6 +4079,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.11.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.12.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -216,7 +216,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.11.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.12.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Update CI README to include Valgrind on AArch64 by @nebeid in https://github.com/aws/aws-lc/pull/1066
* Additional tests for failure modes for KEM API by @dkostic in https://github.com/aws/aws-lc/pull/1048
* Fix potential NULL pointer dereference by @dkostic in https://github.com/aws/aws-lc/pull/1067
* add integration build CI dimension for mySQL by @samuel40791765 in https://github.com/aws/aws-lc/pull/1051
* add integration test CI dimension for MariaDB by @samuel40791765 in https://github.com/aws/aws-lc/pull/1046
* Add SSL_get0_verified_chain  by @andrewhop in https://github.com/aws/aws-lc/pull/1055
* Add OSSL_HANDSHAKE_STATE enum for OpenSSL compatability by @andrewhop in https://github.com/aws/aws-lc/pull/1070
* Upstream merge 2023-06-26 by @dkostic in https://github.com/aws/aws-lc/pull/1072
* Fix DISABLE_PERL=on builds for non-assembly optimized platforms by @skmcgrail in https://github.com/aws/aws-lc/pull/1068
* Fix BORINGSSL_PREFIX build for ppc64le by @skmcgrail in https://github.com/aws/aws-lc/pull/1069
* align X509_VERIFY_PARAM host and email behavior with OpenSSL by @samuel40791765 in https://github.com/aws/aws-lc/pull/1062
* Use build-in string-copy function by @torben-hansen in https://github.com/aws/aws-lc/pull/1078
* Light tidy up of required dependency versions by @torben-hansen in https://github.com/aws/aws-lc/pull/1076
* Remove unused variable declaration in ssl_test.cc by @dkostic in https://github.com/aws/aws-lc/pull/1073
* Upstream merge 2023-06-27 by @torben-hansen in https://github.com/aws/aws-lc/pull/1075
* Reapply "Remove support for "old-style" X509V3_EXT_METHODs" by @samuel40791765 in https://github.com/aws/aws-lc/pull/1065
* Make PRNG model slightly more readable by @torben-hansen in https://github.com/aws/aws-lc/pull/1079
* Add back custom extension support for libssl by @andrewhop in https://github.com/aws/aws-lc/pull/1071
* Save leaf certificate in SSL early to avoid losing external data by @samuel40791765 in https://github.com/aws/aws-lc/pull/1074
* Mark include as PUBLIC not SYSTEM PUBLIC by @skmcgrail in https://github.com/aws/aws-lc/pull/1081


**Full Changelog**: https://github.com/aws/aws-lc/compare/v1.11.0...v1.12.0