### PR TITLE
Simplify HAProxy integration tests by using built in filters

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -1,0 +1,21 @@
+name: aws-lc integration tests
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  haproxy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: haproxy/haproxy
+          path: ./scratch/haproxy
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
+      - name: Run integration build
+        run: |
+          ./tests/ci/integration/run_haproxy_integration.sh

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -14,10 +14,6 @@ jobs:
         run: |
           sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
-        with:
-          repository: haproxy/haproxy
-          path: ./scratch/haproxy
       - name: Run integration build
         run: |
           ./tests/ci/integration/run_haproxy_integration.sh

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -9,13 +9,14 @@ jobs:
   haproxy:
     runs-on: ubuntu-latest
     steps:
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
+      - uses: actions/checkout@v3
       - uses: actions/checkout@v3
         with:
           repository: haproxy/haproxy
           path: ./scratch/haproxy
-      - name: Install OS Dependencies
-        run: |
-          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
       - name: Run integration build
         run: |
           ./tests/ci/integration/run_haproxy_integration.sh

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -4,7 +4,8 @@ on:
     branches: [ '*' ]
   pull_request:
     branches: [ '*' ]
-
+env:
+  CC: gcc
 jobs:
   haproxy:
     runs-on: ubuntu-latest

--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -57,16 +57,6 @@ batch:
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_mariadb_integration.sh"
 
-    - identifier: haproxy_integration
-      buildspec: tests/ci/codebuild/common/run_simple_target.yml
-      env:
-        type: LINUX_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_MEDIUM
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_latest
-        variables:
-          AWS_LC_CI_TARGET: "tests/ci/integration/run_haproxy_integration.sh"
-
     - identifier: curl_integration
       buildspec: tests/ci/codebuild/common/run_simple_target.yml
       env:

--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -17,7 +17,7 @@ source tests/ci/common_posix_setup.sh
 #    - AWS_LC_INSTALL_FOLDER
 
 # Assumes script is executed from the root of aws-lc directory
-SCRATCH_FOLDER=${SYS_ROOT}/"scratch"
+SCRATCH_FOLDER=${SRC_ROOT}/"scratch"
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
 HAPROXY_SRC="${SCRATCH_FOLDER}/haproxy"

--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -26,7 +26,7 @@ export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib"
 function build_and_test_haproxy() {
   cd ${HAPROXY_SRC}
   make CC="${CC}" -j ${NUM_CPU_THREADS} TARGET=linux-glibc USE_OPENSSL_AWSLC=1 SSL_INC="${AWS_LC_INSTALL_FOLDER}/include" \
-      SSL_LIB="${AWS_LC_INSTALL_FOLDER}/lib/" USE_LUA=1  LUA_LIB_NAME=lua5.4
+      SSL_LIB="${AWS_LC_INSTALL_FOLDER}/lib/"
 
   set +e
   make reg-tests VTEST_PROGRAM=../vtest/vtest REGTESTS_TYPES=default,bug,devel

--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -25,23 +25,10 @@ export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib"
 
 function build_and_test_haproxy() {
   cd ${HAPROXY_SRC}
-  make CC="${CC}" -j ${NUM_CPU_THREADS} TARGET=generic USE_OPENSSL=1 SSL_INC="${AWS_LC_INSTALL_FOLDER}/include" \
+  make CC="${CC}" -j ${NUM_CPU_THREADS} TARGET=generic USE_OPENSSL_AWSLC=1 SSL_INC="${AWS_LC_INSTALL_FOLDER}/include" \
       SSL_LIB="${AWS_LC_INSTALL_FOLDER}/lib/" USE_LUA=1  LUA_LIB_NAME=lua5.4
 
-  # These tests are marked as SLOW and should be skipped.
-  # TODO: update this to: make reg-tests VTEST_PROGRAM=../vtest/vtest REGTESTS_TYPES=default,bug,devel
-  # ssl_dh.vtc expects to use libssl with a FFDH ciphersuite which is unsupported, it will be gracefully turned off in
-  # ssl_dh.vtc with the change in https://github.com/andrewhop/haproxy/pull/1
-  excluded_tests=("mcli_show_info.vtc" "mcli_start_progs.vtc" "tls_basic_sync.vtc" "tls_basic_sync_wo_stkt_backend.vtc" "acl_cli_spaces.vtc" "http_reuse_always.vtc" "ocsp_auto_update.vtc" "ssl_dh.vtc")
-  test_paths=""
-
-  for test in reg-tests/**/*; do
-      if [[ "$test" == *.vtc ]] && [[ ! " ${excluded_tests[*]} " =~ $(basename "$test") ]]; then
-          test_paths+="$(realpath "$test") "
-      fi
-  done
-
-  make reg-tests VTEST_PROGRAM=../vtest/vtest REG_TEST_FILES="$test_paths"
+  make reg-tests VTEST_PROGRAM=../vtest/vtest REGTESTS_TYPES=default,bug,devel
 }
 
 # Make script execution idempotent.

--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -6,12 +6,8 @@ source tests/ci/common_posix_setup.sh
 
 # Set up environment.
 
-# SYS_ROOT
-#  |
-#  - SRC_ROOT(aws-lc)
-#  |
+# SRC_ROOT(aws-lc)
 #  - SCRATCH_FOLDER
-#    |
 #    - HAPROXY_SRC
 #    - AWS_LC_BUILD_FOLDER
 #    - AWS_LC_INSTALL_FOLDER


### PR DESCRIPTION
### Description of changes: 
With the better AWS-LC support merged into HAProxy in https://github.com/haproxy/haproxy/commit/b3f94f8b3b6747eac1c22318d03bdb80e008d5c1 and https://github.com/haproxy/haproxy/commit/88988bb06ccadb1c5486d1e61d9aa6c75e36a404 we can now use the built in filters to run the expected development tests that shouldn't time out in our CI. 

### Call-outs:
* These are the recommended tests to run and will be the same ones run by HAProxy eventually.
* This migrates the HAProxy build and test to GitHub actions to avoid a CodeBuild process issue

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
