### PR TITLE
Use passive entropy source method by default for FIPS build mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,16 +22,21 @@ option(BUILD_TOOL "Build bssl tool for AWS-LC" ON)
 option(ENABLE_DILITHIUM "Enable Dilithium signatures in the EVP API" OFF)
 option(DISABLE_PERL "Disable Perl for AWS-LC" OFF)
 option(DISABLE_GO "Disable Go for AWS-LC" OFF)
+option(ENABLE_FIPS_ENTROPY_CPU_JITTER "Enable FIPS entropy source: CPU Jitter" OFF)
 include(cmake/go.cmake)
 
 enable_language(C)
 
 # Configure entropy source in case of FIPS build
 if(FIPS)
-  if(USE_FIPS_ENTROPY_SOURCE_PASSIVE)
-    add_definitions(-DFIPS_ENTROPY_SOURCE_PASSIVE)
-  else()
+  message(STATUS "FIPS build mode configured")
+
+  if(ENABLE_FIPS_ENTROPY_CPU_JITTER)
     add_definitions(-DFIPS_ENTROPY_SOURCE_JITTER_CPU)
+    message(STATUS "FIPS entropy source method configured: CPU Jitter")
+  else()
+    add_definitions(-DFIPS_ENTROPY_SOURCE_PASSIVE)
+    message(STATUS "FIPS entropy source method configured: Passive")
   endif()
 endif()
 

--- a/crypto/fipsmodule/FIPS.md
+++ b/crypto/fipsmodule/FIPS.md
@@ -36,13 +36,7 @@ The utility in `util/fipstools/break-hash.go` can be used to corrupt the FIPS mo
 
 FIPS 140-2 requires that one of its PRNGs be used (which they call DRBGs). In BoringCrypto, we use CTR-DRBG with AES-256 exclusively and `RAND_bytes` (the primary interface for the rest of the system to get random data) takes its output from there.
 
-The DRBG state is kept in a thread-local structure and is seeded from one of the following entropy sources in preference order: RDRAND (on Intel chips), `getrandom`, and `/dev/urandom`. In the case of `/dev/urandom`, in order to ensure that the system has a minimum level of entropy, BoringCrypto polls the kernel until the estimated entropy is at least 256 bits. This is a poor man's version of `getrandom` and we strongly recommend using a kernel recent enough to support the real thing.
-
-In FIPS mode, each of those entropy sources is subject to a 10× overread. That is, when *n* bytes of entropy are needed, *10n* bytes will be read from the entropy source and XORed down to *n* bytes. Reads from the entropy source are also processed in blocks of 16 bytes and if two consecutive chunks are equal the process will abort.
-
-In the case that the seed is taken from RDRAND, getrandom will also be queried with `GRND_NONBLOCK` to attempt to obtain additional entropy from the operating system. If available, that extra entropy will be XORed into the whitened seed.
-
-On Android, only `getrandom` is supported and, when seeding for the first time, the system property `ro.boringcrypto.hwrand` is queried. If set to `true` then `getrandom` will be called with the `GRND_RANDOM` flag. Only entropy draws destined for DRBG seeds are affected by this. We are not suggesting that there is any security advantage at all to doing this, and thus recommend that Android vendors do _not_ set this flag.
+The DRBG state is kept in a thread-local structure and is seeded using the configured entropy source.
 
 The CTR-DRBG is reseeded every 4096 calls to `RAND_bytes`. Thus the process will randomly crash about every 2¹³⁵ calls.
 
@@ -51,6 +45,20 @@ The FIPS PRNGs allow “additional input” to be fed into a given call. We use 
 There is a second interface to the RNG which allows the caller to supply bytes that will be XORed into the generated additional data (`RAND_bytes_with_additional_data`). This is used in the ECDSA code to include the message and private key in the generation of *k*, the ECDSA nonce. This allows ECDSA to be robust to entropy failures while still following the FIPS rules.
 
 FIPS requires that RNG state be zeroed when the process exits. In order to implement this, all per-thread RNG states are tracked in a linked list and a destructor function is included which clears them. In order for this to be safe in the presence of threads, a lock is used to stop all other threads from using the RNG once this process has begun. Thus the main thread exiting may cause other threads to deadlock, and drawing on entropy in a destructor function may also deadlock.
