### PR TITLE
Run additional HAProxy tests

### DIFF
--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
@@ -43,11 +43,12 @@ RUN set -ex && \
     libpcre2-dev \
     libreadline-dev \
     libudev-dev \
+    liblua5.4-dev \
+    socat \
     zlib1g-dev \
     dpkg-dev \
     flex \
     bison \
-    curl \
     jq \
     unzip && \
     # Based on https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html

--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -28,7 +28,8 @@ function build_and_test_haproxy() {
   make CC="${CC}" -j ${NUM_CPU_THREADS} TARGET=generic USE_OPENSSL=1 SSL_INC="${AWS_LC_INSTALL_FOLDER}/include" \
       SSL_LIB="${AWS_LC_INSTALL_FOLDER}/lib/" USE_LUA=1  LUA_LIB_NAME=lua5.4
 
-  # These tests pass when run locally but are not supported in CodeBuild, see CryptoAlg-1965.
+  # These tests are marked as SLOW and should be skipped.
+  # TODO: update this to: make reg-tests VTEST_PROGRAM=../vtest/vtest REGTESTS_TYPES=default,bug,devel
   # ssl_dh.vtc expects to use libssl with a FFDH ciphersuite which is unsupported, it will be gracefully turned off in
   # ssl_dh.vtc with the change in https://github.com/andrewhop/haproxy/pull/1
   excluded_tests=("mcli_show_info.vtc" "mcli_start_progs.vtc" "tls_basic_sync.vtc" "tls_basic_sync_wo_stkt_backend.vtc" "acl_cli_spaces.vtc" "http_reuse_always.vtc" "ocsp_auto_update.vtc" "ssl_dh.vtc")
@@ -40,7 +41,7 @@ function build_and_test_haproxy() {
       fi
   done
 
-  ./scripts/run-regtests.sh "$test_paths"
+  make reg-tests VTEST_PROGRAM=../vtest/vtest REG_TEST_FILES="$test_paths"
 }
 
 # Make script execution idempotent.
@@ -52,7 +53,6 @@ mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 git clone --depth 1 https://github.com/haproxy/haproxy.git
 cd haproxy
 ./scripts/build-vtest.sh
-export VTEST_PROGRAM=$(realpath ../vtest/vtest)
 
 # Test with static AWS-LC libraries
 aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=0

--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -31,7 +31,7 @@ function build_and_test_haproxy() {
   # These tests pass when run locally but are not supported in CodeBuild, see CryptoAlg-1965.
   # ssl_dh.vtc expects to use libssl with a FFDH ciphersuite which is unsupported, it will be gracefully turned off in
   # ssl_dh.vtc with the change in https://github.com/andrewhop/haproxy/pull/1
-  excluded_tests=("mcli_show_info.vtc" "mcli_start_progs.vtc" "tls_basic_sync.vtc" "tls_basic_sync_wo_stkt_backend.vtc" "acl_cli_spaces.vtc" "http_reuse_always.vtc" "ssl_dh.vtc")
+  excluded_tests=("mcli_show_info.vtc" "mcli_start_progs.vtc" "tls_basic_sync.vtc" "tls_basic_sync_wo_stkt_backend.vtc" "acl_cli_spaces.vtc" "http_reuse_always.vtc" "ocsp_auto_update.vtc" "ssl_dh.vtc")
   test_paths=""
 
   for test in reg-tests/**/*; do


### PR DESCRIPTION
### Description of changes: 
This installs the remaining missing test dependencies so our CI agrees with HAProxy's CI and the only failing test is `ssl_dh.vtc` due to our libssl not supporting FFDH ciphersuites. My proposed change in https://github.com/andrewhop/haproxy/pull/1 will turn off this test when built with AWS-LC for now. 

Also removed the duplicate `curl` on line 28 and 50 of the Dockerfile.

### Call-outs:
The filtering can be removed if HAProxy takes the change proposed in https://github.com/andrewhop/haproxy/pull/1. 

### Testing:
Before:
```
0 tests failed, 23 tests skipped, 140 tests passed
```
After:
```
0 tests failed, 9 tests skipped, 165 tests passed
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
