### PR TITLE
Turn on shared library build with HAProxy

### DIFF
--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -21,6 +21,7 @@ SCRATCH_FOLDER=${SYS_ROOT}/"scratch"
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
 HAPROXY_SRC="${SCRATCH_FOLDER}/haproxy"
+export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib"
 
 function build_and_test_haproxy() {
   cd ${HAPROXY_SRC}
@@ -54,8 +55,8 @@ export VTEST_PROGRAM=$(realpath ../vtest/vtest)
 aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_SHARED_LIBS=0
 build_and_test_haproxy $HAPROXY_SRC
 
-rm -rf "$AWS_LC_INSTALL_FOLDER/*"
-rm -rf "$AWS_LC_BUILD_FOLDER/*"
+rm -rf ${AWS_LC_INSTALL_FOLDER}/*
+rm -rf ${AWS_LC_BUILD_FOLDER}/*
 
 # Test with shared AWS-LC libraries
 aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_SHARED_LIBS=1

--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -24,12 +24,9 @@ HAPROXY_SRC="${SCRATCH_FOLDER}/haproxy"
 
 function build_and_test_haproxy() {
   cd ${HAPROXY_SRC}
-
   make CC="${CC}" -j ${NUM_CPU_THREADS} TARGET=generic USE_OPENSSL=1 SSL_INC="${AWS_LC_INSTALL_FOLDER}/include" SSL_LIB="${AWS_LC_INSTALL_FOLDER}/lib/"
-  ./scripts/build-vtest.sh
-  export VTEST_PROGRAM=$(realpath ../vtest/vtest)
 
-  # These tests pass when run local but are not supported in CodeBuild CryptoAlg-1965
+  # These tests pass when run locally but are not supported in CodeBuild, see CryptoAlg-1965
   excluded_tests=("mcli_show_info.vtc" "mcli_start_progs.vtc" "tls_basic_sync.vtc" "tls_basic_sync_wo_stkt_backend.vtc" "acl_cli_spaces.vtc" "http_reuse_always.vtc")
   test_paths=""
 
@@ -49,7 +46,9 @@ cd ${SCRATCH_FOLDER}
 
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 git clone --depth 1 https://github.com/haproxy/haproxy.git
-ls
+cd haproxy
+./scripts/build-vtest.sh
+export VTEST_PROGRAM=$(realpath ../vtest/vtest)
 
 # Test with static AWS-LC libraries
 aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_SHARED_LIBS=0


### PR DESCRIPTION
### Description of changes: 
While working on the HAProxy CI change in https://github.com/andrewhop/haproxy/pull/1 the [HAProxy CI which uses a shared AWS-LC build found an issue](https://github.com/andrewhop/haproxy/actions/runs/5534691073/jobs/10099976679?pr=1#step:12:556) with three new OCSP functions not exported. Once those are exported this CI will pass and unblock their CI.

### Call-outs:
This will need to be updated with the OCSP header change from https://github.com/aws/aws-lc/pull/1091 to work.

### Testing:
This adds a new build for the existing HAProxy CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
