### PR TITLE
Fix AVX512 capability check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 cmake-build-debug/
-.vscode/settings.json
+.vscode/
 build/
 build32/
 build64/

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -116,7 +116,7 @@ OPENSSL_INLINE int CRYPTO_is_SHAEXT_capable(void) {
 }
 
 OPENSSL_INLINE int CRYPTO_is_AVX512_capable(void) {
-  return (OPENSSL_ia32cap_get()[2] & 0xC0030000) != 0;
+  return (OPENSSL_ia32cap_get()[2] & 0xC0030000) == 0xC0030000;
 }
 
 OPENSSL_INLINE int CRYPTO_is_VAES_capable(void) {


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* We require all of the flags for AVX512F, AVX512DQ, AVX512BW and AVX512VL (not just one of them).

### Call-outs:
* The bit flags are shown on page 2-16 of [this reference](https://www.intel.com/content/dam/develop/external/us/en/documents/319433-024-697869.pdf#G6.2165065).

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
