### PR TITLE
Entropy pool implementation

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -422,6 +422,7 @@ add_library(
   poly1305/poly1305_vec.c
   pool/pool.c
   rand_extra/deterministic.c
+  rand_extra/entropy_passive.c
   rand_extra/forkunsafe.c
   rand_extra/fuchsia.c
   rand_extra/rand_extra.c
@@ -726,6 +727,7 @@ if(BUILD_TESTING)
     fipsmodule/pbkdf/pbkdf_test.cc
     fipsmodule/rand/ctrdrbg_test.cc
     fipsmodule/rand/cpu_jitter_test.cc
+    fipsmodule/rand/entropy_pool_test.cc
     fipsmodule/rand/fork_detect_test.cc
     fipsmodule/service_indicator/service_indicator_test.cc
     fipsmodule/sha/sha_test.cc

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -125,6 +125,7 @@
 #include "pbkdf/pbkdf.c"
 #include "rand/ctrdrbg.c"
 #include "rand/fork_detect.c"
+#include "rand/entropy_pool.c"
 #include "rand/rand.c"
 #include "rand/urandom.c"
 #include "rsa/blinding.c"

--- a/crypto/fipsmodule/rand/entropy_pool.c
+++ b/crypto/fipsmodule/rand/entropy_pool.c
@@ -115,4 +115,4 @@ int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
   return 1;
 }
 
-#endif
+#endif // defined(AWSLC_FIPS)

--- a/crypto/fipsmodule/rand/entropy_pool.c
+++ b/crypto/fipsmodule/rand/entropy_pool.c
@@ -56,13 +56,11 @@ static void entropy_pool_cannot_satisfy_request(void) {
 	// And then unlock struct here
 }
 
-// Add documentation in header file
 void RAND_entropy_pool_init(struct entropy_pool *entropy_pool) {
 	RAND_entropy_pool_zeroize(entropy_pool);
 	entropy_pool->capacity = ENTROPY_POOL_SIZE;
 }
 
-// Add documentation
 void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool) {
 	if (entropy_pool == NULL) {
 		abort();
@@ -74,7 +72,6 @@ void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool) {
 	OPENSSL_cleanse(entropy_pool->pool, ENTROPY_POOL_SIZE);
 }
 
-// Add documentation in header file
 void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
 	uint8_t add_buffer[ENTROPY_POOL_SIZE]) {
 
@@ -89,7 +86,6 @@ void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
 	entropy_pool->valid_available = ENTROPY_POOL_SIZE;
 }
 
-// Add documentation in header file
 int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
 	uint8_t *get_buffer, size_t get_size) {
 

--- a/crypto/fipsmodule/rand/entropy_pool.c
+++ b/crypto/fipsmodule/rand/entropy_pool.c
@@ -9,112 +9,112 @@
 // entropy_pool_validate_static_assumptions validates static assumptions on the
 // entropy pool |entropy_pool|.
 static int entropy_pool_validate_static_assumptions(
-	struct entropy_pool *entropy_pool) {
-	// By transitivity, |valid_available| and |index_read| are verified to be at
-	// most |ENTROPY_POOL_SIZE|.
-	if (entropy_pool != NULL &&
-		entropy_pool->capacity <= ENTROPY_POOL_SIZE &&
-		entropy_pool->valid_available <= entropy_pool->capacity &&
-		entropy_pool->index_read <= entropy_pool->capacity) {
-		return 1;
-	}
-	return 0;
+  struct entropy_pool *entropy_pool) {
+  // By transitivity, |valid_available| and |index_read| are verified to be at
+  // most |ENTROPY_POOL_SIZE|.
+  if (entropy_pool != NULL &&
+    entropy_pool->capacity <= ENTROPY_POOL_SIZE &&
+    entropy_pool->valid_available <= entropy_pool->capacity &&
+    entropy_pool->index_read <= entropy_pool->capacity) {
+    return 1;
+  }
+  return 0;
 }
 
 // entropy_pool_ensure_can_satisfy returns 1 if the entropy pool |entropy_pool|
 // contains enough entropy to satisfy a get request of size |get_size|.
 // Returns 0 otherwise.
 static int entropy_pool_ensure_can_satisfy(struct entropy_pool *entropy_pool,
-	size_t get_size) {
-	if (entropy_pool->valid_available >= get_size) {
-		return 1;
-	}
-	return 0;
+  size_t get_size) {
+  if (entropy_pool->valid_available >= get_size) {
+    return 1;
+  }
+  return 0;
 }
 
 static int entropy_pool_consume(struct entropy_pool *entropy_pool,
-	uint8_t *get_buffer, size_t get_size) {
+  uint8_t *get_buffer, size_t get_size) {
 
-	if ((entropy_pool->index_read + get_size) > entropy_pool->capacity) {
-		return 0;
-	}
+  if ((entropy_pool->index_read + get_size) > entropy_pool->capacity) {
+    return 0;
+  }
 
-	OPENSSL_memcpy(get_buffer, entropy_pool->pool + entropy_pool->index_read,
-		get_size);
+  OPENSSL_memcpy(get_buffer, entropy_pool->pool + entropy_pool->index_read,
+    get_size);
 
-	OPENSSL_cleanse(entropy_pool->pool + entropy_pool->index_read, get_size);
-	entropy_pool->index_read = entropy_pool->index_read + get_size;
-	entropy_pool->valid_available = entropy_pool->valid_available - get_size;
+  OPENSSL_cleanse(entropy_pool->pool + entropy_pool->index_read, get_size);
+  entropy_pool->index_read = entropy_pool->index_read + get_size;
+  entropy_pool->valid_available = entropy_pool->valid_available - get_size;
 
-	return 1;
+  return 1;
 }
 
 static void entropy_pool_cannot_satisfy_request(void) {
-	// Out-side module call
-	// Could create a soft-lock in the struct here
-	RAND_module_entropy_depleted();
-	// And then unlock struct here
+  // Out-side module call
+  // Could create a soft-lock in the struct here
+  RAND_module_entropy_depleted();
+  // And then unlock struct here
 }
 
 void RAND_entropy_pool_init(struct entropy_pool *entropy_pool) {
-	RAND_entropy_pool_zeroize(entropy_pool);
-	entropy_pool->capacity = ENTROPY_POOL_SIZE;
+  RAND_entropy_pool_zeroize(entropy_pool);
+  entropy_pool->capacity = ENTROPY_POOL_SIZE;
 }
 
 void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool) {
-	if (entropy_pool == NULL) {
-		abort();
-	}
+  if (entropy_pool == NULL) {
+    abort();
+  }
 
-	entropy_pool->capacity = 0;
-	entropy_pool->valid_available = 0;
-	entropy_pool->index_read = 0;
-	OPENSSL_cleanse(entropy_pool->pool, ENTROPY_POOL_SIZE);
+  entropy_pool->capacity = 0;
+  entropy_pool->valid_available = 0;
+  entropy_pool->index_read = 0;
+  OPENSSL_cleanse(entropy_pool->pool, ENTROPY_POOL_SIZE);
 }
 
 void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
