### PR TITLE
Update for Release v1.14.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4076,7 +4076,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.13.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.14.0");
 }
 
 #else
@@ -4119,6 +4119,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.13.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.14.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -216,7 +216,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.13.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.14.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 

Prepare for release with the following changes:
* Fix formal verification CI by @samuel40791765 in https://github.com/aws/aws-lc/pull/1130
* Pull in the latest changes from s2n-bignum (2023-07-25)  by @aqjune-aws in https://github.com/aws/aws-lc/pull/1114
* Upstream merge 2023 07 28 by @samuel40791765 in https://github.com/aws/aws-lc/pull/1122
* Implementation passive entropy by @torben-hansen in https://github.com/aws/aws-lc/pull/1125
* add curl integration test CI dimension by @samuel40791765 in https://github.com/aws/aws-lc/pull/1134
* Retrieve multiple certificate slot for TLS1.2/1.3 based on negotiated sigalgs by @samuel40791765 in https://github.com/aws/aws-lc/pull/1120
* ABI Diff GitHub Action by @skmcgrail in https://github.com/aws/aws-lc/pull/1116
* Add vzeroupper instruction for AVX512 optimization in AES-XTS by @shirsing0712 in https://github.com/aws/aws-lc/pull/1115
* Avoid UB in test shim by @torben-hansen in https://github.com/aws/aws-lc/pull/1140
* Simplify the Kyber prefix build by @andrewhop in https://github.com/aws/aws-lc/pull/1131
* Pull in the latest changes from s2n-bignum (2023-08-04) by @aqjune-aws in https://github.com/aws/aws-lc/pull/1139
* Detect GCM-SIV alignment change by @justsmth in https://github.com/aws/aws-lc/pull/1144

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
