### PR TITLE
Add back support for SSL_build_cert_chain

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -980,6 +980,40 @@ OPENSSL_EXPORT int SSL_CTX_add_extra_chain_cert(SSL_CTX *ctx, X509 *x509);
 // and may release it freely.
 OPENSSL_EXPORT int SSL_add1_chain_cert(SSL *ssl, X509 *x509);
 
+
+// The following flags are used for configuring |SSL_CTX_build_cert_chain| and
+// |SSL_build_cert_chain|.
+
+// SSL_BUILD_CHAIN_FLAG_UNTRUSTED treats any existing certificates as untrusted
+// CAs.
+#define SSL_BUILD_CHAIN_FLAG_UNTRUSTED 0x1
+
+// SSL_BUILD_CHAIN_FLAG_NO_ROOT omits the root CA from the built chain.
+#define SSL_BUILD_CHAIN_FLAG_NO_ROOT 0x2
+
+// SSL_BUILD_CHAIN_FLAG_CHECK uses only existing chain certificates to build the
+// chain (effectively sanity checking and rearranging them if necessary).
+#define SSL_BUILD_CHAIN_FLAG_CHECK 0x4
+
+// SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR ignores errors during certificate
+// verification, but still pushes the error onto the error queue.
+#define SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR 0x8
+
+// SSL_BUILD_CHAIN_FLAG_CLEAR_ERROR is only used when
+// |SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR| is defined. It clears the error from the
+// error queue if certificate verification has failed.
+#define SSL_BUILD_CHAIN_FLAG_CLEAR_ERROR 0x10
+
+// SSL_CTX_build_cert_chain builds the certificate chain for |ctx|.
+// Normally this uses the chain store or the verify store if the chain store is
+// not set. If the function is successful, the built chain will replace any
+// existing chain in |ctx|.
+OPENSSL_EXPORT int SSL_CTX_build_cert_chain(SSL_CTX *ctx, int flags);
+
+// SSL_build_cert_chain is similar to |SSL_CTX_build_cert_chain|, but the
+// certificate chain is built for |ssl| instead.
+OPENSSL_EXPORT int SSL_build_cert_chain(SSL *ssl, int flags);
+
 // SSL_CTX_clear_chain_certs clears |ctx|'s certificate chain and returns
 // one.
 OPENSSL_EXPORT int SSL_CTX_clear_chain_certs(SSL_CTX *ctx);
@@ -5628,6 +5662,7 @@ OPENSSL_EXPORT int SSL_CTX_set_tlsext_status_arg(SSL_CTX *ctx, void *arg);
 #define SSL_CTX_add0_chain_cert SSL_CTX_add0_chain_cert
 #define SSL_CTX_add1_chain_cert SSL_CTX_add1_chain_cert
 #define SSL_CTX_add_extra_chain_cert SSL_CTX_add_extra_chain_cert
+#define SSL_CTX_build_cert_chain SSL_CTX_build_cert_chain
 #define SSL_CTX_clear_extra_chain_certs SSL_CTX_clear_extra_chain_certs
 #define SSL_CTX_clear_chain_certs SSL_CTX_clear_chain_certs
 #define SSL_CTX_clear_mode SSL_CTX_clear_mode
@@ -5666,6 +5701,7 @@ OPENSSL_EXPORT int SSL_CTX_set_tlsext_status_arg(SSL_CTX *ctx, void *arg);
 #define SSL_CTX_set_tmp_rsa SSL_CTX_set_tmp_rsa
 #define SSL_add0_chain_cert SSL_add0_chain_cert
 #define SSL_add1_chain_cert SSL_add1_chain_cert
+#define SSL_build_cert_chain SSL_build_cert_chain
 #define SSL_clear_chain_certs SSL_clear_chain_certs
 #define SSL_clear_mode SSL_clear_mode
 #define SSL_clear_options SSL_clear_options

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -985,14 +985,18 @@ OPENSSL_EXPORT int SSL_add1_chain_cert(SSL *ssl, X509 *x509);
 // |SSL_build_cert_chain|.
 
 // SSL_BUILD_CHAIN_FLAG_UNTRUSTED treats any existing certificates as untrusted