-	uint8_t add_buffer[ENTROPY_POOL_SIZE]) {
+  uint8_t add_buffer[ENTROPY_POOL_SIZE]) {
 
-	// An explicit (and simplifying) assumption is that the entire pool is
-	// written with fresh entropy, every time.
-	if (entropy_pool == NULL || entropy_pool->capacity != ENTROPY_POOL_SIZE) {
-		abort();
-	}
+  // An explicit (and simplifying) assumption is that the entire pool is
+  // written with fresh entropy, every time.
+  if (entropy_pool == NULL || entropy_pool->capacity != ENTROPY_POOL_SIZE) {
+    abort();
+  }
 
-	OPENSSL_memcpy(entropy_pool->pool, add_buffer, ENTROPY_POOL_SIZE);
-	entropy_pool->index_read = 0;
-	entropy_pool->valid_available = ENTROPY_POOL_SIZE;
+  OPENSSL_memcpy(entropy_pool->pool, add_buffer, ENTROPY_POOL_SIZE);
+  entropy_pool->index_read = 0;
+  entropy_pool->valid_available = ENTROPY_POOL_SIZE;
 }
 
 int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
-	uint8_t *get_buffer, size_t get_size) {
+  uint8_t *get_buffer, size_t get_size) {
 
-	// Doesn't support requests bigger than the total size of the pool or zero.
-	if (entropy_pool == NULL ||
-		get_buffer == NULL ||
-		get_size == 0 ||
-		get_size > entropy_pool->capacity) {
-		return 0;
-	}
+  // Doesn't support requests bigger than the total size of the pool or zero.
+  if (entropy_pool == NULL ||
+    get_buffer == NULL ||
+    get_size == 0 ||
+    get_size > entropy_pool->capacity) {
+    return 0;
+  }
 
-	if (entropy_pool_validate_static_assumptions(entropy_pool) != 1) {
-		return 0;
-	}
+  if (entropy_pool_validate_static_assumptions(entropy_pool) != 1) {
+    return 0;
+  }
 
-	if (entropy_pool_ensure_can_satisfy(entropy_pool, get_size) != 1) {
-		entropy_pool_cannot_satisfy_request();
-		if (entropy_pool_ensure_can_satisfy(entropy_pool, get_size) != 1) {
-			return 0;
-		}
-	}
+  if (entropy_pool_ensure_can_satisfy(entropy_pool, get_size) != 1) {
+    entropy_pool_cannot_satisfy_request();
+    if (entropy_pool_ensure_can_satisfy(entropy_pool, get_size) != 1) {
+      return 0;
+    }
+  }
 
-	// Can't reach this point without entropy pool having enough entropy to
-	// satisfy the request size.
-	if (entropy_pool_consume(entropy_pool, get_buffer, get_size) != 1) {
-		return 0;
-	}
+  // Can't reach this point without entropy pool having enough entropy to
+  // satisfy the request size.
+  if (entropy_pool_consume(entropy_pool, get_buffer, get_size) != 1) {
+    return 0;
+  }
 
-	return 1;
+  return 1;
 }
 
 #endif

--- a/crypto/fipsmodule/rand/entropy_pool.c
+++ b/crypto/fipsmodule/rand/entropy_pool.c
@@ -69,19 +69,21 @@ void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool) {
   OPENSSL_cleanse(entropy_pool, sizeof(struct entropy_pool));
 }
 
-void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
+int RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
   uint8_t add_buffer[ENTROPY_POOL_SIZE]) {
 
   // An explicit (and simplifying) assumption is that the entire pool is
   // written with fresh entropy, every time.
   if (entropy_pool == NULL ||
       entropy_pool->capacity != ENTROPY_POOL_SIZE) {
-    abort();
+    return 0;
   }
 
   OPENSSL_memcpy(entropy_pool->pool, add_buffer, ENTROPY_POOL_SIZE);
   entropy_pool->index_read = 0;
   entropy_pool->valid_available = ENTROPY_POOL_SIZE;
+
+  return 1;
 }
 
 int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,

--- a/crypto/fipsmodule/rand/entropy_pool.c
+++ b/crypto/fipsmodule/rand/entropy_pool.c
@@ -69,10 +69,12 @@ int RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
   // written with fresh entropy, every time.
   if (entropy_pool == NULL ||
       entropy_pool->capacity != ENTROPY_POOL_SIZE) {
+    OPENSSL_cleanse(add_buffer, ENTROPY_POOL_SIZE);
     return 0;
   }
 
   OPENSSL_memcpy(entropy_pool->pool, add_buffer, ENTROPY_POOL_SIZE);
