### PR TITLE
Update FIPS 2022 branch to support Postgres

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -488,6 +488,7 @@ add_library(
   x509v3/v3_utl.c
   decrepit/bio/base64_bio.c
   decrepit/blowfish/blowfish.c
+  decrepit/cast/cast.c
   decrepit/cast/cast_tables.c
   decrepit/cfb/cfb.c
   decrepit/dh/dh_decrepit.c
@@ -732,6 +733,7 @@ if(BUILD_TESTING)
     x509/x509_time_test.cc
     x509v3/tab_test.cc
     decrepit/blowfish/blowfish_test.cc
+    decrepit/cast/cast_test.cc
     decrepit/cfb/cfb_test.cc
     decrepit/evp/evp_test.cc
     decrepit/ripemd/ripemd_test.cc

--- a/crypto/decrepit/cast/cast.c
+++ b/crypto/decrepit/cast/cast.c
@@ -1,0 +1,406 @@
+/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+ * All rights reserved.
+ *
+ * This package is an SSL implementation written
+ * by Eric Young (eay@cryptsoft.com).
+ * The implementation was written so as to conform with Netscapes SSL.
+ *
+ * This library is free for commercial and non-commercial use as long as
+ * the following conditions are aheared to.  The following conditions
+ * apply to all code found in this distribution, be it the RC4, RSA,
+ * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+ * included with this distribution is covered by the same copyright terms
+ * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+ *
+ * Copyright remains Eric Young's, and as such any Copyright notices in
+ * the code are not to be removed.
+ * If this package is used in a product, Eric Young should be given attribution
+ * as the author of the parts of the library used.
+ * This can be in the form of a textual message at program startup or
+ * in documentation (online or textual) provided with the package.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *    "This product includes cryptographic software written by
+ *     Eric Young (eay@cryptsoft.com)"
+ *    The word 'cryptographic' can be left out if the rouines from the library
+ *    being used are not cryptographic related :-).
+ * 4. If you include any Windows specific code (or a derivative thereof) from
+ *    the apps directory (application code) you must include an acknowledgement:
+ *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * The licence and distribution terms for any publically available version or
+ * derivative of this code cannot be changed.  i.e. this code cannot simply be
+ * copied and put under another distribution licence
+ * [including the GNU Public Licence.]. */
+
+#include <openssl/cipher.h>
+#include <openssl/obj.h>
+
+#if defined(OPENSSL_WINDOWS)
+OPENSSL_MSVC_PRAGMA(warning(push, 3))
+#include <intrin.h>
+OPENSSL_MSVC_PRAGMA(warning(pop))
+#endif
+
+#include "../../../crypto/internal.h"
+#include "../../fipsmodule/cipher/internal.h"
+#include "../macros.h"
+#include "internal.h"
+
+
+void CAST_ecb_encrypt(const uint8_t *in, uint8_t *out, const CAST_KEY *ks,
+                      int enc) {
+  uint32_t d[2];
+
+  n2l(in, d[0]);
+  n2l(in, d[1]);
+  if (enc) {
+    CAST_encrypt(d, ks);
+  } else {
+    CAST_decrypt(d, ks);
+  }
+  l2n(d[0], out);
+  l2n(d[1], out);
+}
+
+#if defined(OPENSSL_WINDOWS) && defined(_MSC_VER)
+#define ROTL(a, n) (_lrotl(a, n))
+#else
+#define ROTL(a, n) ((((a) << (n)) | ((a) >> ((-(n))&31))) & 0xffffffffL)
+#endif
+
+#define E_CAST(n, key, L, R, OP1, OP2, OP3)                                   \
+  {                                                                           \
+    uint32_t a, b, c, d;                                                      \
+    t = (key[n * 2] OP1 R) & 0xffffffff;                                      \
+    t = ROTL(t, (key[n * 2 + 1]));                                            \
+    a = CAST_S_table0[(t >> 8) & 0xff];                                       \
+    b = CAST_S_table1[(t)&0xff];                                              \
+    c = CAST_S_table2[(t >> 24) & 0xff];                                      \
+    d = CAST_S_table3[(t >> 16) & 0xff];                                      \
+    L ^= (((((a OP2 b)&0xffffffffL)OP3 c) & 0xffffffffL)OP1 d) & 0xffffffffL; \
+  }
+
+void CAST_encrypt(uint32_t *data, const CAST_KEY *key) {
+  uint32_t l, r, t;
+  const uint32_t *k;
+
+  k = &key->data[0];
+  l = data[0];
+  r = data[1];
+
+  E_CAST(0, k, l, r, +, ^, -);
+  E_CAST(1, k, r, l, ^, -, +);
+  E_CAST(2, k, l, r, -, +, ^);
+  E_CAST(3, k, r, l, +, ^, -);
+  E_CAST(4, k, l, r, ^, -, +);
+  E_CAST(5, k, r, l, -, +, ^);
+  E_CAST(6, k, l, r, +, ^, -);
+  E_CAST(7, k, r, l, ^, -, +);
+  E_CAST(8, k, l, r, -, +, ^);
+  E_CAST(9, k, r, l, +, ^, -);
+  E_CAST(10, k, l, r, ^, -, +);
+  E_CAST(11, k, r, l, -, +, ^);
+
+  if (!key->short_key) {
+    E_CAST(12, k, l, r, +, ^, -);
+    E_CAST(13, k, r, l, ^, -, +);
+    E_CAST(14, k, l, r, -, +, ^);
+    E_CAST(15, k, r, l, +, ^, -);
+  }
+
+  data[1] = l & 0xffffffffL;
+  data[0] = r & 0xffffffffL;
+}
+
+void CAST_decrypt(uint32_t *data, const CAST_KEY *key) {
+  uint32_t l, r, t;
+  const uint32_t *k;
+
+  k = &key->data[0];
+  l = data[0];
+  r = data[1];
+
+  if (!key->short_key) {
+    E_CAST(15, k, l, r, +, ^, -);
+    E_CAST(14, k, r, l, -, +, ^);
+    E_CAST(13, k, l, r, ^, -, +);
+    E_CAST(12, k, r, l, +, ^, -);
+  }
+
+  E_CAST(11, k, l, r, -, +, ^);
+  E_CAST(10, k, r, l, ^, -, +);
+  E_CAST(9, k, l, r, +, ^, -);
+  E_CAST(8, k, r, l, -, +, ^);
+  E_CAST(7, k, l, r, ^, -, +);
+  E_CAST(6, k, r, l, +, ^, -);
+  E_CAST(5, k, l, r, -, +, ^);
+  E_CAST(4, k, r, l, ^, -, +);
+  E_CAST(3, k, l, r, +, ^, -);
+  E_CAST(2, k, r, l, -, +, ^);
+  E_CAST(1, k, l, r, ^, -, +);
+  E_CAST(0, k, r, l, +, ^, -);
+
+  data[1] = l & 0xffffffffL;
+  data[0] = r & 0xffffffffL;
+}
+
+void CAST_cbc_encrypt(const uint8_t *in, uint8_t *out, size_t length,
+                      const CAST_KEY *ks, uint8_t *iv, int enc) {
+  uint32_t tin0, tin1;
+  uint32_t tout0, tout1, xor0, xor1;
+  size_t l = length;
+  uint32_t tin[2];
+
+  if (enc) {
+    n2l(iv, tout0);
+    n2l(iv, tout1);
+    iv -= 8;
+    while (l >= 8) {
+      n2l(in, tin0);
+      n2l(in, tin1);
+      tin0 ^= tout0;
+      tin1 ^= tout1;
+      tin[0] = tin0;
+      tin[1] = tin1;
+      CAST_encrypt(tin, ks);
+      tout0 = tin[0];
+      tout1 = tin[1];
+      l2n(tout0, out);
+      l2n(tout1, out);
+      l -= 8;
+    }
+    if (l != 0) {
+      n2ln(in, tin0, tin1, l);
+      tin0 ^= tout0;
+      tin1 ^= tout1;
+      tin[0] = tin0;
+      tin[1] = tin1;
+      CAST_encrypt(tin, ks);
+      tout0 = tin[0];
+      tout1 = tin[1];
+      l2n(tout0, out);
+      l2n(tout1, out);
+    }
+    l2n(tout0, iv);
+    l2n(tout1, iv);
+  } else {
+    n2l(iv, xor0);
+    n2l(iv, xor1);
+    iv -= 8;
+    while (l >= 8) {
+      n2l(in, tin0);
+      n2l(in, tin1);
+      tin[0] = tin0;
+      tin[1] = tin1;
+      CAST_decrypt(tin, ks);
+      tout0 = tin[0] ^ xor0;
+      tout1 = tin[1] ^ xor1;
+      l2n(tout0, out);
+      l2n(tout1, out);
+      xor0 = tin0;
+      xor1 = tin1;
+      l -= 8;
+    }
+    if (l != 0) {
+      n2l(in, tin0);
+      n2l(in, tin1);
+      tin[0] = tin0;
+      tin[1] = tin1;
+      CAST_decrypt(tin, ks);
+      tout0 = tin[0] ^ xor0;
+      tout1 = tin[1] ^ xor1;
+      l2nn(tout0, tout1, out, l);
+      xor0 = tin0;
+      xor1 = tin1;
+    }
+    l2n(xor0, iv);
+    l2n(xor1, iv);
+  }
+  tin0 = tin1 = tout0 = tout1 = xor0 = xor1 = 0;
+  tin[0] = tin[1] = 0;
+}
+
+#define CAST_exp(l, A, a, n)   \
+  A[n / 4] = l;                \
+  a[n + 3] = (l)&0xff;         \
+  a[n + 2] = (l >> 8) & 0xff;  \
+  a[n + 1] = (l >> 16) & 0xff; \
+  a[n + 0] = (l >> 24) & 0xff;
+#define S4 CAST_S_table4
+#define S5 CAST_S_table5
+#define S6 CAST_S_table6
+#define S7 CAST_S_table7
+
+void CAST_set_key(CAST_KEY *key, size_t len, const uint8_t *data) {
+  uint32_t x[16];
+  uint32_t z[16];
+  uint32_t k[32];
+  uint32_t X[4], Z[4];
+  uint32_t l, *K;
+  size_t i;
+
+  for (i = 0; i < 16; i++) {
+    x[i] = 0;
+  }
+
+  if (len > 16) {
+    len = 16;
+  }
+
+  for (i = 0; i < len; i++) {
+    x[i] = data[i];
+  }
+
+  if (len <= 10) {
+    key->short_key = 1;
+  } else {
+    key->short_key = 0;
+  }
+
+  K = &k[0];
+  X[0] = ((x[0] << 24) | (x[1] << 16) | (x[2] << 8) | x[3]) & 0xffffffffL;
+  X[1] = ((x[4] << 24) | (x[5] << 16) | (x[6] << 8) | x[7]) & 0xffffffffL;
+  X[2] = ((x[8] << 24) | (x[9] << 16) | (x[10] << 8) | x[11]) & 0xffffffffL;
+  X[3] = ((x[12] << 24) | (x[13] << 16) | (x[14] << 8) | x[15]) & 0xffffffffL;
+
+  for (;;) {
+    l = X[0] ^ S4[x[13]] ^ S5[x[15]] ^ S6[x[12]] ^ S7[x[14]] ^ S6[x[8]];
+    CAST_exp(l, Z, z, 0);
+    l = X[2] ^ S4[z[0]] ^ S5[z[2]] ^ S6[z[1]] ^ S7[z[3]] ^ S7[x[10]];
+    CAST_exp(l, Z, z, 4);
+    l = X[3] ^ S4[z[7]] ^ S5[z[6]] ^ S6[z[5]] ^ S7[z[4]] ^ S4[x[9]];
+    CAST_exp(l, Z, z, 8);
+    l = X[1] ^ S4[z[10]] ^ S5[z[9]] ^ S6[z[11]] ^ S7[z[8]] ^ S5[x[11]];
+    CAST_exp(l, Z, z, 12);
+
+    K[0] = S4[z[8]] ^ S5[z[9]] ^ S6[z[7]] ^ S7[z[6]] ^ S4[z[2]];
+    K[1] = S4[z[10]] ^ S5[z[11]] ^ S6[z[5]] ^ S7[z[4]] ^ S5[z[6]];
+    K[2] = S4[z[12]] ^ S5[z[13]] ^ S6[z[3]] ^ S7[z[2]] ^ S6[z[9]];
+    K[3] = S4[z[14]] ^ S5[z[15]] ^ S6[z[1]] ^ S7[z[0]] ^ S7[z[12]];
+
+    l = Z[2] ^ S4[z[5]] ^ S5[z[7]] ^ S6[z[4]] ^ S7[z[6]] ^ S6[z[0]];
+    CAST_exp(l, X, x, 0);
+    l = Z[0] ^ S4[x[0]] ^ S5[x[2]] ^ S6[x[1]] ^ S7[x[3]] ^ S7[z[2]];
+    CAST_exp(l, X, x, 4);
+    l = Z[1] ^ S4[x[7]] ^ S5[x[6]] ^ S6[x[5]] ^ S7[x[4]] ^ S4[z[1]];
+    CAST_exp(l, X, x, 8);
+    l = Z[3] ^ S4[x[10]] ^ S5[x[9]] ^ S6[x[11]] ^ S7[x[8]] ^ S5[z[3]];
+    CAST_exp(l, X, x, 12);
+
+    K[4] = S4[x[3]] ^ S5[x[2]] ^ S6[x[12]] ^ S7[x[13]] ^ S4[x[8]];
+    K[5] = S4[x[1]] ^ S5[x[0]] ^ S6[x[14]] ^ S7[x[15]] ^ S5[x[13]];
+    K[6] = S4[x[7]] ^ S5[x[6]] ^ S6[x[8]] ^ S7[x[9]] ^ S6[x[3]];
+    K[7] = S4[x[5]] ^ S5[x[4]] ^ S6[x[10]] ^ S7[x[11]] ^ S7[x[7]];
+
+    l = X[0] ^ S4[x[13]] ^ S5[x[15]] ^ S6[x[12]] ^ S7[x[14]] ^ S6[x[8]];
+    CAST_exp(l, Z, z, 0);
+    l = X[2] ^ S4[z[0]] ^ S5[z[2]] ^ S6[z[1]] ^ S7[z[3]] ^ S7[x[10]];
+    CAST_exp(l, Z, z, 4);
+    l = X[3] ^ S4[z[7]] ^ S5[z[6]] ^ S6[z[5]] ^ S7[z[4]] ^ S4[x[9]];
+    CAST_exp(l, Z, z, 8);
+    l = X[1] ^ S4[z[10]] ^ S5[z[9]] ^ S6[z[11]] ^ S7[z[8]] ^ S5[x[11]];
+    CAST_exp(l, Z, z, 12);
+
+    K[8] = S4[z[3]] ^ S5[z[2]] ^ S6[z[12]] ^ S7[z[13]] ^ S4[z[9]];
+    K[9] = S4[z[1]] ^ S5[z[0]] ^ S6[z[14]] ^ S7[z[15]] ^ S5[z[12]];
+    K[10] = S4[z[7]] ^ S5[z[6]] ^ S6[z[8]] ^ S7[z[9]] ^ S6[z[2]];
+    K[11] = S4[z[5]] ^ S5[z[4]] ^ S6[z[10]] ^ S7[z[11]] ^ S7[z[6]];
+
+    l = Z[2] ^ S4[z[5]] ^ S5[z[7]] ^ S6[z[4]] ^ S7[z[6]] ^ S6[z[0]];
+    CAST_exp(l, X, x, 0);
+    l = Z[0] ^ S4[x[0]] ^ S5[x[2]] ^ S6[x[1]] ^ S7[x[3]] ^ S7[z[2]];
+    CAST_exp(l, X, x, 4);
+    l = Z[1] ^ S4[x[7]] ^ S5[x[6]] ^ S6[x[5]] ^ S7[x[4]] ^ S4[z[1]];
+    CAST_exp(l, X, x, 8);
+    l = Z[3] ^ S4[x[10]] ^ S5[x[9]] ^ S6[x[11]] ^ S7[x[8]] ^ S5[z[3]];
+    CAST_exp(l, X, x, 12);
+
+    K[12] = S4[x[8]] ^ S5[x[9]] ^ S6[x[7]] ^ S7[x[6]] ^ S4[x[3]];
+    K[13] = S4[x[10]] ^ S5[x[11]] ^ S6[x[5]] ^ S7[x[4]] ^ S5[x[7]];
+    K[14] = S4[x[12]] ^ S5[x[13]] ^ S6[x[3]] ^ S7[x[2]] ^ S6[x[8]];
+    K[15] = S4[x[14]] ^ S5[x[15]] ^ S6[x[1]] ^ S7[x[0]] ^ S7[x[13]];
+    if (K != k) {
+      break;
+    }
+    K += 16;
+  }
+
+  for (i = 0; i < 16; i++) {
+    key->data[i * 2] = k[i];
+    key->data[i * 2 + 1] = ((k[i + 16]) + 16) & 0x1f;
+  }
+}
+
+static int cast_init_key(EVP_CIPHER_CTX *ctx, const uint8_t *key,
+                         const uint8_t *iv, int enc) {
+  CAST_KEY *cast_key = ctx->cipher_data;
+  CAST_set_key(cast_key, ctx->key_len, key);
+  return 1;
+}
+
+static int cast_ecb_cipher(EVP_CIPHER_CTX *ctx, uint8_t *out, const uint8_t *in,
+                           size_t len) {
+  CAST_KEY *cast_key = ctx->cipher_data;
+  assert(len % CAST_BLOCK == 0);
+
+  while (len >= CAST_BLOCK) {
+    CAST_ecb_encrypt(in, out, cast_key, ctx->encrypt);
+    in += CAST_BLOCK;
+    out += CAST_BLOCK;
+    len -= CAST_BLOCK;
+  }
+  assert(len == 0);
+
+  return 1;
+}
+
+static int cast_cbc_cipher(EVP_CIPHER_CTX *ctx, uint8_t *out, const uint8_t *in,
+                           size_t len) {
+  CAST_KEY *cast_key = ctx->cipher_data;
+  CAST_cbc_encrypt(in, out, len, cast_key, ctx->iv, ctx->encrypt);
+  return 1;
+}
+
+static const EVP_CIPHER cast5_ecb = {
+    NID_cast5_ecb,       CAST_BLOCK,
+    CAST_KEY_LENGTH,     CAST_BLOCK /* iv_len */,
+    sizeof(CAST_KEY),    EVP_CIPH_ECB_MODE | EVP_CIPH_VARIABLE_LENGTH,
+    NULL /* app_data */, cast_init_key,
+    cast_ecb_cipher,     NULL /* cleanup */,
+    NULL /* ctrl */,
+};
+
+static const EVP_CIPHER cast5_cbc = {
+    NID_cast5_cbc,       CAST_BLOCK,
+    CAST_KEY_LENGTH,     CAST_BLOCK /* iv_len */,
+    sizeof(CAST_KEY),    EVP_CIPH_CBC_MODE | EVP_CIPH_VARIABLE_LENGTH,
+    NULL /* app_data */, cast_init_key,
+    cast_cbc_cipher,     NULL /* cleanup */,
+    NULL /* ctrl */,
+};
+
+const EVP_CIPHER *EVP_cast5_ecb(void) { return &cast5_ecb; }
+
+const EVP_CIPHER *EVP_cast5_cbc(void) { return &cast5_cbc; }

