### PR TITLE
fix rust sanity check CI

### DIFF
--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches: [ '*' ]
 env:
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   GOPROXY: https://proxy.golang.org,direct
 jobs:
   standard:
@@ -19,7 +18,8 @@ jobs:
           submodules: false
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          # Our aws-lc-sys generation scripts require nightly.
+          toolchain: nightly
           override: true
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Pin the CI to use nightly due to changes introduced in aws-lc-rs: https://github.com/aws/aws-lc-rs/commit/3a454a77020b65ee13ff64abb35c7e12a5f64adf

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
