### PR TITLE
Release AWS-LC-FIPS-1.1.1

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2138,7 +2138,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.1.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.1.1");
 }
 
 #else
@@ -2183,6 +2183,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.1.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.1.1");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -206,7 +206,7 @@ extern "C" {
 // In order to keep track of any changes to AWLC we introduce a string that tracks with the public Github
 // release version at https://github.com/awslabs/aws-lc
 
-#define AWSLC_VERSION_NUMBER_STRING "1.1.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.1.1"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Fix handling of EXFLAG_INVALID_POLICY on the leaf. by @andrewhop in https://github.com/aws/aws-lc/pull/913
* [fips-2021-10-20] Backport CVE-2023-3446, CVE-2023-3817 fixes for DH_check by @skmcgrail in https://github.com/aws/aws-lc/pull/1127


**Full Changelog**: https://github.com/aws/aws-lc/compare/AWS-LC-FIPS-1.1.0...AWS-LC-FIPS-1.1.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
