### PR TITLE
add missing symbols for SSLProxy support

### DIFF
--- a/crypto/conf/conf.c
+++ b/crypto/conf/conf.c
@@ -814,6 +814,8 @@ void CONF_modules_free(void) {}
 
 void CONF_modules_unload(int all) {}
 
+void CONF_modules_finish(void) {}
+
 void OPENSSL_config(const char *config_name) {}
 
 void OPENSSL_no_config(void) {}

--- a/crypto/decrepit/x509/x509_decrepit.c
+++ b/crypto/decrepit/x509/x509_decrepit.c
@@ -25,3 +25,9 @@ X509_EXTENSION *X509V3_EXT_conf_nid(LHASH_OF(CONF_VALUE) *conf,
   assert(conf == NULL);
   return X509V3_EXT_nconf_nid(NULL, ctx, ext_nid, value);
 }
+
+X509_EXTENSION *X509V3_EXT_conf(LHASH_OF(CONF_VALUE) *conf, X509V3_CTX *ctx,
+                                const char *name, const char *value) {
+  assert(conf == NULL);
+  return X509V3_EXT_nconf(NULL, ctx, name, value);
+}

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -140,6 +140,9 @@ OPENSSL_EXPORT void CONF_modules_free(void);
 // CONF_modules_unload does nothing.
 OPENSSL_EXPORT void CONF_modules_unload(int all);
 
+// CONF_modules_finish does nothing.
+OPENSSL_EXPORT void CONF_modules_finish(void);
+
 // OPENSSL_config does nothing.
 OPENSSL_EXPORT void OPENSSL_config(const char *config_name);
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5133,6 +5133,13 @@ OPENSSL_EXPORT int SSL_set1_sigalgs_list(SSL *ssl, const char *str);
 // in AWS-LC.
 OPENSSL_EXPORT int SSL_CTX_get_security_level(const SSL_CTX *ctx);
 
