### PR TITLE
tweak back error string functions with exclamation marks

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5198,16 +5198,16 @@ OPENSSL_EXPORT size_t SSL_get_finished(const SSL *ssl, void *buf, size_t count);
 OPENSSL_EXPORT size_t SSL_get_peer_finished(const SSL *ssl, void *buf,
                                             size_t count);
 
-// SSL_alert_type_string returns "!". Use |SSL_alert_type_string_long|
+// SSL_alert_type_string returns an unintelligible 1 letter string description
+// of |value| as an alert type (W or F). Use |SSL_alert_type_string_long|
 // instead.
 OPENSSL_EXPORT const char *SSL_alert_type_string(int value);
 
-// SSL_alert_desc_string returns "!!". Use |SSL_alert_desc_string_long|
-// instead.
+// SSL_alert_desc_string returns an unintelligible 2 letter string description
+// of |value|. Use |SSL_alert_desc_string_long| instead.
 OPENSSL_EXPORT const char *SSL_alert_desc_string(int value);
 
-// SSL_state_string returns "!!!!!!". Use |SSL_state_string_long| for a more
-// intelligible string.
+// SSL_state_string returns |SSL_state_string_long|.
 OPENSSL_EXPORT const char *SSL_state_string(const SSL *ssl);
 
 // SSL_TXT_* expand to strings.

