### PR TITLE
Implement SSL_get_client_ciphers

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1664,7 +1664,6 @@ OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl);
 // available, or |ssl| is not operating in server mode, NULL is returned.
 OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl);
 
-
 // Connection information.
 
 // SSL_is_init_finished returns one if |ssl| has completed its initial handshake

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1659,11 +1659,6 @@ OPENSSL_EXPORT int SSL_CTX_cipher_in_group(const SSL_CTX *ctx, size_t i);
 // SSL_get_ciphers returns the cipher list for |ssl|, in order of preference.
 OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl);
 
-// SSL_get_client_ciphers returns the stack of available SSL_CIPHERs matching
-// the list received from the client on |ssl|. If |ssl| is NULL, no ciphers are
-// available, or |ssl| is not operating in server mode, NULL is returned.
-OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl);
-
 // Connection information.
 
 // SSL_is_init_finished returns one if |ssl| has completed its initial handshake
@@ -1774,6 +1769,11 @@ OPENSSL_EXPORT int SSL_get_extms_support(const SSL *ssl);
 // SSL_get_current_cipher returns cipher suite used by |ssl|, or NULL if it has
 // not been negotiated yet.
 OPENSSL_EXPORT const SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl);
+
+// SSL_get_client_ciphers returns the stack of available SSL_CIPHERs matching
+// the list received from the client on |ssl|. If |ssl| is NULL, no ciphers are
+// available, or |ssl| is not operating in server mode, NULL is returned.
+OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl);
 
 // SSL_session_reused returns one if |ssl| performed an abbreviated handshake
 // and zero otherwise.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1659,6 +1659,11 @@ OPENSSL_EXPORT int SSL_CTX_cipher_in_group(const SSL_CTX *ctx, size_t i);
 // SSL_get_ciphers returns the cipher list for |ssl|, in order of preference.
 OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl);
 
+// SSL_get_client_ciphers returns the stack of available SSL_CIPHERs matching
+// the list received from the client on |ssl|. If |ssl| is NULL, no ciphers are
+// available, or |ssl| is not operating in server mode, NULL is returned.
+OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl);
+
 
 // Connection information.
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1659,6 +1659,7 @@ OPENSSL_EXPORT int SSL_CTX_cipher_in_group(const SSL_CTX *ctx, size_t i);
 // SSL_get_ciphers returns the cipher list for |ssl|, in order of preference.
 OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl);
 
+
 // Connection information.
 
 // SSL_is_init_finished returns one if |ssl| has completed its initial handshake
@@ -2601,7 +2602,9 @@ OPENSSL_EXPORT const char *SSL_get_group_name(uint16_t group_id);
 // finished.
 // WARNING: Currently only supports |SSL| as server.
 // WARNING: CRYPTO_EX_DATA |ssl->ex_data| is not encoded. Remember set |ex_data|
-// back after decode. WARNING: BIO |ssl->rbio| and |ssl->wbio| are not encoded.
+// back after decode.
+// WARNING: BIO |ssl->rbio| and |ssl->wbio| are not encoded.
+// WARNING: STACK_OF(SSL_CIPHER) |ssl->client_cipher_suites| is not encoded.
 //
 // Initial implementation of this API is made by Evgeny Potemkin.
 OPENSSL_EXPORT int SSL_to_bytes(const SSL *in, uint8_t **out_data,
@@ -2617,6 +2620,8 @@ OPENSSL_EXPORT int SSL_to_bytes(const SSL *in, uint8_t **out_data,
 //          Otherwise, the connections use the same key material.
 // WARNING: Remember set |ssl->rbio| and |ssl->wbio| before using |ssl|.
 // WARNING: Remember set callback functions and |ex_data| back if needed.
+// WARNING: STACK_OF(SSL_CIPHER) |ssl->client_cipher_suites| is not encoded and
+//          will be repopulated on next handshake.
 // WARNING: To ensure behavior unchange, |ctx| setting should be the same.
 //
 // Initial implementation of this API is made by Evgeny Potemkin.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1770,9 +1770,11 @@ OPENSSL_EXPORT int SSL_get_extms_support(const SSL *ssl);
 // not been negotiated yet.
 OPENSSL_EXPORT const SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl);
 
-// SSL_get_client_ciphers returns the stack of available SSL_CIPHERs matching
-// the list received from the client on |ssl|. If |ssl| is NULL, no ciphers are
-// available, or |ssl| is not operating in server mode, NULL is returned.
+// SSL_get_client_ciphers returns stack of ciphers offered by the client during
+// a handshake. If the |ssl| is a client or the handshake hasn't occurred yet,
+// NULL is returned. The stack of ciphers IS NOT de/serialized, so NULL will
+// also be returned for deserialized or transported |ssl|'s that haven't yet
+// performed a new handshake.
 OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl);
 
 // SSL_session_reused returns one if |ssl| performed an abbreviated handshake

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -812,8 +812,8 @@ static enum ssl_hs_wait_t do_select_certificate(SSL_HANDSHAKE *hs) {
     return ssl_hs_error;
   }
 
-  // TODO [childw] return alert/set error here?
   if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->peer_ciphers)) {
+    ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_INTERNAL_ERROR);
     return ssl_hs_error;
   }
 

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -264,7 +264,7 @@ static bool negotiate_version(SSL_HANDSHAKE *hs, uint8_t *out_alert,
   return true;
 }
 
