### PR TITLE
Alias RAND_priv_bytes to RAND_bytes

### DIFF
--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -545,6 +545,10 @@ int RAND_bytes(uint8_t *out, size_t out_len) {
   return 1;
 }
 
+int RAND_priv_bytes(uint8_t *out, size_t out_len) {
+    return RAND_bytes(out, out_len);
+}
+
 int RAND_pseudo_bytes(uint8_t *buf, size_t len) {
   return RAND_bytes(buf, len);
 }

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -29,6 +29,10 @@ extern "C" {
 // event that sufficient random data can not be obtained, |abort| is called.
 OPENSSL_EXPORT int RAND_bytes(uint8_t *buf, size_t len);
 
+// RAND_priv_bytes is a wrapper around |RAND_bytes| provided for compatibility.
+// Consumers should call |RAND_bytes| directly.
+OPENSSL_EXPORT int RAND_priv_bytes(uint8_t *buf, size_t len);
+
 // RAND_get_system_entropy_for_custom_prng writes |len| bytes of random data
 // from a system entropy source to |buf|. The maximum length of entropy which
 // may be requested is 256 bytes. If more than 256 bytes of data is requested,


### PR DESCRIPTION
### Issues:
Improves compatibility with strongSwan.

### Description of changes: 
In OpenSSL, RAND_priv_bytes calls RAND_bytes using independently seeded
values to mitigate against situations where the "public" DRBG gets
compromised and random values can be predicted. It also defers to user
specified random methods if specified. Arguably, AWS-LC is always using
a user specified random method as it has a completely different
implementation from OpenSSL so this change is in-line with the original.

### Call-outs:
Check that adequate mitigations exist in AWS-LC's RAND_bytes implemenations that
we believe are sufficient to avoid replicating the independent seeding behavior
in OpenSSL.

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
