### PR TITLE
Lower returned number for SSL_CTX_get_security_level

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5109,6 +5109,7 @@ OPENSSL_EXPORT int SSL_set1_sigalgs_list(SSL *ssl, const char *str);
 // function returns.
 //
 // Per OpenSSL's definition of Level 0, 1, and 2:
+//
 // Level 0:
 // Everything is permitted. This retains compatibility with previous versions of
 // OpenSSL.
@@ -5127,11 +5128,11 @@ OPENSSL_EXPORT int SSL_set1_sigalgs_list(SSL *ssl, const char *str);
 // addition to the level 1 exclusions any cipher suite using RC4 is also
 // prohibited. SSL version 3 is also not allowed. Compression is disabled.
 //
-// AWS-LC's libssl doesn't support SSL version 2 or 3, and we have no support
-// for MD5 or RC4 related cipher suites. However, we don't directly prohibit 512
-// bit RSA keys like Level 1 in OpenSSL states. Since this function is only
-// retained for OpenSSL compatibility, we set the returned value to 0. This may
-// change if we're asked to support actual Security level setting in AWS-LC.
+// AWS-LC's libssl doesn't support SSLv2 or SSLv3, and we have no support for MD5
+// or RC4 related cipher suites. However, we don't directly prohibit 512 bit RSA
+// keys like Level 1 in OpenSSL states. Since this function is only retained for
+// OpenSSL compatibility, we set the returned value to 0. This may change if
+// we're asked to support actual Security level setting in AWS-LC.
 OPENSSL_EXPORT int SSL_CTX_get_security_level(const SSL_CTX *ctx);
 
 // SSL_CTX_set_security_level does nothing. See documentation in

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5104,22 +5104,34 @@ OPENSSL_EXPORT int SSL_CTX_set1_sigalgs_list(SSL_CTX *ctx, const char *str);
 // more convenient to codesearch for specific algorithm values.
 OPENSSL_EXPORT int SSL_set1_sigalgs_list(SSL *ssl, const char *str);
 
-// SSL_CTX_get_security_level returns 3. This is only to maintain compatibility
+// SSL_CTX_get_security_level returns 0. This is only to maintain compatibility
 // with OpenSSL and no security assumptions should be based on the number this
 // function returns.
 //
-// Per OpenSSL's definition of Level 3:
-// Level 3:
-// Security level set to 128 bits of security. As a result RSA, DSA and DH keys
-// shorter than 3072 bits and ECC keys shorter than 256 bits are prohibited. In
-// addition to the level 2 exclusions cipher suites not offering forward secrecy
-// are prohibited. TLS versions below 1.1 are not permitted. Session tickets are
-// disabled.
+// Per OpenSSL's definition of Level 0, 1, and 2:
+// Level 0:
+// Everything is permitted. This retains compatibility with previous versions of
+// OpenSSL.
 //
-// AWS-LC only supports atl least 128 bits of security, but we don't directly
-// prohibit session tickets and TLS 1.0 like Level 3 in OpenSSL states. This
-// behavior may change if we're asked to support actual Security level setting
-// in AWS-LC.
+// Level 1
+// The security level corresponds to a minimum of 80 bits of security. Any
+// parameters offering below 80 bits of security are excluded. As a result RSA,
+// DSA and DH keys shorter than 1024 bits and ECC keys shorter than 160 bits are
+// prohibited. All export cipher suites are prohibited since they all offer less
+// than 80 bits of security. SSL version 2 is prohibited. Any cipher suite using
+// MD5 for the MAC is also prohibited.
+//
+// Level 2
+// Security level set to 112 bits of security. As a result RSA, DSA and DH keys
+// shorter than 2048 bits and ECC keys shorter than 224 bits are prohibited. In
+// addition to the level 1 exclusions any cipher suite using RC4 is also
+// prohibited. SSL version 3 is also not allowed. Compression is disabled.
+//
+// AWS-LC's libssl doesn't support SSL version 2 or 3, and we have no support
+// for MD5 or RC4 related cipher suites. However, we don't directly prohibit 512
+// bit RSA keys like Level 1 in OpenSSL states. Since this function is only
+// retained for OpenSSL compatibility, we set the returned value to 0. This may
+// change if we're asked to support actual Security level setting in AWS-LC.
 OPENSSL_EXPORT int SSL_CTX_get_security_level(const SSL_CTX *ctx);
 
 // SSL_CTX_set_security_level does nothing. See documentation in

--- a/ssl/ssl_cert.cc
+++ b/ssl/ssl_cert.cc
@@ -1112,6 +1112,6 @@ int SSL_delegated_credential_used(const SSL *ssl) {
   return ssl->s3->delegated_credential_used;
 }
 
-int SSL_CTX_get_security_level(const SSL_CTX *ctx) { return 3; }
+int SSL_CTX_get_security_level(const SSL_CTX *ctx) { return 0; }
 
 void SSL_CTX_set_security_level(const SSL_CTX *ctx, int level) {}


### PR DESCRIPTION
### Description of changes: 
A contributor pointed out that our default SSL settings don't quite align with OpenSSL's definition for different security levels.
* https://github.com/aws/aws-lc/pull/1002#issuecomment-1678675162

I've lowered the return number for `SSL_CTX_get_security_level`, but this function is still only for compatibility purposes.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
