### PR TITLE
Retrieve multiple certificate slot for TLS1.0/1.1 based on negotiated sigalgs

### DIFF
--- a/ssl/extensions.cc
+++ b/ssl/extensions.cc
@@ -4102,11 +4102,12 @@ bool tls1_choose_signature_algorithm(SSL_HANDSHAKE *hs, uint16_t *out) {
   // Before TLS 1.2, the signature algorithm isn't negotiated as part of the
   // handshake.
   if (ssl_protocol_version(ssl) < TLS1_2_VERSION) {
-    if (!tls1_get_legacy_signature_algorithm(out, hs->local_pubkey.get())) {
-      OPENSSL_PUT_ERROR(SSL, SSL_R_NO_COMMON_SIGNATURE_ALGORITHMS);
-      return false;
+    if (tls1_get_legacy_signature_algorithm(out, hs->local_pubkey.get()) ||
+        ssl_cert_private_keys_supports_legacy_signature_algorithm(out, hs)) {
+      return true;
     }
-    return true;
+    OPENSSL_PUT_ERROR(SSL, SSL_R_NO_COMMON_SIGNATURE_ALGORITHMS);
+    return false;
   }
 
   Span<const uint16_t> sigalgs = kSignSignatureAlgorithms;

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -675,8 +675,7 @@ const EVP_MD *ssl_get_handshake_digest(uint16_t version,
 // having support for AES in hardware or not.
 bool ssl_create_cipher_list(UniquePtr<SSLCipherPreferenceList> *out_cipher_list,
                             const bool has_aes_hw, const char *rule_str,
-                            bool strict,
-                            bool config_tls13);
+                            bool strict, bool config_tls13);
 
 // ssl_get_certificate_slot_index returns the |SSL_PKEY_*| certificate slot
 // index corresponding to the private key type of |pkey|. It returns -1 if not
@@ -1107,7 +1106,10 @@ bool ssl_public_key_supports_signature_algorithm(SSL_HANDSHAKE *hs,
 bool ssl_cert_private_keys_supports_signature_algorithm(SSL_HANDSHAKE *hs,
                                                         uint16_t sigalg);
 
-
+// ssl_cert_private_keys_supports_legacy_signature_algorithm is the tls1.0/1.1
+// version of |ssl_cert_private_keys_supports_signature_algorithm|.
+bool ssl_cert_private_keys_supports_legacy_signature_algorithm(
+    uint16_t *out, SSL_HANDSHAKE *hs);
 
 // ssl_public_key_verify verifies that the |signature| is valid for the public
 // key |pkey| and input |in|, using the signature algorithm |sigalg|.
@@ -3933,6 +3935,7 @@ struct ssl_ctx_st {
   // of support for AES hardware. The value is only considered if
   // |aes_hw_override| is true.
   bool aes_hw_override_value : 1;
+
  private:
   ~ssl_ctx_st();
   friend OPENSSL_EXPORT void SSL_CTX_free(SSL_CTX *);

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -5255,10 +5255,9 @@ TEST_P(MultipleCertificateSlotTest, SetChainAndKeyIndex) {
 }
 
 TEST_P(MultipleCertificateSlotTest, AutomaticSelection) {
-  if (version == TLS1_1_VERSION || version == TLS1_VERSION) {
-    // Automatic Multiple Certificate Selection is not supported for
-    // TLS1.0/1.1 yet.
-    // TODO: Add support for TLS1.0/1.1.
+  if ((version == TLS1_1_VERSION || version == TLS1_VERSION) &&
+      slot_index == SSL_PKEY_ED25519) {
+    // ED25519 is not supported in versions prior to TLS1.2.
     return;
   }
 

--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -19614,9 +19614,8 @@ var testMultipleCertSlotsAlgorithms = []struct {
 	{"RSA_PSS_SHA512", TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, signatureRSAPSSWithSHA512, testCertRSA, 0},
 	{"Ed25519", TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, signatureEd25519, testCertEd25519, 0},
 	// Tests for key types prior to TLS 1.2.
-	// TODO: Add support for TLS1.0/1.1
-	//{"RSA", 0, testCertRSA, 0},
-	//{"ECDSA", 0, testCertECDSAP256, CurveP256},
+	{"RSA", TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, 0, testCertRSA, 0},
+	{"ECDSA", TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, 0, testCertECDSAP256, CurveP256},
 }
 
 // TODO: Add more failure test cases.
@@ -19693,7 +19692,7 @@ func addMultipleCertSlotTests() {
 				strictAlgTest.config.CipherSuites = []uint16{alg.cipher}
 			}
 
-			if ver.version >= VersionTLS12 && !shouldFail {
+			if !shouldFail {
 				testCases = append(testCases, strictAlgTest)
 			}
 		}


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1844`

### Description of changes: 
This change is built on top of the multiple certificate slot change we did for TLS1.2/1.3: https://github.com/aws/aws-lc/pull/1120
TLS1.0/1.1 only supports two different signature algorithms and is much simpler. Either the RSA or ECDSA key type will indicate the use of it's corresponding signature. This was what we were originally doing, so we do the same for the private key slots, but with an additional check that the cipher suite allows the key type.

### Call-outs:
Same callouts as https://github.com/aws/aws-lc/pull/1120

### Testing:
Extended existing tests to use TLS1.0/1.1. More ssl runner tests will be added in a subsequent PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
