### PR TITLE
Reset IV in AES-GCM ABI Test

### DIFF
--- a/crypto/fipsmodule/modes/gcm_test.cc
+++ b/crypto/fipsmodule/modes/gcm_test.cc
@@ -240,13 +240,15 @@ TEST(GCMTest, ABI) {
 #if defined(OPENSSL_AARCH64) && defined(HW_GCM)
   if (hwaes_capable() && gcm_pmull_capable()) {
     static const uint8_t kKey[16] = {0};
-    uint8_t iv[16] = {0};
+    uint8_t iv[16];
 
     for (size_t key_bits = 128; key_bits <= 256; key_bits += 64) {
       AES_KEY aes_key;
       aes_hw_set_encrypt_key(kKey, key_bits, &aes_key);
+      OPENSSL_memset(iv, 0, 16);
       CHECK_ABI(aes_gcm_enc_kernel, buf, sizeof(buf) * 8, buf, X, iv, &aes_key,
                 Htable);
+      OPENSSL_memset(iv, 0, 16);
       CHECK_ABI(aes_gcm_dec_kernel, buf, sizeof(buf) * 8, buf, X, iv, &aes_key,
                 Htable);
     }


### PR DESCRIPTION
### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

This modifies the ABI test for AES-GCM to reset the `ivec` (initialization vector) in between encrypt and decrypt calls for ARM assembly.  The `ivec` buffer currently is overwritten during the `aes_gcm_enc_kernel` routine which, when passed to the `aes_gcm_dec_kernel` will produce a decrypted plaintext that does not match the original plaintext.  This change ensures that a decrypt of an encrypt produces the same buffer during testing.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

Although this test is directed at the assembly interface, another suggestion would be to add an EXPECT_EQ of the input buffer and result after encrypt and decrypt to catch problems like this in the future.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

This change was tested on an ARM machine with passing regression.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