--- a/crypto/decrepit/cast/internal.h
+++ b/crypto/decrepit/cast/internal.h
@@ -63,6 +63,10 @@
 extern "C" {
 #endif
 
+struct cast_key_st {
+  uint32_t data[32];
+  int short_key;  // Use reduced rounds for short key
+} /* CAST_KEY */;
 
 extern const uint32_t CAST_S_table0[256];
 extern const uint32_t CAST_S_table1[256];
@@ -73,9 +77,19 @@ extern const uint32_t CAST_S_table5[256];
 extern const uint32_t CAST_S_table6[256];
 extern const uint32_t CAST_S_table7[256];
 
+#define CAST_BLOCK 8
+#define CAST_KEY_LENGTH 16
+
+void CAST_set_key(CAST_KEY *key, size_t len, const uint8_t *data);
+void CAST_ecb_encrypt(const uint8_t *in, uint8_t *out, const CAST_KEY *key,
+                      int enc);
+void CAST_encrypt(uint32_t *data, const CAST_KEY *key);
+void CAST_decrypt(uint32_t *data, const CAST_KEY *key);
+void CAST_cbc_encrypt(const uint8_t *in, uint8_t *out, size_t length,
+                      const CAST_KEY *ks, uint8_t *iv, int enc);
 
 #if defined(__cplusplus)
-}  // extern C
+} // extern C
 #endif
 
 #endif  // OPENSSL_HEADER_CAST_INTERNAL_H

