### PR TITLE
Allow `SSL_CTX` to use the new multiple certificate slots internally

### DIFF
--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -656,6 +656,11 @@ bool ssl_create_cipher_list(UniquePtr<SSLCipherPreferenceList> *out_cipher_list,
                             bool strict,
                             bool config_tls13);
 
+// ssl_get_certificate_slot_index returns the |SSL_PKEY_*| certificate slot
+// index corresponding to the private key type of |pkey|. It returns -1 if not
+// supported. This was |ssl_cert_type| in OpenSSL1.1.1.
+int ssl_get_certificate_slot_index(const EVP_PKEY *pkey);
+
 // ssl_cipher_auth_mask_for_key returns the mask of cipher |algorithm_auth|
 // values suitable for use with |key| in TLS 1.2 and below.
 uint32_t ssl_cipher_auth_mask_for_key(const EVP_PKEY *key);
@@ -3661,6 +3666,9 @@ struct ssl_ctx_st {
                         EVP_PKEY **out_pkey) = nullptr;
 
   CRYPTO_EX_DATA ex_data;
+
+  /// Handle and implement |extra_certs| later. These certs apply to all slots.
+  // STACK_OF(X509) *extra_certs;
 
   // custom_*_extensions stores any callback sets for custom extensions. Note
   // that these pointers will be NULL if the stack would otherwise be empty.

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -658,7 +658,7 @@ bool ssl_create_cipher_list(UniquePtr<SSLCipherPreferenceList> *out_cipher_list,
 
 // ssl_get_certificate_slot_index returns the |SSL_PKEY_*| certificate slot
 // index corresponding to the private key type of |pkey|. It returns -1 if not
-// supported. This was |ssl_cert_type| in OpenSSL1.1.1.
+// supported. This was |ssl_cert_type| in OpenSSL 1.0.2.
 int ssl_get_certificate_slot_index(const EVP_PKEY *pkey);
 
 // ssl_cipher_auth_mask_for_key returns the mask of cipher |algorithm_auth|
@@ -3666,9 +3666,6 @@ struct ssl_ctx_st {
                         EVP_PKEY **out_pkey) = nullptr;
 
   CRYPTO_EX_DATA ex_data;
-
-  /// Handle and implement |extra_certs| later. These certs apply to all slots.
-  // STACK_OF(X509) *extra_certs;
 
   // custom_*_extensions stores any callback sets for custom extensions. Note
   // that these pointers will be NULL if the stack would otherwise be empty.

--- a/ssl/ssl_cipher.cc
+++ b/ssl/ssl_cipher.cc
@@ -1346,6 +1346,19 @@ bool ssl_create_cipher_list(UniquePtr<SSLCipherPreferenceList> *out_cipher_list,
   return true;
 }
 
+int ssl_get_certificate_slot_index(const EVP_PKEY *pkey) {
+  switch (EVP_PKEY_id(pkey)) {
+    case EVP_PKEY_RSA:
+      return SSL_PKEY_RSA;
+    case EVP_PKEY_EC:
+      return SSL_PKEY_ECC;
+    case EVP_PKEY_ED25519:
+      return SSL_PKEY_ED25519;
+    default:
+      return -1;
+  }
+}
+
 uint32_t ssl_cipher_auth_mask_for_key(const EVP_PKEY *key) {
   switch (EVP_PKEY_id(key)) {
     case EVP_PKEY_RSA:

--- a/ssl/ssl_privkey.cc
+++ b/ssl/ssl_privkey.cc
@@ -101,6 +101,7 @@ static bool ssl_set_pkey(CERT *cert, EVP_PKEY *pkey) {
     return false;
   }
 
+  // Update certificate slot index once all checks have passed.
   cert->cert_private_keys[idx].privatekey = UpRef(pkey);
   cert->cert_private_key_idx = idx;
   return true;

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -1648,6 +1648,28 @@ static bssl::UniquePtr<EVP_PKEY> GetECDSATestKey() {
   return KeyFromPEM(kKeyPEM);
 }
 
+static bssl::UniquePtr<X509> GetED25519TestCertificate() {
+  static const char kCertPEM[] =
+      "-----BEGIN CERTIFICATE-----\n"
+      "MIIBRDCB9wIUKI+32tShPulvafJa3xZvj29Z9xgwBQYDK2VwMEUxCzAJBgNVBAYT\n"
+      "AkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRn\n"
+      "aXRzIFB0eSBMdGQwHhcNMjMwNzE4MTg0NzU4WhcNMjMwNzE5MTg0NzU4WjBFMQsw\n"
+      "CQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJu\n"
+      "ZXQgV2lkZ2l0cyBQdHkgTHRkMCowBQYDK2VwAyEAprAzqgxux8R4ZXaxn5mM/5E9\n"
+      "0RNE59r47BJikdOoeUwwBQYDK2VwA0EAMELt0XRGFYo4qkWwOsoSYcdGYqlxVlf9\n"
+      "AhTPaJ6SSzjv3n4r60wfe8Z2OPn415tcj2IIm42T64itI4OAX0aTCg==\n"
+      "-----END CERTIFICATE-----\n";
+  return CertFromPEM(kCertPEM);
+}
+
+static bssl::UniquePtr<EVP_PKEY> GetED25519TestKey() {
+  static const char kKeyPEM[] =
+      "-----BEGIN PRIVATE KEY-----\n"
+      "MC4CAQAwBQYDK2VwBCIEIGPkz4xAobc5gtRidkHl+fxNLHfiWo3efRG2G8Z617yk\n"
+      "-----END PRIVATE KEY-----\n";
+  return KeyFromPEM(kKeyPEM);
+}
+
 static bssl::UniquePtr<CRYPTO_BUFFER> BufferFromPEM(const char *pem) {
   bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem, strlen(pem)));
   char *name, *header;
@@ -5094,6 +5116,87 @@ TEST(SSLTest, EmptyCipherList) {
 
   // But the cipher list is still updated to empty.
   EXPECT_EQ(0u, sk_SSL_CIPHER_num(SSL_CTX_get_ciphers(ctx.get())));
+}
+
+struct TLSVersionTestParams {
+  uint16_t version;
+};
+
+const TLSVersionTestParams kTLSVersionTests[] = {
+    {TLS1_VERSION},
+    {TLS1_1_VERSION},
+    {TLS1_2_VERSION},
+    {TLS1_3_VERSION},
+};
+
+struct CertificateKeyTestParams {
+  bssl::UniquePtr<X509> (*certificate)();
+  bssl::UniquePtr<EVP_PKEY> (*key)();
+  int slot_index;
+};
+
+const CertificateKeyTestParams kCertificateKeyTests[] = {
+    {GetTestCertificate, GetTestKey, SSL_PKEY_RSA},
+    {GetECDSATestCertificate, GetECDSATestKey, SSL_PKEY_ECC},
+    {GetED25519TestCertificate, GetED25519TestKey, SSL_PKEY_ED25519},
+};
+
+class MultipleCertificateSlotTest
+    : public testing::TestWithParam<
+          std::tuple<TLSVersionTestParams, CertificateKeyTestParams>> {
+ public:
+  static TLSVersionTestParams version_param() {
+    return std::get<0>(GetParam());
+  }
+  static CertificateKeyTestParams certificate_key_param() {
+    return std::get<1>(GetParam());
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    MultipleCertificateSlotAllTest, MultipleCertificateSlotTest,
+    testing::Combine(testing::ValuesIn(kTLSVersionTests),
+                     testing::ValuesIn(kCertificateKeyTests)));
+
+TEST_P(MultipleCertificateSlotTest, CertificateSlotIndex) {
+  uint16_t version = version_param().version;
+  int slot_index = certificate_key_param().slot_index;
+  if ((version == TLS1_1_VERSION || version == TLS1_VERSION) &&
+      slot_index == SSL_PKEY_ED25519) {
+    // ED25519 is not supported in versions prior to TLS1.2.
+    return;
+  }
+  bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL_CTX> server_ctx(CreateContextWithCertificate(
+      TLS_method(), certificate_key_param().certificate(),
+      certificate_key_param().key()));
+
+
+  static const uint16_t kPrefs[] = {SSL_SIGN_ED25519,
+                                    SSL_SIGN_ECDSA_SECP256R1_SHA256,
+                                    SSL_SIGN_RSA_PSS_RSAE_SHA256};
+  EXPECT_TRUE(SSL_CTX_set_signing_algorithm_prefs(client_ctx.get(), kPrefs,
+                                                  OPENSSL_ARRAY_SIZE(kPrefs)));
+  EXPECT_TRUE(SSL_CTX_set_verify_algorithm_prefs(client_ctx.get(), kPrefs,
+                                                 OPENSSL_ARRAY_SIZE(kPrefs)));
+
+
+  ASSERT_TRUE(SSL_CTX_set_min_proto_version(client_ctx.get(), version));
+  ASSERT_TRUE(SSL_CTX_set_max_proto_version(client_ctx.get(), version));
+  ASSERT_TRUE(SSL_CTX_set_min_proto_version(server_ctx.get(), version));
+  ASSERT_TRUE(SSL_CTX_set_max_proto_version(server_ctx.get(), version));
+
+  ClientConfig config;
+  bssl::UniquePtr<SSL> client, server;
+
+  ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx.get(),
+                                     server_ctx.get(), config, true));
+
+  ASSERT_TRUE(CompleteHandshakes(client.get(), server.get()));
+
+  // Check the internal slot index to verify that the correct slot is used.
+  EXPECT_EQ(server_ctx->cert->cert_private_key_idx, slot_index);
+  EXPECT_EQ(server->ctx->cert->cert_private_key_idx, slot_index);
 }
 
 struct MultiTransferReadWriteTestParams {

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -5190,13 +5190,16 @@ TEST_P(MultipleCertificateSlotTest, CertificateSlotIndex) {
   bssl::UniquePtr<SSL> client, server;
 
   ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx.get(),
-                                     server_ctx.get(), config, true));
+                                     server_ctx.get(), config, false));
 
   ASSERT_TRUE(CompleteHandshakes(client.get(), server.get()));
 
