### PR TITLE
Disable two "Visual Studio 17 2022" warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,8 @@ elseif(MSVC)
       "C4191" # unsafe conversion from 'type of expression' to 'type required'
               # TODO remove once https://github.com/openssl/openssl/issues/18957 is resolved
       "C4996" # deprecated warnings using low level functions in OpenSSL 3.0
+      "C4746" # consider using __iso_volatile_load/store intrinsic functions
+      "C5264" # 'variable-name': 'const' variable is not used
           )
   set(MSVC_LEVEL4_WARNINGS_LIST
       # See https://connect.microsoft.com/VisualStudio/feedback/details/1217660/warning-c4265-when-using-functional-header


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Disables two warnings generated when compiling with "Visual Studio 17 2022".
* Build succeeds for both shared and static build on Windows/x86-64.

### Call-outs:
N/A

### Testing:
Tested on Windows Server 2019 EC2 instance:
```
\aws-lc\build> cmake -DBUILD_SHARED_LIBS=1 ..
-- Building for: Visual Studio 17 2022
-- The C compiler identification is MSVC 19.36.32535.0
...
repos\aws-lc\build> cmake --build .
MSBuild version 17.6.3+07e294721 for .NET Framework

  Checking Build System
  Building Custom Rule C:/Users/Administrator/repos/aws-lc/CMakeLists.txt
...
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
