### PR TITLE
Remove CRNGT

### DIFF
--- a/crypto/fipsmodule/FIPS.md
+++ b/crypto/fipsmodule/FIPS.md
@@ -27,7 +27,6 @@ Some FIPS tests cannot be broken by replacing a known string in the binary. For 
 
 1. `RSA_PWCT`
 1. `ECDSA_PWCT`
-1. `CRNG`
 
 ## Breaking the integrity test
 

--- a/util/fipstools/break-tests.sh
+++ b/util/fipstools/break-tests.sh
@@ -182,7 +182,7 @@ done
 
 if [ "$MODE" = "local" ]; then
   # TODO(prb): add support for Android devices.
-  for runtime_test in ECDSA_PWCT RSA_PWCT CRNG; do
+  for runtime_test in ECDSA_PWCT RSA_PWCT; do
     echo
     echo -e "\033[1m${runtime_test} failure\033[0m"
     $RUNTIME_BREAK_TEST ${runtime_test}


### PR DESCRIPTION
### Issues:

CryptoAlg-2001

### Description of changes: 

CRNGT is not a requirement for FIPS 140-3.

FIPS 140-2 Section 4.9.2 required the execution of the Continuous Randomness Number Generation Test (CRNGT). However, this requirement is not present in FIPS 140-3. In addition, later stages of FIPS 140-2 this test was not mandatory in all cases either (cf. FIPS 140-2 IG 9.8).

Executing this test requires maintaining state, which inevitably introduces complexity. Given CRNGT is redundant with respect to compliance and really provides zero practical value (see, again, FIPS 140-2 IG 9.8), we axe it.

### Call-outs:

See CryptoAlg-2001.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
