### PR TITLE
(fips-2022-11-02) Add GitHub CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add core contributors to all PRs by default
+* @aws/aws-lc-dev @aws/aws-lc-fips-dev


### PR DESCRIPTION
Configures GitHub CODEOWNERS file to be used with the branch protection rules.

See [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for more information. This is used over in aws-lc-rs as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