--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -67,7 +67,7 @@ static void handle_cpu_env(uint32_t *out, const char *in) {
     fprintf(stderr,
             "Fatal Error: HW capability found: 0x%02X, but HW capability requested: 0x%02X.\n",
             armcap, v);
-    exit(1);
+    abort();
   }
 
   if (invert) {

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -400,6 +400,7 @@ typedef struct blake2b_state_st BLAKE2B_CTX;
 typedef struct bn_gencb_st BN_GENCB;
 typedef struct bn_mont_ctx_st BN_MONT_CTX;
 typedef struct buf_mem_st BUF_MEM;
+typedef struct cast_key_st CAST_KEY;
 typedef struct cbb_st CBB;
 typedef struct cbs_st CBS;
 typedef struct cmac_ctx_st CMAC_CTX;

--- a/include/openssl/cipher.h
+++ b/include/openssl/cipher.h
@@ -527,6 +527,12 @@ OPENSSL_EXPORT const EVP_CIPHER *EVP_bf_cbc(void);
 // EVP_bf_cfb is Blowfish in 64-bit CFB mode and is deprecated.
 OPENSSL_EXPORT const EVP_CIPHER *EVP_bf_cfb(void);
 
+// EVP_cast5_ecb is CAST5 in ECB mode and is deprecated.
+OPENSSL_EXPORT const EVP_CIPHER *EVP_cast5_ecb(void);
+
+// EVP_cast5_cbc is CAST5 in CBC mode and is deprecated.
+OPENSSL_EXPORT const EVP_CIPHER *EVP_cast5_cbc(void);
+
 // The following flags do nothing and are included only to make it easier to
 // compile code with BoringSSL.
 #define EVP_CIPH_CCM_MODE (-1)

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5346,6 +5346,7 @@ OPENSSL_EXPORT uint16_t SSL_CIPHER_get_value(const SSL_CIPHER *cipher);
 #define SSL_CTX_set1_curves SSL_CTX_set1_curves
 #define SSL_CTX_set_max_cert_list SSL_CTX_set_max_cert_list
 #define SSL_CTX_set_max_send_fragment SSL_CTX_set_max_send_fragment
+#define SSL_CTX_set_min_proto_version SSL_CTX_set_min_proto_version
 #define SSL_CTX_set_mode SSL_CTX_set_mode
 #define SSL_CTX_set_msg_callback_arg SSL_CTX_set_msg_callback_arg
 #define SSL_CTX_set_options SSL_CTX_set_options

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -289,6 +289,14 @@ batch:
         variables:
           AWS_LC_SSL_RUNNER_START_INDEX: 7001
 
+    - identifier: postgres_integration_aarch
+      buildspec: ./tests/ci/codebuild/linux-x86/postgres_integration.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:ubuntu-22.04_gcc-12x_latest
+
 #   - identifier: amazonlinux2023_gcc11x_aarch_valgrind
 #     buildspec: ./tests/ci/codebuild/common/run_valgrind_tests.yml
 #     env:

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -328,7 +328,7 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-9x_latest
 
-    - identifier: postgres_integration
+    - identifier: postgres_integration_x86
       buildspec: ./tests/ci/codebuild/linux-x86/postgres_integration.yml
       env:
         type: LINUX_CONTAINER

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -328,6 +328,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-9x_latest
 
+    - identifier: postgres_integration
+      buildspec: ./tests/ci/codebuild/linux-x86/postgres_integration.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_latest
+
     - identifier: install_shared_and_static
       buildspec: ./tests/ci/codebuild/linux-x86/install_shared_and_static.yml
       env:

--- a/tests/ci/codebuild/linux-x86/postgres_integration.yml
+++ b/tests/ci/codebuild/linux-x86/postgres_integration.yml
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+version: 0.2
+
+phases:
+  install:
+    run-as: root
+    commands:
+      # Let postgres user in docker image take ownership of codebuild artifacts.
+      - chown -R postgres:postgres /codebuild/output
+      # Go caches build objects in /root/.cache.
+      - chown -R postgres:postgres /root/
+  build:
+    run-as: postgres
+    commands:
+      - ./tests/ci/run_postgres_integration.sh

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
@@ -22,6 +22,7 @@ RUN set -ex && \
     apt-get -y --no-install-recommends install \
     software-properties-common \
     cmake \
+    make \
     ninja-build \
     perl \
     libunwind-dev \
@@ -32,6 +33,12 @@ RUN set -ex && \
     lld \
     llvm \
     llvm-dev \
+    libicu-dev \
+    libipc-run-perl \
+    libreadline-dev \
+    zlib1g-dev \
+    flex \
+    bison \
     curl \
     unzip && \
     # Based on https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x/Dockerfile
@@ -16,5 +16,11 @@ RUN set -ex && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
 
+# Postgres's integration tests cannot be ran as root, so we have to define
+# a non-root user here to use in Codebuild.
+RUN adduser --disabled-password --gecos '' postgres && \
+    adduser postgres sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 ENV CC=gcc-12
 ENV CXX=g++-12

--- a/tests/ci/run_postgres_integration.sh
+++ b/tests/ci/run_postgres_integration.sh
@@ -1,0 +1,79 @@
+#!/bin/bash -exu
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# ROOT
+#  |
+#  - AWS_LC_DIR
+#    |
+#    - aws-lc
+#  |
+#  - SCRATCH_FOLDER
+#    |
+#    - postgres
+#    - AWS_LC_BUILD_FOLDER
+#    - AWS_LC_INSTALL_FOLDER
+#    - POSTGRES_BUILD_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+AWS_LC_DIR=$(pwd)
+cd ../
+ROOT=$(pwd)
+
+SCRATCH_FOLDER=${ROOT}/"POSTGRES_BUILD_ROOT"
+POSTGRES_SRC_FOLDER="${SCRATCH_FOLDER}/postgres"
+POSTGRES_BUILD_FOLDER="${SCRATCH_FOLDER}/postgres/build"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${POSTGRES_SRC_FOLDER}/aws-lc-install"
+
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf ${SCRATCH_FOLDER}/*
+cd ${SCRATCH_FOLDER}
+
+function aws_lc_build() {
+  ${CMAKE_COMMAND} ${AWS_LC_DIR} -GNinja "-B${AWS_LC_BUILD_FOLDER}" "-DCMAKE_INSTALL_PREFIX=${AWS_LC_INSTALL_FOLDER}"
+  ninja -C ${AWS_LC_BUILD_FOLDER} install
+  ls -R ${AWS_LC_INSTALL_FOLDER}
+  rm -rf ${AWS_LC_BUILD_FOLDER}/*
+}
+
+function postgres_build() {
+  ./configure --with-openssl --enable-tap-tests --with-includes=${AWS_LC_INSTALL_FOLDER}/include --with-libraries=${AWS_LC_INSTALL_FOLDER}/lib --prefix=$(pwd)/build
+  make -j ${NUM_CPU_THREADS}
+  # Build additional modules for postgres.
+  make -j ${NUM_CPU_THREADS} -C contrib all
+  ls -R build
+}
+
+function postgres_run_tests() {
+  make -j ${NUM_CPU_THREADS} check
+  # Run additional tests, particularly the "SSL" tests.
+  make -j ${NUM_CPU_THREADS} check-world PG_TEST_EXTRA='ssl'
+  cd ${SCRATCH_FOLDER}
+}
+
+# SSL tests expect the OpenSSL style of error messages. We patch this to expect AWS-LC's style.
+# TODO: Remove this when we make an upstream contribution.
+function postgres_patch() {
+  POSTGRES_ERROR_STRING=("certificate verify failed" "bad decrypt" "sslv3 alert certificate revoked" "tlsv1 alert unknown ca")
+  AWS_LC_EXPECTED_ERROR_STRING=("CERTIFICATE_VERIFY_FAILED" "BAD_DECRYPT" "SSLV3_ALERT_CERTIFICATE_REVOKED" "TLSV1_ALERT_UNKNOWN_CA")
+  for i in "${!POSTGRES_ERROR_STRING[@]}"; do
+    find ./ -type f -name "001_ssltests.pl" | xargs sed -i -e "s|${POSTGRES_ERROR_STRING[$i]}|${AWS_LC_EXPECTED_ERROR_STRING[$i]}|g"
+  done
+}
+
+# Get latest postgres version.
+git clone https://github.com/postgres/postgres.git ${POSTGRES_SRC_FOLDER}
+mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${POSTGRES_BUILD_FOLDER}
+ls
+
+aws_lc_build
+cd ${POSTGRES_SRC_FOLDER}
+postgres_patch
+postgres_build
+postgres_run_tests
+

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -20,7 +20,12 @@
 
 #include <assert.h>
 #include <errno.h>
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
### Description of changes: 
These changes are required to support Postgres on the future fips-2022-11-02 release. 

### Call-outs:
I had to make one small change to 3ffcd9755718c3b947aa48e614f3dbd6c265e394 to take out the AWS_LC_DEPRECATED which doesn't exist on this branch. I couldn't easily take https://github.com/aws/aws-lc/commit/4cb82544709ef22fb7608cb93836b7a2051729aa as the CI infrastructure has changed a lot between branches. I made a similar change in a new commit. 

### Testing:
Built locally, new CI will handle ARM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
