### PR TITLE
No prefix for OPENSSL_armcap_P on FIPS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,18 +145,20 @@ if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
     set(BORINGSSL_PREFIX_SYMBOLS_PATH ${PROJECT_BINARY_DIR}/${BORINGSSL_PREFIX_SYMBOLS})
   endif()
 
+  set(DELETE_PATTERN " bignum_| curve25519_x25519")
+  if(FIPS)
+    set(DELETE_PATTERN "${DELETE_PATTERN}| OPENSSL_armcap_P")
+  endif()
+
   add_custom_command(
     OUTPUT symbol_prefix_include/openssl/boringssl_prefix_symbols.h
            symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h
            symbol_prefix_include/openssl/boringssl_prefix_symbols_nasm.inc
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl
     COMMAND ${GO_EXECUTABLE} run ${CMAKE_CURRENT_SOURCE_DIR}/util/make_prefix_headers.go -out ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl -prefix ${BORINGSSL_PREFIX} ${BORINGSSL_PREFIX_SYMBOLS_PATH}
-    COMMAND sed -i.bak '/ bignum_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h
-    COMMAND sed -i.bak '/ bignum_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h
-    COMMAND sed -i.bak '/ bignum_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_nasm.inc
-    COMMAND sed -i.bak '/ curve25519_x25519/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h
-    COMMAND sed -i.bak '/ curve25519_x25519/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h
-    COMMAND sed -i.bak '/ curve25519_x25519/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_nasm.inc
+    COMMAND sed -E -i.bak "\"/${DELETE_PATTERN}/d\"" ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h
+    COMMAND sed -E -i.bak "\"/${DELETE_PATTERN}/d\"" ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h
+    COMMAND sed -E -i.bak "\"/${DELETE_PATTERN}/d\"" ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_nasm.inc
     COMMAND ${CMAKE_COMMAND} -E remove
           ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h.bak
           ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h.bak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,9 +146,6 @@ if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
   endif()
 
   set(DELETE_PATTERN " bignum_| curve25519_x25519")
-  if(FIPS)
-    set(DELETE_PATTERN "${DELETE_PATTERN}| OPENSSL_armcap_P")
-  endif()
 
   add_custom_command(
     OUTPUT symbol_prefix_include/openssl/boringssl_prefix_symbols.h

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -115,7 +115,7 @@ function verify_symbols_prefixed {
   #  * "\(bignum\|curve25519_x25519\)": match string of either "bignum" or "curve25519_x25519".
   # Recall that the option "-v" reverse the pattern matching. So, we are really
   # filtering out lines that contain either "bignum" or "curve25519_x25519".
-  cat "$BUILD_ROOT"/symbols_final_crypto.txt  "$BUILD_ROOT"/symbols_final_ssl.txt | grep -v -e '^_\?\(bignum\|curve25519_x25519\|OPENSSL_armcap_P\)' >  "$SRC_ROOT"/symbols_final.txt
+  cat "$BUILD_ROOT"/symbols_final_crypto.txt  "$BUILD_ROOT"/symbols_final_ssl.txt | grep -v -e '^_\?\(bignum\|curve25519_x25519P\)' >  "$SRC_ROOT"/symbols_final.txt
   # Now filter out every line that has the unique prefix $CUSTOM_PREFIX. If we
   # have any lines left, then some symbol(s) weren't prefixed, unexpectedly.
   if [ $(grep -c -v ${CUSTOM_PREFIX}  "$SRC_ROOT"/symbols_final.txt) -ne 0 ]; then

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -115,7 +115,7 @@ function verify_symbols_prefixed {
   #  * "\(bignum\|curve25519_x25519\)": match string of either "bignum" or "curve25519_x25519".
   # Recall that the option "-v" reverse the pattern matching. So, we are really
   # filtering out lines that contain either "bignum" or "curve25519_x25519".
-  cat "$BUILD_ROOT"/symbols_final_crypto.txt  "$BUILD_ROOT"/symbols_final_ssl.txt | grep -v -e '^_\?\(bignum\|curve25519_x25519\)' >  "$SRC_ROOT"/symbols_final.txt
+  cat "$BUILD_ROOT"/symbols_final_crypto.txt  "$BUILD_ROOT"/symbols_final_ssl.txt | grep -v -e '^_\?\(bignum\|curve25519_x25519\|OPENSSL_armcap_P\)' >  "$SRC_ROOT"/symbols_final.txt
   # Now filter out every line that has the unique prefix $CUSTOM_PREFIX. If we
   # have any lines left, then some symbol(s) weren't prefixed, unexpectedly.
   if [ $(grep -c -v ${CUSTOM_PREFIX}  "$SRC_ROOT"/symbols_final.txt) -ne 0 ]; then

--- a/tests/ci/run_prefix_tests.sh
+++ b/tests/ci/run_prefix_tests.sh
@@ -5,17 +5,17 @@ set -exo pipefail
 
 source tests/ci/common_posix_setup.sh
 
-echo "Testing a prefix build of AWS-LC in debug mode."
-build_prefix_and_test
-
-echo "Testing a prefix build of AWS-LC in release mode."
-build_prefix_and_test -DCMAKE_BUILD_TYPE=Release
-
-echo "Testing a prefix build of AWS-LC small compilation."
-build_prefix_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
-
-echo "Testing a prefix build of AWS-LC in no asm mode."
-build_prefix_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
-
+#echo "Testing a prefix build of AWS-LC in debug mode."
+#build_prefix_and_test
+#
+#echo "Testing a prefix build of AWS-LC in release mode."
+#build_prefix_and_test -DCMAKE_BUILD_TYPE=Release
+#
+#echo "Testing a prefix build of AWS-LC small compilation."
+#build_prefix_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
+#
+#echo "Testing a prefix build of AWS-LC in no asm mode."
+#build_prefix_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
+#
 echo "Testing a prefix build of AWS-LC in FIPS mode."
 build_prefix_and_test -DFIPS=1 -DCMAKE_BUILD_TYPE=Release

--- a/tests/ci/run_prefix_tests.sh
+++ b/tests/ci/run_prefix_tests.sh
@@ -16,3 +16,6 @@ build_prefix_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
 
 echo "Testing a prefix build of AWS-LC in no asm mode."
 build_prefix_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
+
+echo "Testing a prefix build of AWS-LC in FIPS mode."
+build_prefix_and_test -DFIPS=1 -DCMAKE_BUILD_TYPE=Release

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -61,7 +61,7 @@ const (
 
 // represents a unique symbol for an occurrence of OPENSSL_ia32cap_P.
 type cpuCapUniqueSymbol struct {
-	registerName string
+	registerName     string
 	suffixUniqueness string
 }
 
@@ -78,8 +78,8 @@ func (uniqueSymbol cpuCapUniqueSymbol) getx86SymbolReturn() string {
 // uniqueness must be a globally unique integer value.
 func newCpuCapUniqueSymbol(uniqueness int, registerName string) *cpuCapUniqueSymbol {
 	return &cpuCapUniqueSymbol{
-	    registerName: strings.Trim(registerName, "%"), // should work with both AT&T and Intel syntax.
-	    suffixUniqueness: strconv.Itoa(uniqueness),
+		registerName:     strings.Trim(registerName, "%"), // should work with both AT&T and Intel syntax.
+		suffixUniqueness: strconv.Itoa(uniqueness),
 	}
 }
 
@@ -424,7 +424,9 @@ func (d *delocation) loadAarch64Address(statement *node32, targetReg string, sym
 	}
 
 	var helperFunc string
-	if symbol == "OPENSSL_armcap_P" {
+	if strings.HasSuffix(symbol, "OPENSSL_armcap_P") {
+		helperFunc = ".L" + symbol + "_addr"
+	} else if symbol == "OPENSSL_armcap_P" {
 		helperFunc = ".LOPENSSL_armcap_P_addr"
 	} else {
 		// GOT helpers also dereference the GOT entry, thus the subsequent ldr
@@ -1804,18 +1806,18 @@ func transform(w stringWriter, inputs []inputFile) error {
 	}
 
 	d := &delocation{
-		symbols:             	symbols,
-		localEntrySymbols:   	localEntrySymbols,
-		processor:           	processor,
-		commentIndicator:    	commentIndicator,
-		output:              	w,
-		cpuCapUniqueSymbols:    []*cpuCapUniqueSymbol{},
-		redirectors:         	make(map[string]string),
-		bssAccessorsNeeded:  	make(map[string]string),
-		tocLoaders:          	make(map[string]struct{}),
-		gotExternalsNeeded:  	make(map[string]struct{}),
-		gotOffsetsNeeded:    	make(map[string]struct{}),
-		gotOffOffsetsNeeded: 	make(map[string]struct{}),
+		symbols:             symbols,
+		localEntrySymbols:   localEntrySymbols,
+		processor:           processor,
+		commentIndicator:    commentIndicator,
+		output:              w,
+		cpuCapUniqueSymbols: []*cpuCapUniqueSymbol{},
+		redirectors:         make(map[string]string),
+		bssAccessorsNeeded:  make(map[string]string),
+		tocLoaders:          make(map[string]struct{}),
+		gotExternalsNeeded:  make(map[string]struct{}),
+		gotOffsetsNeeded:    make(map[string]struct{}),
+		gotOffOffsetsNeeded: make(map[string]struct{}),
 	}
 
 	w.WriteString(".text\n")


### PR DESCRIPTION
### Issues:
CryptoAlg-1845

### Description of changes: 
* In FIPS builds `OPENSSL_armcap_P` also should be excluded from prefixing.

### Call-outs:
N/A

### Testing:
I performed both FIPS and non-FIPS builds on a Linux/aarch64 host and checked the symbols in the resulting binary:
```
...
cpucap.c.o:
3912   │ 0000000000000000 B OPENSSL_armcap_P
3913   │ 0000000000000004 B TESTING_4__OPENSSL_cpucap_initialized
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
