### PR TITLE
Add support for BIO_FP_TEXT in file BIOs

### DIFF
--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -162,26 +162,20 @@ TEST(BIOTest, TextFile) {
 #endif
 
 
-  // Test with CRLF line endings on windows, and standard line endings
-  // elsewhere.
-#if defined(OPENSSL_WINDOWS)
-  const char *test_str = "test\r\n";
-#else
-  const char *test_str = "test\n";
-#endif
-
   // unique_ptr will automatically call fclose on the file descriptior when the
   // variable goes out of scope, so we need to specify BIO_NOCLOSE close flags
   // to avoid a double-free condition.
   using TempFILE = std::unique_ptr<FILE, decltype(&fclose)>;
 
-  // Assert that CRLF line endings get translated out on write and back in on
+  const char *test_str = "test\n";
+
+  // Assert that CRLF line endings get inserted on write and translated back out on
   // read for text mode.
   TempFILE text_bio_file(tmpfile(), fclose);
   ASSERT_TRUE(text_bio_file);
   bssl::UniquePtr<BIO> text_bio(BIO_new_fp(text_bio_file.get(), BIO_NOCLOSE | BIO_FP_TEXT));
   int bytes_written = BIO_write(text_bio.get(), test_str, strlen(test_str));
-  ASSERT_GE(bytes_written, 0);
+  EXPECT_GE(bytes_written, 0);
   ASSERT_TRUE(BIO_flush(text_bio.get()));
   ASSERT_EQ(0, BIO_seek(text_bio.get(), 0));    // 0 indicates success here
   char contents[10];
@@ -190,16 +184,20 @@ TEST(BIOTest, TextFile) {
   EXPECT_GE(bytes_read, bytes_written);
   EXPECT_EQ(test_str, std::string(contents));
 
-  // Windows should have translated '\r\n' to '\n', so validate that by opening
-  // the file in raw binary mode (i.e. no BIO_FP_TEXT).
+  // Windows should have translated '\n' to '\r\n' on write, so validate that
+  // by opening the file in raw binary mode (i.e. no BIO_FP_TEXT).
   bssl::UniquePtr<BIO> text_bio_raw(BIO_new_fp(text_bio_file.get(), BIO_NOCLOSE));
   ASSERT_EQ(0, BIO_seek(text_bio.get(), 0));    // 0 indicates success here
   OPENSSL_memset(contents, 0, sizeof(contents));
   bytes_read = BIO_read(text_bio_raw.get(), contents, sizeof(contents));
   EXPECT_GT(bytes_read, 0);
-  EXPECT_EQ("test\n", std::string(contents));
+#if defined(OPENSSL_WINDOWS)
+  EXPECT_EQ("test\r\n", std::string(contents));
+#else
+  EXPECT_EQ(test_str, std::string(contents));
+#endif
 
-  // Assert that CRLF line endings don't get translated out on write for
+  // Assert that CRLF line endings don't get inserted on write for
   // (default) binary mode.
   TempFILE binary_bio_file(tmpfile(), fclose);
   ASSERT_TRUE(binary_bio_file);

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -236,13 +236,11 @@ TEST(BIOTest, CloseFlags) {
   EXPECT_TRUE(BIO_free(bio));
   // Windows CRT hits an assertion error and stack overflow (exception code
   // 0xc0000409) when calling _tell or lseek on an already-closed file
-  // descriptor, so use _get_osfhandle isntead.
-#if defined(OPENSSL_WINDOWS)
-  EXPECT_EQ(reinterpret_cast<intptr_t>(INVALID_HANDLE_VALUE), _get_osfhandle(tmp_fd));
-#else
+  // descriptor, so only consider the non-Windows case here.
+#if !defined(OPENSSL_WINDOWS)
   EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));
-#endif
   EXPECT_EQ(EBADF, errno);  // EBADF indicates that |BIO_free| closed the file
+#endif
 
   // Assert that BIO_NOCLOSE does not close the underlying file on BIO free
   tmp = tmpfile();

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -224,7 +224,6 @@ TEST(BIOTest, CloseFlags) {
   BIO_gets(binary_bio.get(), b2, sizeof(b2));
   EXPECT_EQ(std::string(b1), std::string(b2));
 
-  /*
   // Assert that BIO_CLOSE causes the underlying file to be closed on BIO free
   // (ftell will return < 0)
   FILE *tmp = tmpfile();
@@ -235,14 +234,13 @@ TEST(BIOTest, CloseFlags) {
   int tmp_fd = fileno(tmp);
   EXPECT_LT(0, tmp_fd);
   EXPECT_TRUE(BIO_free(bio));
-  EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));
-  EXPECT_EQ(errno, EBADF);  // EBADF indicates taht |BIO_free| closed the file
-  */
+  //EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));
+  //EXPECT_EQ(errno, EBADF);  // EBADF indicates taht |BIO_free| closed the file
 
   // Assert that BIO_NOCLOSE does not closethe underlying file on BIO free
-  FILE *tmp = tmpfile();
+  tmp = tmpfile();
   ASSERT_TRUE(tmp);
-  BIO *bio = BIO_new_fp(tmp, BIO_NOCLOSE);
+  bio = BIO_new_fp(tmp, BIO_NOCLOSE);
   EXPECT_EQ(0, BIO_tell(bio));
   EXPECT_TRUE(BIO_free(bio));
   EXPECT_TRUE(tmp);

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -239,7 +239,8 @@ TEST(BIOTest, CloseFlags) {
   // lseek on a closed fd causes an assertion error on windows, so we use the
   // platform-specific _tell there and lseek on *nix.
 #if defined(OPENSSL_WINDOWS)
-  EXPECT_EQ(-1, _tell(tmp_fd));
+  #undef _DEBUG
+  EXPECT_EQ(-1, _lseek(tmp_fd, 0, SEEK_CUR));
 #else
   EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));
 #endif

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -235,7 +235,7 @@ TEST(BIOTest, CloseFlags) {
   EXPECT_LT(0, tmp_fd);
   EXPECT_TRUE(BIO_free(bio));
   // Windows CRT hits an assertion error and stack overflow (exception code
-  // 0xc0000409) when calling ftell or lseek on an already-closed file
+  // 0xc0000409) when calling _tell or lseek on an already-closed file
   // descriptor, so only consider the non-Windows case here.
 #if !defined(OPENSSL_WINDOWS)
   EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -155,6 +155,7 @@ TEST(BIOTest, Printf) {
 }
 
 TEST(BIOTest, CloseFlags) {
+  printf("FOOBAR 0\n");
 #if defined(OPENSSL_ANDROID)
   // On Android, when running from an APK, |tmpfile| does not work. See
   // b/36991167#comment8.
@@ -168,26 +169,34 @@ TEST(BIOTest, CloseFlags) {
 
   const char *test_str = "test\ntest\ntest\n";
 
+  printf("FOOBAR 1\n");
+
   // Assert that CRLF line endings get inserted on write and translated back out on
   // read for text mode.
   TempFILE text_bio_file(tmpfile(), fclose);
   ASSERT_TRUE(text_bio_file);
+  printf("FOOBAR 2\n");
   bssl::UniquePtr<BIO> text_bio(BIO_new_fp(text_bio_file.get(), BIO_NOCLOSE | BIO_FP_TEXT));
   int bytes_written = BIO_write(text_bio.get(), test_str, strlen(test_str));
   EXPECT_GE(bytes_written, 0);
+  printf("FOOBAR 3\n");
   ASSERT_TRUE(BIO_flush(text_bio.get()));
   ASSERT_EQ(0, BIO_seek(text_bio.get(), 0));    // 0 indicates success here
   char contents[256];
+  printf("FOOBAR 4\n");
   OPENSSL_memset(contents, 0, sizeof(contents));
   int bytes_read = BIO_read(text_bio.get(), contents, sizeof(contents));
   EXPECT_GE(bytes_read, bytes_written);
   EXPECT_EQ(test_str, std::string(contents));
 
+  printf("FOOBAR 5\n");
   // Windows should have translated '\n' to '\r\n' on write, so validate that
   // by opening the file in raw binary mode (i.e. no BIO_FP_TEXT).
   bssl::UniquePtr<BIO> text_bio_raw(BIO_new_fp(text_bio_file.get(), BIO_NOCLOSE));
   ASSERT_EQ(0, BIO_seek(text_bio.get(), 0));    // 0 indicates success here
+  printf("FOOBAR 6\n");
   OPENSSL_memset(contents, 0, sizeof(contents));
+  printf("FOOBAR 7\n");
   bytes_read = BIO_read(text_bio_raw.get(), contents, sizeof(contents));
   EXPECT_GT(bytes_read, 0);
 #if defined(OPENSSL_WINDOWS)
@@ -196,15 +205,18 @@ TEST(BIOTest, CloseFlags) {
   EXPECT_EQ(test_str, std::string(contents));
 #endif
 
+  printf("FOOBAR 8\n");
   // Assert that CRLF line endings don't get inserted on write for
   // (default) binary mode.
   TempFILE binary_bio_file(tmpfile(), fclose);
   ASSERT_TRUE(binary_bio_file);
+  printf("FOOBAR 9\n");
   bssl::UniquePtr<BIO> binary_bio(BIO_new_fp(binary_bio_file.get(), BIO_NOCLOSE));
   bytes_written = BIO_write(binary_bio.get(), test_str, strlen(test_str));
   EXPECT_EQ((int) strlen(test_str), bytes_written);
   ASSERT_TRUE(BIO_flush(binary_bio.get()));
   ASSERT_EQ(0, BIO_seek(binary_bio.get(), 0));    // 0 indicates success here
+  printf("FOOBAR 10\n");
   OPENSSL_memset(contents, 0, sizeof(contents));
   bytes_read = BIO_read(binary_bio.get(), contents, sizeof(contents));
   EXPECT_GE(bytes_read, bytes_written);
@@ -216,10 +228,12 @@ TEST(BIOTest, CloseFlags) {
   long pos;
   char b1[256], b2[256];
   binary_bio.reset(BIO_new_fp(binary_bio_file.get(), BIO_NOCLOSE));
+  printf("FOOBAR 11\n");
   ASSERT_EQ(0, BIO_seek(binary_bio.get(), 0));    // 0 indicates success here
   BIO_gets(binary_bio.get(), b1, sizeof(b1));
   pos = BIO_tell(binary_bio.get());
   BIO_gets(binary_bio.get(), b1, sizeof(b1));
+  printf("FOOBAR 12\n");
   BIO_seek(binary_bio.get(), pos);
   BIO_gets(binary_bio.get(), b2, sizeof(b2));
   EXPECT_EQ(std::string(b1), std::string(b2));
@@ -228,25 +242,33 @@ TEST(BIOTest, CloseFlags) {
   // (ftell will return < 0)
   FILE *tmp = tmpfile();
   ASSERT_TRUE(tmp);
+  printf("FOOBAR 13\n");
   BIO *bio = BIO_new_fp(tmp, BIO_CLOSE);
   EXPECT_EQ(0, BIO_tell(bio));
+  printf("FOOBAR 14\n");
   // save off fd to avoid referencing |tmp| after free and angering valgrind
   int tmp_fd = fileno(tmp);
   EXPECT_LT(0, tmp_fd);
   EXPECT_TRUE(BIO_free(bio));
+  printf("FOOBAR 15\n");
   EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));
   EXPECT_EQ(errno, EBADF);  // EBADF indicates taht |BIO_free| closed the file
 
+  printf("FOOBAR 16\n");
   // Assert that BIO_NOCLOSE does not closethe underlying file on BIO free
   tmp = tmpfile();
   ASSERT_TRUE(tmp);
+  printf("FOOBAR 17\n");
   bio = BIO_new_fp(tmp, BIO_NOCLOSE);
   EXPECT_EQ(0, BIO_tell(bio));
   EXPECT_TRUE(BIO_free(bio));
+  printf("FOOBAR 18\n");
   EXPECT_TRUE(tmp);
   EXPECT_EQ(0, ftell(tmp));     // 0 indicates file is still open
+  printf("FOOBAR 19\n");
   EXPECT_LT(0, tmp_fd);
   EXPECT_EQ(0, fclose(tmp));    // 0 indicates success for fclose
+  printf("FOOBAR 20\n");
 }
 
 TEST(BIOTest, ReadASN1) {

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -224,6 +224,7 @@ TEST(BIOTest, CloseFlags) {
   BIO_gets(binary_bio.get(), b2, sizeof(b2));
   EXPECT_EQ(std::string(b1), std::string(b2));
 
+  /*
   // Assert that BIO_CLOSE causes the underlying file to be closed on BIO free
   // (ftell will return < 0)
   FILE *tmp = tmpfile();
@@ -236,16 +237,16 @@ TEST(BIOTest, CloseFlags) {
   EXPECT_TRUE(BIO_free(bio));
   EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));
   EXPECT_EQ(errno, EBADF);  // EBADF indicates taht |BIO_free| closed the file
+  */
 
   // Assert that BIO_NOCLOSE does not closethe underlying file on BIO free
-  tmp = tmpfile();
+  FILE *tmp = tmpfile();
   ASSERT_TRUE(tmp);
-  bio = BIO_new_fp(tmp, BIO_NOCLOSE);
+  BIO *bio = BIO_new_fp(tmp, BIO_NOCLOSE);
   EXPECT_EQ(0, BIO_tell(bio));
   EXPECT_TRUE(BIO_free(bio));
   EXPECT_TRUE(tmp);
   EXPECT_EQ(0, ftell(tmp));     // 0 indicates file is still open
-  EXPECT_LT(0, tmp_fd);
   EXPECT_EQ(0, fclose(tmp));    // 0 indicates success for fclose
 }
 

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -155,7 +155,6 @@ TEST(BIOTest, Printf) {
 }
 
 TEST(BIOTest, CloseFlags) {
-  printf("FOOBAR 0\n");
 #if defined(OPENSSL_ANDROID)
   // On Android, when running from an APK, |tmpfile| does not work. See
   // b/36991167#comment8.
@@ -169,34 +168,26 @@ TEST(BIOTest, CloseFlags) {
 
   const char *test_str = "test\ntest\ntest\n";
 
-  printf("FOOBAR 1\n");
-
   // Assert that CRLF line endings get inserted on write and translated back out on
   // read for text mode.
   TempFILE text_bio_file(tmpfile(), fclose);
   ASSERT_TRUE(text_bio_file);
-  printf("FOOBAR 2\n");
   bssl::UniquePtr<BIO> text_bio(BIO_new_fp(text_bio_file.get(), BIO_NOCLOSE | BIO_FP_TEXT));
   int bytes_written = BIO_write(text_bio.get(), test_str, strlen(test_str));
   EXPECT_GE(bytes_written, 0);
-  printf("FOOBAR 3\n");
   ASSERT_TRUE(BIO_flush(text_bio.get()));
   ASSERT_EQ(0, BIO_seek(text_bio.get(), 0));    // 0 indicates success here
   char contents[256];
-  printf("FOOBAR 4\n");
   OPENSSL_memset(contents, 0, sizeof(contents));
   int bytes_read = BIO_read(text_bio.get(), contents, sizeof(contents));
   EXPECT_GE(bytes_read, bytes_written);
   EXPECT_EQ(test_str, std::string(contents));
 
-  printf("FOOBAR 5\n");
   // Windows should have translated '\n' to '\r\n' on write, so validate that
   // by opening the file in raw binary mode (i.e. no BIO_FP_TEXT).
   bssl::UniquePtr<BIO> text_bio_raw(BIO_new_fp(text_bio_file.get(), BIO_NOCLOSE));
   ASSERT_EQ(0, BIO_seek(text_bio.get(), 0));    // 0 indicates success here
-  printf("FOOBAR 6\n");
   OPENSSL_memset(contents, 0, sizeof(contents));
-  printf("FOOBAR 7\n");
   bytes_read = BIO_read(text_bio_raw.get(), contents, sizeof(contents));
   EXPECT_GT(bytes_read, 0);
 #if defined(OPENSSL_WINDOWS)
@@ -205,18 +196,15 @@ TEST(BIOTest, CloseFlags) {
   EXPECT_EQ(test_str, std::string(contents));
 #endif
 
-  printf("FOOBAR 8\n");
   // Assert that CRLF line endings don't get inserted on write for
   // (default) binary mode.
   TempFILE binary_bio_file(tmpfile(), fclose);
   ASSERT_TRUE(binary_bio_file);
-  printf("FOOBAR 9\n");
   bssl::UniquePtr<BIO> binary_bio(BIO_new_fp(binary_bio_file.get(), BIO_NOCLOSE));
   bytes_written = BIO_write(binary_bio.get(), test_str, strlen(test_str));
   EXPECT_EQ((int) strlen(test_str), bytes_written);
   ASSERT_TRUE(BIO_flush(binary_bio.get()));
   ASSERT_EQ(0, BIO_seek(binary_bio.get(), 0));    // 0 indicates success here
-  printf("FOOBAR 10\n");
   OPENSSL_memset(contents, 0, sizeof(contents));
   bytes_read = BIO_read(binary_bio.get(), contents, sizeof(contents));
   EXPECT_GE(bytes_read, bytes_written);
@@ -228,12 +216,10 @@ TEST(BIOTest, CloseFlags) {
   long pos;
   char b1[256], b2[256];
   binary_bio.reset(BIO_new_fp(binary_bio_file.get(), BIO_NOCLOSE));
-  printf("FOOBAR 11\n");
   ASSERT_EQ(0, BIO_seek(binary_bio.get(), 0));    // 0 indicates success here
   BIO_gets(binary_bio.get(), b1, sizeof(b1));
   pos = BIO_tell(binary_bio.get());
   BIO_gets(binary_bio.get(), b1, sizeof(b1));
-  printf("FOOBAR 12\n");
   BIO_seek(binary_bio.get(), pos);
   BIO_gets(binary_bio.get(), b2, sizeof(b2));
   EXPECT_EQ(std::string(b1), std::string(b2));
@@ -242,33 +228,25 @@ TEST(BIOTest, CloseFlags) {
   // (ftell will return < 0)
   FILE *tmp = tmpfile();
   ASSERT_TRUE(tmp);
-  printf("FOOBAR 13\n");
   BIO *bio = BIO_new_fp(tmp, BIO_CLOSE);
   EXPECT_EQ(0, BIO_tell(bio));
-  printf("FOOBAR 14\n");
   // save off fd to avoid referencing |tmp| after free and angering valgrind
   int tmp_fd = fileno(tmp);
   EXPECT_LT(0, tmp_fd);
   EXPECT_TRUE(BIO_free(bio));
-  printf("FOOBAR 15\n");
   EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));
   EXPECT_EQ(errno, EBADF);  // EBADF indicates taht |BIO_free| closed the file
 
-  printf("FOOBAR 16\n");
   // Assert that BIO_NOCLOSE does not closethe underlying file on BIO free
   tmp = tmpfile();
   ASSERT_TRUE(tmp);
-  printf("FOOBAR 17\n");
   bio = BIO_new_fp(tmp, BIO_NOCLOSE);
   EXPECT_EQ(0, BIO_tell(bio));
   EXPECT_TRUE(BIO_free(bio));
-  printf("FOOBAR 18\n");
   EXPECT_TRUE(tmp);
   EXPECT_EQ(0, ftell(tmp));     // 0 indicates file is still open
-  printf("FOOBAR 19\n");
   EXPECT_LT(0, tmp_fd);
   EXPECT_EQ(0, fclose(tmp));    // 0 indicates success for fclose
-  printf("FOOBAR 20\n");
 }
 
 TEST(BIOTest, ReadASN1) {

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -236,11 +236,13 @@ TEST(BIOTest, CloseFlags) {
   EXPECT_TRUE(BIO_free(bio));
   // Windows CRT hits an assertion error and stack overflow (exception code
   // 0xc0000409) when calling _tell or lseek on an already-closed file
-  // descriptor, so only consider the non-Windows case here.
-#if !defined(OPENSSL_WINDOWS)
+  // descriptor, so use _get_osfhandle isntead.
+#if defined(OPENSSL_WINDOWS)
+  EXPECT_EQ(reinterpret_cast<intptr_t>(INVALID_HANDLE_VALUE), _get_osfhandle(tmp_fd));
+#else
   EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));
-  EXPECT_EQ(EBADF, errno);  // EBADF indicates that |BIO_free| closed the file
 #endif
+  EXPECT_EQ(EBADF, errno);  // EBADF indicates that |BIO_free| closed the file
 
   // Assert that BIO_NOCLOSE does not close the underlying file on BIO free
   tmp = tmpfile();

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -169,26 +169,34 @@ TEST(BIOTest, CloseFlags) {
 
   const char *test_str = "test\ntest\ntest\n";
 
+  printf("FOOBAR 1\n");
+
   // Assert that CRLF line endings get inserted on write and translated back out on
   // read for text mode.
   TempFILE text_bio_file(tmpfile(), fclose);
   ASSERT_TRUE(text_bio_file);
+  printf("FOOBAR 2\n");
   bssl::UniquePtr<BIO> text_bio(BIO_new_fp(text_bio_file.get(), BIO_NOCLOSE | BIO_FP_TEXT));
   int bytes_written = BIO_write(text_bio.get(), test_str, strlen(test_str));
   EXPECT_GE(bytes_written, 0);
+  printf("FOOBAR 3\n");
   ASSERT_TRUE(BIO_flush(text_bio.get()));
   ASSERT_EQ(0, BIO_seek(text_bio.get(), 0));    // 0 indicates success here
   char contents[256];
+  printf("FOOBAR 4\n");
   OPENSSL_memset(contents, 0, sizeof(contents));
   int bytes_read = BIO_read(text_bio.get(), contents, sizeof(contents));
   EXPECT_GE(bytes_read, bytes_written);
   EXPECT_EQ(test_str, std::string(contents));
 
+  printf("FOOBAR 5\n");
   // Windows should have translated '\n' to '\r\n' on write, so validate that
   // by opening the file in raw binary mode (i.e. no BIO_FP_TEXT).
   bssl::UniquePtr<BIO> text_bio_raw(BIO_new_fp(text_bio_file.get(), BIO_NOCLOSE));
   ASSERT_EQ(0, BIO_seek(text_bio.get(), 0));    // 0 indicates success here
+  printf("FOOBAR 6\n");
   OPENSSL_memset(contents, 0, sizeof(contents));
+  printf("FOOBAR 7\n");
   bytes_read = BIO_read(text_bio_raw.get(), contents, sizeof(contents));
   EXPECT_GT(bytes_read, 0);
 #if defined(OPENSSL_WINDOWS)
@@ -197,15 +205,18 @@ TEST(BIOTest, CloseFlags) {
   EXPECT_EQ(test_str, std::string(contents));
 #endif
 
+  printf("FOOBAR 8\n");
   // Assert that CRLF line endings don't get inserted on write for
   // (default) binary mode.
   TempFILE binary_bio_file(tmpfile(), fclose);
   ASSERT_TRUE(binary_bio_file);
+  printf("FOOBAR 9\n");
   bssl::UniquePtr<BIO> binary_bio(BIO_new_fp(binary_bio_file.get(), BIO_NOCLOSE));
   bytes_written = BIO_write(binary_bio.get(), test_str, strlen(test_str));
   EXPECT_EQ((int) strlen(test_str), bytes_written);
   ASSERT_TRUE(BIO_flush(binary_bio.get()));
   ASSERT_EQ(0, BIO_seek(binary_bio.get(), 0));    // 0 indicates success here
+  printf("FOOBAR 10\n");
   OPENSSL_memset(contents, 0, sizeof(contents));
   bytes_read = BIO_read(binary_bio.get(), contents, sizeof(contents));
   EXPECT_GE(bytes_read, bytes_written);
@@ -217,13 +228,47 @@ TEST(BIOTest, CloseFlags) {
   long pos;
   char b1[256], b2[256];
   binary_bio.reset(BIO_new_fp(binary_bio_file.get(), BIO_NOCLOSE));
+  printf("FOOBAR 11\n");
   ASSERT_EQ(0, BIO_seek(binary_bio.get(), 0));    // 0 indicates success here
   BIO_gets(binary_bio.get(), b1, sizeof(b1));
   pos = BIO_tell(binary_bio.get());
   BIO_gets(binary_bio.get(), b1, sizeof(b1));
+  printf("FOOBAR 12\n");
   BIO_seek(binary_bio.get(), pos);
   BIO_gets(binary_bio.get(), b2, sizeof(b2));
   EXPECT_EQ(std::string(b1), std::string(b2));
+
+  // Assert that BIO_CLOSE causes the underlying file to be closed on BIO free
+  // (ftell will return < 0)
+  FILE *tmp = tmpfile();
+  ASSERT_TRUE(tmp);
+  printf("FOOBAR 13\n");
+  BIO *bio = BIO_new_fp(tmp, BIO_CLOSE);
+  EXPECT_EQ(0, BIO_tell(bio));
+  printf("FOOBAR 14\n");
+  // save off fd to avoid referencing |tmp| after free and angering valgrind
+  int tmp_fd = fileno(tmp);
+  EXPECT_LT(0, tmp_fd);
+  EXPECT_TRUE(BIO_free(bio));
+  printf("FOOBAR 15\n");
+  EXPECT_EQ(-1, lseek(tmp_fd, 0, SEEK_CUR));
+  EXPECT_EQ(errno, EBADF);  // EBADF indicates taht |BIO_free| closed the file
+
+  printf("FOOBAR 16\n");
+  // Assert that BIO_NOCLOSE does not closethe underlying file on BIO free
+  tmp = tmpfile();
+  ASSERT_TRUE(tmp);
+  printf("FOOBAR 17\n");
+  bio = BIO_new_fp(tmp, BIO_NOCLOSE);
+  EXPECT_EQ(0, BIO_tell(bio));
+  EXPECT_TRUE(BIO_free(bio));
+  printf("FOOBAR 18\n");
+  EXPECT_TRUE(tmp);
+  EXPECT_EQ(0, ftell(tmp));     // 0 indicates file is still open
+  printf("FOOBAR 19\n");
+  EXPECT_LT(0, tmp_fd);
+  EXPECT_EQ(0, fclose(tmp));    // 0 indicates success for fclose
+  printf("FOOBAR 20\n");
 }
 
 TEST(BIOTest, ReadASN1) {

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -152,6 +152,40 @@ TEST(BIOTest, Printf) {
 
     ASSERT_TRUE(BIO_reset(bio.get()));
   }
+
+  // Assert that we write CRLF line endings on Windows in text mode, and do not
+  // in (default) binary mode.
+  const char *test_str = "test\n";
+  FILE *text_bio_file = fmemopen(nullptr, 10, "r+");
+  ASSERT_TRUE(text_bio_file);
+  bssl::UniquePtr<BIO> text_bio(BIO_new_fp(text_bio_file, BIO_CLOSE | BIO_FP_TEXT));
+  int bytes_written = BIO_write(text_bio.get(), test_str, strlen(test_str));
+  ASSERT_GE(bytes_written, 0);
+  ASSERT_TRUE(BIO_flush(text_bio.get()));
+  ASSERT_EQ(0, BIO_seek(text_bio.get(), 0));    // 0 indicates success here
+  char contents[10];
+  int bytes_read = BIO_read(text_bio.get(), contents, sizeof(contents));
+  printf("FOOBAR :: %d :: %s\n", bytes_written, contents);
+  EXPECT_GE(bytes_read, bytes_written);
+#if defined(__WIN32)
+  EXPECT_EQ("test\r\n", std::string(contents));
+#else
+  EXPECT_EQ(test_str, std::string(contents));
+#endif
+  fclose(text_bio_file);
+
+  FILE *binary_bio_file = fmemopen(nullptr, 10, "r+b");
+  ASSERT_TRUE(binary_bio_file);
+  bssl::UniquePtr<BIO> binary_bio(BIO_new_fp(binary_bio_file, BIO_CLOSE));
+  bytes_written = BIO_write(binary_bio.get(), test_str, strlen(test_str));
+  EXPECT_EQ((int) strlen(test_str), bytes_written);
+  ASSERT_TRUE(BIO_flush(binary_bio.get()));
+  ASSERT_EQ(0, BIO_seek(binary_bio.get(), 0));    // 0 indicates success here
+  OPENSSL_memset(contents, 0, sizeof(contents));
+  bytes_read = BIO_read(binary_bio.get(), contents, sizeof(contents));
+  EXPECT_GE(bytes_read, bytes_written);
+  EXPECT_EQ(test_str, std::string(contents));
+  fclose(binary_bio_file);
 }
 
 TEST(BIOTest, ReadASN1) {

--- a/crypto/bio/file.c
+++ b/crypto/bio/file.c
@@ -203,7 +203,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr) {
       // the file to text mode if caller specifies BIO_FP_TEXT flag.
       //
       // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode?view=msvc-170#remarks
-      _setmode(_fileno(fp), num & BIO_FP_TEXT ? _O_TEXT : _O_BINARY);
+      _setmode(_fileno(b->ptr), num & BIO_FP_TEXT ? _O_TEXT : _O_BINARY);
 #endif
       break;
     case BIO_C_SET_FILENAME:

--- a/crypto/bio/file.c
+++ b/crypto/bio/file.c
@@ -215,11 +215,12 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr) {
         ret = 0;
         break;
       }
-      // Per fopen's man page, this has no effect on Linux
+      // The transaltion modifier is ignored on Linux:
       // https://man7.org/linux/man-pages/man3/fopen.3.html
-      if ((num & BIO_FP_TEXT) == 0) {
-          p[strlen(p)] = 'b';
-      }
+      // but is meaningful on Windows:
+      // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170#generic-text-routine-mappings
+      const char translation_modifier = num & BIO_FP_TEXT ? 't' : 'b';
+      p[strlen(p)] = translation_modifier;
       fp = fopen(ptr, p);
       if (fp == NULL) {
         OPENSSL_PUT_SYSTEM_ERROR();

--- a/crypto/bio/file.c
+++ b/crypto/bio/file.c
@@ -173,6 +173,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr) {
   FILE *fp = (FILE *)b->ptr;
   FILE **fpp;
   char p[4];
+  OPENSSL_memset(p, 0, sizeof(p));
 
   switch (cmd) {
     case BIO_CTRL_RESET:
@@ -213,6 +214,11 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr) {
         OPENSSL_PUT_ERROR(BIO, BIO_R_BAD_FOPEN_MODE);
         ret = 0;
         break;
+      }
+      // Per fopen's man page, this has no effect on Linux
+      // https://man7.org/linux/man-pages/man3/fopen.3.html
+      if ((num & BIO_FP_TEXT) == 0) {
+          p[strlen(p)] = 'b';
       }
       fp = fopen(ptr, p);
       if (fp == NULL) {

--- a/crypto/bio/file.c
+++ b/crypto/bio/file.c
@@ -194,11 +194,11 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr) {
       b->ptr = ptr;
       b->init = 1;
 #if defined(OPENSSL_WINDOWS)
-      // The transaltion modifier is ignored on Linux:
-      // https://man7.org/linux/man-pages/man3/fopen.3.html
-      // but is meaningful on Windows:
-      // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170#generic-text-routine-mappings
-      _set_mode(b->ptr, num & BIO_FP_TEXT ? _O_TEXT : _O_BINARY);
+      // Windows differentiates between "text" and "binary" file modes, so set
+      // the file to text mode if caller specifies BIO_FP_TEXT flag.
+      //
+      // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode?view=msvc-170#remarks
+      _setmode(_fileno(fp), num & BIO_FP_TEXT ? _O_TEXT : _O_BINARY);
 #endif
       break;
     case BIO_C_SET_FILENAME:

--- a/crypto/bio/file.c
+++ b/crypto/bio/file.c
@@ -79,6 +79,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#if defined(OPENSSL_WINDOWS)
+#include <fcntl.h>
+#include <io.h>
+#endif  // OPENSSL_WINDOWS
+
 #include <openssl/err.h>
 #include <openssl/mem.h>
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -395,10 +395,15 @@ OPENSSL_EXPORT int BIO_read_asn1(BIO *bio, uint8_t **out, size_t *out_len,
 //
 // |BIO_ctrl_pending| returns the number of bytes currently stored.
 
-// BIO_NOCLOSE and |BIO_CLOSE| can be used as symbolic arguments when a "close
-// flag" is passed to a BIO function.
+// |BIO_NOCLOSE|, |BIO_CLOSE|, and |BIO_FP_TEXT|  can be used as symbolic
+// arguments when a "close flag" is passed to a BIO function. |BIO_CLOSE| (on
+// by default) will free the backing buffer on BIO close, whereas |BIO_NOCLOSE|
+// will not. Setting |BIO_FP_TEXT| will cause the file to be opened as a text
+// file (this is only relevant on Windows due to CRLF endings) instead of the
+// default behavior of opening the file in binary mode.
 #define BIO_NOCLOSE 0
 #define BIO_CLOSE 1
+#define BIO_FP_TEXT 0x10
 
 // BIO_s_mem returns a |BIO_METHOD| that uses a in-memory buffer.
 OPENSSL_EXPORT const BIO_METHOD *BIO_s_mem(void);

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -457,9 +457,9 @@ OPENSSL_EXPORT int BIO_set_mem_eof_return(BIO *bio, int eof_value);
 // BIO_CLOSE will close the underlying file on BIO free
 #define BIO_CLOSE 1
 
-// BIO_FP_TEXT will cause the file to be opened as a text file (this is only
-// relevant on Windows due to CRLF endings) instead of the default behavior of
-// opening the file in binary mode.
+// BIO_FP_TEXT will cause the file to be treated as a text file instead of the
+// default behavior of treating it as a raw binary file. This is only relevant
+// on Windows due to CRLF endings.
 #define BIO_FP_TEXT 0x10
 
 
@@ -517,7 +517,8 @@ OPENSSL_EXPORT BIO *BIO_new_file(const char *filename, const char *mode);
 
 // BIO_new_fp creates a new file BIO that wraps the given |FILE|. If
 // |close_flag| is |BIO_CLOSE|, then |fclose| will be called on |stream| when
-// the BIO is closed.
+// the BIO is closed. If |close_flag| is |BIO_FP_TEXT|, the file will be set as
+// a text file after opening (only on Windows).
 OPENSSL_EXPORT BIO *BIO_new_fp(FILE *stream, int close_flag);
 
 // BIO_get_fp sets |*out_file| to the current |FILE| for |bio|. It returns one
@@ -525,8 +526,9 @@ OPENSSL_EXPORT BIO *BIO_new_fp(FILE *stream, int close_flag);
 OPENSSL_EXPORT int BIO_get_fp(BIO *bio, FILE **out_file);
 
 // BIO_set_fp sets the |FILE| for |bio|. If |close_flag| is |BIO_CLOSE| then
-// |fclose| will be called on |file| when |bio| is closed. It returns one on
-// success and zero otherwise.
+// |fclose| will be called on |file| when |bio| is closed. If |close_flag| is
+// |BIO_FP_TEXT|, the file will be set as a text file (only on Windows). It
+// returns one on success and zero otherwise.
 OPENSSL_EXPORT int BIO_set_fp(BIO *bio, FILE *file, int close_flag);
 
 // BIO_read_filename opens |filename| for reading and sets the result as the

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -451,10 +451,10 @@ OPENSSL_EXPORT int BIO_set_mem_eof_return(BIO *bio, int eof_value);
 // These can be used as symbolic arguments when a "close flag" is passed to a
 // BIO function.
 
-// BIO_NOCLOSE will not free the backing buffer on BIO close
+// BIO_NOCLOSE will not close the underlying file on BIO free
 #define BIO_NOCLOSE 0
 
-// BIO_CLOSE (default) will free the backing buffer on BIO close, whereas
+// BIO_CLOSE will close the underlying file on BIO free
 #define BIO_CLOSE 1
 
 // BIO_FP_TEXT will cause the file to be opened as a text file (this is only

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -451,13 +451,13 @@ OPENSSL_EXPORT int BIO_set_mem_eof_return(BIO *bio, int eof_value);
 // These can be used as symbolic arguments when a "close flag" is passed to a
 // BIO function.
 
-// |BIO_NOCLOSE| will not free the backing buffer on BIO close
+// BIO_NOCLOSE will not free the backing buffer on BIO close
 #define BIO_NOCLOSE 0
 
-// |BIO_CLOSE| (default) will free the backing buffer on BIO close, whereas
+// BIO_CLOSE (default) will free the backing buffer on BIO close, whereas
 #define BIO_CLOSE 1
 
-// |BIO_FP_TEXT| will cause the file to be opened as a text file (this is only
+// BIO_FP_TEXT will cause the file to be opened as a text file (this is only
 // relevant on Windows due to CRLF endings) instead of the default behavior of
 // opening the file in binary mode.
 #define BIO_FP_TEXT 0x10

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -395,16 +395,6 @@ OPENSSL_EXPORT int BIO_read_asn1(BIO *bio, uint8_t **out, size_t *out_len,
 //
 // |BIO_ctrl_pending| returns the number of bytes currently stored.
 
-// |BIO_NOCLOSE|, |BIO_CLOSE|, and |BIO_FP_TEXT|  can be used as symbolic
-// arguments when a "close flag" is passed to a BIO function. |BIO_CLOSE| (on
-// by default) will free the backing buffer on BIO close, whereas |BIO_NOCLOSE|
-// will not. Setting |BIO_FP_TEXT| will cause the file to be opened as a text
-// file (this is only relevant on Windows due to CRLF endings) instead of the
-// default behavior of opening the file in binary mode.
-#define BIO_NOCLOSE 0
-#define BIO_CLOSE 1
-#define BIO_FP_TEXT 0x10
-
 // BIO_s_mem returns a |BIO_METHOD| that uses a in-memory buffer.
 OPENSSL_EXPORT const BIO_METHOD *BIO_s_mem(void);
 
@@ -454,6 +444,23 @@ OPENSSL_EXPORT int BIO_set_mem_buf(BIO *bio, BUF_MEM *b, int take_ownership);
 // For a read-only BIO, the default is zero (EOF). For a writable BIO, the
 // default is -1 so that additional data can be written once exhausted.
 OPENSSL_EXPORT int BIO_set_mem_eof_return(BIO *bio, int eof_value);
+
+
+// BIO close flags.
+//
+// These can be used as symbolic arguments when a "close flag" is passed to a
+// BIO function.
+
+// |BIO_NOCLOSE| will not free the backing buffer on BIO close
+#define BIO_NOCLOSE 0
+
+// |BIO_CLOSE| (default) will free the backing buffer on BIO close, whereas
+#define BIO_CLOSE 1
+
+// |BIO_FP_TEXT| will cause the file to be opened as a text file (this is only
+// relevant on Windows due to CRLF endings) instead of the default behavior of
+// opening the file in binary mode.
+#define BIO_FP_TEXT 0x10
 
 
 // File descriptor BIOs.


### PR DESCRIPTION
# Issues
Addresses CryptoAlg-2036

# Notes

OpenSSL defines a "close flag" `BIO_FP_TEXT` which is used by callers to indicate that file-backed BIOs should be opened in "text" mode as opposed to the default of raw "binary" mode. Of platforms currently supported by AWS-LC, this is only meaningful on windows. From linux's `fopen` [man page](https://man7.org/linux/man-pages/man3/fopen.3.html):

```
        The mode string can also include the letter 'b' either as a last
        character or as a character between the characters in any of the
        two-character strings described above.  This is strictly for
        compatibility with ISO C and has no effect; the 'b' is ignored on
        all POSIX conforming systems, including Linux.  (Other systems
        may treat text files and binary files differently, and adding the
        'b' may be a good idea if you do I/O to a binary file and expect
        that your program may be ported to non-UNIX environments.)
```

And from [Windows](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170#generic-text-routine-mappings):

```
t     Open in text (translated) mode. Carriage return-line feed (CR-LF)
      combinations are translated into single line feeds (LF) on input and LF
      characters are translated to CR-LF combinations on output. Also, CTRL+Z is
      interpreted as an end-of-file character on input.
b     Open in binary (untranslated) mode; translations involving
      carriage-return and line feed characters are suppressed.
```

The terminology here is a bit confusing. In text mode, "Input" here refers to reading files and "output" refers to writing files to disk. So, if an application is using conventional unixy LF line endings (`\n`) and then writes a line of text to a file, the Windows CRT will instead write a CRLF line ending (`\r\n`). When reading from a file, the CRT will translate CRLF back to LF transparently to the application. In binary mode, what you see is what you get and no translation occurs.

OpenSSL supports setting text mode for a variety of BIO operations (including [when opening files with `fopen`](https://github.com/openssl/openssl/blob/3d254b31344e82b8f10fda8bab196757a377eb63/crypto/bio/bss_file.c#L267-L290)), but only sets this flag internally [when calling `BIO_new_fp`](https://github.com/search?q=repo%3Aopenssl/openssl%20BIO_FP_TEXT&type=code). Note that `BIO_new_fp` operates on open `FILE *`s, and [does not itself open the file](https://github.com/openssl/openssl/blob/3d254b31344e82b8f10fda8bab196757a377eb63/crypto/bio/bss_file.c#L207-L266). Instead, it uses the Windows CRT-specific function `_setmode` to set binary/text mode on the already opened file.

To implement this functionality in AWS-LC, we only set translation mode in functions [using the `BIO_C_SET_FILE_PTR` control directive](https://github.com/aws/aws-lc/blob/main/crypto/bio/file.c#L191C10-L191C28): `BIO_set_fp` and `BIO_new_fp`. AWS-LC's BIO functions that call `fopen` along the way [do not provide the caller a parameter for specifying flags](https://github.com/aws/aws-lc/blob/main/crypto/bio/file.c#L287-L306), so we're limited here by the interface.

Finally, it's a little odd to refer to `BIO_FP_TEXT` as a "close flag", as the behavior it determines has nothing to do with how or if the file is closed. However, this is how OpenSSL's code refers to it, so it's the terminology we use here.

## Links

Documentation links for the Windows-specific functions used in this change can be found here:

- [`_setmode`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode?view=msvc-170): used to set translation mode on an open file
- [`_fileno`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fileno?view=msvc-170): used to convert a `FILE *` to a file descriptor

# Testing
- CI runs with new platform-aware test

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
