### PR TITLE
Add EVP_MD_do_all

### DIFF
--- a/crypto/decrepit/evp/evp_do_all.c
+++ b/crypto/decrepit/evp/evp_do_all.c
@@ -91,3 +91,10 @@ void EVP_MD_do_all_sorted(void (*callback)(const EVP_MD *cipher,
   callback(EVP_sha512(), "sha512", NULL, arg);
   callback(EVP_sha512_256(), "sha512-256", NULL, arg);
 }
+
+void EVP_MD_do_all(void (*callback)(const EVP_MD *cipher,
+                                    const char *name, const char *unused,
+                                    void *arg),
+                          void *arg) {
+    EVP_MD_do_all_sorted(callback, arg);
+}

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -976,6 +976,15 @@ OPENSSL_EXPORT void EVP_MD_do_all_sorted(void (*callback)(const EVP_MD *cipher,
                                                           void *arg),
                                          void *arg);
 
+// |EVP_MD_do_all| is the same as |EVP_MD_do_all_sorted|. We include both for
+// compatibility reasons.
+OPENSSL_EXPORT void EVP_MD_do_all(void (*callback)(const EVP_MD *cipher,
+                                                   const char *name,
+                                                   const char *unused,
+                                                   void *arg),
+                                         void *arg);
+
+
 // i2d_PrivateKey marshals a private key from |key| to type-specific format, as
 // described in |i2d_SAMPLE|.
 //

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -976,7 +976,7 @@ OPENSSL_EXPORT void EVP_MD_do_all_sorted(void (*callback)(const EVP_MD *cipher,
                                                           void *arg),
                                          void *arg);
 
-// |EVP_MD_do_all| is the same as |EVP_MD_do_all_sorted|. We include both for
+// EVP_MD_do_all is the same as |EVP_MD_do_all_sorted|. We include both for
 // compatibility reasons.
 OPENSSL_EXPORT void EVP_MD_do_all(void (*callback)(const EVP_MD *cipher,
                                                    const char *name,


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-2036

### Description of changes: 

OpenSSL has a function `EVP_MD_do_all` that works the same way as `EVP_MD_do_all_sorted` (which AWS-LC currently provides), except that it gives no guarantees on the order in which it calls its input function over the digest collection. Presumably, OpenSSL separates these two functions out for performance reasons, as `EVP_MD_do_all_sorted` [performs a runtime quicksort](https://github.com/openssl/openssl/blob/master/crypto/objects/o_names.c#L291-L349) (see also [here](https://github.com/openssl/openssl/blob/f7b2942c041ee803557a009a4554760c56484c9d/crypto/evp/names.c#L229-L254)) on the collection. AWS-LC [does the "sort" manually at build time](https://github.com/aws/aws-lc/blob/9b323d575d6ad4771592e77083169416275b793d/crypto/decrepit/evp/evp_do_all.c#L70), so there's no runtime sorting cost and we can just call out to `EVP_MD_do_all_sorted` in our `EVP_MD_do_all` implementation.

### Call-outs:
n/a

### Testing:
- CI testing in this repo
- built my [cpython 3.10 fork](https://github.com/WillChilds-Klein/cpython/tree/3.10) against this change locally

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