-static UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
+UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
     const SSL_CLIENT_HELLO *client_hello) {
   CBS cipher_suites;
   CBS_init(&cipher_suites, client_hello->cipher_suites,
@@ -275,7 +275,6 @@ static UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
     return nullptr;
   }
 
-  // TODO [childw] factor this out into common routine
   while (CBS_len(&cipher_suites) > 0) {
     uint16_t cipher_suite;
 

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -368,6 +368,8 @@ static const SSL_CIPHER *choose_cipher(
     allow = server_pref->ciphers.get();
   }
 
+  ssl->ctx->peer_ciphers = std::move(client_pref);
+
   uint32_t mask_k, mask_a;
   ssl_get_compatible_server_ciphers(hs, &mask_k, &mask_a);
 

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -274,6 +274,7 @@ bool ssl_parse_client_cipher_list(
 
   // Cipher suites are encoded as 2-byte unsigned integers
   if (CBS_len(&cipher_suites) % 2 != 0) {
+    OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
     return false;
   }
 
@@ -292,6 +293,7 @@ bool ssl_parse_client_cipher_list(
 
     const SSL_CIPHER *c = SSL_get_cipher_by_value(cipher_suite);
     if (c != NULL && !sk_SSL_CIPHER_push(sk.get(), c)) {
+      OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
       return false;
     }
   }
@@ -813,7 +815,7 @@ static enum ssl_hs_wait_t do_select_certificate(SSL_HANDSHAKE *hs) {
   }
 
   if (!ssl_parse_client_cipher_list(&client_hello, &ssl->client_cipher_suites)) {
-    OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
+    OPENSSL_PUT_ERROR(SSL, SSL_R_NO_SHARED_CIPHER);
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
     return ssl_hs_error;
   }

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -813,7 +813,8 @@ static enum ssl_hs_wait_t do_select_certificate(SSL_HANDSHAKE *hs) {
   }
 
   if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->client_ciphers)) {
-    ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_INTERNAL_ERROR);
+    OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
+    ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
     return ssl_hs_error;
   }
 

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -363,9 +363,9 @@ static const SSL_CIPHER *choose_cipher(SSL_HANDSHAKE *hs,
   if (ssl->options & SSL_OP_CIPHER_SERVER_PREFERENCE) {
     prio = server_pref->ciphers.get();
     in_group_flags = server_pref->in_group_flags;
-    allow = ssl->s3->peer_ciphers.get();
+    allow = ssl->s3->client_ciphers.get();
   } else {
-    prio = ssl->s3->peer_ciphers.get();
+    prio = ssl->s3->client_ciphers.get();
     in_group_flags = NULL;
     allow = server_pref->ciphers.get();
   }
@@ -812,7 +812,7 @@ static enum ssl_hs_wait_t do_select_certificate(SSL_HANDSHAKE *hs) {
     return ssl_hs_error;
   }
 
-  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->peer_ciphers)) {
+  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->client_ciphers)) {
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_INTERNAL_ERROR);
     return ssl_hs_error;
   }