-// CAs.
+// CAs. This is mutually exclusive to |SSL_BUILD_CHAIN_FLAG_CHECK| and
+// |SSL_BUILD_CHAIN_FLAG_CHECK| will be prioritized to use the existing chain
+// certificates instead.
 #define SSL_BUILD_CHAIN_FLAG_UNTRUSTED 0x1
 
 // SSL_BUILD_CHAIN_FLAG_NO_ROOT omits the root CA from the built chain.
 #define SSL_BUILD_CHAIN_FLAG_NO_ROOT 0x2
 
 // SSL_BUILD_CHAIN_FLAG_CHECK uses only existing chain certificates to build the
-// chain (effectively sanity checking and rearranging them if necessary).
+// chain (effectively sanity checking and rearranging them if necessary). This
+// is mutually exclusive to |SSL_BUILD_CHAIN_FLAG_UNTRUSTED| and
+// |SSL_BUILD_CHAIN_FLAG_CHECK| will be prioritized.
 #define SSL_BUILD_CHAIN_FLAG_CHECK 0x4
 
 // SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR ignores errors during certificate
@@ -1008,6 +1012,11 @@ OPENSSL_EXPORT int SSL_add1_chain_cert(SSL *ssl, X509 *x509);
 // Normally this uses the chain store or the verify store if the chain store is
 // not set. If the function is successful, the built chain will replace any
 // existing chain in |ctx|.
+// This function returns 1 on success and -1 on failure, unless
+// |SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR| is set. If
+// |SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR| is set, then this function returns 1 on
+// success, 2 if certificate verification has failed, and -1 on all other types
+// of failures.
 OPENSSL_EXPORT int SSL_CTX_build_cert_chain(SSL_CTX *ctx, int flags);
 
 // SSL_build_cert_chain is similar to |SSL_CTX_build_cert_chain|, but the

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -1020,7 +1020,7 @@ static int ssl_build_cert_chain(CERT *cert, X509_STORE *cert_store, int flags) {
         return 0;
       }
     }