+  OPENSSL_cleanse(add_buffer, ENTROPY_POOL_SIZE);
   entropy_pool->index_read = 0;
   entropy_pool->valid_available = ENTROPY_POOL_SIZE;
 

--- a/crypto/fipsmodule/rand/entropy_pool.c
+++ b/crypto/fipsmodule/rand/entropy_pool.c
@@ -65,10 +65,8 @@ void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool) {
     return;
   }
 
-  entropy_pool->capacity = 0;
-  entropy_pool->valid_available = 0;
-  entropy_pool->index_read = 0;
   OPENSSL_cleanse(entropy_pool->pool, ENTROPY_POOL_SIZE);
+  OPENSSL_cleanse(entropy_pool, sizeof(struct entropy_pool));
 }
 
 void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,

--- a/crypto/fipsmodule/rand/entropy_pool.c
+++ b/crypto/fipsmodule/rand/entropy_pool.c
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include "internal.h"
+#include "../../internal.h"
+
+#if defined(AWSLC_FIPS)
+
+// entropy_pool_validate_static_assumptions validates static assumptions on the
+// entropy pool |entropy_pool|.
+static int entropy_pool_validate_static_assumptions(
+	struct entropy_pool *entropy_pool) {
+	// By transitivity, |valid_available| and |index_read| are verified to be at
+	// most |ENTROPY_POOL_SIZE|.
+	if (entropy_pool != NULL &&
+		entropy_pool->capacity <= ENTROPY_POOL_SIZE &&
+		entropy_pool->valid_available <= entropy_pool->capacity &&
+		entropy_pool->index_read <= entropy_pool->capacity) {
+		return 1;
+	}
+	return 0;
+}
+
+// entropy_pool_ensure_can_satisfy returns 1 if the entropy pool |entropy_pool|
+// contains enough entropy to satisfy a get request of size |get_size|.
+// Returns 0 otherwise.
+static int entropy_pool_ensure_can_satisfy(struct entropy_pool *entropy_pool,
+	size_t get_size) {
+	if (entropy_pool->valid_available >= get_size) {
+		return 1;
+	}
+	return 0;
+}
+
+static int entropy_pool_consume(struct entropy_pool *entropy_pool,
+	uint8_t *get_buffer, size_t get_size) {
+
+	if ((entropy_pool->index_read + get_size) > entropy_pool->capacity) {
+		return 0;
+	}
+
+	OPENSSL_memcpy(get_buffer, entropy_pool->pool + entropy_pool->index_read,
+		get_size);
+
+	OPENSSL_cleanse(entropy_pool->pool + entropy_pool->index_read, get_size);
+	entropy_pool->index_read = entropy_pool->index_read + get_size;
+	entropy_pool->valid_available = entropy_pool->valid_available - get_size;
+
+	return 1;
+}
+
+static void entropy_pool_cannot_satisfy_request(void) {
+	// Out-side module call
+	// Could create a soft-lock in the struct here
+	RAND_module_entropy_depleted();
+	// And then unlock struct here
+}
+
+// Add documentation in header file
+void RAND_entropy_pool_init(struct entropy_pool *entropy_pool) {
+	RAND_entropy_pool_zeroize(entropy_pool);
+	entropy_pool->capacity = ENTROPY_POOL_SIZE;
+}
+
+// Add documentation
+void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool) {
+	if (entropy_pool == NULL) {
+		abort();
+	}
+
+	entropy_pool->capacity = 0;
+	entropy_pool->valid_available = 0;
+	entropy_pool->index_read = 0;
+	OPENSSL_cleanse(entropy_pool->pool, ENTROPY_POOL_SIZE);
+}
+
+// Add documentation in header file
+void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
+	uint8_t add_buffer[ENTROPY_POOL_SIZE]) {
+
+	// An explicit (and simplifying) assumption is that the entire pool is
+	// written with fresh entropy, every time.
+	if (entropy_pool == NULL || entropy_pool->capacity != ENTROPY_POOL_SIZE) {
+		abort();
+	}
+
+	OPENSSL_memcpy(entropy_pool->pool, add_buffer, ENTROPY_POOL_SIZE);
+	entropy_pool->index_read = 0;
+	entropy_pool->valid_available = ENTROPY_POOL_SIZE;
+}
+
+// Add documentation in header file
+int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
+	uint8_t *get_buffer, size_t get_size) {
+
+	// Doesn't support requests bigger than the total size of the pool or zero.
+	if (entropy_pool == NULL ||
+		get_buffer == NULL ||
+		get_size == 0 ||
+		get_size > entropy_pool->capacity) {
+		return 0;
+	}
+
+	if (entropy_pool_validate_static_assumptions(entropy_pool) != 1) {
+		return 0;
+	}
+
+	if (entropy_pool_ensure_can_satisfy(entropy_pool, get_size) != 1) {
+		entropy_pool_cannot_satisfy_request();
+		if (entropy_pool_ensure_can_satisfy(entropy_pool, get_size) != 1) {
+			return 0;
+		}
+	}
+
+	// Can't reach this point without entropy pool having enough entropy to
+	// satisfy the request size.
+	if (entropy_pool_consume(entropy_pool, get_buffer, get_size) != 1) {
+		return 0;
+	}
+
+	return 1;
+}
+
+#endif

--- a/crypto/fipsmodule/rand/entropy_pool_test.cc
+++ b/crypto/fipsmodule/rand/entropy_pool_test.cc
@@ -41,7 +41,7 @@ TEST(EntropyPool, BasicFlow) {
 
   // After adding entropy to the pool, expect the number of valid bytes to
   // match the amount added.
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy));
   EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
