### PR TITLE
MSVC 2022 - Ignore C5266 and C5267

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,6 +473,8 @@ elseif(MSVC)
       "C4996" # deprecated warnings using low level functions in OpenSSL 3.0
       "C4746" # consider using __iso_volatile_load/store intrinsic functions
       "C5264" # 'variable-name': 'const' variable is not used
+      "C5266" # 'const' qualifier on return type has no effect
+      "C5267" # definition of implicit copy constructor for '...' is deprecated because it has a user-provided destructor
           )
   set(MSVC_LEVEL4_WARNINGS_LIST
       # See https://connect.microsoft.com/VisualStudio/feedback/details/1217660/warning-c4265-when-using-functional-header


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Build was failing with error codes "C5266" and "C5267" using MS Visual Studio Community 2022. This change allows these errors to be ignored and the build to succeed.

### Call-outs:
* Neither of these error codes is fully documented. They should appear on [this page](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c4800-through-c4999).
   * There is an open issue [here](https://github.com/MicrosoftDocs/cpp-docs/issues/4554) concerning C5266 not being documented.

### Testing:
* Built successfully completed using "Visual Studio Community 2022" on Windows Server 2019.
* crypto_test and ssl_test succeeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