-    // Add EE cert too: it might be self signed.
+    // Add end-entity certificate too: it might be self-signed.
     if (!X509_STORE_add_cert(store.get(), leaf.get())) {
       return 0;
     }

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -984,6 +984,7 @@ int SSL_add1_chain_cert(SSL *ssl, X509 *x509) {
 #define is_flag_set(flags, query) (flags & query)
 
 static int ssl_build_cert_chain(CERT *cert, X509_STORE *cert_store, int flags) {
+  assert(cert_store);
   if (!ssl_cert_check_cert_private_keys_usage(cert)) {
     return 0;
   }

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -981,6 +981,133 @@ int SSL_add1_chain_cert(SSL *ssl, X509 *x509) {
   return ssl_cert_add1_chain_cert(ssl->config->cert.get(), x509);
 }
 
+#define is_flag_set(flags, query) (flags & query)
+
+static int ssl_build_cert_chain(CERT *cert, X509_STORE *cert_store, int flags) {
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
+    return 0;
+  }
+
+  CERT_PKEY *cert_pkey = &cert->cert_private_keys[cert->cert_private_key_idx];
+  CRYPTO_BUFFER *leaf_buffer =
+      sk_CRYPTO_BUFFER_value(cert_pkey->chain.get(), 0);
+  if (leaf_buffer == nullptr) {
+    OPENSSL_PUT_ERROR(SSL, SSL_R_NO_CERTIFICATE_SET);
+    return 0;
+  }
+  UniquePtr<X509> leaf(X509_parse_from_buffer(leaf_buffer));
+  if (leaf == nullptr) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_X509_LIB);
+    return 0;
+  }
+
+  UniquePtr<X509_STORE> store(X509_STORE_new());
+  UniquePtr<X509_STORE_CTX> store_ctx(X509_STORE_CTX_new());
+  if (store == nullptr || store_ctx == nullptr) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_MALLOC_FAILURE);
+    return 0;
+  }
+
+  // Rearranging and check the chain: add everything to a store
+  UniquePtr<STACK_OF(X509)> untrusted(sk_X509_new_null());
+  if (is_flag_set(flags, SSL_BUILD_CHAIN_FLAG_CHECK)) {
+    // Push certs onto |X509_STORE|.
+    for (size_t i = 1; i < sk_CRYPTO_BUFFER_num(cert_pkey->chain.get()); i++) {
+      CRYPTO_BUFFER *buffer = sk_CRYPTO_BUFFER_value(cert_pkey->chain.get(), i);
+      UniquePtr<X509> x509(X509_parse_from_buffer(buffer));
+      if (!x509 || !X509_STORE_add_cert(store.get(), x509.get())) {
+        return 0;
+      }
+    }
+    // Add EE cert too: it might be self signed.
+    if (!X509_STORE_add_cert(store.get(), leaf.get())) {
+      return 0;
+    }
+  } else {
+    // Use associated |cert_store| from |SSL_CTX|. Reference count added to
+    // avoid double freeing of |X509_STORE|.
+    store.reset(cert_store);
+    X509_STORE_up_ref(cert_store);
+
+    if (is_flag_set(flags, SSL_BUILD_CHAIN_FLAG_UNTRUSTED)) {
+      // Push certs onto untrusted stack.
+      for (size_t i = 1; i < sk_CRYPTO_BUFFER_num(cert_pkey->chain.get());
+           i++) {
+        CRYPTO_BUFFER *buffer =
+            sk_CRYPTO_BUFFER_value(cert_pkey->chain.get(), i);
+        UniquePtr<X509> x509(X509_parse_from_buffer(buffer));
+        if (!x509 || !PushToStack(untrusted.get(), std::move(x509))) {
+          return 0;
+        }
+      }
+    }
+  }
+
+  if (!X509_STORE_CTX_init(store_ctx.get(), store.get(), leaf.get(),
+                           untrusted.get())) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_X509_LIB);
+    return 0;
+  }
+
+  bool ignore_error = false;
+  if (X509_verify_cert(store_ctx.get()) <= 0) {
+    // Fail if |SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR| is not set.
+    if(!is_flag_set(flags, SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR)) {
+      OPENSSL_PUT_ERROR(SSL, SSL_R_CERTIFICATE_VERIFY_FAILED);
+      ERR_add_error_data(2, "Verify error:",
+                         X509_verify_cert_error_string(
+                             X509_STORE_CTX_get_error(store_ctx.get())));
+      return 0;
+    }
+
+    if (is_flag_set(flags, SSL_BUILD_CHAIN_FLAG_CLEAR_ERROR)) {
+      ERR_clear_error();
+    }
+    ignore_error = true;
+  }
+
+  UniquePtr<STACK_OF(X509)> built_chain(
+      X509_STORE_CTX_get1_chain(store_ctx.get()));
+  // Remove EE certificate from chain.
+  X509_free(sk_X509_shift(built_chain.get()));
+
+  if (is_flag_set(flags, SSL_BUILD_CHAIN_FLAG_NO_ROOT)) {
+    if (sk_X509_num(built_chain.get()) > 0) {
+      // See if last cert is self-signed.
+      if (X509_get_extension_flags(sk_X509_value(
+              built_chain.get(), sk_X509_num(built_chain.get()) - 1)) &
+          EXFLAG_SS) {
+        X509_free(sk_X509_pop(built_chain.get()));
+      }
+    }
+  }
+  if (!ssl_cert_set_chain(cert, built_chain.get())) {
+    return 0;
+  }
+
+  // Anything that has passed successfully up to here is valid.
+  // 2 is used to indicate a verification error has happened, but was ignored
+  // because |SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR| was set.
+  if(ignore_error) {
+    return 2;
+  }
+  return 1;
+}
+
+int SSL_CTX_build_cert_chain(SSL_CTX *ctx, int flags) {
+  check_ssl_ctx_x509_method(ctx);
+  return ssl_build_cert_chain(ctx->cert.get(), ctx->cert_store, flags);
+}
+
+int SSL_build_cert_chain(SSL *ssl, int flags) {
+  check_ssl_x509_method(ssl);
+  if (!ssl->config) {
+    return 0;
+  }
+  return ssl_build_cert_chain(ssl->config->cert.get(), ssl->ctx->cert_store,
+                              flags);
+}
+
 int SSL_CTX_clear_chain_certs(SSL_CTX *ctx) {
   check_ssl_ctx_x509_method(ctx);
   return SSL_CTX_set0_chain(ctx, NULL);


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2087`

### Description of changes: 
This is a reimport of the code that was removed in https://github.com/google/boringssl/commit/b2a9d6ab788dffdfd804d8be231634d1ab470873.
Some of the function documentation was taken from OpenSSL's: https://www.openssl.org/docs/man3.1/man3/SSL_CTX_build_cert_chain.html
This change ties into some of the code changes for multiple certificate work that we had done recently. The code looks slightly different from the original due to the C->C++ translation and rearrangements for cleaner logic. 

### Call-outs:
N/A

### Testing:
Tests for the new build flags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
