### PR TITLE
Check for unset certificates in servers

### DIFF
--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -1421,6 +1421,11 @@ OPENSSL_EXPORT bool ssl_cert_check_key_usage(const CBS *in,
 // nullptr and pushes to the error queue.
 UniquePtr<EVP_PKEY> ssl_cert_parse_pubkey(const CBS *in);
 
+// ssl_cert_parse_leaf_pubkey calls |ssl_cert_parse_pubkey| and extracts the
+// public key from the first element of |chain|. It's expected that the first
+// element of |chain| is the leaf certificate.
+UniquePtr<EVP_PKEY> ssl_cert_parse_leaf_pubkey(STACK_OF(CRYPTO_BUFFER) *chain);
+
 // ssl_parse_client_CA_list parses a CA list from |cbs| in the format used by a
 // TLS CertificateRequest message. On success, it returns a newly-allocated
 // |CRYPTO_BUFFER| list and advances |cbs|. Otherwise, it returns nullptr and

--- a/ssl/ssl_cert.cc
+++ b/ssl/ssl_cert.cc
@@ -824,15 +824,13 @@ bool ssl_handshake_load_local_pubkey(SSL_HANDSHAKE *hs) {
       hs->config->cert
           ->cert_private_keys[hs->config->cert->cert_private_key_idx]
           .chain.get();
-  CBS leaf;
-  CRYPTO_BUFFER_init_CBS(sk_CRYPTO_BUFFER_value(chain, 0), &leaf);
 
   if (ssl_signing_with_dc(hs)) {
     hs->local_pubkey = UpRef(hs->config->cert->dc->pkey);
   } else {
-    hs->local_pubkey = ssl_cert_parse_pubkey(&leaf);
+    hs->local_pubkey = ssl_cert_parse_leaf_pubkey(chain);
   }
-  return hs->local_pubkey != NULL;
+  return hs->local_pubkey != nullptr;
 }
 
 


### PR DESCRIPTION
### Issues:
Resolves `V991528578`

### Description of changes: 
Static analysis revealed that we were expecting a certificate to always exist with the paired private key. This may not always be the case however. Connecting with a private key set, but no certificate set will lead to a segfault. This commit resolves that and fails the connection accordingly.

### Call-outs:
N/A

### Testing:
New tests for missing cert and missing private key set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
