### PR TITLE
Fix build for ppc64le

### DIFF
--- a/crypto/fipsmodule/modes/internal.h
+++ b/crypto/fipsmodule/modes/internal.h
@@ -385,9 +385,9 @@ size_t aesv8_gcm_8x_dec_256(const uint8_t *in, size_t bit_len, uint8_t *out,
 #define GHASH_ASM_PPC64LE
 #define GCM_FUNCREF
 void gcm_init_p8(u128 Htable[16], const uint64_t Xi[2]);
-void gcm_gmult_p8(uint64_t Xi[2], const u128 Htable[16]);
-void gcm_ghash_p8(uint64_t Xi[2], const u128 Htable[16], const uint8_t *inp,
-                  size_t len);
+void gcm_gmult_p8(uint8_t Xi[16], const u128 Htable[16]);
+void gcm_ghash_p8(uint8_t Xi[16], const u128 Htable[16],
+                  const uint8_t *inp, size_t len);
 #endif
 #endif  // OPENSSL_NO_ASM
 


### PR DESCRIPTION
### Issues:
* V1008777835
* https://github.com/aws/aws-lc-rs/pull/222

### Description of changes: 
* Fixes build for ppc64le.

### Call-outs:
* This was broken when we merged this upstream commit: https://github.com/google/boringssl/commit/5b32e81407cd044e76c995eb99343dca954a17b8#diff-5ded05174f8be4359aeee63a4e1c84b83123cd6dec5e1a12afc9f7a8d1ec6a26

### Testing:
* Build and "crypto_test" succeed in both Debug and Release configurations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