@@ -1336,7 +1336,7 @@ static enum ssl_hs_wait_t do_read_client_certificate(SSL_HANDSHAKE *hs) {
 
   CBS certificate_msg = msg.body;
   uint8_t alert = SSL_AD_DECODE_ERROR;
-  if (!ssl_parse_cert_chain(&alert, &hs->new_session.get()->certs, &hs->peer_pubkey,
+  if (!ssl_parse_cert_chain(&alert, &hs->new_session->certs, &hs->peer_pubkey,
                             hs->config->retain_only_sha256_of_client_certs
                                 ? hs->new_session->peer_sha256
                                 : nullptr,

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -363,9 +363,9 @@ static const SSL_CIPHER *choose_cipher(SSL_HANDSHAKE *hs,
   if (ssl->options & SSL_OP_CIPHER_SERVER_PREFERENCE) {
     prio = server_pref->ciphers.get();
     in_group_flags = server_pref->in_group_flags;
-    allow = ssl->s3->client_ciphers.get();
+    allow = ssl->s3->client_cipher_suites.get();
   } else {
-    prio = ssl->s3->client_ciphers.get();
+    prio = ssl->s3->client_cipher_suites.get();
     in_group_flags = NULL;
     allow = server_pref->ciphers.get();
   }
@@ -812,7 +812,7 @@ static enum ssl_hs_wait_t do_select_certificate(SSL_HANDSHAKE *hs) {
     return ssl_hs_error;
   }
 
-  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->client_ciphers)) {
+  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->client_cipher_suites)) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
     return ssl_hs_error;

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -352,23 +352,23 @@ static const SSL_CIPHER *choose_cipher(
   // such value exists yet.
   int group_min = -1;
 
-  UniquePtr<STACK_OF(SSL_CIPHER)> client_pref =
-      ssl_parse_client_cipher_list(client_hello);
-  if (!client_pref) {
+  ssl->ctx->peer_ciphers = ssl_parse_client_cipher_list(client_hello);
+  if (!ssl->ctx->peer_ciphers) {
     return nullptr;
   }
 
   if (ssl->options & SSL_OP_CIPHER_SERVER_PREFERENCE) {
     prio = server_pref->ciphers.get();
     in_group_flags = server_pref->in_group_flags;
-    allow = client_pref.get();
+    allow = ssl->ctx->peer_ciphers.get();
   } else {
-    prio = client_pref.get();
+    prio = ssl->ctx->peer_ciphers.get();
     in_group_flags = NULL;
     allow = server_pref->ciphers.get();
   }
 
-  ssl->ctx->peer_ciphers = std::move(client_pref);
+  //bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers(sk_SSL_CIPHER_dup(client_pref.get()));
+  //ssl->ctx->peer_ciphers = std::move(peer_ciphers);
 
   uint32_t mask_k, mask_a;
   ssl_get_compatible_server_ciphers(hs, &mask_k, &mask_a);

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -363,9 +363,9 @@ static const SSL_CIPHER *choose_cipher(SSL_HANDSHAKE *hs,
   if (ssl->options & SSL_OP_CIPHER_SERVER_PREFERENCE) {
     prio = server_pref->ciphers.get();
     in_group_flags = server_pref->in_group_flags;
-    allow = ssl->s3->client_cipher_suites.get();
+    allow = ssl->client_cipher_suites.get();
   } else {
-    prio = ssl->s3->client_cipher_suites.get();
+    prio = ssl->client_cipher_suites.get();
     in_group_flags = NULL;
     allow = server_pref->ciphers.get();
   }
@@ -812,7 +812,7 @@ static enum ssl_hs_wait_t do_select_certificate(SSL_HANDSHAKE *hs) {
     return ssl_hs_error;
   }
 
-  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->client_cipher_suites)) {
+  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->client_cipher_suites)) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
     return ssl_hs_error;

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -275,6 +275,7 @@ static UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
     return nullptr;
   }
 
+  // TODO [childw] factor this out into common routine
   while (CBS_len(&cipher_suites) > 0) {
     uint16_t cipher_suite;
 
@@ -366,9 +367,6 @@ static const SSL_CIPHER *choose_cipher(
     in_group_flags = NULL;
     allow = server_pref->ciphers.get();
   }
-
-  //bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers(sk_SSL_CIPHER_dup(client_pref.get()));
-  //ssl->ctx->peer_ciphers = std::move(peer_ciphers);
 
   uint32_t mask_k, mask_a;
   ssl_get_compatible_server_ciphers(hs, &mask_k, &mask_a);

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -1858,6 +1858,8 @@ static enum ssl_hs_wait_t do_finish_server_handshake(SSL_HANDSHAKE *hs) {
     ssl->s3->established_session = UpRef(ssl->session);
   }
 
+  ssl->s3->peer_ciphers.reset(hs->peer_ciphers.release());
+
   hs->handshake_finalized = true;
   ssl->s3->initial_handshake_complete = true;
   if (has_new_session) {

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -363,9 +363,9 @@ static const SSL_CIPHER *choose_cipher(SSL_HANDSHAKE *hs,
   if (ssl->options & SSL_OP_CIPHER_SERVER_PREFERENCE) {
     prio = server_pref->ciphers.get();
     in_group_flags = server_pref->in_group_flags;
-    allow = hs->peer_ciphers.get();
+    allow = ssl->s3->peer_ciphers.get();
   } else {
-    prio = hs->peer_ciphers.get();
+    prio = ssl->s3->peer_ciphers.get();
     in_group_flags = NULL;
     allow = server_pref->ciphers.get();
   }
@@ -813,7 +813,7 @@ static enum ssl_hs_wait_t do_select_certificate(SSL_HANDSHAKE *hs) {
   }
 
   // TODO [childw] return alert/set error here?
-  if (!ssl_parse_client_cipher_list(&client_hello, &hs->peer_ciphers)) {
+  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->peer_ciphers)) {
     return ssl_hs_error;
   }
 
@@ -1857,8 +1857,6 @@ static enum ssl_hs_wait_t do_finish_server_handshake(SSL_HANDSHAKE *hs) {
     assert(ssl->session != nullptr);
     ssl->s3->established_session = UpRef(ssl->session);
   }
-
-  ssl->s3->peer_ciphers.reset(hs->peer_ciphers.release());
 
   hs->handshake_finalized = true;
   ssl->s3->initial_handshake_complete = true;

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -264,7 +264,7 @@ static bool negotiate_version(SSL_HANDSHAKE *hs, uint8_t *out_alert,
   return true;
 }
 
-UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
+static UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
     const SSL_CLIENT_HELLO *client_hello) {
   CBS cipher_suites;
   CBS_init(&cipher_suites, client_hello->cipher_suites,
@@ -275,6 +275,7 @@ UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
     return nullptr;
   }
 
+  // TODO [childw] factor this out into common routine
   while (CBS_len(&cipher_suites) > 0) {
     uint16_t cipher_suite;
 

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2041,6 +2041,9 @@ struct SSL_HANDSHAKE {
   // peer_pubkey is the public key parsed from the peer's leaf certificate.
   UniquePtr<EVP_PKEY> peer_pubkey;
 
+  // peer_ciphers holds the peer's declared cipher preferences, in order.
+  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers;
+
   // new_session is the new mutable session being established by the current
   // handshake. It should not be cached.
   UniquePtr<SSL_SESSION> new_session;
@@ -2426,8 +2429,8 @@ bool ssl_client_cipher_list_contains_cipher(
     const SSL_CLIENT_HELLO *client_hello, uint16_t id);
 
 // ssl_parse_client_cipher_list TODO [childw]
-UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
-    const SSL_CLIENT_HELLO *client_hello);
+bool ssl_parse_client_cipher_list(const SSL_CLIENT_HELLO *client_hello,
+                                  UniquePtr<STACK_OF(SSL_CIPHER)> *ciphers_out);
 
 
 // GREASE.
@@ -3649,10 +3652,6 @@ struct ssl_ctx_st {
 
   // tls13_cipher_list holds the tls1.3 and above ciphersuites.
   bssl::UniquePtr<bssl::SSLCipherPreferenceList> tls13_cipher_list;
-
-  // peer_ciphers holds the peer's declared cipher preferences, in order.
-  // This field will be empty on the client side of a TLS connection.
-  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers;
 
   X509_STORE *cert_store = nullptr;
   LHASH_OF(SSL_SESSION) *sessions = nullptr;

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -703,12 +703,12 @@ bool ssl_cipher_requires_server_key_exchange(const SSL_CIPHER *cipher);
 size_t ssl_cipher_get_record_split_len(const SSL_CIPHER *cipher);
 
 // ssl_choose_tls13_cipher returns an |SSL_CIPHER| corresponding with the best
-// available from |client_ciphers| compatible with |version|, |group_id| and
+// available from |client_cipher_suites| compatible with |version|, |group_id| and
 // configured |tls13_ciphers|. It returns NULL if there isn't a compatible
 // cipher. |has_aes_hw| indicates if the choice should be made as if support for
 // AES in hardware is available.
 const SSL_CIPHER *ssl_choose_tls13_cipher(
-    const STACK_OF(SSL_CIPHER) *client_ciphers, bool has_aes_hw, uint16_t version,
+    const STACK_OF(SSL_CIPHER) *client_cipher_suites, bool has_aes_hw, uint16_t version,
     uint16_t group_id, const STACK_OF(SSL_CIPHER) *tls13_ciphers);
 
 
@@ -2981,9 +2981,10 @@ struct SSL3_STATE {
   // immutable.
   UniquePtr<SSL_SESSION> established_session;
 
-  // client_ciphers holds the peer's declared cipher preferences, in order. This
-  // field is NOT serialized and is only populated if used in a server context.
-  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> client_ciphers;
+  // client_cipher_suites contains cipher suites offered by the client during
+  // the handshake, with preference order maintained. This field is NOT
+  // serialized and is only populated if used in a server context.
+  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> client_cipher_suites;
 
   // Next protocol negotiation. For the client, this is the protocol that we
   // sent in NextProtocol and is set when handling ServerHello extensions.

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -3646,6 +3646,10 @@ struct ssl_ctx_st {
   // tls13_cipher_list holds the tls1.3 and above ciphersuites.
   bssl::UniquePtr<bssl::SSLCipherPreferenceList> tls13_cipher_list;
 
+  // peer_ciphers holds the peer's declared cipher preferences, in order.
+  // This field will be empty on the client side of a TLS connection.
+  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers;
+
   X509_STORE *cert_store = nullptr;
   LHASH_OF(SSL_SESSION) *sessions = nullptr;
   // Most session-ids that will be cached, default is

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -703,13 +703,13 @@ bool ssl_cipher_requires_server_key_exchange(const SSL_CIPHER *cipher);
 size_t ssl_cipher_get_record_split_len(const SSL_CIPHER *cipher);
 
 // ssl_choose_tls13_cipher returns an |SSL_CIPHER| corresponding with the best
-// available from |cipher_suites| compatible with |version|, |group_id| and
+// available from |client_ciphers| compatible with |version|, |group_id| and
 // configured |tls13_ciphers|. It returns NULL if there isn't a compatible
 // cipher. |has_aes_hw| indicates if the choice should be made as if support for
 // AES in hardware is available.
 const SSL_CIPHER *ssl_choose_tls13_cipher(
-    CBS cipher_suites, bool has_aes_hw, uint16_t version, uint16_t group_id,
-    const STACK_OF(SSL_CIPHER) *tls13_ciphers);
+    const STACK_OF(SSL_CIPHER) *client_ciphers, bool has_aes_hw, uint16_t version,
+    uint16_t group_id, const STACK_OF(SSL_CIPHER) *tls13_ciphers);
 
 
 // Transcript layer.
@@ -2424,6 +2424,10 @@ bool ssl_client_hello_get_extension(const SSL_CLIENT_HELLO *client_hello,
 
 bool ssl_client_cipher_list_contains_cipher(
     const SSL_CLIENT_HELLO *client_hello, uint16_t id);
+
+// ssl_parse_client_cipher_list TODO [childw]
+UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
+    const SSL_CLIENT_HELLO *client_hello);
 
 
 // GREASE.

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2981,9 +2981,9 @@ struct SSL3_STATE {
   // immutable.
   UniquePtr<SSL_SESSION> established_session;
 
-  // peer_ciphers holds the peer's declared cipher preferences, in order. This
-  // field is NOT serialized.
-  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers;
+  // client_ciphers holds the peer's declared cipher preferences, in order. This
+  // field is NOT serialized and is only populated if used in a server context.
+  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> client_ciphers;
 
   // Next protocol negotiation. For the client, this is the protocol that we
   // sent in NextProtocol and is set when handling ServerHello extensions.

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -703,13 +703,13 @@ bool ssl_cipher_requires_server_key_exchange(const SSL_CIPHER *cipher);
 size_t ssl_cipher_get_record_split_len(const SSL_CIPHER *cipher);
 
 // ssl_choose_tls13_cipher returns an |SSL_CIPHER| corresponding with the best
-// available from |client_ciphers| compatible with |version|, |group_id| and
+// available from |cipher_suites| compatible with |version|, |group_id| and
 // configured |tls13_ciphers|. It returns NULL if there isn't a compatible
 // cipher. |has_aes_hw| indicates if the choice should be made as if support for
 // AES in hardware is available.
 const SSL_CIPHER *ssl_choose_tls13_cipher(
-    const STACK_OF(SSL_CIPHER) *client_ciphers, bool has_aes_hw, uint16_t version,
-    uint16_t group_id, const STACK_OF(SSL_CIPHER) *tls13_ciphers);
+    CBS cipher_suites, bool has_aes_hw, uint16_t version, uint16_t group_id,
+    const STACK_OF(SSL_CIPHER) *tls13_ciphers);
 
 
 // Transcript layer.
@@ -2424,10 +2424,6 @@ bool ssl_client_hello_get_extension(const SSL_CLIENT_HELLO *client_hello,
 
 bool ssl_client_cipher_list_contains_cipher(
     const SSL_CLIENT_HELLO *client_hello, uint16_t id);
-
-// ssl_parse_client_cipher_list TODO [childw]
-UniquePtr<STACK_OF(SSL_CIPHER)> ssl_parse_client_cipher_list(
-    const SSL_CLIENT_HELLO *client_hello);
 
 
 // GREASE.

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2982,6 +2982,9 @@ struct SSL3_STATE {
   // immutable.
   UniquePtr<SSL_SESSION> established_session;
 
+  // peer_ciphers TODO [childw]
+  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers;
+
   // Next protocol negotiation. For the client, this is the protocol that we
   // sent in NextProtocol and is set when handling ServerHello extensions.
   //

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2425,7 +2425,9 @@ bool ssl_client_hello_get_extension(const SSL_CLIENT_HELLO *client_hello,
 bool ssl_client_cipher_list_contains_cipher(
     const SSL_CLIENT_HELLO *client_hello, uint16_t id);
 
-// ssl_parse_client_cipher_list TODO [childw]
+// ssl_parse_client_cipher_list returns the ciphers offered by the client
+// during handshake, or null if the handshake hasn't occurred or there was an
+// error.
 bool ssl_parse_client_cipher_list(const SSL_CLIENT_HELLO *client_hello,
                                   UniquePtr<STACK_OF(SSL_CIPHER)> *ciphers_out);
 
@@ -2979,7 +2981,8 @@ struct SSL3_STATE {
   // immutable.
   UniquePtr<SSL_SESSION> established_session;
 
-  // peer_ciphers holds the peer's declared cipher preferences, in order.
+  // peer_ciphers holds the peer's declared cipher preferences, in order. This
+  // field is NOT serialized.
   bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers;
 
   // Next protocol negotiation. For the client, this is the protocol that we

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2981,11 +2981,6 @@ struct SSL3_STATE {
   // immutable.
   UniquePtr<SSL_SESSION> established_session;
 
-  // client_cipher_suites contains cipher suites offered by the client during
-  // the handshake, with preference order maintained. This field is NOT
-  // serialized and is only populated if used in a server context.
-  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> client_cipher_suites;
-
   // Next protocol negotiation. For the client, this is the protocol that we
   // sent in NextProtocol and is set when handling ServerHello extensions.
   //
@@ -4010,6 +4005,11 @@ struct ssl_st {
   // session is the configured session to be offered by the client. This session
   // is immutable.
   bssl::UniquePtr<SSL_SESSION> session;
+
+  // client_cipher_suites contains cipher suites offered by the client during
+  // the handshake, with preference order maintained. This field is NOT
+  // serialized and is only populated if used in a server context.
+  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> client_cipher_suites;
 
   void (*info_callback)(const SSL *ssl, int type, int value) = nullptr;
 

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2041,9 +2041,6 @@ struct SSL_HANDSHAKE {
   // peer_pubkey is the public key parsed from the peer's leaf certificate.
   UniquePtr<EVP_PKEY> peer_pubkey;
 
-  // peer_ciphers holds the peer's declared cipher preferences, in order.
-  bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers;
-
   // new_session is the new mutable session being established by the current
   // handshake. It should not be cached.
   UniquePtr<SSL_SESSION> new_session;
@@ -2982,7 +2979,7 @@ struct SSL3_STATE {
   // immutable.
   UniquePtr<SSL_SESSION> established_session;
 
-  // peer_ciphers TODO [childw]
+  // peer_ciphers holds the peer's declared cipher preferences, in order.
   bssl::UniquePtr<STACK_OF(SSL_CIPHER)> peer_ciphers;
 
   // Next protocol negotiation. For the client, this is the protocol that we

--- a/ssl/s3_both.cc
+++ b/ssl/s3_both.cc
@@ -686,15 +686,15 @@ class CipherScorer {
 };
 
 const SSL_CIPHER *ssl_choose_tls13_cipher(
-    const STACK_OF(SSL_CIPHER) *client_ciphers, bool has_aes_hw, uint16_t version, uint16_t group_id,
-    const STACK_OF(SSL_CIPHER) *tls13_ciphers) {
+    const STACK_OF(SSL_CIPHER) *client_cipher_suites, bool has_aes_hw, uint16_t version,
+    uint16_t group_id, const STACK_OF(SSL_CIPHER) *tls13_ciphers) {
 
   const SSL_CIPHER *best = nullptr;
   CipherScorer scorer(has_aes_hw);
   CipherScorer::Score best_score = scorer.MinScore();
 
-  for (size_t i = 0; i < sk_SSL_CIPHER_num(client_ciphers); i++) {
-    const SSL_CIPHER *client_cipher = sk_SSL_CIPHER_value(client_ciphers, i);
+  for (size_t i = 0; i < sk_SSL_CIPHER_num(client_cipher_suites); i++) {
+    const SSL_CIPHER *client_cipher = sk_SSL_CIPHER_value(client_cipher_suites, i);
     const SSL_CIPHER *candidate = nullptr;
     if (tls13_ciphers != nullptr) {
       // Limit to customized TLS 1.3 ciphers if configured.

--- a/ssl/s3_both.cc
+++ b/ssl/s3_both.cc
@@ -686,9 +686,9 @@ class CipherScorer {
 };
 
 const SSL_CIPHER *ssl_choose_tls13_cipher(
-    CBS cipher_suites, bool has_aes_hw, uint16_t version, uint16_t group_id,
+    const STACK_OF(SSL_CIPHER) *client_ciphers, bool has_aes_hw, uint16_t version, uint16_t group_id,
     const STACK_OF(SSL_CIPHER) *tls13_ciphers) {
-  if (CBS_len(&cipher_suites) % 2 != 0) {
+  if (sk_SSL_CIPHER_num(client_ciphers) % 2 != 0) {
     return nullptr;
   }
 
@@ -696,26 +696,21 @@ const SSL_CIPHER *ssl_choose_tls13_cipher(
   CipherScorer scorer(has_aes_hw);
   CipherScorer::Score best_score = scorer.MinScore();
 
-  while (CBS_len(&cipher_suites) > 0) {
-    uint16_t cipher_suite;
-    if (!CBS_get_u16(&cipher_suites, &cipher_suite)) {
-      return nullptr;
-    }
-
-    SSL_CIPHER *candidate = nullptr;
+  for (size_t i = 0; i < sk_SSL_CIPHER_num(client_ciphers); i++) {
+    const SSL_CIPHER *client_cipher = sk_SSL_CIPHER_value(client_ciphers, i);
+    const SSL_CIPHER *candidate = nullptr;
     if (tls13_ciphers != nullptr) {
       // Limit to customized TLS 1.3 ciphers if configured.
-      uint32_t cipher_suite_id = 0x03000000L | cipher_suite;
-      for (size_t i = 0; i < sk_SSL_CIPHER_num(tls13_ciphers); i++) {
-        const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(tls13_ciphers, i);
-        if (cipher != nullptr && cipher->id == cipher_suite_id) {
+      for (size_t j = 0; j < sk_SSL_CIPHER_num(tls13_ciphers); j++) {
+        const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(tls13_ciphers, j);
+        if (cipher != nullptr && cipher->id == client_cipher->id) {
           candidate = (SSL_CIPHER *)cipher;
           break;
         }
       }
     } else {
       // Limit to TLS 1.3 ciphers we know about.
-      candidate = (SSL_CIPHER *)SSL_get_cipher_by_value(cipher_suite);
+      candidate = client_cipher;
     }
     if (candidate == nullptr ||
         SSL_CIPHER_get_min_version(candidate) > version ||

--- a/ssl/s3_both.cc
+++ b/ssl/s3_both.cc
@@ -688,9 +688,6 @@ class CipherScorer {
 const SSL_CIPHER *ssl_choose_tls13_cipher(
     const STACK_OF(SSL_CIPHER) *client_ciphers, bool has_aes_hw, uint16_t version, uint16_t group_id,
     const STACK_OF(SSL_CIPHER) *tls13_ciphers) {
-  if (sk_SSL_CIPHER_num(client_ciphers) % 2 != 0) {
-    return nullptr;
-  }
 
   const SSL_CIPHER *best = nullptr;
   CipherScorer scorer(has_aes_hw);

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2091,17 +2091,6 @@ STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl) {
                                   : ssl->ctx->cipher_list->ciphers.get();
 }
 
-STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl) {
-  if (ssl == NULL || !ssl->s3 || !ssl->server) {
-      return NULL;
-  }
-  const SSL_HANDSHAKE *hs = ssl->s3->hs.get();
-  if (!hs || !hs->peer_ciphers) {
-    return NULL;
-  }
-  return hs->peer_ciphers.get();
-}
-
 const char *SSL_get_cipher_list(const SSL *ssl, int n) {
   if (ssl == NULL) {
     return NULL;
@@ -2554,6 +2543,17 @@ EVP_PKEY *SSL_CTX_get0_privatekey(const SSL_CTX *ctx) {
 const SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl) {
   const SSL_SESSION *session = SSL_get_session(ssl);
   return session == nullptr ? nullptr : session->cipher;
+}
+
+STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl) {
+  if (ssl->s3->hs != nullptr) {
+    return ssl->s3->hs->peer_ciphers.get();
+  }
+  // TODO [childw] go all in on ssl->s3->peer_ciphers?
+  if (ssl->s3 != nullptr) {
+    return ssl->s3->peer_ciphers.get();
+  }
+  return nullptr;
 }
 
 int SSL_session_reused(const SSL *ssl) {

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2549,7 +2549,7 @@ STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl) {
   if (ssl == NULL || ssl->s3 == NULL) {
     return NULL;
   }
-  return ssl->s3->peer_ciphers.get();
+  return ssl->s3->client_ciphers.get();
 }
 
 int SSL_session_reused(const SSL *ssl) {
@@ -3069,7 +3069,7 @@ int SSL_clear(SSL *ssl) {
     return 0;  // SSL_clear may not be used after shedding config.
   }
 
-  ssl->s3->peer_ciphers.reset();
+  ssl->s3->client_ciphers.reset();
 
   // In OpenSSL, reusing a client |SSL| with |SSL_clear| causes the previously
   // established session to be offered the next time around. wpa_supplicant

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2091,6 +2091,14 @@ STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl) {
                                   : ssl->ctx->cipher_list->ciphers.get();
 }
 
+STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl) {
+  if (ssl == NULL || !ssl->server || !ssl->ctx->peer_ciphers) {
+    return NULL;
+  }
+
+  return ssl->ctx->peer_ciphers.get();
+}
+
 const char *SSL_get_cipher_list(const SSL *ssl, int n) {
   if (ssl == NULL) {
     return NULL;

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2546,10 +2546,10 @@ const SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl) {
 }
 
 STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl) {
-  if (ssl->s3 != nullptr) {
-    return ssl->s3->peer_ciphers.get();
+  if (ssl == NULL || ssl->s3 == NULL) {
+    return NULL;
   }
-  return nullptr;
+  return ssl->s3->peer_ciphers.get();
 }
 
 int SSL_session_reused(const SSL *ssl) {
@@ -3068,6 +3068,8 @@ int SSL_clear(SSL *ssl) {
   if (!ssl->config) {
     return 0;  // SSL_clear may not be used after shedding config.
   }
+
+  ssl->s3->peer_ciphers.reset();
 
   // In OpenSSL, reusing a client |SSL| with |SSL_clear| causes the previously
   // established session to be offered the next time around. wpa_supplicant

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2546,10 +2546,6 @@ const SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl) {
 }
 
 STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl) {
-  if (ssl->s3->hs != nullptr) {
-    return ssl->s3->hs->peer_ciphers.get();
-  }
-  // TODO [childw] go all in on ssl->s3->peer_ciphers?
   if (ssl->s3 != nullptr) {
     return ssl->s3->peer_ciphers.get();
   }

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2092,11 +2092,14 @@ STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl) {
 }
 
 STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl) {
-  if (ssl == NULL || !ssl->server || !ssl->ctx->peer_ciphers) {
+  if (ssl == NULL || !ssl->s3 || !ssl->server) {
+      return NULL;
+  }
+  const SSL_HANDSHAKE *hs = ssl->s3->hs.get();
+  if (!hs || !hs->peer_ciphers) {
     return NULL;
   }
-
-  return ssl->ctx->peer_ciphers.get();
+  return hs->peer_ciphers.get();
 }
 
 const char *SSL_get_cipher_list(const SSL *ssl, int n) {

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2549,7 +2549,7 @@ STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl) {
   if (ssl == NULL || ssl->s3 == NULL) {
     return NULL;
   }
-  return ssl->s3->client_cipher_suites.get();
+  return ssl->client_cipher_suites.get();
 }
 
 int SSL_session_reused(const SSL *ssl) {
@@ -3069,7 +3069,7 @@ int SSL_clear(SSL *ssl) {
     return 0;  // SSL_clear may not be used after shedding config.
   }
 
-  ssl->s3->client_cipher_suites.reset();
+  ssl->client_cipher_suites.reset();
 
   // In OpenSSL, reusing a client |SSL| with |SSL_clear| causes the previously
   // established session to be offered the next time around. wpa_supplicant

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2549,7 +2549,7 @@ STACK_OF(SSL_CIPHER) *SSL_get_client_ciphers(const SSL *ssl) {
   if (ssl == NULL || ssl->s3 == NULL) {
     return NULL;
   }
-  return ssl->s3->client_ciphers.get();
+  return ssl->s3->client_cipher_suites.get();
 }
 
 int SSL_session_reused(const SSL *ssl) {
@@ -3069,7 +3069,7 @@ int SSL_clear(SSL *ssl) {
     return 0;  // SSL_clear may not be used after shedding config.
   }
 
-  ssl->s3->client_ciphers.reset();
+  ssl->s3->client_cipher_suites.reset();
 
   // In OpenSSL, reusing a client |SSL| with |SSL_clear| causes the previously
   // established session to be offered the next time around. wpa_supplicant

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -3503,7 +3503,7 @@ TEST_P(SSLVersionTest, GetPeerCertificate) {
   //  The client should have no view of the server's preferences.
   EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
   //  TODO [childw]
-  EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
+  //EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
 
   // Client and server should both see the leaf certificate.
   bssl::UniquePtr<X509> peer(SSL_get_peer_certificate(server_.get()));
@@ -7634,7 +7634,7 @@ TEST_F(QUICMethodTest, Basic) {
   // The client should have no view of the server's preferences.
   EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
   // TODO [childw]
-  EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
+  //EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
 
   // The server sent NewSessionTicket messages in the handshake.
   EXPECT_FALSE(g_last_session);

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -4329,8 +4329,8 @@ TEST_P(SSLVersionTest, SSLClearFailsWithShedding) {
 }
 
 TEST_P(SSLVersionTest, SSLClientCiphers) {
-  // Client ciphers ARE NOT SERIALIZED, so skip tests that rely on
-  // transport/serialization of the |ssl| objects under test.
+  // Client ciphers ARE NOT SERIALIZED, so skip tests that rely on transfer or
+  // serialization of |ssl| and accompanying objects under test.
   if (GetParam().transfer_ssl) {
       return;
   }
@@ -4341,12 +4341,12 @@ TEST_P(SSLVersionTest, SSLClientCiphers) {
   shed_handshake_config_ = false;
   ASSERT_TRUE(Connect());
 
-  //  The client should still have no view of the server's preferences, but the
-  //  server should have seen at least one cipher from the client.
+  // The client should still have no view of the server's preferences, but the
+  // server should have seen at least one cipher from the client.
   EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
   EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
 
-  // With shedding has been disabled, clearing |server| shouldn't error and
+  // With config shedding disabled, clearing |server| shouldn't error and
   // should reset server's client ciphers
   ASSERT_TRUE(SSL_clear(server_.get()));
   EXPECT_FALSE(SSL_get_client_ciphers(server_.get()));

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -3502,11 +3502,8 @@ TEST_P(SSLVersionTest, GetPeerCertificate) {
 
   //  The client should have no view of the server's preferences.
   EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
-  //  The server should register the ciphers sent to it by the client.
-  EXPECT_EQ(
-      sk_SSL_CIPHER_num(SSL_CTX_get_ciphers(client_.get()->ctx.get())),
-      sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get()))
-  );
+  //  TODO [childw]
+  EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
 
   // Client and server should both see the leaf certificate.
   bssl::UniquePtr<X509> peer(SSL_get_peer_certificate(server_.get()));
@@ -7636,11 +7633,8 @@ TEST_F(QUICMethodTest, Basic) {
 
   // The client should have no view of the server's preferences.
   EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
-  // The server should register the ciphers sent to it by the client.
-  EXPECT_EQ(
-      sk_SSL_CIPHER_num(SSL_CTX_get_ciphers(client_.get()->ctx.get())),
-      sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get()))
-  );
+  // TODO [childw]
+  EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
 
   // The server sent NewSessionTicket messages in the handshake.
   EXPECT_FALSE(g_last_session);

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -3500,11 +3500,6 @@ TEST_P(SSLVersionTest, GetPeerCertificate) {
 
   ASSERT_TRUE(Connect());
 
-  //  The client should have no view of the server's preferences.
-  EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
-  //  TODO [childw]
-  //EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
-
   // Client and server should both see the leaf certificate.
   bssl::UniquePtr<X509> peer(SSL_get_peer_certificate(server_.get()));
   ASSERT_TRUE(peer);
@@ -4331,6 +4326,20 @@ TEST_P(SSLVersionTest, SSLClearFailsWithShedding) {
   // |SSL_clear| should now fail.
   ASSERT_FALSE(SSL_clear(client_.get()));
   ASSERT_FALSE(SSL_clear(server_.get()));
+}
+
+TEST_P(SSLVersionTest, SSLClientCiphers) {
+  if (GetParam().transfer_ssl) {
+      GTEST_SKIP();
+  }
+
+  shed_handshake_config_ = false;
+  ASSERT_TRUE(Connect());
+
+  //  The client should have no view of the server's preferences.
+  EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
+  //  TODO [childw]
+  EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
 }
 
 static bool ChainsEqual(STACK_OF(X509) *chain,
@@ -7630,11 +7639,6 @@ TEST_F(QUICMethodTest, Basic) {
   ExpectHandshakeSuccess();
   EXPECT_FALSE(SSL_session_reused(client_.get()));
   EXPECT_FALSE(SSL_session_reused(server_.get()));
-
-  // The client should have no view of the server's preferences.
-  EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
-  // TODO [childw]
-  //EXPECT_GT(sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get())), (size_t) 0);
 
   // The server sent NewSessionTicket messages in the handshake.
   EXPECT_FALSE(g_last_session);

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -3504,7 +3504,7 @@ TEST_P(SSLVersionTest, GetPeerCertificate) {
   EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
   //  The server should register the ciphers sent to it by the client.
   EXPECT_EQ(
-      sk_SSL_CIPHER_num(SSL_get_ciphers(client_.get())),
+      sk_SSL_CIPHER_num(SSL_CTX_get_ciphers(client_.get()->ctx.get())),
       sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get()))
   );
 
@@ -7558,14 +7558,6 @@ class QUICMethodTest : public testing::Test {
     // SSL_do_handshake is now idempotent.
     EXPECT_EQ(SSL_do_handshake(client_.get()), 1);
     EXPECT_EQ(SSL_do_handshake(server_.get()), 1);
-
-    //  The client should have no view of the server's preferences.
-    EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
-    //  The server should register the ciphers sent to it by the client.
-    EXPECT_EQ(
-        sk_SSL_CIPHER_num(SSL_get_ciphers(client_.get())),
-        sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get()))
-    );
   }
 
   // Returns a default SSL_QUIC_METHOD. Individual methods may be overwritten by
@@ -7641,6 +7633,14 @@ TEST_F(QUICMethodTest, Basic) {
   ExpectHandshakeSuccess();
   EXPECT_FALSE(SSL_session_reused(client_.get()));
   EXPECT_FALSE(SSL_session_reused(server_.get()));
+
+  // The client should have no view of the server's preferences.
+  EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
+  // The server should register the ciphers sent to it by the client.
+  EXPECT_EQ(
+      sk_SSL_CIPHER_num(SSL_CTX_get_ciphers(client_.get()->ctx.get())),
+      sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get()))
+  );
 
   // The server sent NewSessionTicket messages in the handshake.
   EXPECT_FALSE(g_last_session);

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -3500,6 +3500,14 @@ TEST_P(SSLVersionTest, GetPeerCertificate) {
 
   ASSERT_TRUE(Connect());
 
+  //  The client should have no view of the server's preferences.
+  EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
+  //  The server should register the ciphers sent to it by the client.
+  EXPECT_EQ(
+      sk_SSL_CIPHER_num(SSL_get_ciphers(client_.get())),
+      sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get()))
+  );
+
   // Client and server should both see the leaf certificate.
   bssl::UniquePtr<X509> peer(SSL_get_peer_certificate(server_.get()));
   ASSERT_TRUE(peer);
@@ -7550,6 +7558,14 @@ class QUICMethodTest : public testing::Test {
     // SSL_do_handshake is now idempotent.
     EXPECT_EQ(SSL_do_handshake(client_.get()), 1);
     EXPECT_EQ(SSL_do_handshake(server_.get()), 1);
+
+    //  The client should have no view of the server's preferences.
+    EXPECT_FALSE(SSL_get_client_ciphers(client_.get()));
+    //  The server should register the ciphers sent to it by the client.
+    EXPECT_EQ(
+        sk_SSL_CIPHER_num(SSL_get_ciphers(client_.get())),
+        sk_SSL_CIPHER_num(SSL_get_client_ciphers(server_.get()))
+    );
   }
 
   // Returns a default SSL_QUIC_METHOD. Individual methods may be overwritten by

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -116,7 +116,7 @@ static const SSL_CIPHER *choose_tls13_cipher(const SSL *ssl, uint16_t group_id) 
     tls13_ciphers = ssl->ctx->tls13_cipher_list.get()->ciphers.get();
   }
 
-  return ssl_choose_tls13_cipher(ssl->s3->client_ciphers.get(),
+  return ssl_choose_tls13_cipher(ssl->s3->client_cipher_suites.get(),
                                  ssl->config->aes_hw_override
                                      ? ssl->config->aes_hw_override_value
                                      : EVP_has_aes_hardware(),
@@ -232,7 +232,7 @@ static enum ssl_hs_wait_t do_select_parameters(SSL_HANDSHAKE *hs) {
     return ssl_hs_error;
   }
 
-  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->client_ciphers)) {
+  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->client_cipher_suites)) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
     return ssl_hs_error;

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -233,7 +233,7 @@ static enum ssl_hs_wait_t do_select_parameters(SSL_HANDSHAKE *hs) {
   }
 
   if (!ssl_parse_client_cipher_list(&client_hello, &ssl->client_cipher_suites)) {
-    OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
+    OPENSSL_PUT_ERROR(SSL, SSL_R_NO_SHARED_CIPHER);
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
     return ssl_hs_error;
   }

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -233,7 +233,8 @@ static enum ssl_hs_wait_t do_select_parameters(SSL_HANDSHAKE *hs) {
   }
 
   if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->client_ciphers)) {
-    ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_INTERNAL_ERROR);
+    OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
+    ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
     return ssl_hs_error;
   }
 

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -110,9 +110,23 @@ static int ssl_ext_supported_versions_add_serverhello(SSL_HANDSHAKE *hs,
 
 static const SSL_CIPHER *choose_tls13_cipher(
     const SSL *ssl, const SSL_CLIENT_HELLO *client_hello, uint16_t group_id) {
-  ssl->ctx->peer_ciphers = ssl_parse_client_cipher_list(client_hello);
-  if (!ssl->ctx->peer_ciphers) {
-    return nullptr;
+  CBS cipher_suites;
+  CBS_init(&cipher_suites, client_hello->cipher_suites,
+           client_hello->cipher_suites_len);
+
+  // TODO [childw] factor this out into common routine
+  ssl->ctx->peer_ciphers = UniquePtr<STACK_OF(SSL_CIPHER)>(sk_SSL_CIPHER_new_null());
+  while (CBS_len(&cipher_suites) > 0) {
+    uint16_t cipher_suite;
+    if (!CBS_get_u16(&cipher_suites, &cipher_suite)) {
+      OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
+      return nullptr;
+    }
+    const SSL_CIPHER *c = SSL_get_cipher_by_value(cipher_suite);
+    *(ssl->ctx);
+    if (c == NULL || !sk_SSL_CIPHER_push(ssl->ctx->peer_ciphers.get(), c)) {
+      return nullptr;
+    }
   }
 
   STACK_OF(SSL_CIPHER) *tls13_ciphers = nullptr;
@@ -122,7 +136,11 @@ static const SSL_CIPHER *choose_tls13_cipher(
     tls13_ciphers = ssl->ctx->tls13_cipher_list.get()->ciphers.get();
   }
 
-  return ssl_choose_tls13_cipher(ssl->ctx->peer_ciphers.get(),
+  // Reset |cipher_suites| before passing
+  CBS_init(&cipher_suites, client_hello->cipher_suites,
+           client_hello->cipher_suites_len);
+
+  return ssl_choose_tls13_cipher(cipher_suites,
                                  ssl->config->aes_hw_override
                                      ? ssl->config->aes_hw_override_value
                                      : EVP_has_aes_hardware(),

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -234,8 +234,8 @@ static enum ssl_hs_wait_t do_select_parameters(SSL_HANDSHAKE *hs) {
     return ssl_hs_error;
   }
 
-  // TODO [childw]
   if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->peer_ciphers)) {
+    ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_INTERNAL_ERROR);
     return ssl_hs_error;
   }
 

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -118,7 +118,7 @@ static const SSL_CIPHER *choose_tls13_cipher(const SSL_HANDSHAKE *hs,
     tls13_ciphers = ssl->ctx->tls13_cipher_list.get()->ciphers.get();
   }
 
-  return ssl_choose_tls13_cipher(hs->peer_ciphers.get(),
+  return ssl_choose_tls13_cipher(ssl->s3->peer_ciphers.get(),
                                  ssl->config->aes_hw_override
                                      ? ssl->config->aes_hw_override_value
                                      : EVP_has_aes_hardware(),
@@ -235,7 +235,7 @@ static enum ssl_hs_wait_t do_select_parameters(SSL_HANDSHAKE *hs) {
   }
 
   // TODO [childw]
-  if (!ssl_parse_client_cipher_list(&client_hello, &hs->peer_ciphers)) {
+  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->peer_ciphers)) {
     return ssl_hs_error;
   }
 

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -116,7 +116,7 @@ static const SSL_CIPHER *choose_tls13_cipher(const SSL *ssl, uint16_t group_id) 
     tls13_ciphers = ssl->ctx->tls13_cipher_list.get()->ciphers.get();
   }
 
-  return ssl_choose_tls13_cipher(ssl->s3->client_cipher_suites.get(),
+  return ssl_choose_tls13_cipher(ssl->client_cipher_suites.get(),
                                  ssl->config->aes_hw_override
                                      ? ssl->config->aes_hw_override_value
                                      : EVP_has_aes_hardware(),
@@ -232,7 +232,7 @@ static enum ssl_hs_wait_t do_select_parameters(SSL_HANDSHAKE *hs) {
     return ssl_hs_error;
   }
 
-  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->s3->client_cipher_suites)) {
+  if (!ssl_parse_client_cipher_list(&client_hello, &ssl->client_cipher_suites)) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST);
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
     return ssl_hs_error;


### PR DESCRIPTION
# Issues
Addresses CryptoAlg-2036

# Notes

This commit implements `SSL_get_client_ciphers`, which returns a "stack" (really just a list) of `SSL_CIPHER` structs [presented by the client](https://github.com/openssl/openssl/blob/master/ssl/statem/statem_srvr.c#L2002) during the `|ssl|`'s most recent handshake. [Like OpenSSL](https://github.com/openssl/openssl/blob/e2972982c64f3f1ac10b3ebe1086d99ec67631bd/ssl/ssl_lib.c#L1433), we free this list when the connection is freed. OpenSSL [obtains this list](https://github.com/openssl/openssl/blob/7a5f58b2cf0d7b2fa0451603a88c3976c657dae9/ssl/ssl_lib.c#L3205-L3212) from from an `SSL_CONNECTION` object, something that we or BoringSSL appear to have removed.

So, we're left with the choice of where to store client ciphers. Options include internal/opaque structs `SSL_CTX`, `SSL_HANDSHAKE`, `SSL_SESSION`, `SSL_CONFIG`, and `SSL3_STATE`. Of these, `SSL_HANDSHAKE` or `SSL_SESSION` seemed most appropriate, but `SSL_HANDSHAKE` is [reset](https://github.com/aws/aws-lc/blob/main/ssl/ssl_lib.cc#L871) immediately after the handshake phase completes and `SSL_SESSION` incurs complications around caching. `SSL_CTX` appears to hold more configuration than mutable state, so we went with storing the client ciphers on `SSL3_STATE`. One important drawback to note here is that `SSL3_STATE` has "experimental" support for ASN.1 serialization. To avoid introducing irrevocable changes to that format, we do not include the client ciphers in that serialized object. When deserialized, client ciphers will be populated as "null". We can add support for this as an optional field in the future if required.

# Testing
- CI runs with new test

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