@@ -66,7 +66,7 @@ TEST(EntropyPool, BasicFlow) {
   // Initialize again but now consume a total of |ENTROPY_POOL_SIZE| bytes of
   // entropy over two get invocations.
   RAND_entropy_pool_init(&entropy_pool);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy));
 
   OPENSSL_cleanse(entropy_buffer, ENTROPY_POOL_SIZE);
   EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, entropy_pool_size_halfed));
@@ -101,7 +101,7 @@ TEST(EntropyPool, BasicFailure) {
   fill_fake_entropy(fake_entropy, 'A');
 
   RAND_entropy_pool_init(&entropy_pool);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy));
 
   // Input validation. Cannot:
   //  * Consume strictly more than |ENTROPY_POOL_SIZE| bytes per invocation.
@@ -119,7 +119,7 @@ TEST(EntropyPool, BasicFailure) {
 
   // Modify internal state to capture validations
   OPENSSL_cleanse(entropy_buffer, ENTROPY_POOL_SIZE);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy));
   entropy_pool.capacity = ENTROPY_POOL_SIZE + 1;
   EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
   EXPECT_EQ(OPENSSL_memcmp(entropy_buffer, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
@@ -127,7 +127,7 @@ TEST(EntropyPool, BasicFailure) {
   EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
 
   OPENSSL_cleanse(entropy_buffer, ENTROPY_POOL_SIZE);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy));
   entropy_pool.valid_available = ENTROPY_POOL_SIZE + 1;
   EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
   EXPECT_EQ(OPENSSL_memcmp(entropy_buffer, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
@@ -135,7 +135,7 @@ TEST(EntropyPool, BasicFailure) {
   EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
 
   OPENSSL_cleanse(entropy_buffer, ENTROPY_POOL_SIZE);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy));
   entropy_pool.index_read = ENTROPY_POOL_SIZE + 1;
   EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
   EXPECT_EQ(OPENSSL_memcmp(entropy_buffer, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
@@ -154,10 +154,10 @@ TEST(EntropyPool, EntirePoolRefreshedAtAddTime) {
   // Even though there is still valid available entropy in the pool, the entire
   // pool must be refreshed when adding fresh entropy.
   RAND_entropy_pool_init(&entropy_pool);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy_A));
   EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, entropy_pool_size_halfed));
   EXPECT_GT(entropy_pool.valid_available, (size_t) 0);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy_B);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy_B));
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_B, ENTROPY_POOL_SIZE), 0);
 
   // If adding entropy twice in a row, entire pool should be refreshed even
@@ -165,10 +165,10 @@ TEST(EntropyPool, EntirePoolRefreshedAtAddTime) {
   // previous unit test).
   RAND_entropy_pool_zeroize(&entropy_pool);
   RAND_entropy_pool_init(&entropy_pool);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy_A));
   EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_A, ENTROPY_POOL_SIZE), 0);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy_B);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy_B));
   EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_B, ENTROPY_POOL_SIZE), 0);
 
@@ -176,13 +176,13 @@ TEST(EntropyPool, EntirePoolRefreshedAtAddTime) {
   // though all entropy had been consumed.
   RAND_entropy_pool_zeroize(&entropy_pool);
   RAND_entropy_pool_init(&entropy_pool);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy_A));
   EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
   EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy_A));
   EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
-  RAND_entropy_pool_add(&entropy_pool, fake_entropy_B);
+  EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy_B));
   EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_B, ENTROPY_POOL_SIZE), 0);
 }