-  // Check the internal slot index to verify that the correct slot is used.
+  // Check the internal slot index to verify that the correct slot had been set.
   EXPECT_EQ(server_ctx->cert->cert_private_key_idx, slot_index);
   EXPECT_EQ(server->ctx->cert->cert_private_key_idx, slot_index);
+
+  // Check the internal slot index to verify that the correct slot was used.
+  EXPECT_EQ(server->config->cert->cert_private_key_idx, slot_index);
 }
 
 struct MultiTransferReadWriteTestParams {

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -776,6 +776,8 @@ static int ssl_use_certificate(CERT *cert, X509 *x) {
   }
   // We set the |x509_leaf| here to prevent any external data set from being
   // lost. The rest of the chain still uses |CRYPTO_BUFFER|s.
+  UniquePtr<EVP_PKEY> pubkey(X509_get_pubkey(x));
+  cert->cert_private_key_idx = ssl_get_certificate_slot_index(pubkey.get());
   X509 *&x509_leaf =
       cert->cert_private_keys[cert->cert_private_key_idx].x509_leaf;
   X509_free(x509_leaf);

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -766,7 +766,7 @@ void SSL_CTX_set_cert_store(SSL_CTX *ctx, X509_STORE *store) {
 }
 
 static int ssl_use_certificate(CERT *cert, X509 *x) {
-  if (x == NULL) {
+  if (x == nullptr) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_PASSED_NULL_PARAMETER);
     return 0;
   }
@@ -774,22 +774,20 @@ static int ssl_use_certificate(CERT *cert, X509 *x) {
   if (!ssl_cert_check_cert_private_keys_usage(cert)) {
     return 0;
   }
+
+  UniquePtr<CRYPTO_BUFFER> buffer = x509_to_buffer(x);
+  if (!buffer || !ssl_set_cert(cert, std::move(buffer))) {
+    return 0;
+  }
+
   // We set the |x509_leaf| here to prevent any external data set from being
   // lost. The rest of the chain still uses |CRYPTO_BUFFER|s.
-  UniquePtr<EVP_PKEY> pubkey(X509_get_pubkey(x));
-  cert->cert_private_key_idx = ssl_get_certificate_slot_index(pubkey.get());
   X509 *&x509_leaf =
       cert->cert_private_keys[cert->cert_private_key_idx].x509_leaf;
   X509_free(x509_leaf);
   X509_up_ref(x);
   x509_leaf = x;
-
-  UniquePtr<CRYPTO_BUFFER> buffer = x509_to_buffer(x);
-  if (!buffer) {
-    return 0;
-  }
-
-  return ssl_set_cert(cert, std::move(buffer));
+  return 1;
 }
 
 int SSL_use_certificate(SSL *ssl, X509 *x) {


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1844`

### Description of changes: 
This builds upon the new framework in https://github.com/aws/aws-lc/pull/1086 to use the new multiple certificate slots available. The SSL connection should use the corresponding index of the certificate and pkey type assigned. As of now, the connection will directly use the last certificate that was set for it's connection. This corresponds with our original behavior before we reintroduced the multiple certificate slots framework, where we only maintained one `x509_leaf` and one `pkey per `CERT`.`
A subsequent PR will be introduced to allow the user to manually select which certificate slots they wish to use.

### Call-outs:
These functions change the certificate slot index:
* `SSL_CTX_use_certificate_ASN1` / `SSL_use_certificate_ASN1`/ `SSL_CTX_use_certificate` / `SSL_use_certificate`  (functions that call `ssl_set_cert` internally)
* `SSL_use_*_PrivateKey_*` (functions that call `ssl_set_pkey` internally)

The naming for the list of functions are pretty straightforward. Users setting these functions would have expected `SSL_CTX` to use the new set certificate/pkey, so it's natural that we switch over to that slot. Despite it seeming straightforward, definately let me know if I should add more documentation regarding this anyways

`SSL_CTX_select_current_cert` is a bit more interesting since it selects an existing cert in `SSL_CTX` to use. This will be implemented in one of the next PRs.
* https://github.com/aws/aws-lc/commit/44628096232d22160840b2fa2ea8438343879f6f

### Testing:
I've added a new test that sets up a connection with different certificate types and checks if the correct slot is being used.
`ED25519` is incompatible with older versions of TLS, so those are skipped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
