### PR TITLE
Remove duplicate handling of OPENSSL_NO_ASM from CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,10 +672,6 @@ if(MALLOC_FAILURE_TESTING)
   add_definitions(-DBORINGSSL_MALLOC_FAILURE_TESTING)
 endif()
 
-if(OPENSSL_NO_ASM)
-  add_definitions(-DOPENSSL_NO_ASM)
-endif()
-
 TEST_BIG_ENDIAN(BIG_ENDIAN)
 if(BIG_ENDIAN)
   message(FATAL_ERROR "Big Endian is not supported.")


### PR DESCRIPTION
### Description of changes: 

Remove duplicate handling of `OPENSSL_NO_ASM` from CMake.

### Call-outs:

`OPENSSL_NO_ASM` is handled a few lines below.

It looks like this block was added as part of a bad cherry-pick/merge (compare the original commit [boringssl@261ec612](https://github.com/google/boringssl/commit/261ec612e21b81a4c16bbda615d0850556483b4f)
with the cherry-pick [aws-lc@1da6816b](https://github.com/aws/aws-lc/commit/1da6816b658eed1336398406e30a0fc499bd4865)).

### Testing:

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
