### PR TITLE
Add BN_CTX_secure_new alias for BN_CTX_new

### DIFF
--- a/crypto/fipsmodule/bn/ctx.c
+++ b/crypto/fipsmodule/bn/ctx.c
@@ -120,6 +120,8 @@ BN_CTX *BN_CTX_new(void) {
   return ret;
 }
 
+BN_CTX *BN_CTX_secure_new(void) { return BN_CTX_new(); }
+
 void BN_CTX_free(BN_CTX *ctx) {
   if (ctx == NULL) {
     return;

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -1005,6 +1005,8 @@ OPENSSL_EXPORT int BN_bn2binpad(const BIGNUM *in, uint8_t *out, int len);
 // BN_secure_new calls |BN_new|.
 OPENSSL_EXPORT BIGNUM *BN_secure_new(void);
 
+// BN_CTX_secure_new calls |BN_CTX_new|.
+OPENSSL_EXPORT BN_CTX *BN_CTX_secure_new(void);
 
 // Private functions
 


### PR DESCRIPTION
### Issues:
Helps with AWS-LC compatibility with strongSwan. [Discussion link](https://github.com/strongswan/strongswan/discussions/1878)

### Description of changes: 
OpenSSL defines BN_CTX_secure_new which allocates BNs using
BN_secure_new. In LC, all BNs are allocated "securely" (i.e. they 0 out
memory during alloc/free).

We already define an alias for BN_secure_new like this, so we are just
completing the compatibility layer with this change.

### Call-outs:
- Double check that BN_CTX_secure_new doesn't do anything else noteworthy.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
