### PR TITLE
add back CERT_PKEY structure and refactor pointers

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1361,7 +1361,8 @@ struct ssl_private_key_method_st {
 };
 
 // SSL_set_private_key_method configures a custom private key on |ssl|.
-// |key_method| must remain valid for the lifetime of |ssl|.
+// |key_method| must remain valid for the lifetime of |ssl|. Using custom
+// keys with the multiple certificate slots feature is not supported.
 OPENSSL_EXPORT void SSL_set_private_key_method(
     SSL *ssl, const SSL_PRIVATE_KEY_METHOD *key_method);
 

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2465,9 +2465,9 @@ struct CERT {
   // cert_privatekey_idx ALWAYS points to an element of the |cert_pkeys|
   // array. OpenSSL implements this as a pointer, but an index is more
   // efficient.
-  int cert_privatekey_idx = -1;
+  int cert_private_key_idx = -1;
 
-  Array<CERT_PKEY> cert_privatekeys;
+  Array<CERT_PKEY> cert_private_keys;
 
   /// We'lll see what we want to do about the |x509_stash| below later.
 
@@ -3236,6 +3236,11 @@ bool ssl_is_key_type_supported(int key_type);
 bool ssl_compare_public_and_private_key(const EVP_PKEY *pubkey,
                                         const EVP_PKEY *privkey);
 bool ssl_cert_check_private_key(const CERT *cert, const EVP_PKEY *privkey);
+
+// ssl_cert_check_cert_private_keys_usage returns true if |cert_private_keys|
+// in |cert| has a valid index and a sufficient amount of slots.
+bool ssl_cert_check_cert_private_keys_usage(const CERT *cert);
+
 bool ssl_get_new_session(SSL_HANDSHAKE *hs);
 bool ssl_encrypt_ticket(SSL_HANDSHAKE *hs, CBB *out,
                         const SSL_SESSION *session);

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2430,7 +2430,7 @@ bool tls12_check_peer_sigalg(const SSL_HANDSHAKE *hs, uint8_t *out_alert,
 #define SSL_PKEY_RSA 0
 #define SSL_PKEY_ECC 1
 #define SSL_PKEY_ED25519 2
-#define SSL_PKEY_NUM 3
+#define SSL_PKEY_SIZE 3
 
 struct CERT_PKEY {
   UniquePtr<EVP_PKEY> privatekey;
@@ -2448,9 +2448,11 @@ struct CERT_PKEY {
   // pointer to the certificate chain.
   STACK_OF(X509) *x509_chain = nullptr;
 
-  // x509_leaf may contain a parsed copy of the first element of |chain|. This
-  // is only used as a cache in order to implement “get0” functions that return
-  // a non-owning pointer to the certificate chain.
+  // x509_leaf retains the |X509| structure of the first element of |chain|.
+  // However, if certs are set with |SSL_CTX_use_certificate_ASN1| or
+  // |SSL_use_certificate_ASN1|, this is only used as a cache in order to
+  // implement “get0” functions that return a non-owning pointer to the
+  // certificate chain.
   X509 *x509_leaf = nullptr;
 };
 
@@ -2463,7 +2465,7 @@ struct CERT {
   // cert_privatekey_idx ALWAYS points to an element of the |cert_pkeys|
   // array. OpenSSL implements this as a pointer, but an index is more
   // efficient.
-  int cert_privatekey_idx = SSL_PKEY_RSA;
+  int cert_privatekey_idx = -1;
 
   Array<CERT_PKEY> cert_privatekeys;
 

--- a/ssl/ssl_cert.cc
+++ b/ssl/ssl_cert.cc
@@ -160,7 +160,7 @@ UniquePtr<CERT> ssl_cert_dup(CERT *cert) {
   }
 
   ret->cert_private_key_idx = cert->cert_private_key_idx;
-  if (!ssl_cert_check_cert_private_keys_usage(cert) &&
+  if (!ssl_cert_check_cert_private_keys_usage(cert) ||
       !ssl_cert_check_cert_private_keys_usage(ret.get())) {
     return nullptr;
   }

--- a/ssl/ssl_cert.cc
+++ b/ssl/ssl_cert.cc
@@ -154,6 +154,10 @@ static CRYPTO_BUFFER *buffer_up_ref(const CRYPTO_BUFFER *buffer) {
 }
 
 UniquePtr<CERT> ssl_cert_dup(CERT *cert) {
+  if(cert == nullptr) {
+    return nullptr;
+  }
+
   UniquePtr<CERT> ret = MakeUnique<CERT>(cert->x509_method);
   if (!ret) {
     return nullptr;
@@ -216,16 +220,16 @@ UniquePtr<CERT> ssl_cert_dup(CERT *cert) {
 
 // Free up and clear all certificates and chains
 void ssl_cert_clear_certs(CERT *cert) {
-  if (cert == NULL) {
+  if (cert == nullptr) {
     return;
   }
 
   cert->x509_method->cert_clear(cert);
 
   cert->cert_private_key_idx = -1;
-  for (int i = 0; i < SSL_PKEY_SIZE; i++) {
-    cert->cert_private_keys[i].chain.reset();
-    cert->cert_private_keys[i].privatekey.reset();
+  for (auto &cert_private_key : cert->cert_private_keys) {
+    cert_private_key.chain.reset();
+    cert_private_key.privatekey.reset();
   }
   cert->key_method = nullptr;
 
@@ -907,7 +911,7 @@ static int cert_set_dc(CERT *cert, CRYPTO_BUFFER *const raw, EVP_PKEY *privkey,
 }
 
 bool ssl_cert_check_cert_private_keys_usage(const CERT *cert) {
-  if (cert->cert_private_keys.size() != SSL_PKEY_SIZE ||
+  if (cert == nullptr || cert->cert_private_keys.size() != SSL_PKEY_SIZE ||
       cert->cert_private_key_idx < SSL_PKEY_RSA ||
       cert->cert_private_key_idx >= SSL_PKEY_SIZE) {
     return false;

--- a/ssl/ssl_cert.cc
+++ b/ssl/ssl_cert.cc
@@ -154,7 +154,7 @@ static CRYPTO_BUFFER *buffer_up_ref(const CRYPTO_BUFFER *buffer) {
 }
 
 UniquePtr<CERT> ssl_cert_dup(CERT *cert) {
-  if(cert == nullptr) {
+  if (cert == nullptr) {
     return nullptr;
   }
 
@@ -459,6 +459,7 @@ bool ssl_add_cert_chain(SSL_HANDSHAKE *hs, CBB *cbb) {
     return false;
   }
 
+  // |cert_private_keys| already checked above in |ssl_has_certificate|.
   int idx = hs->config->cert->cert_private_key_idx;
   STACK_OF(CRYPTO_BUFFER) *chain =
       hs->config->cert->cert_private_keys[idx].chain.get();
@@ -563,6 +564,8 @@ bool ssl_cert_check_private_key(const CERT *cert, const EVP_PKEY *privkey) {
     return false;
   }
 
+  // |cert_private_keys| already checked before usages of
+  // |ssl_cert_check_private_key|.
   STACK_OF(CRYPTO_BUFFER) *chain =
       cert->cert_private_keys[cert->cert_private_key_idx].chain.get();
 
@@ -774,6 +777,7 @@ bool ssl_on_certificate_selected(SSL_HANDSHAKE *hs) {
     return false;
   }
 
+  // |cert_private_keys| already checked above in |ssl_has_certificate|.
   STACK_OF(CRYPTO_BUFFER) *chain =
       hs->config->cert
           ->cert_private_keys[hs->config->cert->cert_private_key_idx]
@@ -912,7 +916,7 @@ static int cert_set_dc(CERT *cert, CRYPTO_BUFFER *const raw, EVP_PKEY *privkey,
 
 bool ssl_cert_check_cert_private_keys_usage(const CERT *cert) {
   if (cert == nullptr || cert->cert_private_keys.size() != SSL_PKEY_SIZE ||
-      cert->cert_private_key_idx < SSL_PKEY_RSA ||
+      cert->cert_private_key_idx < 0 ||
       cert->cert_private_key_idx >= SSL_PKEY_SIZE) {
     return false;
   }

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1757,16 +1757,21 @@ int SSL_has_pending(const SSL *ssl) {
 }
 
 int SSL_CTX_check_private_key(const SSL_CTX *ctx) {
-  return ssl_cert_check_private_key(ctx->cert.get(),
-                                    ctx->cert->privatekey.get());
+  return ssl_cert_check_private_key(
+      ctx->cert.get(),
+      ctx->cert->cert_privatekeys[ctx->cert->cert_privatekey_idx]
+          .privatekey.get());
 }
 
 int SSL_check_private_key(const SSL *ssl) {
   if (!ssl->config) {
     return 0;
   }
-  return ssl_cert_check_private_key(ssl->config->cert.get(),
-                                    ssl->config->cert->privatekey.get());
+  return ssl_cert_check_private_key(
+      ssl->config->cert.get(),
+      ssl->config->cert
+          ->cert_privatekeys[ssl->config->cert->cert_privatekey_idx]
+          .privatekey.get());
 }
 
 long SSL_get_default_timeout(const SSL *ssl) {
@@ -2477,7 +2482,9 @@ EVP_PKEY *SSL_get_privatekey(const SSL *ssl) {
     return NULL;
   }
   if (ssl->config->cert != NULL) {
-    return ssl->config->cert->privatekey.get();
+    return ssl->config->cert
+        ->cert_privatekeys[ssl->config->cert->cert_privatekey_idx]
+        .privatekey.get();
   }
 
   return NULL;
@@ -2485,7 +2492,8 @@ EVP_PKEY *SSL_get_privatekey(const SSL *ssl) {
 
 EVP_PKEY *SSL_CTX_get0_privatekey(const SSL_CTX *ctx) {
   if (ctx->cert != NULL) {
-    return ctx->cert->privatekey.get();
+    return ctx->cert->cert_privatekeys[ctx->cert->cert_privatekey_idx]
+        .privatekey.get();
   }
 
   return NULL;

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2485,8 +2485,7 @@ EVP_PKEY *SSL_get_privatekey(const SSL *ssl) {
     assert(ssl->config);
     return NULL;
   }
-  if (ssl->config->cert != NULL &&
-      ssl_cert_check_cert_private_keys_usage(ssl->config->cert.get())) {
+  if (ssl_cert_check_cert_private_keys_usage(ssl->config->cert.get())) {
     return ssl->config->cert
         ->cert_private_keys[ssl->config->cert->cert_private_key_idx]
         .privatekey.get();
@@ -2496,8 +2495,7 @@ EVP_PKEY *SSL_get_privatekey(const SSL *ssl) {
 }
 
 EVP_PKEY *SSL_CTX_get0_privatekey(const SSL_CTX *ctx) {
-  if (ctx->cert != NULL &&
-      ssl_cert_check_cert_private_keys_usage(ctx->cert.get())) {
+  if (ssl_cert_check_cert_private_keys_usage(ctx->cert.get())) {
     return ctx->cert->cert_private_keys[ctx->cert->cert_private_key_idx]
         .privatekey.get();
   }

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1757,20 +1757,24 @@ int SSL_has_pending(const SSL *ssl) {
 }
 
 int SSL_CTX_check_private_key(const SSL_CTX *ctx) {
+  if (!ssl_cert_check_cert_private_keys_usage(ctx->cert.get())) {
+    return 0;
+  }
   return ssl_cert_check_private_key(
       ctx->cert.get(),
-      ctx->cert->cert_privatekeys[ctx->cert->cert_privatekey_idx]
+      ctx->cert->cert_private_keys[ctx->cert->cert_private_key_idx]
           .privatekey.get());
 }
 
 int SSL_check_private_key(const SSL *ssl) {
-  if (!ssl->config) {
+  if (!ssl->config ||
+      !ssl_cert_check_cert_private_keys_usage(ssl->config->cert.get())) {
     return 0;
   }
   return ssl_cert_check_private_key(
       ssl->config->cert.get(),
       ssl->config->cert
-          ->cert_privatekeys[ssl->config->cert->cert_privatekey_idx]
+          ->cert_private_keys[ssl->config->cert->cert_private_key_idx]
           .privatekey.get());
 }
 
@@ -2481,9 +2485,10 @@ EVP_PKEY *SSL_get_privatekey(const SSL *ssl) {
     assert(ssl->config);
     return NULL;
   }
-  if (ssl->config->cert != NULL) {
+  if (ssl->config->cert != NULL &&
+      ssl_cert_check_cert_private_keys_usage(ssl->config->cert.get())) {
     return ssl->config->cert
-        ->cert_privatekeys[ssl->config->cert->cert_privatekey_idx]
+        ->cert_private_keys[ssl->config->cert->cert_private_key_idx]
         .privatekey.get();
   }
 
@@ -2491,8 +2496,9 @@ EVP_PKEY *SSL_get_privatekey(const SSL *ssl) {
 }
 
 EVP_PKEY *SSL_CTX_get0_privatekey(const SSL_CTX *ctx) {
-  if (ctx->cert != NULL) {
-    return ctx->cert->cert_privatekeys[ctx->cert->cert_privatekey_idx]
+  if (ctx->cert != NULL &&
+      ssl_cert_check_cert_private_keys_usage(ctx->cert.get())) {
+    return ctx->cert->cert_private_keys[ctx->cert->cert_private_key_idx]
         .privatekey.get();
   }
 

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -150,8 +150,8 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
-#include "internal.h"
 #include "../crypto/internal.h"
+#include "internal.h"
 
 
 BSSL_NAMESPACE_BEGIN
@@ -187,8 +187,7 @@ static UniquePtr<CRYPTO_BUFFER> x509_to_buffer(X509 *x509) {
 // new_leafless_chain returns a fresh stack of buffers set to {NULL}.
 static UniquePtr<STACK_OF(CRYPTO_BUFFER)> new_leafless_chain(void) {
   UniquePtr<STACK_OF(CRYPTO_BUFFER)> chain(sk_CRYPTO_BUFFER_new_null());
-  if (!chain ||
-      !sk_CRYPTO_BUFFER_push(chain.get(), nullptr)) {
+  if (!chain || !sk_CRYPTO_BUFFER_push(chain.get(), nullptr)) {
     return nullptr;
   }
 
@@ -200,7 +199,7 @@ static UniquePtr<STACK_OF(CRYPTO_BUFFER)> new_leafless_chain(void) {
 // which case no change to |cert->chain| is made. It preverses the existing
 // leaf from |cert->chain|, if any.
 static bool ssl_cert_set_chain(CERT *cert, STACK_OF(X509) *chain) {
-  if(!ssl_cert_check_cert_private_keys_usage(cert)) {
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
     return false;
   }
 
@@ -241,14 +240,14 @@ static bool ssl_cert_set_chain(CERT *cert, STACK_OF(X509) *chain) {
 }
 
 static void ssl_crypto_x509_cert_flush_leaf(CERT *cert) {
-  for (auto & cert_privatekey : cert->cert_private_keys) {
+  for (auto &cert_privatekey : cert->cert_private_keys) {
     X509_free(cert_privatekey.x509_leaf);
     cert_privatekey.x509_leaf = nullptr;
   }
 }
 
 static void ssl_crypto_x509_cert_flush_cached_chain(CERT *cert) {
-  for (auto & cert_privatekey : cert->cert_private_keys) {
+  for (auto &cert_privatekey : cert->cert_private_keys) {
     sk_X509_pop_free(cert_privatekey.x509_chain, X509_free);
     cert_privatekey.x509_chain = nullptr;
   }
@@ -398,8 +397,7 @@ static bool ssl_crypto_x509_session_verify_cert_chain(SSL_SESSION *session,
   size_t name_len;
   SSL_get0_ech_name_override(ssl, &name, &name_len);
   UniquePtr<X509_STORE_CTX> ctx(X509_STORE_CTX_new());
-  if (!ctx ||
-      !X509_STORE_CTX_init(ctx.get(), verify_store, leaf, cert_chain) ||
+  if (!ctx || !X509_STORE_CTX_init(ctx.get(), verify_store, leaf, cert_chain) ||
       !X509_STORE_CTX_set_ex_data(ctx.get(),
                                   SSL_get_ex_data_X509_STORE_CTX_idx(), ssl) ||
       // We need to inherit the verify parameters. These can be determined by
@@ -471,14 +469,15 @@ static void ssl_crypto_x509_ssl_config_free(SSL_CONFIG *cfg) {
 }
 
 static bool ssl_crypto_x509_ssl_auto_chain_if_needed(SSL_HANDSHAKE *hs) {
-  if(!ssl_cert_check_cert_private_keys_usage(hs->config->cert.get())) {
+  if (!ssl_cert_check_cert_private_keys_usage(hs->config->cert.get())) {
     return false;
   }
 
   // Only build a chain if there are no intermediates configured and the feature
   // isn't disabled.
   UniquePtr<STACK_OF(CRYPTO_BUFFER)> &cert_chain =
-      hs->config->cert->cert_private_keys[hs->config->cert->cert_private_key_idx]
+      hs->config->cert
+          ->cert_private_keys[hs->config->cert->cert_private_key_idx]
           .chain;
   if ((hs->ssl->mode & SSL_MODE_NO_AUTO_CHAIN) || !ssl_has_certificate(hs) ||
       cert_chain == nullptr || sk_CRYPTO_BUFFER_num(cert_chain.get()) > 1) {
@@ -716,10 +715,8 @@ void SSL_set_verify_depth(SSL *ssl, int depth) {
   X509_VERIFY_PARAM_set_depth(ssl->config->param, depth);
 }
 
-void SSL_CTX_set_cert_verify_callback(SSL_CTX *ctx,
-                                      int (*cb)(X509_STORE_CTX *store_ctx,
-                                                void *arg),
-                                      void *arg) {
+void SSL_CTX_set_cert_verify_callback(
+    SSL_CTX *ctx, int (*cb)(X509_STORE_CTX *store_ctx, void *arg), void *arg) {
   check_ssl_ctx_x509_method(ctx);
   ctx->app_verify_callback = cb;
   ctx->app_verify_arg = arg;
@@ -774,7 +771,7 @@ static int ssl_use_certificate(CERT *cert, X509 *x) {
     return 0;
   }
 
-  if(!ssl_cert_check_cert_private_keys_usage(cert)) {
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
     return 0;
   }
   // We set the |x509_leaf| here to prevent any external data set from being
@@ -811,7 +808,7 @@ int SSL_CTX_use_certificate(SSL_CTX *ctx, X509 *x) {
 // |SSL_CTX_use_certificate_ASN1| or |SSL_use_certificate_ASN1| in AWS-LC.
 static int ssl_cert_cache_leaf_cert(CERT *cert) {
   assert(cert->x509_method);
-  if(!ssl_cert_check_cert_private_keys_usage(cert)) {
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
     return 0;
   }
 
@@ -834,7 +831,7 @@ static int ssl_cert_cache_leaf_cert(CERT *cert) {
 }
 
 static X509 *ssl_cert_get0_leaf(CERT *cert) {
-  if(!ssl_cert_check_cert_private_keys_usage(cert)) {
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
     return nullptr;
   }
 
@@ -858,7 +855,7 @@ X509 *SSL_get_certificate(const SSL *ssl) {
 
 X509 *SSL_CTX_get0_certificate(const SSL_CTX *ctx) {
   check_ssl_ctx_x509_method(ctx);
-  MutexWriteLock lock(const_cast<CRYPTO_MUTEX*>(&ctx->lock));
+  MutexWriteLock lock(const_cast<CRYPTO_MUTEX *>(&ctx->lock));
   return ssl_cert_get0_leaf(ctx->cert.get());
 }
 
@@ -883,7 +880,7 @@ static int ssl_cert_set1_chain(CERT *cert, STACK_OF(X509) *chain) {
 
 static int ssl_cert_append_cert(CERT *cert, X509 *x509) {
   assert(cert->x509_method);
-  if(!ssl_cert_check_cert_private_keys_usage(cert)) {
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
     return 0;
   }
 
@@ -1003,7 +1000,7 @@ int SSL_clear_chain_certs(SSL *ssl) {
 // |cert->chain|.
 static int ssl_cert_cache_chain_certs(CERT *cert) {
   assert(cert->x509_method);
-  if(!ssl_cert_check_cert_private_keys_usage(cert)) {
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
     return 0;
   }
 
@@ -1017,20 +1014,20 @@ static int ssl_cert_cache_chain_certs(CERT *cert) {
     return 1;
   }
 
-  UniquePtr<STACK_OF(X509)> new_chain(sk_X509_new_null());
-  if (!new_chain) {
+  UniquePtr<STACK_OF(X509)> new_x509_chain(sk_X509_new_null());
+  if (!new_x509_chain) {
     return 0;
   }
 
   for (size_t i = 1; i < sk_CRYPTO_BUFFER_num(chain.get()); i++) {
     CRYPTO_BUFFER *buffer = sk_CRYPTO_BUFFER_value(chain.get(), i);
     UniquePtr<X509> x509(X509_parse_from_buffer(buffer));
-    if (!x509 || !PushToStack(new_chain.get(), std::move(x509))) {
+    if (!x509 || !PushToStack(new_x509_chain.get(), std::move(x509))) {
       return 0;
     }
   }
 
-  x509_chain = new_chain.release();
+  x509_chain = new_x509_chain.release();
   return 1;
 }
 
@@ -1042,6 +1039,7 @@ int SSL_CTX_get0_chain_certs(const SSL_CTX *ctx, STACK_OF(X509) **out_chain) {
     return 0;
   }
 
+  // |cert_private_keys| already checked above in |ssl_cert_cache_chain_certs|.
   *out_chain =
       ctx->cert->cert_private_keys[ctx->cert->cert_private_key_idx].x509_chain;
   return 1;
@@ -1063,6 +1061,7 @@ int SSL_get0_chain_certs(const SSL *ssl, STACK_OF(X509) **out_chain) {
     return 0;
   }
 
+  // |cert_private_keys| already checked above in |ssl_cert_cache_chain_certs|.
   *out_chain = ssl->config->cert
                    ->cert_private_keys[ssl->config->cert->cert_private_key_idx]
                    .x509_chain;
@@ -1140,8 +1139,7 @@ static void set_client_CA_list(UniquePtr<STACK_OF(CRYPTO_BUFFER)> *ca_list,
 
     UniquePtr<CRYPTO_BUFFER> buffer(CRYPTO_BUFFER_new(outp, len, pool));
     OPENSSL_free(outp);
-    if (!buffer ||
-        !PushToStack(buffers.get(), std::move(buffer))) {
+    if (!buffer || !PushToStack(buffers.get(), std::move(buffer))) {
       return;
     }
   }
@@ -1166,9 +1164,8 @@ void SSL_CTX_set_client_CA_list(SSL_CTX *ctx, STACK_OF(X509_NAME) *name_list) {
   sk_X509_NAME_pop_free(name_list, X509_NAME_free);
 }
 
-static STACK_OF(X509_NAME) *
-    buffer_names_to_x509(const STACK_OF(CRYPTO_BUFFER) *names,
-                         STACK_OF(X509_NAME) **cached) {
+static STACK_OF(X509_NAME) *buffer_names_to_x509(
+    const STACK_OF(CRYPTO_BUFFER) *names, STACK_OF(X509_NAME) **cached) {
   if (names == NULL) {
     return NULL;
   }
@@ -1318,8 +1315,7 @@ static int do_client_cert_cb(SSL *ssl, void *arg) {
   UniquePtr<EVP_PKEY> free_pkey(pkey);
 
   if (ret != 0) {
-    if (!SSL_use_certificate(ssl, x509) ||
-        !SSL_use_PrivateKey(ssl, pkey)) {
+    if (!SSL_use_certificate(ssl, x509) || !SSL_use_PrivateKey(ssl, pkey)) {
       return 0;
     }
   }
@@ -1327,9 +1323,9 @@ static int do_client_cert_cb(SSL *ssl, void *arg) {
   return 1;
 }
 
-void SSL_CTX_set_client_cert_cb(SSL_CTX *ctx, int (*cb)(SSL *ssl,
-                                                        X509 **out_x509,
-                                                        EVP_PKEY **out_pkey)) {
+void SSL_CTX_set_client_cert_cb(SSL_CTX *ctx,
+                                int (*cb)(SSL *ssl, X509 **out_x509,
+                                          EVP_PKEY **out_pkey)) {
   check_ssl_ctx_x509_method(ctx);
   // Emulate the old client certificate callback with the new one.
   SSL_CTX_set_cert_cb(ctx, do_client_cert_cb, NULL);

--- a/ssl/tls13_both.cc
+++ b/ssl/tls13_both.cc
@@ -415,7 +415,7 @@ bool tls13_add_certificate(SSL_HANDSHAKE *hs) {
     return ssl_add_message_cbb(ssl, cbb.get());
   }
   UniquePtr<STACK_OF(CRYPTO_BUFFER)> &chain =
-      cert->cert_privatekeys[cert->cert_privatekey_idx].chain;
+      cert->cert_private_keys[cert->cert_private_key_idx].chain;
   CRYPTO_BUFFER *leaf_buf = sk_CRYPTO_BUFFER_value(chain.get(), 0);
   CBB leaf, extensions;
   if (!CBB_add_u24_length_prefixed(&certificate_list, &leaf) ||

--- a/ssl/tls13_both.cc
+++ b/ssl/tls13_both.cc
@@ -414,6 +414,7 @@ bool tls13_add_certificate(SSL_HANDSHAKE *hs) {
   if (!ssl_has_certificate(hs)) {
     return ssl_add_message_cbb(ssl, cbb.get());
   }
+  // |cert_private_keys| already checked above in |ssl_has_certificate|.
   UniquePtr<STACK_OF(CRYPTO_BUFFER)> &chain =
       cert->cert_private_keys[cert->cert_private_key_idx].chain;
   CRYPTO_BUFFER *leaf_buf = sk_CRYPTO_BUFFER_value(chain.get(), 0);


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1844`

### Description of changes: 
This doesn't actually implement multiple cert functionality, but sets up the structures to do so. All certs currently use the first index (`SSL_PKEY_RSA`) during the SSL connection. 
A subsequent PR will be introduced to implement usage of the new certificate slots.

### Call-outs:
Overall functionality of the code shouldn't be effected right now, this is just letting the code point to new pointers.

### Testing:
Original tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