+// SSL_CTX_set_security_level does nothing. See documentation in
+// |SSL_CTX_get_security_level| about implied security levels for AWS-LC.
+OPENSSL_EXPORT void SSL_CTX_set_security_level(const SSL_CTX *ctx, int level);
+
+// SSL_SESSION_print prints the contents of |sess| to |bp|.
+OPENSSL_EXPORT int SSL_SESSION_print(BIO *bp, const SSL_SESSION *sess);
+
 #define SSL_set_app_data(s, arg) (SSL_set_ex_data(s, 0, (char *)(arg)))
 #define SSL_get_app_data(s) (SSL_get_ex_data(s, 0))
 #define SSL_SESSION_set_app_data(s, a) \

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -632,13 +632,23 @@ OPENSSL_EXPORT X509_EXTENSION *X509V3_EXT_nconf_nid(const CONF *conf,
 
 // X509V3_EXT_conf_nid calls |X509V3_EXT_nconf_nid|. |conf| must be NULL.
 //
-// TODO(davidben): This is the only exposed instance of an LHASH in our public
-// headers. cryptography.io wraps this function so we cannot, yet, replace the
-// type with a dummy struct.
+// TODO(davidben): This and |X509V3_EXT_conf| are the only exposed instance of
+// |LHASH| in our public headers. cryptography.io wraps this function so we
+// cannot replace the type with a dummy struct.
 OPENSSL_EXPORT X509_EXTENSION *X509V3_EXT_conf_nid(LHASH_OF(CONF_VALUE) *conf,
                                                    const X509V3_CTX *ctx,
                                                    int ext_nid,
                                                    const char *value);
+
+// X509V3_EXT_conf calls |X509V3_EXT_nconf|. |conf| must be NULL.
+//
+// NOTE: This is only provided for compatibility. See |X509V3_EXT_nconf|
+// instead.
+OPENSSL_EXPORT X509_EXTENSION *X509V3_EXT_conf(LHASH_OF(CONF_VALUE) *conf,
+                                               X509V3_CTX *ctx,
+                                               const char *name,
+                                               const char *value);
+
 
 // X509V3_EXT_add_nconf_sk looks up the section named |section| in |conf|. For
 // each |CONF_VALUE| in the section, it constructs an extension as in

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -23,12 +23,14 @@ add_library(
   ssl_buffer.cc
   ssl_cert.cc
   ssl_cipher.cc
+  ssl_decrepit.c
   ssl_file.cc
   ssl_key_share.cc
   ssl_lib.cc
   ssl_privkey.cc
   ssl_session.cc
   ssl_stat.cc
+  ssl_text.cc
   ssl_transcript.cc
   ssl_transfer_asn1.cc
   ssl_versions.cc
@@ -40,7 +42,6 @@ add_library(
   tls13_client.cc
   tls13_enc.cc
   tls13_server.cc
-  ssl_decrepit.c
 )
 target_compile_definitions(ssl PRIVATE BORINGSSL_IMPLEMENTATION)
 

--- a/ssl/ssl_cert.cc
+++ b/ssl/ssl_cert.cc
@@ -1113,3 +1113,5 @@ int SSL_delegated_credential_used(const SSL *ssl) {
 }
 
 int SSL_CTX_get_security_level(const SSL_CTX *ctx) { return 3; }
+
+void SSL_CTX_set_security_level(const SSL_CTX *ctx, int level) {}

--- a/ssl/ssl_text.cc
+++ b/ssl/ssl_text.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2005 Nokia. All rights reserved.
+ */
+
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+// Modifications Copyright Amazon.com, Inc. or its affiliates.
+
+
+#include <openssl/ssl.h>
+
+#include "internal.h"
+
+
+int SSL_SESSION_print(BIO *bp, const SSL_SESSION *sess) {
+  if (sess == nullptr) {
+    return 0;
+  }
+
+  bool tls13 = (sess->ssl_version == TLS1_3_VERSION);
+  if (BIO_puts(bp, "SSL-Session:\n") <= 0) {
+    return 0;
+  }
+  if (BIO_printf(bp, "    Protocol  : %s\n", SSL_SESSION_get_version(sess)) <=
+      0) {
+    return 0;
+  }
+
+  if (sess->cipher == nullptr) {
+    if (((sess->cipher->id) & 0xff000000) == 0x02000000) {
+      if (BIO_printf(bp, "    Cipher    : %06X\n",
+                     sess->cipher->id & 0xffffff) <= 0) {
+        return 0;
+      }
+    } else {
+      if (BIO_printf(bp, "    Cipher    : %04X\n", sess->cipher->id & 0xffff) <=
+          0) {
+        return 0;
+      }
+    }
+  } else {
+    if (BIO_printf(bp, "    Cipher    : %s\n",
+                   ((sess->cipher->name == nullptr) ? "unknown"
+                                                    : sess->cipher->name)) <=
+        0) {
+      return 0;
+    }
+  }
+  if (BIO_puts(bp, "    Session-ID: ") <= 0) {
+    return 0;
+  }
+  for (size_t i = 0; i < sess->session_id_length; i++) {
+    if (BIO_printf(bp, "%02X", sess->session_id[i]) <= 0) {
+      return 0;
+    }
+  }
+  if (BIO_puts(bp, "\n    Session-ID-ctx: ") <= 0) {
+    return 0;
+  }
+  for (size_t i = 0; i < sess->sid_ctx_length; i++) {
+    if (BIO_printf(bp, "%02X", sess->sid_ctx[i]) <= 0) {
+      return 0;
+    }
+  }
+  if (tls13) {
+    if (BIO_puts(bp, "\n    Resumption PSK: ") <= 0) {
+      return 0;
+    }
+  } else if (BIO_puts(bp, "\n    Master-Key: ") <= 0) {
+    return 0;
+  }
+  for (size_t i = 0; i < sess->secret_length; i++) {
+    if (BIO_printf(bp, "%02X", sess->secret[i]) <= 0) {
+      return 0;
+    }
+  }
+  if (BIO_puts(bp, "\n    PSK identity: ") <= 0) {
+    return 0;
+  }
+  if (BIO_printf(
+          bp, "%s",
+          sess->psk_identity.get() ? sess->psk_identity.get() : "None") <= 0) {
+    return 0;
+  }
+
+  if (sess->ticket_lifetime_hint) {
+    if (BIO_printf(bp, "\n    TLS session ticket lifetime hint: %u (seconds)",
+                   sess->ticket_lifetime_hint) <= 0) {
+      return 0;
+    }
+  }
+  if (!sess->ticket.empty()) {
+    if (BIO_puts(bp, "\n    TLS session ticket:\n    ") <= 0) {
+      return 0;
+    }
+    for (uint8_t i : sess->ticket) {
+      if (BIO_printf(bp, "%02X", i) <= 0) {
+        return 0;
+      }
+    }
+  }
+
+  if (sess->time != 0) {
+    if (BIO_printf(bp, "\n    Start Time: %lld", (long long)sess->time) <= 0) {
+      return 0;
+    }
+  }
+  if (sess->timeout != 0) {
+    if (BIO_printf(bp, "\n    Timeout   : %u (sec)", sess->timeout) <= 0) {
+      return 0;
+    }
+  }
+  if (BIO_puts(bp, "\n") <= 0) {
+    return 0;
+  }
+
+  if (BIO_puts(bp, "    Verify return code: ") <= 0) {
+    return 0;
+  }
+  if (BIO_printf(bp, "%ld (%s)\n", sess->verify_result,
+                 X509_verify_cert_error_string(sess->verify_result)) <= 0) {
+    return 0;
+  }
+
+  if (BIO_printf(bp, "    Extended master secret: %s\n",
+                 sess->extended_master_secret ? "yes" : "no") <= 0) {
+    return 0;
+  }
+
+  if (tls13) {
+    if (BIO_printf(bp, "    Max Early Data: %u\n",
+                   sess->ticket_max_early_data) <= 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+

--- a/ssl/ssl_text.cc
+++ b/ssl/ssl_text.cc
@@ -26,19 +26,7 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *sess) {
     return 0;
   }
 
-  if (sess->cipher == nullptr) {
-    if (((sess->cipher->id) & 0xff000000) == 0x02000000) {
-      if (BIO_printf(bp, "    Cipher    : %06X\n",
-                     sess->cipher->id & 0xffffff) <= 0) {
-        return 0;
-      }
-    } else {
-      if (BIO_printf(bp, "    Cipher    : %04X\n", sess->cipher->id & 0xffff) <=
-          0) {
-        return 0;
-      }
-    }
-  } else {
+  if (sess->cipher != nullptr) {
     if (BIO_printf(bp, "    Cipher    : %s\n",
                    ((sess->cipher->name == nullptr) ? "unknown"
                                                     : sess->cipher->name)) <=


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1957`

### Description of changes: 
This pulls in the missing symbols needed to integrate with SSLProxy.
1. I've followed the same pattern with `X509V3_EXT_conf_nid` and added the `X509V3_EXT_conf` version here as well. The goal is to only maintain it for basic compatibility and push users to use `X509V3_EXT_nconf*` instead.
2. Added `SSL_CTX_set_security_level` and `CONF_modules_finish` as no-ops. We don't support security levels and adding any configurations to do so should be it's own story.
3. Added tests and functionality for `SSL_SESSION_print`. Taken from: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/ssl/ssl_txt.c#L32-L162

### Call-outs:
N/A

### Testing:
New unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
