### PR TITLE
Fix ARM capability functions that were reset after merge into 1MU branch

### DIFF
--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1009,33 +1009,15 @@ int CRYPTO_is_ARMv8_PMULL_capable_at_runtime(void);
 // CRYPTO_is_NEON_capable returns true if the current CPU has a NEON unit. If
 // this is known statically, it is a constant inline function.
 OPENSSL_INLINE int CRYPTO_is_NEON_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP_NEON) || defined(__ARM_NEON)
-  return 1;
-#elif defined(OPENSSL_STATIC_ARMCAP)
-  return 0;
-#else
   return CRYPTO_is_NEON_capable_at_runtime();
-#endif
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_AES_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP_AES) || defined(__ARM_FEATURE_AES)
-  return 1;
-#elif defined(OPENSSL_STATIC_ARMCAP)
-  return 0;
-#else
   return CRYPTO_is_ARMv8_AES_capable_at_runtime();
-#endif
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_PMULL_capable(void) {
-#if defined(OPENSSL_STATIC_ARMCAP_PMULL) || defined(__ARM_FEATURE_AES)
-  return 1;
-#elif defined(OPENSSL_STATIC_ARMCAP)
-  return 0;
-#else
   return CRYPTO_is_ARMv8_PMULL_capable_at_runtime();
-#endif
 }
 
 #endif  // OPENSSL_ARM || OPENSSL_AARCH64


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1764 and CryptoAlg-1873

### Description of changes: 
The changes made to the ARM capability functions in PR https://github.com/aws/aws-lc/pull/1045 were lost when rebasing the changes to be moved into the 1MU branch in https://github.com/aws/aws-lc/pull/1124. This PR fixes that and makes the feature behave as expected.

### Call-outs:
N/A

### Testing:
Tests pass locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