--- a/crypto/fipsmodule/rand/entropy_pool_test.cc
+++ b/crypto/fipsmodule/rand/entropy_pool_test.cc
@@ -122,6 +122,8 @@ TEST(EntropyPool, BasicFailure) {
   EXPECT_EQ(OPENSSL_memcmp(entropy_buffer, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
   EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, NULL, ENTROPY_POOL_SIZE));
   EXPECT_EQ(OPENSSL_memcmp(entropy_buffer, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
+  // Nothing should have touched the entropy pool
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_check_output, ENTROPY_POOL_SIZE), 0);
 
   // Modify internal state to capture validations
   OPENSSL_cleanse(entropy_buffer, ENTROPY_POOL_SIZE);

--- a/crypto/fipsmodule/rand/entropy_pool_test.cc
+++ b/crypto/fipsmodule/rand/entropy_pool_test.cc
@@ -108,6 +108,9 @@ TEST(EntropyPool, BasicFailure) {
   fill_fake_entropy(fake_entropy, 'A');
   EXPECT_TRUE(RAND_entropy_pool_add(&entropy_pool, fake_entropy));
 
+  // Shouldn't abort
+  RAND_entropy_pool_zeroize(NULL);
+
   // Input validation. Cannot:
   //  * Consume strictly more than |ENTROPY_POOL_SIZE| bytes per invocation.
   //  * Consume zero bytes.

--- a/crypto/fipsmodule/rand/entropy_pool_test.cc
+++ b/crypto/fipsmodule/rand/entropy_pool_test.cc
@@ -1,0 +1,173 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include "internal.h"
+
+#include <gtest/gtest.h>
+
+#if defined(AWSLC_FIPS)
+
+// For standalone entropy pool tests, we add entropy through
+// RAND_entropy_pool_add_entropy(). If we activate the "deplete" workflow
+// the workflow will add entropy to the thread-local entropy pool, not the
+// locally initialized pool in the standalone tests below.
+
+const size_t entropy_pool_size_halfed = ENTROPY_POOL_SIZE / 2;
+const uint8_t zero_entropy_pool[ENTROPY_POOL_SIZE] = {0};
+
+static void fill_fake_entropy(uint8_t fake_entropy_buffer[ENTROPY_POOL_SIZE], char ch);
+static void fill_fake_entropy(uint8_t fake_entropy_buffer[ENTROPY_POOL_SIZE], char ch) {
+  for (size_t i = 0; i < ENTROPY_POOL_SIZE; i++) {
+    fake_entropy_buffer[i] = ch;
+  }
+}
+
+TEST(EntropyPool, BasicFlow) {
+  uint8_t fake_entropy[ENTROPY_POOL_SIZE] = {0};
+  fill_fake_entropy(fake_entropy, 'A');
+
+  uint8_t entropy_buffer[ENTROPY_POOL_SIZE] = {0};
+  struct entropy_pool entropy_pool;
+
+  // Initially, the capacity should indicate |ENTROPY_POOL_SIZE|. Rest of the
+  // object should be zeroized.
+  RAND_entropy_pool_init(&entropy_pool);
+  EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
+  EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
+
+  // After adding entropy to the pool, expect to object fields to match.
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy, ENTROPY_POOL_SIZE), 0);
+
+  // Consuming the entire pool. Expects the valid available bytes to be zero
+  // and that we increment the read pointer.
+  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
+  EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
+  EXPECT_EQ(entropy_pool.index_read, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
+
+  // Zeroing the object must lead to the capacity being zero.
+  RAND_entropy_pool_zeroize(&entropy_pool);
+  EXPECT_EQ(entropy_pool.capacity, (size_t) 0);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
+  EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
+
+  // Initialize again but now consume a total of |ENTROPY_POOL_SIZE| bytes of
+  // entropy over two get invocations.
+  RAND_entropy_pool_init(&entropy_pool);
+  EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
+  EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
+
+  // After adding entropy to the pool, expect to object fields to match.
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy, ENTROPY_POOL_SIZE), 0);
+
+  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, entropy_pool_size_halfed));
+  EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) entropy_pool_size_halfed);
+  EXPECT_EQ(entropy_pool.index_read, (size_t) entropy_pool_size_halfed);
+  // Should have zeroized first half of pool.
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, zero_entropy_pool, entropy_pool_size_halfed), 0);
+
+  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, entropy_pool_size_halfed));
+  EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
+  EXPECT_EQ(entropy_pool.index_read, (size_t) ENTROPY_POOL_SIZE);
+  // Entire pool must now be zeroized.
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
+}
+
+TEST(EntropyPool, BasicFailure) {
+  uint8_t fake_entropy[ENTROPY_POOL_SIZE] = {0};
+  fill_fake_entropy(fake_entropy, 'A');
+
+  uint8_t entropy_buffer[ENTROPY_POOL_SIZE] = {0};
+  struct entropy_pool entropy_pool;
+
+  RAND_entropy_pool_init(&entropy_pool);
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+
+  // Input validation. Cannot:
+  //  * Consume strictly more than |ENTROPY_POOL_SIZE| bytes per invocation.
+  //  * Consume zero bytes.
+  //  * Use NULL as argument for entropy pool.
+  //  * Use NULL as argument for output buffer.
+  EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE+1));
+  EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, 0));
+  EXPECT_FALSE(RAND_entropy_pool_get(NULL, entropy_buffer, ENTROPY_POOL_SIZE));
+
+  // Consuming zero bytes is not supported.
+  EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE+1));
+
+  // Modify internal state to capture validations
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  entropy_pool.capacity = ENTROPY_POOL_SIZE + 1;
+  EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
+  entropy_pool.capacity = ENTROPY_POOL_SIZE;
+  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
+
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  entropy_pool.valid_available = ENTROPY_POOL_SIZE + 1;
+  EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
+  entropy_pool.valid_available = ENTROPY_POOL_SIZE;
+  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
+
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy);
+  entropy_pool.index_read = ENTROPY_POOL_SIZE + 1;
+  EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
+  entropy_pool.index_read = 0;
+  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
+}
+
+TEST(EntropyPool, EntirePoolRefreshedAtAddTime) {
+  uint8_t entropy_buffer[ENTROPY_POOL_SIZE] = {0};
+  uint8_t fake_entropy_A[ENTROPY_POOL_SIZE] = {0};
+  uint8_t fake_entropy_B[ENTROPY_POOL_SIZE] = {0};
+  fill_fake_entropy(fake_entropy_A, 'A');
+  fill_fake_entropy(fake_entropy_B, 'B');
+
+  struct entropy_pool entropy_pool;
+
+  // Even though there is still valid available entropy in the pool, the entire
+  // pool must be refreshed when adding fresh entropy.
+  RAND_entropy_pool_init(&entropy_pool);
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, entropy_pool_size_halfed));
+  EXPECT_GT(entropy_pool.valid_available, (size_t) 0);
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy_B);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_B, ENTROPY_POOL_SIZE), 0);
+
+  // If adding entropy twice in a row, entire pool should be refreshed even
+  // though no entropy has been consumed (extra check for the special case of
+  // previous unit test).
+  RAND_entropy_pool_zeroize(&entropy_pool);
+  RAND_entropy_pool_init(&entropy_pool);
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_A, ENTROPY_POOL_SIZE), 0);
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy_B);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_B, ENTROPY_POOL_SIZE), 0);
+
+  // If adding entropy twice in a row, entire pool should be refreshed even
+  // though all entropy had been consumed.
+  RAND_entropy_pool_zeroize(&entropy_pool);
+  RAND_entropy_pool_init(&entropy_pool);
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, entropy_pool_size_halfed));
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  RAND_entropy_pool_add(&entropy_pool, fake_entropy_B);
+  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_B, ENTROPY_POOL_SIZE), 0);
+}
+
+#endif

