### PR TITLE
Handle x30 target register in delocator for aarch64 to avoid clobbering the register

### DIFF
--- a/crypto/fipsmodule/ec/p224-64.c
+++ b/crypto/fipsmodule/ec/p224-64.c
@@ -178,10 +178,6 @@ static const p224_felem g_p224_pre_comp[2][16][3] = {
 
 // Helper functions to convert field elements to/from internal representation
 
-#if defined(AWSLC_FIPS)
-// Related to delocate issue with gcc-11
-__attribute__((noinline))
-#endif
 static void p224_generic_to_felem(p224_felem out, const EC_FELEM *in) {
   // |p224_felem|'s minimal representation uses four 56-bit words. |EC_FELEM|
   // uses four 64-bit words. (The top-most word only has 32 bits.)

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -451,6 +451,15 @@ func (d *delocation) loadAarch64Address(statement *node32, targetReg string, sym
 		// If the target happens to be x0 then restore the link register from the
 		// stack and send the saved value of x0 to the zero register.
 		d.output.WriteString("\tldp xzr, lr, [sp], #16\n")
+	} else if targetReg == "x30" {
+		// If the target is x30, restore x0 only because the lr (just an alias
+		// name for x30) register is used as a general-purpose register.
+		// We assume that if the target register is x30 then the routine handles
+		// returning the correct return address to x30 before the routine
+		// returns. One case requiring handling x30 is gcc 11.4 that emitted:
+		//   adrp x30, :got:__stack_chk_guard
+		d.output.WriteString("\tmov " + targetReg + ", x0\n")
+		d.output.WriteString("\tldp x0, xzr, [sp], #16\n")
 	} else {
 		// Otherwise move the result into place and restore registers.
 		d.output.WriteString("\tmov " + targetReg + ", x0\n")

--- a/util/fipstools/delocate/testdata/aarch64-Basic/in.s
+++ b/util/fipstools/delocate/testdata/aarch64-Basic/in.s
@@ -29,6 +29,10 @@ foo:
 	adrp x1, OPENSSL_armcap_P
 	ldr w2, [x1, :lo12:OPENSSL_armcap_P]
 
+	// armcap to x30
+	adrp x30, OPENSSL_armcap_P
+	ldr w2, [x30, :lo12:OPENSSL_armcap_P]
+
 	// armcap to w0
 	adrp x0, OPENSSL_armcap_P
 	ldr w1, [x1, :lo12:OPENSSL_armcap_P]

--- a/util/fipstools/delocate/testdata/aarch64-Basic/out.s
+++ b/util/fipstools/delocate/testdata/aarch64-Basic/out.s
@@ -64,6 +64,17 @@ foo:
 // WAS ldr w2, [x1, :lo12:OPENSSL_armcap_P]
 	ldr	w2, [x1]
 
+	// armcap to x30
+// WAS adrp x30, OPENSSL_armcap_P
+	sub sp, sp, 128
+	stp x0, lr, [sp, #-16]!
+	bl .LOPENSSL_armcap_P_addr
+	mov x30, x0
+	ldp x0, xzr, [sp], #16
+	add sp, sp, 128
+// WAS ldr w2, [x30, :lo12:OPENSSL_armcap_P]
+	ldr	w2, [x30]
+
 	// armcap to w0
 // WAS adrp x0, OPENSSL_armcap_P
 	sub sp, sp, 128


### PR DESCRIPTION
### Description of changes: 

When taking the commit: https://github.com/justsmth/aws-lc/commit/3800f0fcb53c3fc2bb2ffa5bba57de0a67774a5f gcc 11.4 emitted the following in the routine `ec_GFp_nistp224_felem_sqr()`:
```
adrp    x30, :got:__stack_chk_guard
```
This uncovered an unsupported case in the delocater. 

When seeing the line above, the delocater resolved the relocation like this:
```
// WAS adrp    x30, :got:__stack_chk_guard
    sub sp, sp, 128
    stp x0, lr, [sp, #-16]!
    bl .Lboringssl_loadgot___stack_chk_guard
    mov x30, x0
    ldp x0, lr, [sp], #16
    add sp, sp, 128
```
But `x30` is an alias for the aarch64 link register `lr`.  Hence, `mov x30, x0` would clobber `x30` that is used as a general-purpose register in the un-modified routine; the routine pushes the state onto the stack and pops before returning making x30 available for scratch purposes. This caused a false-positive "stack smashing" event in the stack guard detector. The clobbered register `x30` contained the stack guard value that is verified before returning from the routine. When the register got clobbered, the stack guard value got corrupted causing the validation to fail with very high probability.

Fix this by handling `x30` as a special case in the delocater.  If `x30` is a target register, we assume that the routine use `x30` as a (volatile) general-purpose register and will recover the link register value, using an appropriate method, before returning. This is really similar to how the `x0` case is handled since x0 holds the return value from the subroutine and is not to be overwritten by the value saved on the stack..

### Testing:

Added a test case in the delocater tests:
```
$ pwd
/[...]/aws-lc/util/fipstools/delocate

$ go test
PASS
ok      boringssl.googlesource.com/boringssl/util/fipstools/delocate    0.010s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