+
+## Entropy sources
+
+By default, entropy is sourced using a "Passive" method where the specific entropy source depends on the OE. Seeding and reseeding material for the DRBG is sourced from the specific entropy source.
+
+In FIPS mode, each of the entropy sources is subject to a 10× overread. That is, when *n* bytes of entropy are needed, *10n* bytes will be read from the entropy source and XORed down to *n* bytes.
+
+### Modify entropy source - not recommended
+
+Modifying the entropy source can invalidate your validation status. Changing the entropy is **not** recommended.
+
+It is possible to modify the entropy method at build-time. Using `ENABLE_FIPS_ENTROPY_CPU_JITTER=ON`, the entropy source is switched to [CPU Jitter](https://github.com/smuellerDD/jitterentropy-library).
+
+CPU Jitter is less performant than the default method and can incur up to a 2-digit millisecond latency when queried.
 
 ## Integrity Test
 

--- a/crypto/fipsmodule/FIPS.md
+++ b/crypto/fipsmodule/FIPS.md
@@ -58,7 +58,7 @@ Modifying the entropy source can invalidate your validation status. Changing the
 
 It is possible to modify the entropy method at build-time. Using `ENABLE_FIPS_ENTROPY_CPU_JITTER=ON`, the entropy source is switched to [CPU Jitter](https://github.com/smuellerDD/jitterentropy-library).
 
-CPU Jitter is less performant than the default method and can incur up to a 2-digit millisecond latency when queried.
+CPU Jitter is less performant than the default method and can incur up to a 2-digit millisecond latency when queried. You can test CPU Jitter entropy on your system using `bssl speed -filter Jitter`.
 
 ## Integrity Test
 

--- a/crypto/rand_extra/rand_test.cc
+++ b/crypto/rand_extra/rand_test.cc
@@ -327,20 +327,26 @@ TEST(RandTest, PassiveEntropyDepletedObviouslyNotBroken) {
   uint8_t buf2[CTR_DRBG_ENTROPY_LEN] = {0};
   int out_want_additional_input_false_default = 0;
   int out_want_additional_input_true_default = 1;
-  int want_additional_input_expect = 0;
 
   RAND_module_entropy_depleted(buf1, &out_want_additional_input_false_default);
   RAND_module_entropy_depleted(buf2, &out_want_additional_input_true_default);
+  EXPECT_TRUE(out_want_additional_input_false_default == 0 || out_want_additional_input_false_default == 1);
+  EXPECT_TRUE(out_want_additional_input_true_default == 0 || out_want_additional_input_true_default == 1);
 
+// |have_rdrand| inlines the cpu capability vector ending up with an undefined
+// reference because the variable has internal linkage in the shared build. So,
+// we can only validate the correct value is set on the static build type.
+#if !defined(BORINGSSL_SHARED_LIBRARY)
+  int want_additional_input_expect = 0;
   if (have_rdrand()) {
     want_additional_input_expect = 1;
   }
-
   EXPECT_EQ(out_want_additional_input_false_default, want_additional_input_expect);
   EXPECT_EQ(out_want_additional_input_true_default, want_additional_input_expect);
+#endif
+
   EXPECT_NE(Bytes(buf1), Bytes(buf2));
   EXPECT_NE(Bytes(buf1), Bytes(kZeros));
   EXPECT_NE(Bytes(buf2), Bytes(kZeros));
-
 }
 #endif

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -7,6 +7,9 @@ source tests/ci/common_posix_setup.sh
 echo "Testing AWS-LC shared library in FIPS Release mode."
 fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 
+echo "Testing AWS-LC shared library in FIPS Release mode with FIPS entropy source method CPU Jitter."
+fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DENABLE_FIPS_ENTROPY_CPU_JITTER=ON
+
 # Static FIPS build works only on Linux platforms.
 if [[ ("$(uname -s)" == 'Linux'*) && (("$(uname -p)" == 'x86_64'*) || ("$(uname -p)" == 'aarch64'*)) ]]; then
   echo "Testing AWS-LC static library in FIPS Release mode."
@@ -20,8 +23,8 @@ if [[ ("$(uname -s)" == 'Linux'*) && (("$(uname -p)" == 'x86_64'*) || ("$(uname 
   # These build parameters may be needed by our aws-lc-fips-sys Rust package
   run_build -DFIPS=1 -DBUILD_LIBSSL=OFF -DBUILD_TESTING=OFF
 
-  echo "Testing FIPS entropy source method: CPU Jitter."
-  fips_build_and_test -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DENABLE_FIPS_ENTROPY_CPU_JITTER=ON
+  echo "Testing AWS-LC static library in FIPS Release mode with FIPS entropy source method CPU Jitter."
+  fips_build_and_test -DCMAKE_BUILD_TYPE=Release -DENABLE_FIPS_ENTROPY_CPU_JITTER=ON
 fi
 
 # The AL2 version of Clang does not have all of the required artifacts for address sanitizer, see P45594051

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -21,7 +21,7 @@ if [[ ("$(uname -s)" == 'Linux'*) && (("$(uname -p)" == 'x86_64'*) || ("$(uname 
   run_build -DFIPS=1 -DBUILD_LIBSSL=OFF -DBUILD_TESTING=OFF
 
   echo "Testing FIPS entropy source: Passive."
-  fips_build_and_test -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DUSE_FIPS_ENTROPY_SOURCE_PASSIVE=1
+  fips_build_and_test -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DENABLE_FIPS_ENTROPY_CPU_JITTER=ON
 fi
 
 # The AL2 version of Clang does not have all of the required artifacts for address sanitizer, see P45594051

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -20,7 +20,7 @@ if [[ ("$(uname -s)" == 'Linux'*) && (("$(uname -p)" == 'x86_64'*) || ("$(uname 
   # These build parameters may be needed by our aws-lc-fips-sys Rust package
   run_build -DFIPS=1 -DBUILD_LIBSSL=OFF -DBUILD_TESTING=OFF
 
-  echo "Testing FIPS entropy source: Passive."
+  echo "Testing FIPS entropy source method: CPU Jitter."
   fips_build_and_test -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DENABLE_FIPS_ENTROPY_CPU_JITTER=ON
 fi
 


### PR DESCRIPTION
### Issues:

CryptoAlg-1953

### Description of changes: 

Enables passive entropy method by default. In addition, adds a build-time config that can modify (at build-time) the entropy source method to CPU Jitter.

### Call-outs:

Follow-up to https://github.com/aws/aws-lc/pull/1125.

### Testing:

For both entropy methods, ran:

```
$ valgrind --trace-children=yes ./crypto/crypto_test --gtest_filter=RandTest.*

[...]

ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