--- a/crypto/fipsmodule/rand/entropy_pool_test.cc
+++ b/crypto/fipsmodule/rand/entropy_pool_test.cc
@@ -107,6 +107,7 @@ TEST(EntropyPool, BasicFailure) {
   EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE+1));
   EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, 0));
   EXPECT_FALSE(RAND_entropy_pool_get(NULL, entropy_buffer, ENTROPY_POOL_SIZE));
+  EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, NULL, ENTROPY_POOL_SIZE));
 
   // Consuming zero bytes is not supported.
   EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE+1));

--- a/crypto/fipsmodule/rand/entropy_pool_test.cc
+++ b/crypto/fipsmodule/rand/entropy_pool_test.cc
@@ -8,28 +8,30 @@
 #if defined(AWSLC_FIPS)
 
 // For standalone entropy pool tests, we add entropy through
-// RAND_entropy_pool_add_entropy(). If we activate the "deplete" workflow
-// the workflow will add entropy to the thread-local entropy pool, not the
-// locally initialized pool in the standalone tests below.
+// RAND_entropy_pool_add(). The reason is that if a valid RAND_entropy_pool_get()
+// request cannot be satisfied, the "depleted" workflow will add entropy to the
+// thread-local entropy pool, not the locally initialized pool in the standalone
+// tests below.
 
 const size_t entropy_pool_size_halfed = ENTROPY_POOL_SIZE / 2;
 const uint8_t zero_entropy_pool[ENTROPY_POOL_SIZE] = {0};
 
-static void fill_fake_entropy(uint8_t fake_entropy_buffer[ENTROPY_POOL_SIZE], char ch);
-static void fill_fake_entropy(uint8_t fake_entropy_buffer[ENTROPY_POOL_SIZE], char ch) {
+static void fill_fake_entropy(uint8_t fake_entropy_buffer[ENTROPY_POOL_SIZE],
+  char ch);
+static void fill_fake_entropy(uint8_t fake_entropy_buffer[ENTROPY_POOL_SIZE],
+  char ch) {
   for (size_t i = 0; i < ENTROPY_POOL_SIZE; i++) {
     fake_entropy_buffer[i] = ch;
   }
 }
 
 TEST(EntropyPool, BasicFlow) {
+  uint8_t entropy_buffer[ENTROPY_POOL_SIZE] = {0};
+  struct entropy_pool entropy_pool;
   uint8_t fake_entropy[ENTROPY_POOL_SIZE] = {0};
   fill_fake_entropy(fake_entropy, 'A');
 
-  uint8_t entropy_buffer[ENTROPY_POOL_SIZE] = {0};
-  struct entropy_pool entropy_pool;
-
-  // Initially, the capacity should indicate |ENTROPY_POOL_SIZE|. Rest of the
+  // Initially, the capacity should have value |ENTROPY_POOL_SIZE|. Rest of the
   // object should be zeroized.
   RAND_entropy_pool_init(&entropy_pool);
   EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
@@ -37,22 +39,22 @@ TEST(EntropyPool, BasicFlow) {
   EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
 
-  // After adding entropy to the pool, expect to object fields to match.
+  // After adding entropy to the pool, expect the number of valid bytes to
+  // match the amount added.
   RAND_entropy_pool_add(&entropy_pool, fake_entropy);
   EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy, ENTROPY_POOL_SIZE), 0);
 
-  // Consuming the entire pool. Expects the valid available bytes to be zero
-  // and that we increment the read pointer.
+  // Consuming the entire pool. Expect the valid available bytes to be zero
+  // and read pointer to be incremented by the consumed amount.
   EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
   EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
   EXPECT_EQ(entropy_pool.index_read, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
 
-  // Zeroing the object must lead to the capacity being zero.
   RAND_entropy_pool_zeroize(&entropy_pool);
   EXPECT_EQ(entropy_pool.capacity, (size_t) 0);
   EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
@@ -62,17 +64,7 @@ TEST(EntropyPool, BasicFlow) {
   // Initialize again but now consume a total of |ENTROPY_POOL_SIZE| bytes of
   // entropy over two get invocations.
   RAND_entropy_pool_init(&entropy_pool);
-  EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
-  EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
-  EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
-  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, zero_entropy_pool, ENTROPY_POOL_SIZE), 0);
-
-  // After adding entropy to the pool, expect to object fields to match.
   RAND_entropy_pool_add(&entropy_pool, fake_entropy);
-  EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
-  EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
-  EXPECT_EQ(entropy_pool.index_read, (size_t) 0);
-  EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy, ENTROPY_POOL_SIZE), 0);
 
   EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, entropy_pool_size_halfed));
   EXPECT_EQ(entropy_pool.capacity, (size_t) ENTROPY_POOL_SIZE);
@@ -90,11 +82,10 @@ TEST(EntropyPool, BasicFlow) {
 }
 
 TEST(EntropyPool, BasicFailure) {
-  uint8_t fake_entropy[ENTROPY_POOL_SIZE] = {0};
-  fill_fake_entropy(fake_entropy, 'A');
-
   uint8_t entropy_buffer[ENTROPY_POOL_SIZE] = {0};
   struct entropy_pool entropy_pool;
+  uint8_t fake_entropy[ENTROPY_POOL_SIZE] = {0};
+  fill_fake_entropy(fake_entropy, 'A');
 
   RAND_entropy_pool_init(&entropy_pool);
   RAND_entropy_pool_add(&entropy_pool, fake_entropy);
@@ -108,9 +99,6 @@ TEST(EntropyPool, BasicFailure) {
   EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, 0));
   EXPECT_FALSE(RAND_entropy_pool_get(NULL, entropy_buffer, ENTROPY_POOL_SIZE));
   EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, NULL, ENTROPY_POOL_SIZE));
