### PR TITLE
Remove a few lingering references to Rust bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,6 @@ ssl/test/runner/runner
 *.swo
 doc/*.html
 doc/doc.css
-bindings/rust/tmp/*
-bindings/rust/generate/target
-!bindings/rust/aws-lc-sys-template/build
-!bindings/rust/aws-lc-fips-sys-template/build
 
 util/bot/android_ndk
 util/bot/android_sdk/public

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -266,11 +266,6 @@ else()
   file(COPY ${GENERATE_CODE_ROOT}/err_data.c DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 endif()
 
-set(CRYPTO_RUST_SOURCES )
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/rust_wrapper.c)
-  list(APPEND CRYPTO_RUST_SOURCES rust_wrapper.c)
-endif()
-
 set(DILITHIUM_SOURCES)
 if(ENABLE_DILITHIUM)
   set(
@@ -526,7 +521,6 @@ add_library(
   decrepit/ripemd/ripemd.c
   decrepit/rsa/rsa_decrepit.c
   decrepit/x509/x509_decrepit.c
-  ${CRYPTO_RUST_SOURCES}
 
   ${CRYPTO_ARCH_SOURCES}
 )

--- a/tests/check_licenses.go
+++ b/tests/check_licenses.go
@@ -34,7 +34,6 @@ func main() {
 		"ssl",
 		"util",
 		"sources.cmake",
-		"rust/wrapper.h",
 	}
 
 	// Collect all non-excluded source files into |files|

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -41,7 +41,7 @@ would look like this:
 $ docker build -t ubuntu-18.04:base -f tests/ci/docker_images/linux-x86/ubuntu-18.04_base/Dockerfile tests/ci/docker_images/dependencies
 ```
 For more examples, see `build_images.sh` script in directories corresponding
-to different platforms (linux-x86, linux-aarch, windows, rust).
+to different platforms (linux-x86, linux-aarch, windows).
 
 ### Issues with proxy.golang.org when running images locally
 


### PR DESCRIPTION
### Issues:
N/Q

### Description of changes: 
* Rust bindings were removed from this repo in https://github.com/aws/aws-lc/pull/850.  This PR removes a few lingering references to that code.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
