### PR TITLE
Silence static analyser by validating pointer prior to function call

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1490,9 +1490,14 @@ static bool SpeedEvpEcdhCurve(const std::string &name, int nid,
     BM_NAMESPACE::UniquePtr<EVP_PKEY> only_public_key_evp_pkey(EVP_PKEY_new());
     BM_NAMESPACE::UniquePtr<EC_KEY> only_public_key_ec_key(EC_KEY_new_by_curve_name(nid));
     if (only_public_key_ec_key == nullptr ||
-        only_public_key_evp_pkey == nullptr ||
+        only_public_key_evp_pkey == nullptr) {
+      return false;
+    }
+    // Non-owning reference.
+    EC_KEY *peer_key_ec_key = EVP_PKEY_get0_EC_KEY(peer_key.get());
+    if (peer_key_ec_key == nullptr ||
         !EC_KEY_set_public_key(only_public_key_ec_key.get(),
-          EC_KEY_get0_public_key(EVP_PKEY_get0_EC_KEY(peer_key.get()))) ||
+          EC_KEY_get0_public_key(peer_key_ec_key)) ||
         !EVP_PKEY_assign_EC_KEY(only_public_key_evp_pkey.get(), only_public_key_ec_key.release())) {
       return false;
     }

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1494,7 +1494,7 @@ static bool SpeedEvpEcdhCurve(const std::string &name, int nid,
       return false;
     }
     // Non-owning reference.
-    EC_KEY *peer_key_ec_key = EVP_PKEY_get0_EC_KEY(peer_key.get());
+    const EC_KEY *peer_key_ec_key = EVP_PKEY_get0_EC_KEY(peer_key.get());
     if (peer_key_ec_key == nullptr ||
         !EC_KEY_set_public_key(only_public_key_ec_key.get(),
           EC_KEY_get0_public_key(peer_key_ec_key)) ||


### PR DESCRIPTION
### Issues:

V963870416

### Description of changes: 

Attempts to silence the static analyser...

`EC_KEY_get0_public_key` doesn't validate the pointer argument and can de-reference `NULL`. This is common for the getters. Avoid changing that behaviour and just fix-up the speed tool code instead using a non-owning pointer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