-
-  // Consuming zero bytes is not supported.
-  EXPECT_FALSE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE+1));
 
   // Modify internal state to capture validations
   RAND_entropy_pool_add(&entropy_pool, fake_entropy);
@@ -134,12 +122,11 @@ TEST(EntropyPool, BasicFailure) {
 
 TEST(EntropyPool, EntirePoolRefreshedAtAddTime) {
   uint8_t entropy_buffer[ENTROPY_POOL_SIZE] = {0};
-  uint8_t fake_entropy_A[ENTROPY_POOL_SIZE] = {0};
-  uint8_t fake_entropy_B[ENTROPY_POOL_SIZE] = {0};
-  fill_fake_entropy(fake_entropy_A, 'A');
-  fill_fake_entropy(fake_entropy_B, 'B');
-
   struct entropy_pool entropy_pool;
+  uint8_t fake_entropy_A[ENTROPY_POOL_SIZE] = {0};
+  fill_fake_entropy(fake_entropy_A, 'A');
+  uint8_t fake_entropy_B[ENTROPY_POOL_SIZE] = {0};
+  fill_fake_entropy(fake_entropy_B, 'B');
 
   // Even though there is still valid available entropy in the pool, the entire
   // pool must be refreshed when adding fresh entropy.
@@ -156,8 +143,10 @@ TEST(EntropyPool, EntirePoolRefreshedAtAddTime) {
   RAND_entropy_pool_zeroize(&entropy_pool);
   RAND_entropy_pool_init(&entropy_pool);
   RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_A, ENTROPY_POOL_SIZE), 0);
   RAND_entropy_pool_add(&entropy_pool, fake_entropy_B);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_B, ENTROPY_POOL_SIZE), 0);
 
   // If adding entropy twice in a row, entire pool should be refreshed even
@@ -165,9 +154,13 @@ TEST(EntropyPool, EntirePoolRefreshedAtAddTime) {
   RAND_entropy_pool_zeroize(&entropy_pool);
   RAND_entropy_pool_init(&entropy_pool);
   RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
-  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, entropy_pool_size_halfed));
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
+  EXPECT_TRUE(RAND_entropy_pool_get(&entropy_pool, entropy_buffer, ENTROPY_POOL_SIZE));
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) 0);
   RAND_entropy_pool_add(&entropy_pool, fake_entropy_A);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   RAND_entropy_pool_add(&entropy_pool, fake_entropy_B);
+  EXPECT_EQ(entropy_pool.valid_available, (size_t) ENTROPY_POOL_SIZE);
   EXPECT_EQ(OPENSSL_memcmp(entropy_pool.pool, fake_entropy_B, ENTROPY_POOL_SIZE), 0);
 }
 

--- a/crypto/fipsmodule/rand/entropy_pool_test.cc
+++ b/crypto/fipsmodule/rand/entropy_pool_test.cc
@@ -17,8 +17,6 @@ const size_t entropy_pool_size_halfed = ENTROPY_POOL_SIZE / 2;
 const uint8_t zero_entropy_pool[ENTROPY_POOL_SIZE] = {0};
 
 static void fill_fake_entropy(uint8_t fake_entropy_buffer[ENTROPY_POOL_SIZE],
-  char ch);
-static void fill_fake_entropy(uint8_t fake_entropy_buffer[ENTROPY_POOL_SIZE],
   char ch) {
   for (size_t i = 0; i < ENTROPY_POOL_SIZE; i++) {
     fake_entropy_buffer[i] = ch;

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -177,7 +177,9 @@ OPENSSL_EXPORT int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
 // |entropy_pool|. The capacity of |entropy_pool| must be exactly
 // |ENTROPY_POOL_SIZE| and the amount of (entropy) bytes in |add_buffer| must
 // also be exactly |ENTROPY_POOL_SIZE|.
-OPENSSL_EXPORT void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
+// Returns 1 if entropy is successfully added to the entropy pool and 0
+// otherwise.
+OPENSSL_EXPORT int RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
   uint8_t add_buffer[ENTROPY_POOL_SIZE]);
 
 // TODO

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -178,7 +178,8 @@ OPENSSL_EXPORT int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
 // |ENTROPY_POOL_SIZE| and the amount of (entropy) bytes in |add_buffer| must
 // also be exactly |ENTROPY_POOL_SIZE|.
 // Returns 1 if entropy is successfully added to the entropy pool and 0
-// otherwise.
+// otherwise. |RAND_entropy_pool_add| will zeroise the content of |add_buffer|
+// regardless of the return value.
 OPENSSL_EXPORT int RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
   uint8_t add_buffer[ENTROPY_POOL_SIZE]);
 

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -133,6 +133,39 @@ OPENSSL_EXPORT void HAZMAT_set_urandom_test_mode_for_testing(void);
 #define JITTER_MAX_NUM_TRIES (3)
 #endif
 
+
+#if defined(AWSLC_FIPS)
+
+// CRNGT_BLOCK_SIZE is the number of bytes in a “block” for the purposes of the
+// continuous random number generator test in FIPS 140-2, section 4.9.2.
+#define CRNGT_BLOCK_SIZE 16
+
+#define FIPS_CRNGT_TEST_SIZE CRNGT_BLOCK_SIZE
+#define AWSLC_PASSIVE_ENTROPY_OVERREAD_MULTIPLER 10
+#define AWSLC_PASSIVE_ENTROPY_SOURCE_DRAW_SIZE (FIPS_CRNGT_TEST_SIZE + (CTR_DRBG_ENTROPY_LEN * AWSLC_PASSIVE_ENTROPY_OVERREAD_MULTIPLER))
+#define ENTROPY_POOL_SIZE AWSLC_PASSIVE_ENTROPY_SOURCE_DRAW_SIZE
+
+// Fixed-sized flat memory buffer definition used for passive entropy
+// implementation.
+struct entropy_pool {
+  size_t capacity;
+  size_t valid_available;
+  size_t index_read;
+  uint8_t pool[ENTROPY_POOL_SIZE];
+};
+
+void RAND_entropy_pool_init(struct entropy_pool *entropy_pool);
+void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool);
+int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
+  uint8_t *get_buffer, size_t get_size);
+void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
+  uint8_t add_buffer[ENTROPY_POOL_SIZE]);
+
+void RAND_module_entropy_depleted(void);
+void RAND_load_entropy(uint8_t load_entropy[ENTROPY_POOL_SIZE]);
+
+#endif
+
 #if defined(__cplusplus)
 }  // extern C
 #endif

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -154,11 +154,11 @@ struct entropy_pool {
   uint8_t pool[ENTROPY_POOL_SIZE];
 };
 