--- a/ssl/ssl_stat.cc
+++ b/ssl/ssl_stat.cc
@@ -98,7 +98,7 @@ const char *SSL_state_string_long(const SSL *ssl) {
 }
 
 const char *SSL_state_string(const SSL *ssl) {
-  return "!!!!!!";
+  return SSL_state_string_long(ssl);
 }
 
 const char *SSL_alert_type_string_long(int value) {
@@ -113,11 +113,111 @@ const char *SSL_alert_type_string_long(int value) {
 }
 
 const char *SSL_alert_type_string(int value) {
-  return "!";
+  value >>= 8;
+  if (value == SSL3_AL_WARNING) {
+    return "W";
+  } else if (value == SSL3_AL_FATAL) {
+    return "F";
+  }
+
+  return "U";
 }
 
 const char *SSL_alert_desc_string(int value) {
-  return "!!";
+  switch (value & 0xff) {
+    case SSL3_AD_CLOSE_NOTIFY:
+      return "CN";
+
+    case SSL3_AD_UNEXPECTED_MESSAGE:
+      return "UM";
+
+    case SSL3_AD_BAD_RECORD_MAC:
+      return "BM";
+
+    case SSL3_AD_DECOMPRESSION_FAILURE:
+      return "DF";
+
+    case SSL3_AD_HANDSHAKE_FAILURE:
+      return "HF";
+
+    case SSL3_AD_NO_CERTIFICATE:
+      return "NC";
+
+    case SSL3_AD_BAD_CERTIFICATE:
+      return "BC";
+
+    case SSL3_AD_UNSUPPORTED_CERTIFICATE:
+      return "UC";
+
+    case SSL3_AD_CERTIFICATE_REVOKED:
+      return "CR";
+
+    case SSL3_AD_CERTIFICATE_EXPIRED:
+      return "CE";
+
+    case SSL3_AD_CERTIFICATE_UNKNOWN:
+      return "CU";
+
+    case SSL3_AD_ILLEGAL_PARAMETER:
+      return "IP";
+
+    case TLS1_AD_DECRYPTION_FAILED:
+      return "DC";
+
+    case TLS1_AD_RECORD_OVERFLOW:
+      return "RO";
+
+    case TLS1_AD_UNKNOWN_CA:
+      return "CA";
+
+    case TLS1_AD_ACCESS_DENIED:
+      return "AD";
+
+    case TLS1_AD_DECODE_ERROR:
+      return "DE";
+
+    case TLS1_AD_DECRYPT_ERROR:
+      return "CY";
+
+    case TLS1_AD_EXPORT_RESTRICTION:
+      return "ER";
+
+    case TLS1_AD_PROTOCOL_VERSION:
+      return "PV";
+
+    case TLS1_AD_INSUFFICIENT_SECURITY:
+      return "IS";
+
+    case TLS1_AD_INTERNAL_ERROR:
+      return "IE";
+
+    case TLS1_AD_USER_CANCELLED:
+      return "US";
+
+    case TLS1_AD_NO_RENEGOTIATION:
+      return "NR";
+
+    case TLS1_AD_UNSUPPORTED_EXTENSION:
+      return "UE";
+
+    case TLS1_AD_CERTIFICATE_UNOBTAINABLE:
+      return "CO";
+
+    case TLS1_AD_UNRECOGNIZED_NAME:
+      return "UN";
+
+    case TLS1_AD_BAD_CERTIFICATE_STATUS_RESPONSE:
+      return "BR";
+
+    case TLS1_AD_BAD_CERTIFICATE_HASH_VALUE:
+      return "BH";
+
+    case TLS1_AD_UNKNOWN_PSK_IDENTITY:
+      return "UP";
+
+    default:
+      return "UK";
+  }
 }
 
 const char *SSL_alert_desc_string_long(int value) {

--- a/ssl/ssl_stat.cc
+++ b/ssl/ssl_stat.cc
@@ -102,6 +102,7 @@ const char *SSL_state_string(const SSL *ssl) {
 }
 
 const char *SSL_alert_type_string_long(int value) {
+  value &= 0x0f00;
   value >>= 8;
   if (value == SSL3_AL_WARNING) {
     return "warning";
@@ -113,6 +114,7 @@ const char *SSL_alert_type_string_long(int value) {
 }
 
 const char *SSL_alert_type_string(int value) {
+  value &= 0x0f00;
   value >>= 8;
   if (value == SSL3_AL_WARNING) {
     return "W";

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -9683,5 +9683,20 @@ TEST(SSLTest, InvalidSignatureAlgorithm) {
       ctx.get(), kDuplicatePrefs, OPENSSL_ARRAY_SIZE(kDuplicatePrefs)));
 }
 
+TEST(SSLTest, ErrorStrings){
+  int warning_value = SSL3_AD_CLOSE_NOTIFY | (SSL3_AL_WARNING << 8);
+  int fatal_value = SSL3_AD_UNEXPECTED_MESSAGE | (SSL3_AL_FATAL << 8);
+  int unknown_value = 99999;
+
+  EXPECT_EQ(SSL_alert_desc_string(warning_value), "CN");
+  EXPECT_EQ(SSL_alert_desc_string(fatal_value), "UM");
+  EXPECT_EQ(SSL_alert_desc_string(unknown_value), "UK");
+
+  EXPECT_EQ(SSL_alert_type_string(warning_value), "W");
+  EXPECT_EQ(SSL_alert_type_string(fatal_value), "F");
+  EXPECT_EQ(SSL_alert_type_string(unknown_value), "U");
+
+}
+
 }  // namespace
 BSSL_NAMESPACE_END

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -9683,19 +9683,18 @@ TEST(SSLTest, InvalidSignatureAlgorithm) {
       ctx.get(), kDuplicatePrefs, OPENSSL_ARRAY_SIZE(kDuplicatePrefs)));
 }
 
-TEST(SSLTest, ErrorStrings){
+TEST(SSLTest, ErrorStrings) {
   int warning_value = SSL3_AD_CLOSE_NOTIFY | (SSL3_AL_WARNING << 8);
   int fatal_value = SSL3_AD_UNEXPECTED_MESSAGE | (SSL3_AL_FATAL << 8);
   int unknown_value = 99999;
 
-  EXPECT_EQ(SSL_alert_desc_string(warning_value), "CN");
-  EXPECT_EQ(SSL_alert_desc_string(fatal_value), "UM");
-  EXPECT_EQ(SSL_alert_desc_string(unknown_value), "UK");
+  EXPECT_EQ(strncmp(SSL_alert_desc_string(warning_value), "CN", 2), 0);
+  EXPECT_EQ(strncmp(SSL_alert_desc_string(fatal_value), "UM", 2), 0);
+  EXPECT_EQ(strncmp(SSL_alert_desc_string(unknown_value), "UK", 2), 0);
 
-  EXPECT_EQ(SSL_alert_type_string(warning_value), "W");
-  EXPECT_EQ(SSL_alert_type_string(fatal_value), "F");
-  EXPECT_EQ(SSL_alert_type_string(unknown_value), "U");
-
+  EXPECT_EQ(strncmp(SSL_alert_type_string(warning_value), "W", 1), 0);
+  EXPECT_EQ(strncmp(SSL_alert_type_string(fatal_value), "F", 1), 0);
+  EXPECT_EQ(strncmp(SSL_alert_type_string(unknown_value), "U", 1), 0);
 }
 
 }  // namespace

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -9688,13 +9688,13 @@ TEST(SSLTest, ErrorStrings) {
   int fatal_value = SSL3_AD_UNEXPECTED_MESSAGE | (SSL3_AL_FATAL << 8);
   int unknown_value = 99999;
 
-  EXPECT_EQ(strncmp(SSL_alert_desc_string(warning_value), "CN", 2), 0);
-  EXPECT_EQ(strncmp(SSL_alert_desc_string(fatal_value), "UM", 2), 0);
-  EXPECT_EQ(strncmp(SSL_alert_desc_string(unknown_value), "UK", 2), 0);
+  EXPECT_EQ(Bytes(SSL_alert_desc_string(warning_value)), Bytes("CN"));
+  EXPECT_EQ(Bytes(SSL_alert_desc_string(fatal_value)), Bytes("UM"));
+  EXPECT_EQ(Bytes(SSL_alert_desc_string(unknown_value)), Bytes("UK"));
 
-  EXPECT_EQ(strncmp(SSL_alert_type_string(warning_value), "W", 1), 0);
-  EXPECT_EQ(strncmp(SSL_alert_type_string(fatal_value), "F", 1), 0);
-  EXPECT_EQ(strncmp(SSL_alert_type_string(unknown_value), "U", 1), 0);
+  EXPECT_EQ(Bytes(SSL_alert_type_string(warning_value)), Bytes("W"));
+  EXPECT_EQ(Bytes(SSL_alert_type_string(fatal_value)), Bytes("F"));
+  EXPECT_EQ(Bytes(SSL_alert_type_string(unknown_value)), Bytes("U"));
 }
 
 }  // namespace


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1995`

### Description of changes: 
Tweak back string functions with exclamation marks.
Reverted from: https://github.com/aws/aws-lc/commit/c2ae53db6dff3b8a773c43e16e3efaf20ff4c7da

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
