### PR TITLE
ABI Diff GitHub Action

### DIFF
--- a/.github/docker_images/abidiff/Dockerfile
+++ b/.github/docker_images/abidiff/Dockerfile
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+FROM amazonlinux:2023
+
+VOLUME ["/previous", "/next"]
+
+RUN yum install -y libabigail ninja-build cmake golang gcc gcc-c++
+
+COPY build.sh /
+COPY diff.sh /
+
+ENTRYPOINT ["/diff.sh"]
+
+CMD ["crypto"]

--- a/.github/docker_images/abidiff/build.sh
+++ b/.github/docker_images/abidiff/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -ex
+cmake -S . -B build -GNinja -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build

--- a/.github/docker_images/abidiff/diff.sh
+++ b/.github/docker_images/abidiff/diff.sh
@@ -19,8 +19,22 @@ else
 fi
 
 set +e
+
+# https://sourceware.org/libabigail/manual/abidiff.html
 abidiff --hd1 "/previous/include" --hd2 "/next/include" "/previous/${ARTIFACT_PATH}" "/next/${ARTIFACT_PATH}"
-if [[ $? -ge 8 ]]; then
+
+# From the manual page:
+#
+# The exit code of the abidiff command is either 0 if the ABI of the binaries being compared are equal,
+# or non-zero if they differ or if the tool encountered an error.
+# ...
+# The third bit, of value 4, named ABIDIFF_ABI_CHANGE means the ABI of the binaries being compared are different.
+# The fourth bit, of value 8, named ABIDIFF_ABI_INCOMPATIBLE_CHANGE means the ABI of the binaries compared are different
+# in an incompatible way. If this bit is set, then the ABIDIFF_ABI_CHANGE bit must be set as well. If the
+# ABIDIFF_ABI_CHANGE is set and the ABIDIFF_INCOMPATIBLE_CHANGE is NOT set, then it means that the ABIs being compared
+# might or might not be compatible. In that case, a human being needs to review the ABI changes to decide if they are
+# compatible or not.
+if [[ $? -ge 4 ]]; then
   exit 1
 else
   exit 0

--- a/.github/docker_images/abidiff/diff.sh
+++ b/.github/docker_images/abidiff/diff.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -ex
+
+cd /previous && /build.sh
+cd /next && /build.sh
+
+CHECK_LIB="$1"
+ARTIFACT_PATH="build"
+if [[ "${CHECK_LIB}" == "crypto" ]]; then
+  ARTIFACT_PATH="${ARTIFACT_PATH}/crypto/libcrypto.so"
+elif [[ "${CHECK_LIB}" == "ssl" ]]; then
+  ARTIFACT_PATH="${ARTIFACT_PATH}/ssl/libssl.so"
+else
+  exit 1
+fi
+
+set +e
+abidiff --hd1 "/previous/include" --hd2 "/next/include" "/previous/${ARTIFACT_PATH}" "/next/${ARTIFACT_PATH}"
+if [[ $? -ge 8 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -1,0 +1,50 @@
+name: AWS-LC ABI Diff
+on:
+  pull_request:
+    branches: [ '*' ]
+env:
+  DOCKER_BUILDKIT: 1
+  GOPROXY: https://proxy.golang.org,direct
+jobs:
+  crypto:
+    name: libcrypto
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ github.ref }}
+          path: ${{ github.workspace }}/next
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ github.base.ref }}
+          path: ${{ github.workspace }}/previous
+      - name: Build Docker Image
+        working-directory: ${{ github.workspace }}/next/.github/docker_images/abidiff
+        run: |
+          docker build -t abidiff .
+      - name: Perform ABI Diff
+        run: |
+          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next -- abidiff crypto
+  ssl:
+    name: libssl
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ github.ref }}
+          path: ${{ github.workspace }}/next
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ github.base.ref }}
+          path: ${{ github.workspace }}/previous
+      - name: Build Docker Image
+        working-directory: ${{ github.workspace }}/next/.github/docker_images/abidiff
+        run: |
+          docker build -t abidiff .
+      - name: Perform ABI Diff
+        run: |
+          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next -- abidiff ssl

--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -6,8 +6,8 @@ env:
   DOCKER_BUILDKIT: 1
   GOPROXY: https://proxy.golang.org,direct
 jobs:
-  crypto:
-    name: libcrypto
+  libs:
+    name: libcrypto and libssl
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,27 +24,10 @@ jobs:
         working-directory: ${{ github.workspace }}/next/.github/docker_images/abidiff
         run: |
           docker build -t abidiff .
-      - name: Perform ABI Diff
+      - name: Perform libcrypto ABI Diff
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next -- abidiff crypto
-  ssl:
-    name: libssl
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: aws/aws-lc
-          ref: ${{ github.ref }}
-          path: ${{ github.workspace }}/next
-      - uses: actions/checkout@v3
-        with:
-          repository: aws/aws-lc
-          ref: ${{ github.base.ref }}
-          path: ${{ github.workspace }}/previous
-      - name: Build Docker Image
-        working-directory: ${{ github.workspace }}/next/.github/docker_images/abidiff
+          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff crypto
+      - name: Perform libssl ABI Diff
+        if: ${{ success() || failure() }}
         run: |
-          docker build -t abidiff .
-      - name: Perform ABI Diff
-        run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next -- abidiff ssl
+          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff ssl


### PR DESCRIPTION
### Description of changes: 
Uses [libabigail](https://sourceware.org/libabigail/), which is available in Amazon Linux repositories for doing simple ABI Diffing between a pull request and the target branch to be merged into.

#### Notes
* Currently just diffs the "standard" non-FIPS build, on x86-64 just to give some base coverage. We can expand this further at a later date.
* The comparison is between the PR branch and the target branch. In a future revision I intend to also have it diff the PR branch to the last tagged release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
