### PR TITLE
Avoid UB in test shim

### DIFF
--- a/ssl/test/bssl_shim.cc
+++ b/ssl/test/bssl_shim.cc
@@ -305,6 +305,9 @@ static bool CheckListContains(const char *type,
   std::vector<const char *> list(list_func(nullptr, 0));
   list_func(list.data(), list.size());
   for (const char *expected : list) {
+    if (str == nullptr) {
+      break;
+    }
     if (strcmp(expected, str) == 0) {
       return true;
     }


### PR DESCRIPTION
### Issues:

V980180360

### Description of changes: 

`NULL` arguments to standard library functions is generally undefined behaviour. This is test code, but prevent it anyway.

One such occurrence is if `SSL_get_signature_algorithm_name( SSL_get_peer_signature_algorithm(ssl), 0)` ends up returning `NULL`:
```
CheckListContains("sigalg", SSL_get_all_signature_algorithm_names,  SSL_get_signature_algorithm_name( SSL_get_peer_signature_algorithm(ssl), 0))
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
