### PR TITLE
Fix build on gcc 4.8.3

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -21,7 +21,12 @@
 
 #include <assert.h>
 #include <errno.h>
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
### Description of changes: 
We recently had a team reach out to us about our broken build on gcc 4.8.3. This is due to a bug that we've previously encountered in this commit: https://github.com/aws/aws-lc/commit/65661035692572f9e399a162a4e908ad5b4bd509

### Call-outs:
N/A

### Testing:
We may have to add new CI to check for this, but it seems like this specific version is hard to find. We already have CI for gcc4.8.5.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