-void RAND_entropy_pool_init(struct entropy_pool *entropy_pool);
-void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool);
-int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
+OPENSSL_EXPORT void RAND_entropy_pool_init(struct entropy_pool *entropy_pool);
+OPENSSL_EXPORT void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool);
+OPENSSL_EXPORT int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
   uint8_t *get_buffer, size_t get_size);
-void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
+OPENSSL_EXPORT void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
   uint8_t add_buffer[ENTROPY_POOL_SIZE]);
 
 void RAND_module_entropy_depleted(void);

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -154,14 +154,36 @@ struct entropy_pool {
   uint8_t pool[ENTROPY_POOL_SIZE];
 };
 
+// RAND_entropy_pool_init initializes the entropy pool |entropy_pool|.
 OPENSSL_EXPORT void RAND_entropy_pool_init(struct entropy_pool *entropy_pool);
+
+// RAND_entropy_pool_zeroize zeroes all data stored in the entropy pool
+// |entropy_pool| as well as zeroing all values.
 OPENSSL_EXPORT void RAND_entropy_pool_zeroize(struct entropy_pool *entropy_pool);
+
+// RAND_entropy_pool_get returns |get_size| bytes from the entropy pool
+// |entropy_pool| in |get_buffer|. |get_buffer| must be of size at least
+// |get_size|. The value of |get_size| must be in the
+// interval: (0, ENTROPY_POOL_SIZE]. If |entropy_pool| does not contain enough
+// bytes to satisfy a valid |get_size| request, fresh bytes are automatically
+// sourced into the entropy pool. The process of sourcing will abort if a
+// failure arises.
+// Returns 1 if |get_size| bytes of entropy is successfully filled into
+// |get_buffer|. Returns 0 otherwise.
 OPENSSL_EXPORT int RAND_entropy_pool_get(struct entropy_pool *entropy_pool,
   uint8_t *get_buffer, size_t get_size);
+
+// RAND_entropy_pool_add adds entropy from |add_buffer| to the entropy pool
+// |entropy_pool|. The capacity of |entropy_pool| must be exactly
+// |ENTROPY_POOL_SIZE| and the amount of (entropy) bytes in |add_buffer| must
+// also be exactly |ENTROPY_POOL_SIZE|.
 OPENSSL_EXPORT void RAND_entropy_pool_add(struct entropy_pool *entropy_pool,
   uint8_t add_buffer[ENTROPY_POOL_SIZE]);
 
+// TODO
 void RAND_module_entropy_depleted(void);
+
+// TODO
 void RAND_load_entropy(uint8_t load_entropy[ENTROPY_POOL_SIZE]);
 
 #endif

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -138,7 +138,10 @@ void RAND_load_entropy(uint8_t load_entropy[ENTROPY_POOL_SIZE]) {
   if (state == NULL) {
     abort();
   }
-  RAND_entropy_pool_add(state->entropy_pool, load_entropy);
+  
+  if (RAND_entropy_pool_add(state->entropy_pool, load_entropy) != 1) {
+    abort();
+  }
 }
 
 #endif

--- a/crypto/rand_extra/entropy_passive.c
+++ b/crypto/rand_extra/entropy_passive.c
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include "../fipsmodule/rand/internal.h"
+
+#if defined(AWSLC_FIPS)
+
+void RAND_module_entropy_depleted(void) {
+  uint8_t entropy[ENTROPY_POOL_SIZE] = {0};
+
+  // Next step: draw entropy from either CPU source of system source
+  // and put into |entropy|.
+
+  RAND_load_entropy(entropy);
+}
+
+#endif

--- a/crypto/rand_extra/entropy_passive.c
+++ b/crypto/rand_extra/entropy_passive.c
@@ -9,7 +9,7 @@ void RAND_module_entropy_depleted(void) {
   uint8_t entropy[ENTROPY_POOL_SIZE] = {0};
 
   // Next step: draw entropy from either CPU source of system source
-  // and put into |entropy|.
+  // and copy into |entropy|.
 
   RAND_load_entropy(entropy);
 }


### PR DESCRIPTION
### Issues:

CryptoAlg-1952

### Description of changes: 

Implements the backend for passive entropy. The integration as the actual entropy backend for `RAND_bytes` (for fips build), will occur in the next PR.

The entropy pool has one main action: `RAND_entropy_pool_get`. This function can be used to fetch entropy from the pool. If the pool is depleted, the "depleted workflow" is activated, that workflow requests a need for more entropy outside the module. New entropy is loaded into the module through `RAND_load_entropy` (the entropy sourcing part is not implemented yet).

### Call-outs:

As noted in the source code:
```
	// Out-side module call
	// Could create a soft-lock in the struct here
	RAND_module_entropy_depleted();
	// And then unlock struct here
```
I could soft-lock the pool during the depleted workflow. This shouldn't really be necessary since the every operation is serialised in the thread.

### Testing:

Added a bunch of tests. Can add  more if needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
