### PR TITLE
Preparing for release v1.15.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4076,7 +4076,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.14.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.15.0");
 }
 
 #else
@@ -4119,6 +4119,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.14.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.15.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -216,7 +216,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.14.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.15.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Bump minor version number to prepare for the release.

List of changes to be included:
#### What's Changed
* Add EVP_MD_do_all by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1154
* error: '%s' directive argument is null by @justsmth in https://github.com/aws/aws-lc/pull/1158
* Fix build on gcc 4.8.3 by @samuel40791765 in https://github.com/aws/aws-lc/pull/1156
* Remove duplicate handling of OPENSSL_NO_ASM from CMake. by @PiotrSikora in https://github.com/aws/aws-lc/pull/1149
* Add -DBUILD_TOOL=OFF to CMake. by @PiotrSikora in https://github.com/aws/aws-lc/pull/1148
* Upstream merge 2023 08 09 by @justsmth in https://github.com/aws/aws-lc/pull/1152, https://github.com/aws/aws-lc/pull/1160, https://github.com/aws/aws-lc/pull/1161
* Add missing symbols for SSLProxy support by @samuel40791765 in https://github.com/aws/aws-lc/pull/1155
* Update montgomery multiplication to use s2n-bignum's verified scalar bignum functions by @aqjune-aws in https://github.com/aws/aws-lc/pull/1135
* Add more ssl runner tests for multiple certificate support by @samuel40791765 in https://github.com/aws/aws-lc/pull/1141
* CVE-2023-3446 and CVE-2023-3817 by @dkostic in https://github.com/aws/aws-lc/pull/1163
* Minor fix in aead test by @dkostic in https://github.com/aws/aws-lc/pull/1165
* Conditionally enable Neon version of s2n-bignum implementations for montgomery multiplications by @aqjune-aws in https://github.com/aws/aws-lc/pull/1164
* Fix build for ppc64le by @justsmth in https://github.com/aws/aws-lc/pull/1167
* add additional documentation for X509 headers by @samuel40791765 in https://github.com/aws/aws-lc/pull/1142

#### New Contributors
* @PiotrSikora made their first contribution in https://github.com/aws/aws-lc/pull/1149

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
