### PR TITLE
Add BoringSSL Dispatch Test for aarch64

### DIFF
--- a/crypto/fipsmodule/aes/asm/aesv8-armx.pl
+++ b/crypto/fipsmodule/aes/asm/aesv8-armx.pl
@@ -102,7 +102,7 @@ ${prefix}_set_encrypt_key:
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#2]
+	strb w7, [x6,#3]
 #endif
 ___
 $code.=<<___	if ($flavour =~ /64/);
@@ -355,7 +355,7 @@ ${prefix}_${dir}crypt:
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6]
+	strb w7, [x6,#1]
 #endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	$rounds,[$key,#240]
@@ -734,6 +734,13 @@ $code.=<<___;
 .type	${prefix}_ctr32_encrypt_blocks,%function
 .align	5
 ${prefix}_ctr32_encrypt_blocks:
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern        BORINGSSL_function_hit
+    adrp	x6,:pg_hi21:BORINGSSL_function_hit
+    add x6, x6, :lo12:BORINGSSL_function_hit
+	mov w7, #1
+	strb w7, [x6]
+#endif
 ___
 $code.=<<___	if ($flavour =~ /64/);
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.

--- a/crypto/fipsmodule/aes/asm/aesv8-armx.pl
+++ b/crypto/fipsmodule/aes/asm/aesv8-armx.pl
@@ -97,15 +97,15 @@ $code.=<<___;
 .align	5
 ${prefix}_set_encrypt_key:
 .Lenc_key:
+___
+$code.=<<___	if ($flavour =~ /64/);
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
-	mov w7, #1
-	strb w7, [x6,#3]
+    mov w7, #1
+    strb w7, [x6,#3]
 #endif
-___
-$code.=<<___	if ($flavour =~ /64/);
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
 	stp	x29,x30,[sp,#-16]!
@@ -350,6 +350,8 @@ $code.=<<___;
 .type	${prefix}_${dir}crypt,%function
 .align	5
 ${prefix}_${dir}crypt:
+___
+$code.=<<___	if ($flavour =~ /64/);
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
@@ -357,6 +359,8 @@ ${prefix}_${dir}crypt:
 	mov w7, #1
 	strb w7, [x6,#1]
 #endif
+___
+$code.=<<___;
 	AARCH64_VALID_CALL_TARGET
 	ldr	$rounds,[$key,#240]
 	vld1.32	{$rndkey0},[$key],#16
@@ -734,6 +738,8 @@ $code.=<<___;
 .type	${prefix}_ctr32_encrypt_blocks,%function
 .align	5
 ${prefix}_ctr32_encrypt_blocks:
+___
+$code.=<<___	if ($flavour =~ /64/);
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
@@ -741,8 +747,6 @@ ${prefix}_ctr32_encrypt_blocks:
 	mov w7, #1
 	strb w7, [x6]
 #endif
-___
-$code.=<<___	if ($flavour =~ /64/);
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
 	stp		x29,x30,[sp,#-16]!

--- a/crypto/fipsmodule/aes/asm/aesv8-armx.pl
+++ b/crypto/fipsmodule/aes/asm/aesv8-armx.pl
@@ -101,10 +101,10 @@ ___
 $code.=<<___	if ($flavour =~ /64/);
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
-    adrp	x6,:pg_hi21:BORINGSSL_function_hit
-    add x6, x6, :lo12:BORINGSSL_function_hit
-    mov w7, #1
-    strb w7, [x6,#3]
+	adrp	x6,:pg_hi21:BORINGSSL_function_hit
+	add x6, x6, :lo12:BORINGSSL_function_hit
+	mov w7, #1
+	strb w7, [x6,#3]
 #endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
@@ -354,8 +354,8 @@ ___
 $code.=<<___	if ($flavour =~ /64/);
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
-    adrp	x6,:pg_hi21:BORINGSSL_function_hit
-    add x6, x6, :lo12:BORINGSSL_function_hit
+	adrp	x6,:pg_hi21:BORINGSSL_function_hit
+	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
 	strb w7, [x6,#1]
 #endif
@@ -742,8 +742,8 @@ ___
 $code.=<<___	if ($flavour =~ /64/);
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
-    adrp	x6,:pg_hi21:BORINGSSL_function_hit
-    add x6, x6, :lo12:BORINGSSL_function_hit
+	adrp	x6,:pg_hi21:BORINGSSL_function_hit
+	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
 	strb w7, [x6]
 #endif

--- a/crypto/fipsmodule/aes/asm/aesv8-armx.pl
+++ b/crypto/fipsmodule/aes/asm/aesv8-armx.pl
@@ -97,6 +97,13 @@ $code.=<<___;
 .align	5
 ${prefix}_set_encrypt_key:
 .Lenc_key:
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern        BORINGSSL_function_hit
+    adrp	x6,:pg_hi21:BORINGSSL_function_hit
+    add x6, x6, :lo12:BORINGSSL_function_hit
+	mov x8, #1
+	str x8, [x6,#2]
+#endif
 ___
 $code.=<<___	if ($flavour =~ /64/);
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
@@ -343,6 +350,13 @@ $code.=<<___;
 .type	${prefix}_${dir}crypt,%function
 .align	5
 ${prefix}_${dir}crypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern        BORINGSSL_function_hit
+    adrp	x6,:pg_hi21:BORINGSSL_function_hit
+    add x6, x6, :lo12:BORINGSSL_function_hit
+	mov x8, #1
+	str x8, [x6]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	$rounds,[$key,#240]
 	vld1.32	{$rndkey0},[$key],#16

--- a/crypto/fipsmodule/aes/asm/aesv8-armx.pl
+++ b/crypto/fipsmodule/aes/asm/aesv8-armx.pl
@@ -104,7 +104,7 @@ $code.=<<___	if ($flavour =~ /64/);
 	adrp	x6,:pg_hi21:BORINGSSL_function_hit
 	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#3]
+	strb w7, [x6,#3] // kFlag_aes_hw_set_encrypt_key
 #endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
@@ -357,7 +357,7 @@ $code.=<<___	if ($flavour =~ /64/);
 	adrp	x6,:pg_hi21:BORINGSSL_function_hit
 	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#1]
+	strb w7, [x6,#1] // kFlag_aes_hw_encrypt
 #endif
 ___
 $code.=<<___;
@@ -745,7 +745,7 @@ $code.=<<___	if ($flavour =~ /64/);
 	adrp	x6,:pg_hi21:BORINGSSL_function_hit
 	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6]
+	strb w7, [x6] // kFlag_aes_hw_ctr32_encrypt_blocks
 #endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET

--- a/crypto/fipsmodule/aes/asm/aesv8-armx.pl
+++ b/crypto/fipsmodule/aes/asm/aesv8-armx.pl
@@ -101,8 +101,8 @@ ${prefix}_set_encrypt_key:
 .extern        BORINGSSL_function_hit
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
-	mov x8, #1
-	str x8, [x6,#2]
+	mov w7, #1
+	strb w7, [x6,#2]
 #endif
 ___
 $code.=<<___	if ($flavour =~ /64/);
@@ -354,8 +354,8 @@ ${prefix}_${dir}crypt:
 .extern        BORINGSSL_function_hit
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
-	mov x8, #1
-	str x8, [x6]
+	mov w7, #1
+	strb w7, [x6]
 #endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	$rounds,[$key,#240]

--- a/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
@@ -266,8 +266,8 @@ _vpaes_encrypt_core:
 vpaes_encrypt:
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
-    adrp	x6,:pg_hi21:BORINGSSL_function_hit
-    add x6, x6, :lo12:BORINGSSL_function_hit
+	adrp	x6,:pg_hi21:BORINGSSL_function_hit
+	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
 	strb w7, [x6,#4]
 #endif
@@ -1081,8 +1081,8 @@ _vpaes_schedule_mangle:
 vpaes_set_encrypt_key:
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
-    adrp	x6,:pg_hi21:BORINGSSL_function_hit
-    add x6, x6, :lo12:BORINGSSL_function_hit
+	adrp	x6,:pg_hi21:BORINGSSL_function_hit
+	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
 	strb w7, [x6,#5]
 #endif

--- a/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
@@ -269,7 +269,7 @@ vpaes_encrypt:
 	adrp	x6,:pg_hi21:BORINGSSL_function_hit
 	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#4]
+	strb w7, [x6,#4] // kFlag_vpaes_encrypt
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
@@ -1084,7 +1084,7 @@ vpaes_set_encrypt_key:
 	adrp	x6,:pg_hi21:BORINGSSL_function_hit
 	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#5]
+	strb w7, [x6,#5] // kFlag_vpaes_set_encrypt_key
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!

--- a/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
@@ -264,6 +264,13 @@ _vpaes_encrypt_core:
 .type	vpaes_encrypt,%function
 .align	4
 vpaes_encrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern        BORINGSSL_function_hit
+    adrp	x6,:pg_hi21:BORINGSSL_function_hit
+    add x6, x6, :lo12:BORINGSSL_function_hit
+	mov x8, #1
+	str x8, [x6,#1]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
@@ -1072,6 +1079,13 @@ _vpaes_schedule_mangle:
 .type	vpaes_set_encrypt_key,%function
 .align	4
 vpaes_set_encrypt_key:
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern        BORINGSSL_function_hit
+    adrp	x6,:pg_hi21:BORINGSSL_function_hit
+    add x6, x6, :lo12:BORINGSSL_function_hit
+	mov x8, #1
+	str x8, [x6,#3]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0

--- a/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
@@ -268,8 +268,8 @@ vpaes_encrypt:
 .extern        BORINGSSL_function_hit
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
-	mov x8, #1
-	str x8, [x6,#1]
+	mov w7, #1
+	strb w7, [x6,#1]
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
@@ -1083,8 +1083,8 @@ vpaes_set_encrypt_key:
 .extern        BORINGSSL_function_hit
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
-	mov x8, #1
-	str x8, [x6,#3]
+	mov w7, #1
+	strb w7, [x6,#3]
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!

--- a/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-armv8.pl
@@ -269,7 +269,7 @@ vpaes_encrypt:
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#1]
+	strb w7, [x6,#4]
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
@@ -1084,7 +1084,7 @@ vpaes_set_encrypt_key:
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#3]
+	strb w7, [x6,#5]
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!

--- a/crypto/fipsmodule/cpucap/cpucap.c
+++ b/crypto/fipsmodule/cpucap/cpucap.c
@@ -85,7 +85,7 @@ HIDDEN uint32_t OPENSSL_armcap_P = 0;
 
 #if defined(BORINGSSL_DISPATCH_TEST)
 // This value must be explicitly initialized to zero. See similar comment above.
-HIDDEN uint8_t BORINGSSL_function_hit[8] = {0};
+HIDDEN uint8_t BORINGSSL_function_hit[9] = {0};
 #endif // BORINGSSL_DISPATCH_TEST
 
 // This variable is used only for testing purposes to ensure that the library

--- a/crypto/fipsmodule/cpucap/cpucap.c
+++ b/crypto/fipsmodule/cpucap/cpucap.c
@@ -85,12 +85,12 @@ HIDDEN uint32_t OPENSSL_armcap_P = 0;
 
 #if defined(BORINGSSL_DISPATCH_TEST)
 // This value must be explicitly initialized to zero. See similar comment above.
-#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
-HIDDEN uint8_t BORINGSSL_function_hit[8] = {0};
-#elif defined(OPENSSL_AARCH64)
+#if defined(OPENSSL_AARCH64)
 HIDDEN uint8_t BORINGSSL_function_hit[7] = {0};
+#else
+HIDDEN uint8_t BORINGSSL_function_hit[8] = {0};
 #endif
-#endif
+#endif // BORINGSSL_DISPATCH_TEST
 
 // This variable is used only for testing purposes to ensure that the library
 // constructor is executed and the capability variable is initialized.

--- a/crypto/fipsmodule/cpucap/cpucap.c
+++ b/crypto/fipsmodule/cpucap/cpucap.c
@@ -85,11 +85,7 @@ HIDDEN uint32_t OPENSSL_armcap_P = 0;
 
 #if defined(BORINGSSL_DISPATCH_TEST)
 // This value must be explicitly initialized to zero. See similar comment above.
-#if defined(OPENSSL_AARCH64)
-HIDDEN uint8_t BORINGSSL_function_hit[7] = {0};
-#else
 HIDDEN uint8_t BORINGSSL_function_hit[8] = {0};
-#endif
 #endif // BORINGSSL_DISPATCH_TEST
 
 // This variable is used only for testing purposes to ensure that the library

--- a/crypto/fipsmodule/cpucap/cpucap.c
+++ b/crypto/fipsmodule/cpucap/cpucap.c
@@ -85,7 +85,11 @@ HIDDEN uint32_t OPENSSL_armcap_P = 0;
 
 #if defined(BORINGSSL_DISPATCH_TEST)
 // This value must be explicitly initialized to zero. See similar comment above.
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 HIDDEN uint8_t BORINGSSL_function_hit[8] = {0};
+#elif defined(OPENSSL_AARCH64)
+HIDDEN uint8_t BORINGSSL_function_hit[7] = {0};
+#endif
 #endif
 
 // This variable is used only for testing purposes to ensure that the library

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
@@ -262,6 +262,13 @@ $code.=<<___;
 .type   aesv8_gcm_8x_enc_128,%function
 .align  4
 aesv8_gcm_8x_enc_128:
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern        BORINGSSL_function_hit
+    adrp	x6,:pg_hi21:BORINGSSL_function_hit
+    add x6, x6, :lo12:BORINGSSL_function_hit
+	mov w7, #1
+	strb w7, [x6,#7]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, .L128_enc_ret
 	stp	d8, d9, [sp, #-80]!

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
@@ -267,7 +267,7 @@ aesv8_gcm_8x_enc_128:
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#7]
+	strb w7, [x6,#6]
 #endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, .L128_enc_ret

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
@@ -267,7 +267,7 @@ aesv8_gcm_8x_enc_128:
 	adrp	x6,:pg_hi21:BORINGSSL_function_hit
 	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#6]
+	strb w7, [x6,#6] // kFlag_aesv8_gcm_8x_enc_128
 #endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, .L128_enc_ret

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
@@ -264,8 +264,8 @@ $code.=<<___;
 aesv8_gcm_8x_enc_128:
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
-    adrp	x6,:pg_hi21:BORINGSSL_function_hit
-    add x6, x6, :lo12:BORINGSSL_function_hit
+	adrp	x6,:pg_hi21:BORINGSSL_function_hit
+	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
 	strb w7, [x6,#6]
 #endif

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8-unroll8.pl
@@ -267,7 +267,7 @@ aesv8_gcm_8x_enc_128:
 	adrp	x6,:pg_hi21:BORINGSSL_function_hit
 	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#6] // kFlag_aesv8_gcm_8x_enc_128
+	strb w7, [x6,#7] // kFlag_aesv8_gcm_8x_enc_128
 #endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, .L128_enc_ret

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
@@ -290,8 +290,8 @@ $code.=<<___;
 aes_gcm_enc_kernel:
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
-    adrp	x6,:pg_hi21:BORINGSSL_function_hit
-    add x6, x6, :lo12:BORINGSSL_function_hit
+	adrp	x6,:pg_hi21:BORINGSSL_function_hit
+	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
 	strb w7, [x6,#2]
 #endif

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
@@ -293,7 +293,7 @@ aes_gcm_enc_kernel:
     adrp	x6,:pg_hi21:BORINGSSL_function_hit
     add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#5]
+	strb w7, [x6,#2]
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
@@ -293,7 +293,7 @@ aes_gcm_enc_kernel:
 	adrp	x6,:pg_hi21:BORINGSSL_function_hit
 	add x6, x6, :lo12:BORINGSSL_function_hit
 	mov w7, #1
-	strb w7, [x6,#2]
+	strb w7, [x6,#2] // kFlag_aes_gcm_enc_kernel
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
@@ -288,6 +288,13 @@ $code.=<<___;
 .type   aes_gcm_enc_kernel,%function
 .align  4
 aes_gcm_enc_kernel:
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern        BORINGSSL_function_hit
+    adrp	x6,:pg_hi21:BORINGSSL_function_hit
+    add x6, x6, :lo12:BORINGSSL_function_hit
+	mov w7, #1
+	strb w7, [x6,#5]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!
 	mov	x29, sp

--- a/crypto/fipsmodule/sha/asm/sha512-armv8.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-armv8.pl
@@ -362,6 +362,13 @@ $code.=<<___;
 .align	6
 sha256_block_armv8:
 .Lv8_entry:
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern        BORINGSSL_function_hit
+	adrp	x6,:pg_hi21:BORINGSSL_function_hit
+	add x6, x6, :lo12:BORINGSSL_function_hit
+	mov w7, #1
+	strb w7, [x6,#6] // kFlag_sha256_hw
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	stp		x29,x30,[sp,#-16]!
 	add		x29,sp,#0
@@ -448,6 +455,13 @@ $code.=<<___;
 .align	6
 sha512_block_armv8:
 .Lv8_entry:
+#ifdef BORINGSSL_DISPATCH_TEST
+.extern        BORINGSSL_function_hit
+	adrp	x6,:pg_hi21:BORINGSSL_function_hit
+	add x6, x6, :lo12:BORINGSSL_function_hit
+	mov w7, #1
+	strb w7, [x6,#8] // kFlag_sha512_hw
+#endif
 	stp		x29,x30,[sp,#-16]!
 	add		x29,sp,#0
 

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -208,7 +208,7 @@ TEST_F(ImplDispatchTest, SHA256) {
 
 constexpr size_t kFlag_aes_hw_ctr32_encrypt_blocks = 0; // unimplemented for aarch64
 constexpr size_t kFlag_aes_hw_encrypt = 1;
-// constexpr size_t kFlag_aesni_gcm_encrypt = 2; // unimplemented for aarch64
+constexpr size_t kFlag_aes_gcm_enc_kernel = 2; // unique to aarch64
 constexpr size_t kFlag_aes_hw_set_encrypt_key = 3;
 constexpr size_t kFlag_vpaes_encrypt = 4;
 constexpr size_t kFlag_vpaes_set_encrypt_key = 5;
@@ -221,9 +221,7 @@ TEST_F(ImplDispatchTest, AEAD_AES_GCM) {
           {kFlag_aes_hw_ctr32_encrypt_blocks, armv8_aes_ && !armv8_gcm_pmull_ && !armv8_gcm_8x_}, // if hw aes supported but no gcm supported
           {kFlag_aes_hw_encrypt, armv8_aes_},
           {kFlag_aes_hw_set_encrypt_key, armv8_aes_},
-          // {kFlag_aesni_gcm_encrypt,
-          //  is_x86_64_ && armv8_aes_ && avx_movbe_ &&
-          //  !is_assembler_too_old && !vaes_vpclmulqdq_},
+          {kFlag_aes_gcm_enc_kernel, armv8_aes_ && armv8_gcm_pmull_ && !armv8_gcm_8x_},
           {kFlag_vpaes_encrypt, neon_ && !armv8_aes_},
           {kFlag_vpaes_set_encrypt_key, neon_ && !armv8_aes_},
           // {kFlag_aes_gcm_encrypt_avx512,

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -119,13 +119,12 @@ constexpr size_t kFlag_aes_hw_set_encrypt_key = 3;
 constexpr size_t kFlag_vpaes_encrypt = 4;
 constexpr size_t kFlag_vpaes_set_encrypt_key = 5;
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
-constexpr size_t kFlag_aesni_gcm_encrypt = 2; // unique to x86
-constexpr size_t kFlag_sha256_shaext = 6; //unique to x86
-constexpr size_t kFlag_aes_gcm_encrypt_avx512 = 7; // unique to x86
+constexpr size_t kFlag_aesni_gcm_encrypt = 2;
+constexpr size_t kFlag_sha256_shaext = 6;
+constexpr size_t kFlag_aes_gcm_encrypt_avx512 = 7;
 #else // AARCH64
-constexpr size_t kFlag_aes_gcm_enc_kernel = 2; // unique to aarch64
-// Flag 6 is unused on aarch64.
-constexpr size_t kFlag_aesv8_gcm_8x_enc_128 = 7; // unique to aarch64
+constexpr size_t kFlag_aes_gcm_enc_kernel = 2;
+constexpr size_t kFlag_aesv8_gcm_8x_enc_128 = 6;
 #endif
 
 TEST_F(ImplDispatchTest, AEAD_AES_GCM) {

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -160,7 +160,11 @@ TEST_F(ImplDispatchTest, AEAD_AES_GCM) {
       },
       [] {
         const uint8_t kZeros[16] = {0};
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
+        const uint8_t kPlaintext[40] = {1, 2, 3, 4, 0};
+#else
         const uint8_t kPlaintext[256] = {1, 2, 3, 4, 0};
+#endif
         uint8_t ciphertext[sizeof(kPlaintext) + 16];
         size_t ciphertext_len;
         bssl::ScopedEVP_AEAD_CTX ctx;

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -66,9 +66,7 @@ class ImplDispatchTest : public ::testing::Test {
 #else
         false;
 #endif // MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-#endif  // X86 || X86_64
-
-#if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
+#else // AARCH64
     aes_hw = CRYPTO_is_NEON_capable();
     aes_vpaes = CRYPTO_is_ARMv8_AES_capable();
     armv8_gcm_pmull_ = CRYPTO_is_ARMv8_PMULL_capable();
@@ -109,7 +107,7 @@ class ImplDispatchTest : public ::testing::Test {
   bool is_x86_64_ = false;
   bool is_assembler_too_old = false;
   bool is_assembler_too_old_avx512 = false;
-#elif defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
+#else // AARCH64
   bool armv8_gcm_pmull_ = false;
   bool armv8_gcm_8x_ = false;
 #endif

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -66,12 +66,12 @@ class ImplDispatchTest : public ::testing::Test {
 #else
         false;
 #endif // MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-#else // AARCH64
+#elif defined(OPENSSL_AARCH64)
     aes_hw = CRYPTO_is_NEON_capable();
     aes_vpaes = CRYPTO_is_ARMv8_AES_capable();
     armv8_gcm_pmull_ = CRYPTO_is_ARMv8_PMULL_capable();
     armv8_gcm_8x_ = CRYPTO_is_ARMv8_GCM_8x_capable();
-#endif // ARM || AARCH64
+#endif
   }
 
  protected:
@@ -114,7 +114,8 @@ class ImplDispatchTest : public ::testing::Test {
 
 };
 
-#if !defined(OPENSSL_NO_ASM)
+#if !defined(OPENSSL_NO_ASM) && (defined(OPENSSL_X86) || \
+    defined(OPENSSL_X86_64) || defined(OPENSSL_AARCH64))
 
 constexpr size_t kFlag_aes_hw_ctr32_encrypt_blocks = 0;
 constexpr size_t kFlag_aes_hw_encrypt = 1;
@@ -220,6 +221,6 @@ TEST_F(ImplDispatchTest, SHA256) {
 }
 #endif // OPENSSL_X86 || OPENSSL_X86_64
 
-#endif  // !OPENSSL_NO_ASM
+#endif  // !OPENSSL_NO_ASM && (OPENSSL_X86 || OPENSSL_X86_64 || OPENSSL_AARCH64)
 
 #endif  // DISPATCH_TEST && !SHARED_LIBRARY

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -31,14 +31,19 @@
 #include "fipsmodule/cpucap/internal.h"
 #include "fipsmodule/modes/internal.h"
 
-
+  // bool vaes_vpclmulqdq_ = false;
+  // bool avx_movbe_ = false;
+  // bool sha_ext_ = false;
+  // bool is_x86_64_ = false;
+  // bool is_assembler_too_old = false;
+  // bool is_assembler_too_old_avx512 = false;
 class ImplDispatchTest : public ::testing::Test {
  public:
   void SetUp() override {
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
     aes_hw = CRYPTO_is_AESNI_capable();
-    aes_vpaes = CRYPTO_is_AVX_capable() && CRYPTO_is_MOVBE_capable();
-    ssse3_ = CRYPTO_is_SSSE3_capable();
+    avx_movbe_ = CRYPTO_is_AVX_capable() && CRYPTO_is_MOVBE_capable();
+    aes_vpaes = CRYPTO_is_SSSE3_capable();
     sha_ext_ = CRYPTO_is_SHAEXT_capable();
     vaes_vpclmulqdq_ =
         (OPENSSL_ia32cap_P[2] & 0xC0030000) &&         // AVX512{F+DQ+BW+VL}

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -67,8 +67,8 @@ class ImplDispatchTest : public ::testing::Test {
         false;
 #endif // MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 #elif defined(OPENSSL_AARCH64)
-    aes_hw = CRYPTO_is_NEON_capable();
-    aes_vpaes = CRYPTO_is_ARMv8_AES_capable();
+    aes_hw = CRYPTO_is_ARMv8_AES_capable();
+    aes_vpaes = CRYPTO_is_NEON_capable();
     armv8_gcm_pmull_ = CRYPTO_is_ARMv8_PMULL_capable();
     armv8_gcm_8x_ = CRYPTO_is_ARMv8_GCM_8x_capable();
 #endif

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -68,7 +68,6 @@ class ImplDispatchTest : public ::testing::Test {
     armv8_aes_ = CRYPTO_is_ARMv8_AES_capable();
     armv8_gcm_pmull_ = CRYPTO_is_ARMv8_PMULL_capable();
     armv8_gcm_8x_ = CRYPTO_is_ARMv8_GCM_8x_capable();
-    armv8_wide_mult_ = CRYPTO_is_ARMv8_wide_multiplier_capable();
 #endif // ARM || AARCH64
   }
 
@@ -110,7 +109,6 @@ class ImplDispatchTest : public ::testing::Test {
   bool armv8_aes_ = false;
   bool armv8_gcm_pmull_ = false;
   bool armv8_gcm_8x_ = false;
-  bool armv8_wide_mult_ = false;
 #endif
 };
 
@@ -212,7 +210,6 @@ constexpr size_t kFlag_aes_gcm_enc_kernel = 2; // unique to aarch64
 constexpr size_t kFlag_aes_hw_set_encrypt_key = 3;
 constexpr size_t kFlag_vpaes_encrypt = 4;
 constexpr size_t kFlag_vpaes_set_encrypt_key = 5;
-// constexpr size_t kFlag_sha256_shaext = 6; // unimplemented for aarch64
 constexpr size_t kFlag_aesv8_gcm_8x_enc_128 = 7; // unique to aarch64
 
 TEST_F(ImplDispatchTest, AEAD_AES_GCM) {

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -206,32 +206,29 @@ TEST_F(ImplDispatchTest, SHA256) {
 #if !defined(OPENSSL_NO_ASM) && \
     (defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))
 
-constexpr size_t kFlag_aes_hw_ctr32_encrypt_blocks = 0; // unimplemented for aarch64
+constexpr size_t kFlag_aes_hw_ctr32_encrypt_blocks = 0;
 constexpr size_t kFlag_aes_hw_encrypt = 1;
 constexpr size_t kFlag_aes_gcm_enc_kernel = 2; // unique to aarch64
 constexpr size_t kFlag_aes_hw_set_encrypt_key = 3;
 constexpr size_t kFlag_vpaes_encrypt = 4;
 constexpr size_t kFlag_vpaes_set_encrypt_key = 5;
 // constexpr size_t kFlag_sha256_shaext = 6; // unimplemented for aarch64
-// constexpr size_t kFlag_aes_gcm_encrypt_avx512 = 7; // unimplemented for aarch64
+constexpr size_t kFlag_aesv8_gcm_8x_enc_128 = 7; // unique to aarch64
 
 TEST_F(ImplDispatchTest, AEAD_AES_GCM) {
   AssertFunctionsHit(
       {
-          {kFlag_aes_hw_ctr32_encrypt_blocks, armv8_aes_ && !armv8_gcm_pmull_ && !armv8_gcm_8x_}, // if hw aes supported but no gcm supported
+          {kFlag_aes_hw_ctr32_encrypt_blocks, armv8_aes_ && !armv8_gcm_pmull_ && !armv8_gcm_8x_},
           {kFlag_aes_hw_encrypt, armv8_aes_},
           {kFlag_aes_hw_set_encrypt_key, armv8_aes_},
           {kFlag_aes_gcm_enc_kernel, armv8_aes_ && armv8_gcm_pmull_ && !armv8_gcm_8x_},
           {kFlag_vpaes_encrypt, neon_ && !armv8_aes_},
           {kFlag_vpaes_set_encrypt_key, neon_ && !armv8_aes_},
-          // {kFlag_aes_gcm_encrypt_avx512,
-          //  is_x86_64_ && armv8_aes_ &&
-          //  !is_assembler_too_old_avx512 &&
-          //  vaes_vpclmulqdq_},
+          {kFlag_aesv8_gcm_8x_enc_128, armv8_aes_ && armv8_gcm_pmull_ && armv8_gcm_8x_}
       },
       [] {
         const uint8_t kZeros[16] = {0};
-        const uint8_t kPlaintext[40] = {1, 2, 3, 4, 0};
+        const uint8_t kPlaintext[256] = {1, 2, 3, 4, 0};
         uint8_t ciphertext[sizeof(kPlaintext) + 16];
         size_t ciphertext_len;
         bssl::ScopedEVP_AEAD_CTX ctx;

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1013,6 +1013,7 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 
 // BORINGSSL_function_hit is an array of flags. The following functions will
 // set these flags if BORINGSSL_DISPATCH_TEST is defined.
+#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 // On x86 and x86_64:
 //   0: aes_hw_ctr32_encrypt_blocks
 //   1: aes_hw_encrypt
@@ -1022,6 +1023,8 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 //   5: vpaes_set_encrypt_key
 //   6: sha256_block_data_order_shaext
 //   7: aes_gcm_encrypt_avx512
+extern uint8_t BORINGSSL_function_hit[8];
+#else // aarch64
 // On aarch64:
 //   0: aes_hw_ctr32_encrypt_blocks
 //   1: aes_hw_encrypt
@@ -1029,9 +1032,9 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 //   3: aes_hw_set_encrypt_key
 //   4: vpaes_encrypt
 //   5: vpaes_set_encrypt_key
-//   6: unused
-//   7: aesv8_gcm_8x_enc_128
-extern uint8_t BORINGSSL_function_hit[8];
+//   6: aesv8_gcm_8x_enc_128
+extern uint8_t BORINGSSL_function_hit[7];
+#endif
 #endif  // BORINGSSL_DISPATCH_TEST
 
 #if !defined(AWSLC_FIPS) && !defined(BORINGSSL_SHARED_LIBRARY)

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1013,7 +1013,6 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 
 // BORINGSSL_function_hit is an array of flags. The following functions will
 // set these flags if BORINGSSL_DISPATCH_TEST is defined.
-#if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
 // On x86 and x86_64:
 //   0: aes_hw_ctr32_encrypt_blocks
 //   1: aes_hw_encrypt
@@ -1023,8 +1022,6 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 //   5: vpaes_set_encrypt_key
 //   6: sha256_block_data_order_shaext
 //   7: aes_gcm_encrypt_avx512
-extern uint8_t BORINGSSL_function_hit[8];
-#elif defined(OPENSSL_AARCH64)
 // On AARCH64:
 //   0: aes_hw_ctr32_encrypt_blocks
 //   1: aes_hw_encrypt
@@ -1033,7 +1030,10 @@ extern uint8_t BORINGSSL_function_hit[8];
 //   4: vpaes_encrypt
 //   5: vpaes_set_encrypt_key
 //   6: aesv8_gcm_8x_enc_128
+#if defined(OPENSSL_AARCH64)
 extern uint8_t BORINGSSL_function_hit[7];
+#else
+extern uint8_t BORINGSSL_function_hit[8];
 #endif
 #endif  // BORINGSSL_DISPATCH_TEST
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1024,8 +1024,8 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 //   6: sha256_block_data_order_shaext
 //   7: aes_gcm_encrypt_avx512
 extern uint8_t BORINGSSL_function_hit[8];
-#else // aarch64
-// On aarch64:
+#else // AARCH64
+// On AARCH64:
 //   0: aes_hw_ctr32_encrypt_blocks
 //   1: aes_hw_encrypt
 //   2: aes_gcm_enc_kernel

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1013,6 +1013,7 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 
 // BORINGSSL_function_hit is an array of flags. The following functions will
 // set these flags if BORINGSSL_DISPATCH_TEST is defined.
+// On x86 and x86_64:
 //   0: aes_hw_ctr32_encrypt_blocks
 //   1: aes_hw_encrypt
 //   2: aesni_gcm_encrypt
@@ -1021,6 +1022,15 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 //   5: vpaes_set_encrypt_key
 //   6: sha256_block_data_order_shaext
 //   7: aes_gcm_encrypt_avx512
+// On aarch64:
+//   0: aes_hw_ctr32_encrypt_blocks
+//   1: aes_hw_encrypt
+//   2: aes_gcm_enc_kernel
+//   3: aes_hw_set_encrypt_key
+//   4: vpaes_encrypt
+//   5: vpaes_set_encrypt_key
+//   6: unused
+//   7: aesv8_gcm_8x_enc_128
 extern uint8_t BORINGSSL_function_hit[8];
 #endif  // BORINGSSL_DISPATCH_TEST
 

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1030,11 +1030,7 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 //   4: vpaes_encrypt
 //   5: vpaes_set_encrypt_key
 //   6: aesv8_gcm_8x_enc_128
-#if defined(OPENSSL_AARCH64)
-extern uint8_t BORINGSSL_function_hit[7];
-#else
 extern uint8_t BORINGSSL_function_hit[8];
-#endif
 #endif  // BORINGSSL_DISPATCH_TEST
 
 #if !defined(AWSLC_FIPS) && !defined(BORINGSSL_SHARED_LIBRARY)

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1024,7 +1024,7 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 //   6: sha256_block_data_order_shaext
 //   7: aes_gcm_encrypt_avx512
 extern uint8_t BORINGSSL_function_hit[8];
-#else // AARCH64
+#elif defined(OPENSSL_AARCH64)
 // On AARCH64:
 //   0: aes_hw_ctr32_encrypt_blocks
 //   1: aes_hw_encrypt

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1029,8 +1029,10 @@ OPENSSL_INLINE int boringssl_fips_break_test(const char *test) {
 //   3: aes_hw_set_encrypt_key
 //   4: vpaes_encrypt
 //   5: vpaes_set_encrypt_key
-//   6: aesv8_gcm_8x_enc_128
-extern uint8_t BORINGSSL_function_hit[8];
+//   6: sha256_block_armv8
+//   7: aesv8_gcm_8x_enc_128
+//   8: sha512_block_armv8
+extern uint8_t BORINGSSL_function_hit[9];
 #endif  // BORINGSSL_DISPATCH_TEST
 
 #if !defined(AWSLC_FIPS) && !defined(BORINGSSL_SHARED_LIBRARY)

--- a/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-armx.S
@@ -37,7 +37,7 @@ Lenc_key:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6,#3]
+	strb	w7, [x6,#3] // kFlag_aes_hw_set_encrypt_key
 #endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
@@ -256,7 +256,7 @@ _aes_hw_encrypt:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6,#1]
+	strb	w7, [x6,#1] // kFlag_aes_hw_encrypt
 #endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
@@ -294,7 +294,7 @@ _aes_hw_decrypt:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6,#1]
+	strb	w7, [x6,#1] // kFlag_aes_hw_encrypt
 #endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
@@ -625,7 +625,7 @@ _aes_hw_ctr32_encrypt_blocks:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6]
+	strb	w7, [x6] // kFlag_aes_hw_ctr32_encrypt_blocks
 #endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET

--- a/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-armx.S
@@ -32,6 +32,13 @@ Lrcon:
 .align	5
 _aes_hw_set_encrypt_key:
 Lenc_key:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6,#3]
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
 	stp	x29,x30,[sp,#-16]!
@@ -244,6 +251,13 @@ Ldec_key_abort:
 
 .align	5
 _aes_hw_encrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6,#1]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
 	ld1	{v0.4s},[x2],#16
@@ -275,6 +289,13 @@ Loop_enc:
 
 .align	5
 _aes_hw_decrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6,#1]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
 	ld1	{v0.4s},[x2],#16
@@ -599,6 +620,13 @@ Lcbc_abort:
 
 .align	5
 _aes_hw_ctr32_encrypt_blocks:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6]
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
 	stp	x29,x30,[sp,#-16]!

--- a/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
@@ -22,6 +22,13 @@
 
 .align	4
 _aesv8_gcm_8x_enc_128:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6,#6]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, L128_enc_ret
 	stp	d8, d9, [sp, #-80]!

--- a/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
@@ -27,7 +27,7 @@ _aesv8_gcm_8x_enc_128:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6,#6] // kFlag_aesv8_gcm_8x_enc_128
+	strb	w7, [x6,#7] // kFlag_aesv8_gcm_8x_enc_128
 #endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, L128_enc_ret

--- a/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
@@ -27,7 +27,7 @@ _aesv8_gcm_8x_enc_128:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6,#6]
+	strb	w7, [x6,#6] // kFlag_aesv8_gcm_8x_enc_128
 #endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, L128_enc_ret

--- a/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
@@ -22,6 +22,13 @@
 
 .align	4
 _aes_gcm_enc_kernel:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6,#5]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!
 	mov	x29, sp

--- a/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
@@ -27,7 +27,7 @@ _aes_gcm_enc_kernel:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6,#2]
+	strb	w7, [x6,#2] // kFlag_aes_gcm_enc_kernel
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!

--- a/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
@@ -27,7 +27,7 @@ _aes_gcm_enc_kernel:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6,#5]
+	strb	w7, [x6,#2]
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!

--- a/generated-src/ios-aarch64/crypto/fipsmodule/sha256-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/sha256-armv8.S
@@ -1072,6 +1072,13 @@ LK256:
 .align	6
 sha256_block_armv8:
 Lv8_entry:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6,#6] // kFlag_sha256_hw
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0

--- a/generated-src/ios-aarch64/crypto/fipsmodule/sha512-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/sha512-armv8.S
@@ -1096,6 +1096,13 @@ LK512:
 .align	6
 sha512_block_armv8:
 Lv8_entry:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6,#8] // kFlag_sha512_hw
+#endif
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
 

--- a/generated-src/ios-aarch64/crypto/fipsmodule/vpaes-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/vpaes-armv8.S
@@ -221,7 +221,7 @@ _vpaes_encrypt:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6,#4]
+	strb	w7, [x6,#4] // kFlag_vpaes_encrypt
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
@@ -1031,7 +1031,7 @@ _vpaes_set_encrypt_key:
 	adrp	x6,_BORINGSSL_function_hit@PAGE
 	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
 	mov	w7, #1
-	strb	w7, [x6,#5]
+	strb	w7, [x6,#5] // kFlag_vpaes_set_encrypt_key
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!

--- a/generated-src/ios-aarch64/crypto/fipsmodule/vpaes-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/vpaes-armv8.S
@@ -216,6 +216,13 @@ Lenc_entry:
 
 .align	4
 _vpaes_encrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6,#4]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
@@ -1019,6 +1026,13 @@ Lschedule_mangle_both:
 
 .align	4
 _vpaes_set_encrypt_key:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,_BORINGSSL_function_hit@PAGE
+	add	x6, x6, _BORINGSSL_function_hit@PAGEOFF
+	mov	w7, #1
+	strb	w7, [x6,#5]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0

--- a/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-armx.S
@@ -37,7 +37,7 @@ aes_hw_set_encrypt_key:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#3]
+	strb	w7, [x6,#3] // kFlag_aes_hw_set_encrypt_key
 #endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
@@ -256,7 +256,7 @@ aes_hw_encrypt:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#1]
+	strb	w7, [x6,#1] // kFlag_aes_hw_encrypt
 #endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
@@ -294,7 +294,7 @@ aes_hw_decrypt:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#1]
+	strb	w7, [x6,#1] // kFlag_aes_hw_encrypt
 #endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
@@ -625,7 +625,7 @@ aes_hw_ctr32_encrypt_blocks:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6]
+	strb	w7, [x6] // kFlag_aes_hw_ctr32_encrypt_blocks
 #endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET

--- a/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-armx.S
@@ -32,6 +32,13 @@
 .align	5
 aes_hw_set_encrypt_key:
 .Lenc_key:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#3]
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
 	stp	x29,x30,[sp,#-16]!
@@ -244,6 +251,13 @@ aes_hw_set_decrypt_key:
 .type	aes_hw_encrypt,%function
 .align	5
 aes_hw_encrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#1]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
 	ld1	{v0.4s},[x2],#16
@@ -275,6 +289,13 @@ aes_hw_encrypt:
 .type	aes_hw_decrypt,%function
 .align	5
 aes_hw_decrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#1]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
 	ld1	{v0.4s},[x2],#16
@@ -599,6 +620,13 @@ aes_hw_cbc_encrypt:
 .type	aes_hw_ctr32_encrypt_blocks,%function
 .align	5
 aes_hw_ctr32_encrypt_blocks:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6]
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
 	stp	x29,x30,[sp,#-16]!

--- a/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
@@ -27,7 +27,7 @@ aesv8_gcm_8x_enc_128:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#6]
+	strb	w7, [x6,#6] // kFlag_aesv8_gcm_8x_enc_128
 #endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, .L128_enc_ret

--- a/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
@@ -22,6 +22,13 @@
 .type	aesv8_gcm_8x_enc_128,%function
 .align	4
 aesv8_gcm_8x_enc_128:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#6]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, .L128_enc_ret
 	stp	d8, d9, [sp, #-80]!

--- a/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
@@ -27,7 +27,7 @@ aesv8_gcm_8x_enc_128:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#6] // kFlag_aesv8_gcm_8x_enc_128
+	strb	w7, [x6,#7] // kFlag_aesv8_gcm_8x_enc_128
 #endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, .L128_enc_ret

--- a/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
@@ -27,7 +27,7 @@ aes_gcm_enc_kernel:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#5]
+	strb	w7, [x6,#2]
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!

--- a/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
@@ -27,7 +27,7 @@ aes_gcm_enc_kernel:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#2]
+	strb	w7, [x6,#2] // kFlag_aes_gcm_enc_kernel
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!

--- a/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
@@ -22,6 +22,13 @@
 .type	aes_gcm_enc_kernel,%function
 .align	4
 aes_gcm_enc_kernel:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#5]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!
 	mov	x29, sp

--- a/generated-src/linux-aarch64/crypto/fipsmodule/sha256-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/sha256-armv8.S
@@ -1072,6 +1072,13 @@ sha256_block_data_order:
 .align	6
 sha256_block_armv8:
 .Lv8_entry:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#6] // kFlag_sha256_hw
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0

--- a/generated-src/linux-aarch64/crypto/fipsmodule/sha512-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/sha512-armv8.S
@@ -1096,6 +1096,13 @@ sha512_block_data_order:
 .align	6
 sha512_block_armv8:
 .Lv8_entry:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#8] // kFlag_sha512_hw
+#endif
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
 

--- a/generated-src/linux-aarch64/crypto/fipsmodule/vpaes-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/vpaes-armv8.S
@@ -216,6 +216,13 @@ _vpaes_encrypt_core:
 .type	vpaes_encrypt,%function
 .align	4
 vpaes_encrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#4]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
@@ -1019,6 +1026,13 @@ _vpaes_schedule_mangle:
 .type	vpaes_set_encrypt_key,%function
 .align	4
 vpaes_set_encrypt_key:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#5]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0

--- a/generated-src/linux-aarch64/crypto/fipsmodule/vpaes-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/vpaes-armv8.S
@@ -221,7 +221,7 @@ vpaes_encrypt:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#4]
+	strb	w7, [x6,#4] // kFlag_vpaes_encrypt
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
@@ -1031,7 +1031,7 @@ vpaes_set_encrypt_key:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#5]
+	strb	w7, [x6,#5] // kFlag_vpaes_set_encrypt_key
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!

--- a/generated-src/win-aarch64/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/aesv8-armx.S
@@ -39,7 +39,7 @@ Lenc_key:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#3]
+	strb	w7, [x6,#3] // kFlag_aes_hw_set_encrypt_key
 #endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
@@ -262,7 +262,7 @@ aes_hw_encrypt:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#1]
+	strb	w7, [x6,#1] // kFlag_aes_hw_encrypt
 #endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
@@ -302,7 +302,7 @@ aes_hw_decrypt:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#1]
+	strb	w7, [x6,#1] // kFlag_aes_hw_encrypt
 #endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
@@ -637,7 +637,7 @@ aes_hw_ctr32_encrypt_blocks:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6]
+	strb	w7, [x6] // kFlag_aes_hw_ctr32_encrypt_blocks
 #endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET

--- a/generated-src/win-aarch64/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/aesv8-armx.S
@@ -34,6 +34,13 @@ Lrcon:
 .align	5
 aes_hw_set_encrypt_key:
 Lenc_key:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#3]
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
 	stp	x29,x30,[sp,#-16]!
@@ -250,6 +257,13 @@ Ldec_key_abort:
 .endef
 .align	5
 aes_hw_encrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#1]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
 	ld1	{v0.4s},[x2],#16
@@ -283,6 +297,13 @@ Loop_enc:
 .endef
 .align	5
 aes_hw_decrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#1]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	ldr	w3,[x2,#240]
 	ld1	{v0.4s},[x2],#16
@@ -611,6 +632,13 @@ Lcbc_abort:
 .endef
 .align	5
 aes_hw_ctr32_encrypt_blocks:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6]
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	AARCH64_VALID_CALL_TARGET
 	stp	x29,x30,[sp,#-16]!

--- a/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
@@ -29,7 +29,7 @@ aesv8_gcm_8x_enc_128:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#6]
+	strb	w7, [x6,#6] // kFlag_aesv8_gcm_8x_enc_128
 #endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, L128_enc_ret

--- a/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
@@ -29,7 +29,7 @@ aesv8_gcm_8x_enc_128:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#6] // kFlag_aesv8_gcm_8x_enc_128
+	strb	w7, [x6,#7] // kFlag_aesv8_gcm_8x_enc_128
 #endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, L128_enc_ret

--- a/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8-unroll8.S
@@ -24,6 +24,13 @@
 .endef
 .align	4
 aesv8_gcm_8x_enc_128:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#6]
+#endif
 	AARCH64_VALID_CALL_TARGET
 	cbz	x1, L128_enc_ret
 	stp	d8, d9, [sp, #-80]!

--- a/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
@@ -29,7 +29,7 @@ aes_gcm_enc_kernel:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#2]
+	strb	w7, [x6,#2] // kFlag_aes_gcm_enc_kernel
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!

--- a/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
@@ -24,6 +24,13 @@
 .endef
 .align	4
 aes_gcm_enc_kernel:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#5]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!
 	mov	x29, sp

--- a/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/aesv8-gcm-armv8.S
@@ -29,7 +29,7 @@ aes_gcm_enc_kernel:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#5]
+	strb	w7, [x6,#2]
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29, x30, [sp, #-128]!

--- a/generated-src/win-aarch64/crypto/fipsmodule/sha256-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/sha256-armv8.S
@@ -1076,6 +1076,13 @@ LK256:
 .align	6
 sha256_block_armv8:
 Lv8_entry:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#6] // kFlag_sha256_hw
+#endif
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later.
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0

--- a/generated-src/win-aarch64/crypto/fipsmodule/sha512-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/sha512-armv8.S
@@ -1100,6 +1100,13 @@ LK512:
 .align	6
 sha512_block_armv8:
 Lv8_entry:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#8] // kFlag_sha512_hw
+#endif
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
 

--- a/generated-src/win-aarch64/crypto/fipsmodule/vpaes-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/vpaes-armv8.S
@@ -222,6 +222,13 @@ Lenc_entry:
 .endef
 .align	4
 vpaes_encrypt:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#4]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
@@ -1049,6 +1056,13 @@ Lschedule_mangle_both:
 .endef
 .align	4
 vpaes_set_encrypt_key:
+#ifdef BORINGSSL_DISPATCH_TEST
+
+	adrp	x6,BORINGSSL_function_hit
+	add	x6, x6, :lo12:BORINGSSL_function_hit
+	mov	w7, #1
+	strb	w7, [x6,#5]
+#endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0

--- a/generated-src/win-aarch64/crypto/fipsmodule/vpaes-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/vpaes-armv8.S
@@ -227,7 +227,7 @@ vpaes_encrypt:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#4]
+	strb	w7, [x6,#4] // kFlag_vpaes_encrypt
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
@@ -1061,7 +1061,7 @@ vpaes_set_encrypt_key:
 	adrp	x6,BORINGSSL_function_hit
 	add	x6, x6, :lo12:BORINGSSL_function_hit
 	mov	w7, #1
-	strb	w7, [x6,#5]
+	strb	w7, [x6,#5] // kFlag_vpaes_set_encrypt_key
 #endif
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1873 by unblocking https://github.com/aws/aws-lc/pull/1045

### Description of changes: 
Currently AWS-LC only checks whether the correct hardware code is being reached on x86 and x86_64 and not aarch64. This PR fixes that so that we can ensure that the correct code path is taken whenever change OPENSSL_armcap on aarch64 systems.

### Call-outs:
N/A

### Testing:
Tests pass locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
