### PR TITLE
Add a FFDH benchmark to demonstrate how slow it is

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1642,7 +1642,7 @@ static bool SpeedFFDHGroup(const std::string &name, int nid,
     return true;
   }
 
-  bssl::UniquePtr<DH> server_dh(DH_new_by_nid(nid));
+  BM_NAMESPACE::UniquePtr<DH> server_dh(DH_new_by_nid(nid));
   if(!DH_generate_key(server_dh.get())) {
     return false;
   }
@@ -1653,7 +1653,7 @@ static bool SpeedFFDHGroup(const std::string &name, int nid,
 
   TimeResults results;
   if (!TimeFunction(&results, [&shared_secret, &server_pub, &dh_size, &nid]() -> bool {
-        bssl::UniquePtr<DH> client_dh(DH_new_by_nid(nid));
+        BM_NAMESPACE::UniquePtr<DH> client_dh(DH_new_by_nid(nid));
         return DH_generate_key(client_dh.get()) &&
                dh_size == DH_compute_key_padded(shared_secret.get(), server_pub, client_dh.get());
       })) {

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1633,6 +1633,9 @@ static bool SpeedECMUL(const std::string &selected) {
          SpeedECMULCurve("ECMUL secp256k1", NID_secp256k1, selected);
 }
 
+#endif // !defined(OPENSSL_1_0_BENCHMARK)
+
+#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK)) || AWSLC_API_VERSION >= 22
 static bool SpeedFFDHGroup(const std::string &name, int nid,
                            const std::string &selected) {
   if (!selected.empty() && name.find(selected) == std::string::npos) {
@@ -1665,7 +1668,7 @@ static bool SpeedFFDH(const std::string &selected) {
   return SpeedFFDHGroup("FFDH 2048", NID_ffdhe2048, selected) &&
          SpeedFFDHGroup("FFDH 4096", NID_ffdhe4096, selected);
 }
-#endif // OPENSSL_1_0_BENCHMARK
+#endif //(!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK)) || AWSLC_API_VERSION >= 22
 
 #if !defined(OPENSSL_BENCHMARK)
 static bool Speed25519(const std::string &selected) {
@@ -2621,7 +2624,9 @@ bool Speed(const std::vector<std::string> &args) {
        !SpeedECMUL(selected) ||
        // OpenSSL 1.0 doesn't support Scrypt
        !SpeedScrypt(selected) ||
-       // OpenSSL 1.0 doesn't support DH_new_by_nid, NID_ffdhe2048, or NID_ffdhe4096
+#endif
+#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK)) || AWSLC_API_VERSION >= 22
+       // OpenSSL 1.0 and BoringSSL don't support DH_new_by_nid, NID_ffdhe2048, or NID_ffdhe4096
        !SpeedFFDH(selected) ||
 #endif
        !SpeedRSA(selected) ||

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1642,13 +1642,13 @@ static bool SpeedFFDHGroup(const std::string &name, int nid,
     return true;
   }
 
-  bssl::UniquePtr<DH> sever_dh(DH_new_by_nid(nid));
-  if(!DH_generate_key(sever_dh.get())) {
+  bssl::UniquePtr<DH> server_dh(DH_new_by_nid(nid));
+  if(!DH_generate_key(server_dh.get())) {
     return false;
   }
-  const BIGNUM *server_pub = DH_get0_pub_key(sever_dh.get());
+  const BIGNUM *server_pub = DH_get0_pub_key(server_dh.get());
 
-  int dh_size = DH_size(sever_dh.get());
+  int dh_size = DH_size(server_dh.get());
   std::unique_ptr<uint8_t[]> shared_secret(new uint8_t[dh_size]);
 
   TimeResults results;

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1289,35 +1289,6 @@ static bool SpeedECDHCurve(const std::string &name, int nid,
   return true;
 }
 
-static bool SpeedFFDHGroup(const std::string &name, int nid,
-                           const std::string &selected) {
-  if (!selected.empty() && name.find(selected) == std::string::npos) {
-    return true;
-  }
-
-  bssl::UniquePtr<DH> sever_dh(DH_new_by_nid(nid));
-  if(!DH_generate_key(sever_dh.get())) {
-        return false;
-  }
-  const BIGNUM *sever_pub = DH_get0_pub_key(sever_dh.get());
-
-  int dh_size = DH_size(sever_dh.get());
-  std::unique_ptr<uint8_t[]> shared_secret(new uint8_t[dh_size]);
-
-  TimeResults results;
-  if (!TimeFunction(&results, [&shared_secret, &sever_pub, &dh_size, &nid]() -> bool {
-        bssl::UniquePtr<DH> client_dh(DH_new_by_nid(nid));
-        return DH_generate_key(client_dh.get()) &&
-               dh_size == DH_compute_key_padded(shared_secret.get(), sever_pub, client_dh.get());
-      })) {
-    return false;
-  }
-
-  results.Print(name);
-  return true;
-}
-
-
 
 static bool SpeedECKeyGenerateKey(bool is_fips, const std::string &name,
                                       int nid, const std::string &selected) {
@@ -1442,11 +1413,6 @@ static bool SpeedECDH(const std::string &selected) {
          SpeedECDHCurve("ECDH P-384", NID_secp384r1, selected) &&
          SpeedECDHCurve("ECDH P-521", NID_secp521r1, selected) &&
          SpeedECDHCurve("ECDH secp256k1", NID_secp256k1, selected);
-}
-
-static bool SpeedFFDH(const std::string &selected) {
-  return SpeedFFDHGroup("FFDH 2048", NID_ffdhe2048, selected) &&
-         SpeedFFDHGroup("FFDH 4096", NID_ffdhe4096, selected);
 }
 
 static bool SpeedECKeyGen(const std::string &selected) {
@@ -1666,7 +1632,40 @@ static bool SpeedECMUL(const std::string &selected) {
          SpeedECMULCurve("ECMUL P-521", NID_secp521r1, selected) &&
          SpeedECMULCurve("ECMUL secp256k1", NID_secp256k1, selected);
 }
-#endif
+
+static bool SpeedFFDHGroup(const std::string &name, int nid,
+                           const std::string &selected) {
+  if (!selected.empty() && name.find(selected) == std::string::npos) {
+    return true;
+  }
+
+  bssl::UniquePtr<DH> sever_dh(DH_new_by_nid(nid));
+  if(!DH_generate_key(sever_dh.get())) {
+    return false;
+  }
+  const BIGNUM *server_pub = DH_get0_pub_key(sever_dh.get());
+
+  int dh_size = DH_size(sever_dh.get());
+  std::unique_ptr<uint8_t[]> shared_secret(new uint8_t[dh_size]);
+
+  TimeResults results;
+  if (!TimeFunction(&results, [&shared_secret, &server_pub, &dh_size, &nid]() -> bool {
+        bssl::UniquePtr<DH> client_dh(DH_new_by_nid(nid));
+        return DH_generate_key(client_dh.get()) &&
+               dh_size == DH_compute_key_padded(shared_secret.get(), server_pub, client_dh.get());
+      })) {
+    return false;
+  }
+
+  results.Print(name);
+  return true;
+}
+
+static bool SpeedFFDH(const std::string &selected) {
+  return SpeedFFDHGroup("FFDH 2048", NID_ffdhe2048, selected) &&
+         SpeedFFDHGroup("FFDH 4096", NID_ffdhe4096, selected);
+}
+#endif // OPENSSL_1_0_BENCHMARK
 
 #if !defined(OPENSSL_BENCHMARK)
 static bool Speed25519(const std::string &selected) {
@@ -2611,7 +2610,6 @@ bool Speed(const std::vector<std::string> &args) {
        !SpeedHmacOneShot(EVP_sha384(), "HMAC-SHA384-OneShot", selected) ||
        !SpeedHmacOneShot(EVP_sha512(), "HMAC-SHA512-OneShot", selected) ||
        !SpeedRandom(selected) ||
-       !SpeedFFDH(selected) ||
        !SpeedECDH(selected) ||
        !SpeedECDSA(selected) ||
        !SpeedECKeyGen(selected) ||
@@ -2623,6 +2621,8 @@ bool Speed(const std::vector<std::string> &args) {
        !SpeedECMUL(selected) ||
        // OpenSSL 1.0 doesn't support Scrypt
        !SpeedScrypt(selected) ||
+       // OpenSSL 1.0 doesn't support DH_new_by_nid, NID_ffdhe2048, or NID_ffdhe4096
+       !SpeedFFDH(selected) ||
 #endif
        !SpeedRSA(selected) ||
        !SpeedRSAKeyGen(false, selected) ||


### PR DESCRIPTION
### Description of changes: 
This FFDH benchmark is based on the ECDH benchmark: the timed code includes one key generation and the shared secret calculation.

### Testing:
Ran locally on an M1 mac:
```
./tool/bssl speed -filter FFDH
Did 221 FFDH 2048 operations in 1069156us (206.7 ops/sec)
Did 30 FFDH 4096 operations in 1036635us (28.9 ops/sec)

./tool/bssl speed -filter ECDH
Did 21550 ECDH P-224 operations in 1015522us (21220.6 ops/sec)
Did 22000 ECDH P-256 operations in 1035035us (21255.3 ops/sec)
Did 5313 ECDH P-384 operations in 1055558us (5033.4 ops/sec)
Did 3674 ECDH P-521 operations in 1038192us (3538.8 ops/sec)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
