### PR TITLE
Release v1.13.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4076,7 +4076,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.12.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.13.0");
 }
 
 #else
@@ -4119,6 +4119,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.12.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.13.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -216,7 +216,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.12.1"
+#define AWSLC_VERSION_NUMBER_STRING "1.13.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* EVP API ECDHE speed tool support by @torben-hansen in https://github.com/aws/aws-lc/pull/1080
* fix rust sanity check CI by @samuel40791765 in https://github.com/aws/aws-lc/pull/1106
* Silence static analyser by validating pointer prior to function call by @torben-hansen in https://github.com/aws/aws-lc/pull/1107
* Improve LICENSE readability by @skmcgrail in https://github.com/aws/aws-lc/pull/1110
* add back CERT_PKEY structure and refactor pointers by @samuel40791765 in https://github.com/aws/aws-lc/pull/1086
* Turn on tests in CI dimension for mySQL  by @samuel40791765 in https://github.com/aws/aws-lc/pull/1063
* Fix DH_check() excessive time with oversized modulus by @skmcgrail in https://github.com/aws/aws-lc/pull/1109
* Add GitHub CODEOWNERS by @skmcgrail in https://github.com/aws/aws-lc/pull/1103
* Add BoringSSL Dispatch Test for aarch64 by @billbo-yang in https://github.com/aws/aws-lc/pull/1093
* Run additional HAProxy tests by @andrewhop in https://github.com/aws/aws-lc/pull/1097
* Add webhook event support for push to main and fips branches by @skmcgrail in https://github.com/aws/aws-lc/pull/1082
* Remove CRNGT by @torben-hansen in https://github.com/aws/aws-lc/pull/1112
* Make dispatch tests use corruptible registers on aarch64. by @nebeid in https://github.com/aws/aws-lc/pull/1118
* Allow `SSL_CTX` to use the new multiple certificate slots internally by @samuel40791765 in https://github.com/aws/aws-lc/pull/1100
* Upstream merge 2023 07 18 by @nebeid in https://github.com/aws/aws-lc/pull/1101
* tweak back error string functions with exclamation marks by @samuel40791765 in https://github.com/aws/aws-lc/pull/1117
* Support changing OPENSSL_armcap with environment variable on Apple 64-bit ARM systems by @billbo-yang in https://github.com/aws/aws-lc/pull/1045
* Abstract fips entropy functions by @torben-hansen in https://github.com/aws/aws-lc/pull/1113
* Silence static analyser with additional checks by @samuel40791765 in https://github.com/aws/aws-lc/pull/1123
* Fix Excessive time spent checking DH q parameter value by @skmcgrail in https://github.com/aws/aws-lc/pull/1121


**Full Changelog**: https://github.com/aws/aws-lc/compare/v1.12.1...v1.12.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
