### PR TITLE
add curl integration test CI dimension

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -66,3 +66,13 @@ batch:
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_haproxy_integration.sh"
+
+    - identifier: curl_integration
+      buildspec: tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_MEDIUM
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_curl_integration.sh"

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
@@ -24,6 +24,7 @@ RUN set -ex && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install \
     software-properties-common \
+    automake \
     cmake \
     curl \
     make \
@@ -43,6 +44,7 @@ RUN set -ex && \
     libjson-perl \
     libpcre2-dev \
     libreadline-dev \
+    libtool \
     libudev-dev \
     liblua5.4-dev \
     socat \

--- a/tests/ci/integration/run_curl_integration.sh
+++ b/tests/ci/integration/run_curl_integration.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -exu
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# SYS_ROOT
+#  |
+#  - SRC_ROOT(aws-lc)
+#  |
+#  - SCRATCH_FOLDER
+#    |
+#    - curl
+#    - AWS_LC_BUILD_FOLDER
+#    - AWS_LC_INSTALL_FOLDER
+#    - CURL_BUILD_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER=${SYS_ROOT}/"CURL_BUILD_ROOT"
+CURL_SRC_FOLDER="${SCRATCH_FOLDER}/curl"
+CURL_BUILD_FOLDER="${SCRATCH_FOLDER}/curl/build"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${CURL_SRC_FOLDER}/aws-lc-install"
+
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf ${SCRATCH_FOLDER}/*
+cd ${SCRATCH_FOLDER}
+
+function curl_build() {
+  autoreconf -fi
+  ./configure --enable-warnings --enable-werror --with-openssl=${AWS_LC_INSTALL_FOLDER}
+  make -j ${NUM_CPU_THREADS}
+  make -j ${NUM_CPU_THREADS} examples
+}
+
+function curl_run_tests() {
+  make -j ${NUM_CPU_THREADS} tests
+  make test-ci
+  cd ${SCRATCH_FOLDER}
+}
+
+# Get latest curl version.
+git clone https://github.com/curl/curl.git ${CURL_SRC_FOLDER}
+mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${CURL_BUILD_FOLDER}
+ls
+
+aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
+cd ${CURL_SRC_FOLDER}
+curl_build
+curl_run_tests
+


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1886`

### Description of changes: 
We've recently done integration efforts with libcurl. This is to maintain our compatibility with their tip of main.

### Call-outs:
N/A

### Testing:
New CI dimension

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
