### PR TITLE
error: '%s' directive argument is null

### DIFF
--- a/ssl/test/bssl_shim.cc
+++ b/ssl/test/bssl_shim.cc
@@ -312,7 +312,7 @@ static bool CheckListContains(const char *type,
       return true;
     }
   }
-  fprintf(stderr, "Unexpected %s: %s\n", type, str);
+  fprintf(stderr, "Unexpected %s: %s\n", type, (str == nullptr) ? "<null>" : str);
   return false;
 }
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Fix compiler error
```
ssl/test/bssl_shim.cc:315:35: error: '%s' directive argument is null [-Werror=format-overflow=]
  315 |   fprintf(stderr, "Unexpected %s: %s\n", type, str);
```

### Call-outs:
This was missed in previous PR review: https://github.com/aws/aws-lc/pull/1140

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
