### PR TITLE
[fips-2021-10-20-1MU] Backport CVE-2023-3446, CVE-2023-3817 fixes for DH_check

### DIFF
--- a/crypto/fipsmodule/dh/check.c
+++ b/crypto/fipsmodule/dh/check.c
@@ -58,6 +58,7 @@
 
 #include <openssl/bn.h>
 
+#define OPENSSL_DH_CHECK_MAX_MODULUS_BITS  32768
 
 int DH_check_pub_key(const DH *dh, const BIGNUM *pub_key, int *out_flags) {
   *out_flags = 0;
@@ -123,6 +124,13 @@ int DH_check(const DH *dh, int *out_flags) {
   BIGNUM *t1 = NULL, *t2 = NULL;
 
   *out_flags = 0;
+
+  /* Don't do any checks at all with an excessively large modulus */
+  if (BN_num_bits(dh->p) > OPENSSL_DH_CHECK_MAX_MODULUS_BITS) {
+    OPENSSL_PUT_ERROR(DH, DH_R_MODULUS_TOO_LARGE);
+    return 0;
+  }
+
   ctx = BN_CTX_new();
   if (ctx == NULL) {
     goto err;

--- a/crypto/fipsmodule/dh/check.c
+++ b/crypto/fipsmodule/dh/check.c
@@ -118,7 +118,7 @@ int DH_check(const DH *dh, int *out_flags) {
   //   for 3, p mod 12 == 5
   //   for 5, p mod 10 == 3 or 7
   // should hold.
-  int ok = 0, r;
+  int ok = 0, r, q_good = 0;
   BN_CTX *ctx = NULL;
   BN_ULONG l;
   BIGNUM *t1 = NULL, *t2 = NULL;
@@ -146,6 +146,14 @@ int DH_check(const DH *dh, int *out_flags) {
   }
 
   if (dh->q) {
+    if (BN_ucmp(dh->p, dh->q) > 0) {
+      q_good = 1;
+    } else {
+      *out_flags |= DH_CHECK_INVALID_Q_VALUE;
+    }
+  }
+
+  if (q_good) {
     if (BN_cmp(dh->g, BN_value_one()) <= 0) {
       *out_flags |= DH_CHECK_NOT_SUITABLE_GENERATOR;
     } else if (BN_cmp(dh->g, dh->p) >= 0) {


### PR DESCRIPTION
Backports CVE-2023-3446, CVE-2023-3817 fixes from main:
https://github.com/aws/aws-lc/pull/1109
https://github.com/aws/aws-lc/pull/1121

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
