### PR TITLE
Disable XTS use of AVX512 on Windows

### DIFF
--- a/crypto/fipsmodule/aes/internal.h
+++ b/crypto/fipsmodule/aes/internal.h
@@ -161,7 +161,7 @@ OPENSSL_EXPORT int aes_hw_xts_cipher(const uint8_t *in, uint8_t *out, size_t len
                                       const AES_KEY *key1, const AES_KEY *key2,
                                       const uint8_t iv[16], int enc);
 
-#if defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
+#if defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) && !defined(OPENSSL_WINDOWS)
 #define AES_XTS_X86_64_AVX512
 void aes_hw_xts_encrypt_avx512(const uint8_t *in, uint8_t *out, size_t length,
                                const AES_KEY *key1, const AES_KEY *key2,

--- a/crypto/fipsmodule/modes/gcm.c
+++ b/crypto/fipsmodule/modes/gcm.c
@@ -829,6 +829,7 @@ int crypto_gcm_clmul_enabled(void) {
 }
 
 int crypto_gcm_avx512_enabled(void) {
+  // This must align with ImplDispatchTest.AEAD_AES_GCM
 #if defined(GHASH_ASM_X86_64) && \
     !defined(OPENSSL_WINDOWS) && \
     !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -40,9 +40,16 @@ class ImplDispatchTest : public ::testing::Test {
     avx_movbe_ = CRYPTO_is_AVX_capable() && CRYPTO_is_MOVBE_capable();
     aes_vpaes_ = CRYPTO_is_SSSE3_capable();
     sha_ext_ = CRYPTO_is_SHAEXT_capable();
-    vaes_vpclmulqdq_ = CRYPTO_is_AVX512_capable() && 
-                        CRYPTO_is_VAES_capable() &&
-                        CRYPTO_is_VPCLMULQDQ_capable();
+    vaes_vpclmulqdq_ =
+#if !defined(OPENSSL_WINDOWS)
+  // crypto_gcm_avx512_enabled excludes Windows
+        CRYPTO_is_AVX512_capable() &&
+        CRYPTO_is_VAES_capable() &&
+        CRYPTO_is_VPCLMULQDQ_capable();
+#else
+        false;
+#endif
+
     is_x86_64_ =
 #if defined(OPENSSL_X86_64)
         true;


### PR DESCRIPTION
### Issues:
N/A

### Description of changes:
* Disable XTS's use of AVX-512 on Windows.
* Fix `ImplDispatchTest.AEAD_AES_GCM` which was failing on Windows hosts with AVX-512 capable CPUs.

### Call-outs:
N/A

### Testing:
Tests pass locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
