### PR TITLE
Add BIGNUM support for big-endian architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,7 +701,7 @@ endif()
 
 TEST_BIG_ENDIAN(BIG_ENDIAN)
 if(BIG_ENDIAN)
-  message(FATAL_ERROR "Big Endian is not supported.")
+  message(STATUS "Continuing with experimental support on big endian platform")
 endif()
 
 if(OPENSSL_NO_SSE2_FOR_TESTING)
@@ -741,7 +741,7 @@ elseif (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "riscv64")
 elseif (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "loongarch64")
   set(ARCH "loongarch64")
 else()
-  message(STATUS "Unknown processor found. Using generic implementations. Processor:" ${CMAKE_SYSTEM_PROCESSOR})
+  message(STATUS "Unknown processor found. Using generic implementations. Processor: " ${CMAKE_SYSTEM_PROCESSOR})
   set(ARCH "generic")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,9 +701,11 @@ endif()
 
 TEST_BIG_ENDIAN(BIG_ENDIAN)
 if(BIG_ENDIAN)
-  message(FATAL_ERROR "Big Endian is not supported.")
-# TODO: Enable BIG_ENDIAN once we have better support
-#  message(STATUS "Continuing with experimental support on big endian platform")
+  if(ENABLE_EXPERIMENTAL_BIG_ENDIAN_SUPPORT)
+    message(STATUS "Continuing with experimental support on big endian platform")
+  else()
+    message(FATAL_ERROR "Big Endian is not supported.")
+  endif()
 endif()
 
 if(OPENSSL_NO_SSE2_FOR_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,7 +701,9 @@ endif()
 
 TEST_BIG_ENDIAN(BIG_ENDIAN)
 if(BIG_ENDIAN)
-  message(STATUS "Continuing with experimental support on big endian platform")
+  message(FATAL_ERROR "Big Endian is not supported.")
+# TODO: Enable BIG_ENDIAN once we have better support
+#  message(STATUS "Continuing with experimental support on big endian platform")
 endif()
 
 if(OPENSSL_NO_SSE2_FOR_TESTING)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -717,6 +717,7 @@ if(BUILD_TESTING)
     digest_extra/digest_test.cc
     dilithium/p_dilithium_test.cc
     dsa/dsa_test.cc
+    endian_test.cc
     err/err_test.cc
     evp_extra/evp_extra_test.cc
     evp_extra/evp_test.cc

--- a/crypto/bytestring/cbs.c
+++ b/crypto/bytestring/cbs.c
@@ -521,8 +521,18 @@ int CBS_get_asn1_int64(CBS *cbs, int64_t *out) {
   uint8_t sign_extend[sizeof(int64_t)];
   memset(sign_extend, is_negative ? 0xff : 0, sizeof(sign_extend));
   for (size_t i = 0; i < len; i++) {
+#ifdef OPENSSL_BIG_ENDIAN
+    // sign_extend[sizeof(int64_t) - 0 - 1] = data[0];
+    // sign_extend[8 - 0 - 1] = data[0];
+    // sign_extend[7] = data[0];
+    sign_extend[sizeof(sign_extend) - i - 1] = data[len - i - 1];
+#else
+    // sign_extend[0] = data[1 - 0 - 1];
+    // sign_extend[0] = data[0];
     sign_extend[i] = data[len - i - 1];
+#endif
   }
+
   memcpy(out, sign_extend, sizeof(sign_extend));
   return 1;
 }

--- a/crypto/bytestring/cbs.c
+++ b/crypto/bytestring/cbs.c
@@ -521,14 +521,13 @@ int CBS_get_asn1_int64(CBS *cbs, int64_t *out) {
   uint8_t sign_extend[sizeof(int64_t)];
   memset(sign_extend, is_negative ? 0xff : 0, sizeof(sign_extend));
   for (size_t i = 0; i < len; i++) {
+// `data` is big-endian.
+// Values are always shifted toward the "little" end.
 #ifdef OPENSSL_BIG_ENDIAN
-    // sign_extend[sizeof(int64_t) - 0 - 1] = data[0];
-    // sign_extend[8 - 0 - 1] = data[0];
-    // sign_extend[7] = data[0];
+    // Bytes are written starting at the highest index.
     sign_extend[sizeof(sign_extend) - i - 1] = data[len - i - 1];
 #else
-    // sign_extend[0] = data[1 - 0 - 1];
-    // sign_extend[0] = data[0];
+    // Bytes are written starting at the lowest index.
     sign_extend[i] = data[len - i - 1];
 #endif
   }

--- a/crypto/compiler_test.cc
+++ b/crypto/compiler_test.cc
@@ -41,10 +41,13 @@ static void CheckRepresentation(T value) {
   UnsignedT value_u = static_cast<UnsignedT>(value);
   EXPECT_EQ(sizeof(UnsignedT), sizeof(T));
 
-  // Integers must be little-endian.
   uint8_t expected[sizeof(UnsignedT)];
   for (size_t i = 0; i < sizeof(UnsignedT); i++) {
+#ifdef OPENSSL_BIG_ENDIAN
+    expected[sizeof(UnsignedT) - i - 1] = static_cast<uint8_t>(value_u);
+#else
     expected[i] = static_cast<uint8_t>(value_u);
+#endif
     // Divide instead of right-shift to appease compilers that warn if |T| is a
     // char. The explicit cast is also needed to appease MSVC if integer
     // promotion happened.

--- a/crypto/digest_extra/digest_test.cc
+++ b/crypto/digest_extra/digest_test.cc
@@ -242,6 +242,7 @@ static void CompareDigest(const DigestTestVector *test,
 }
 
 static void TestDigest(const DigestTestVector *test) {
+    SCOPED_TRACE(test->md.name);
     bssl::ScopedEVP_MD_CTX ctx;
     // Test the input provided.
     ASSERT_TRUE(EVP_DigestInit_ex(ctx.get(), test->md.func(), nullptr));

--- a/crypto/endian_test.cc
+++ b/crypto/endian_test.cc
@@ -53,8 +53,6 @@ uint8_t expected_le[4] = {0x78, 0x56, 0x34, 0x12};
 
 TEST(EndianTest, TestRotate32) {
   uint32_t value = 0b00000010000000000000000000000;
-  // 0x12345678  = 0b10010001101000101011001111000
-  // Rotate 4    = 0b00110100010101100111100010010
   uint32_t expected = 0b00100000000000000000000000000;
 
   uint32_t rotl_by = 4;
@@ -208,8 +206,8 @@ TEST(EndianTest, BN_bn2bin_padded) {
   EXPECT_EQ(1, BN_bn2bin_padded(out, sizeof(out), x.get()));
   EXPECT_EQ(Bytes(input), Bytes(out));
 }
-#define round_key_size  4 * (AES_MAXNR + 1)
-TEST(EndianTest, AES_disabled) {
+
+TEST(EndianTest, AES) {
   // Initialize the key and message buffers with zeros
   uint8_t key[AES_BLOCK_SIZE] = {0};
   key[0] = 0xaa;
@@ -224,7 +222,6 @@ TEST(EndianTest, AES_disabled) {
   // Create an AES_KEY struct
   AES_KEY aes_key = {{0}, 0};
   ASSERT_EQ(0, AES_set_encrypt_key(key, 128, &aes_key));
-  ASSERT_EQ((unsigned)10, aes_key.rounds);
 
   AES_encrypt(message, encrypted_message, &aes_key);
 

--- a/crypto/endian_test.cc
+++ b/crypto/endian_test.cc
@@ -1,0 +1,253 @@
+#include <gtest/gtest.h>
+#include "internal.h"
+#include "openssl/aes.h"
+#include "openssl/bn.h"
+#include "test/test_util.h"
+
+
+TEST(EndianTest, u32Operations) {
+  uint8_t buffer[4];
+  uint32_t val = 0x12345678;
+  uint8_t expected_be[4] = {0x12, 0x34, 0x56, 0x78};
+  uint8_t expected_le[4] = {0x78, 0x56, 0x34, 0x12};
+
+
+  CRYPTO_store_u32_le(buffer, val);
+  EXPECT_EQ(Bytes(expected_le), Bytes(buffer));
+  EXPECT_EQ(val, CRYPTO_load_u32_le(buffer));
+
+  CRYPTO_store_u32_be(buffer, val);
+  EXPECT_EQ(Bytes(expected_be), Bytes(buffer));
+  EXPECT_EQ(val, CRYPTO_load_u32_be(buffer));
+}
+
+TEST(EndianTest, u64Operations) {
+  uint8_t buffer[8];
+  uint64_t val = 0x123456789abcdef0;
+  uint8_t expected_be[8] = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0};
+  uint8_t expected_le[8] = {0xf0, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12};
+
+  CRYPTO_store_u64_le(buffer, val);
+  EXPECT_EQ(Bytes(expected_le), Bytes(buffer));
+  EXPECT_EQ(val, CRYPTO_load_u64_le(buffer));
+
+  CRYPTO_store_u64_be(buffer, val);
+  EXPECT_EQ(Bytes(expected_be), Bytes(buffer));
+  EXPECT_EQ(val, CRYPTO_load_u64_be(buffer));
+}
+
+TEST(EndianTest, wordOperations) {
+  uint8_t buffer[sizeof(crypto_word_t)];
+#if defined(OPENSSL_64_BIT)
+  size_t val = 0x123456789abcdef0;
+  uint8_t expected_le[8] = {0xf0, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12};
+#else
+size_t val = 0x12345678;
+uint8_t expected_le[4] = {0x78, 0x56, 0x34, 0x12};
+#endif
+
+  CRYPTO_store_word_le(buffer, val);
+  EXPECT_EQ(Bytes(expected_le), Bytes(buffer));
+  EXPECT_EQ(val, CRYPTO_load_word_le(buffer));
+}
+
+TEST(EndianTest, TestRotate32) {
+  uint32_t value = 0b00000010000000000000000000000;
+  // 0x12345678  = 0b10010001101000101011001111000
+  // Rotate 4    = 0b00110100010101100111100010010
+  uint32_t expected = 0b00100000000000000000000000000;
+
+  uint32_t rotl_by = 4;
+  uint32_t rotr_by = 32 - rotl_by;
+
+  uint32_t rotl_value = CRYPTO_rotl_u32(value, rotl_by);
+  uint32_t rotr_value = CRYPTO_rotr_u32(value, rotr_by);
+
+  ASSERT_EQ(rotl_value, rotr_value);
+  EXPECT_EQ(expected, rotl_value);
+  ASSERT_EQ(CRYPTO_rotr_u32(rotl_value, rotl_by), value);
+}
+
+TEST(EndianTest, TestRotate64) {
+  uint64_t value = 0b0000001000000000000000000000000000010000000000000000000000;
+  uint64_t expected = 0b0010000000000000000000000000000100000000000000000000000000;
+
+  uint64_t rotl_by = 4;
+  uint64_t rotr_by = 64 - rotl_by;
+
+  uint64_t rotl_value = CRYPTO_rotl_u64(value, rotl_by);
+  uint64_t rotr_value = CRYPTO_rotr_u64(value, rotr_by);
+
+  ASSERT_EQ(rotl_value, rotr_value);
+  EXPECT_EQ(expected, rotl_value);
+  ASSERT_EQ(CRYPTO_rotr_u64(rotl_value, rotl_by), value);
+}
+
+union test_union {
+  uint16_t big[2];
+  uint8_t small[4];
+};
+
+struct test_struct {
+  test_union union_val;
+};
+
+TEST(EndianTest, TestStructUnion) {
+  struct test_struct val = {{{0}}};
+  val.union_val.big[0] = 0x1234;
+  val.union_val.big[1] = 0x5678;
+
+
+#if defined(OPENSSL_BIG_ENDIAN)
+  ASSERT_EQ(val.union_val.small[0], 0x12);
+  ASSERT_EQ(val.union_val.small[1], 0x34);
+  ASSERT_EQ(val.union_val.small[2], 0x56);
+  ASSERT_EQ(val.union_val.small[3], 0x78);
+#else
+  ASSERT_EQ(val.union_val.small[0], 0x34);
+  ASSERT_EQ(val.union_val.small[1], 0x12);
+  ASSERT_EQ(val.union_val.small[2], 0x78);
+  ASSERT_EQ(val.union_val.small[3], 0x56);
+#endif
+}
+
+// Shift left is increasing value/significance
+// shift right decreases value/drops values
+TEST(EndianTest, Shifting) {
+  uint32_t test = 0b1010000000010001;
+  ASSERT_EQ(test << 4, (uint32_t)0b10100000000100010000);
+  ASSERT_EQ(test >> 4, (uint32_t)0b101000000001);
+}
+
+TEST(EndianTest, Swap) {
+  EXPECT_EQ(0x3412, CRYPTO_bswap2(0x1234));
+  EXPECT_EQ((uint32_t)0x78563412, CRYPTO_bswap4(0x12345678));
+  EXPECT_EQ(0xf0debc9a78563412, CRYPTO_bswap8(0x123456789abcdef0));
+}
+
+TEST(EndianTest, BN_bin2bn) {
+  bssl::UniquePtr<BIGNUM> x(BN_new());
+  uint8_t input[256];
+  OPENSSL_memset(input, 0, sizeof(input));
+  input[0] = 0xaa;
+  input[1] = 0x01;
+  input[254] = 0x01;
+  input[255] = 0x02;
+  ASSERT_NE(nullptr, BN_bin2bn(input, sizeof(input), x.get()));
+  EXPECT_FALSE(BN_is_zero(x.get()));
+  for (int i = 1; i < (256*8/BN_BITS2) - 1; i++) {
+    SCOPED_TRACE(i);
+    EXPECT_EQ((uint64_t)0, x.get()->d[i]);
+  }
+  EXPECT_EQ((uint64_t)0x0102, x.get()->d[0]);
+  EXPECT_EQ((uint64_t)0xaa01 << (BN_BITS2-16), x.get()->d[(256*8/BN_BITS2)-1]);
+}
+
+TEST(EndianTest, BN_le2bn) {
+  bssl::UniquePtr<BIGNUM> x(BN_new());
+  uint8_t input[256];
+  OPENSSL_memset(input, 0, sizeof(input));
+  input[0] = 0xaa;
+  input[1] = 0x01;
+  input[254] = 0x01;
+  input[255] = 0x02;
+  ASSERT_NE(nullptr, BN_le2bn(input, sizeof(input), x.get()));
+  EXPECT_FALSE(BN_is_zero(x.get()));
+  for (int i = 1; i < (256*8/BN_BITS2) - 1; i++) {
+    SCOPED_TRACE(i);
+    EXPECT_EQ((uint64_t)0, x.get()->d[i]);
+  }
+  EXPECT_EQ((uint64_t)0x01aa, x.get()->d[0]);
+  EXPECT_EQ((uint64_t)0x0201 << (BN_BITS2-16), x.get()->d[(256*8/BN_BITS2)-1]);
+}
+
+TEST(EndianTest, BN_bn2bin) {
+  bssl::UniquePtr<BIGNUM> x(BN_new());
+  uint8_t input[256];
+  OPENSSL_memset(input, 0, sizeof(input));
+  input[0] = 0xaa;
+  input[1] = 0x01;
+  input[254] = 0x01;
+  input[255] = 0x02;
+  ASSERT_NE(nullptr, BN_bin2bn(input, sizeof(input), x.get()));
+
+  uint8_t out[256];
+  OPENSSL_memset(out, 0, sizeof(out));
+  EXPECT_EQ((size_t)256, BN_bn2bin(x.get(), out));
+  EXPECT_EQ(Bytes(input), Bytes(out));
+}
+
+TEST(EndianTest, BN_bn2le_padded) {
+  bssl::UniquePtr<BIGNUM> x(BN_new());
+  uint8_t input[256];
+  OPENSSL_memset(input, 0, sizeof(input));
+  input[0] = 0xaa;
+  input[1] = 0x01;
+  input[254] = 0x01;
+  input[255] = 0x02;
+  ASSERT_NE(nullptr, BN_le2bn(input, sizeof(input), x.get()));
+
+  uint8_t out[256];
+  OPENSSL_memset(out, 0, sizeof(out));
+  EXPECT_EQ(1, BN_bn2le_padded(out, sizeof(out), x.get()));
+  EXPECT_EQ(Bytes(input), Bytes(out));
+}
+
+TEST(EndianTest, BN_bn2bin_padded) {
+  bssl::UniquePtr<BIGNUM> x(BN_new());
+  uint8_t input[256];
+  OPENSSL_memset(input, 0, sizeof(input));
+  input[0] = 0xaa;
+  input[1] = 0x01;
+  input[254] = 0x01;
+  input[255] = 0x02;
+  ASSERT_NE(nullptr, BN_bin2bn(input, sizeof(input), x.get()));
+
+  uint8_t out[256];
+  OPENSSL_memset(out, 0, sizeof(out));
+  EXPECT_EQ(1, BN_bn2bin_padded(out, sizeof(out), x.get()));
+  EXPECT_EQ(Bytes(input), Bytes(out));
+}
+#define round_key_size  4 * (AES_MAXNR + 1)
+TEST(EndianTest, AES_disabled) {
+  // Initialize the key and message buffers with zeros
+  uint8_t key[AES_BLOCK_SIZE] = {0};
+  key[0] = 0xaa;
+  key[0] = 0xbb;
+  uint8_t message[AES_BLOCK_SIZE] = {0};
+  message[0] = 0xcc;
+  message[1] = 0xdd;
+
+  // Allocate buffer to store the encrypted message
+  uint8_t encrypted_message[AES_BLOCK_SIZE];
+
+  // Create an AES_KEY struct
+  AES_KEY aes_key = {{0}, 0};
+  ASSERT_EQ(0, AES_set_encrypt_key(key, 128, &aes_key));
+  ASSERT_EQ((unsigned)10, aes_key.rounds);
+
+  AES_encrypt(message, encrypted_message, &aes_key);
+
+  const uint8_t known_value_bytes[AES_BLOCK_SIZE] = {
+      0x15, 0x81, 0x0f, 0xf3, 0x0d, 0x23, 0x08, 0x71, 0x96, 0x05, 0x94, 0x12, 0x14, 0xb7, 0xd6, 0x69
+  };
+  EXPECT_EQ(Bytes(known_value_bytes), Bytes(encrypted_message));
+}
+
+TEST(EndianTest, memcpy) {
+  uint8_t buffer[2] = {0xab, 0xcd};
+  uint16_t out = 0;
+  memcpy(&out, buffer, 2);
+#if defined(OPENSSL_BIG_ENDIAN)
+  EXPECT_EQ(out, 0xabcd);
+#else
+  EXPECT_EQ(out, 0xcdab);
+#endif
+}
+
+TEST(EndianTest, masking) {
+  uint16_t value = 0xabcd;
+  uint16_t mask = 0xf00f;
+  uint16_t result = value & mask;
+  EXPECT_EQ(result, 0xa00d);
+}

--- a/crypto/endian_test.cc
+++ b/crypto/endian_test.cc
@@ -133,7 +133,7 @@ TEST(EndianTest, BN_bin2bn) {
   input[255] = 0x02;
   ASSERT_NE(nullptr, BN_bin2bn(input, sizeof(input), x.get()));
   EXPECT_FALSE(BN_is_zero(x.get()));
-  for (int i = 1; i < (256*8/BN_BITS2) - 1; i++) {
+  for (size_t i = 1; i < (sizeof(input)*8/BN_BITS2) - 1; i++) {
     SCOPED_TRACE(i);
     EXPECT_EQ((uint64_t)0, x.get()->d[i]);
   }
@@ -211,7 +211,7 @@ TEST(EndianTest, AES) {
   // Initialize the key and message buffers with zeros
   uint8_t key[AES_BLOCK_SIZE] = {0};
   key[0] = 0xaa;
-  key[0] = 0xbb;
+  key[1] = 0xbb;
   uint8_t message[AES_BLOCK_SIZE] = {0};
   message[0] = 0xcc;
   message[1] = 0xdd;
@@ -226,7 +226,7 @@ TEST(EndianTest, AES) {
   AES_encrypt(message, encrypted_message, &aes_key);
 
   const uint8_t known_value_bytes[AES_BLOCK_SIZE] = {
-      0x15, 0x81, 0x0f, 0xf3, 0x0d, 0x23, 0x08, 0x71, 0x96, 0x05, 0x94, 0x12, 0x14, 0xb7, 0xd6, 0x69
+      0xf6, 0x8a, 0x88, 0x76, 0x05, 0x23, 0xd4, 0x14, 0x7e, 0x5a, 0xb8, 0x52, 0x8f, 0x56, 0x62, 0x3e
   };
   EXPECT_EQ(Bytes(known_value_bytes), Bytes(encrypted_message));
 }

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -228,7 +228,7 @@ static void BORINGSSL_bcm_power_on_self_test(void) __attribute__ ((constructor))
 #endif
 
 static void BORINGSSL_bcm_power_on_self_test(void) {
-#if !defined(OPENSSL_NO_ASM)
+#if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_PPC32BE)
   OPENSSL_cpuid_setup();
 #endif
 

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -228,8 +228,10 @@ static void BORINGSSL_bcm_power_on_self_test(void) __attribute__ ((constructor))
 #endif
 
 static void BORINGSSL_bcm_power_on_self_test(void) {
+// TODO: remove !defined(OPENSSL_PPC64BE) from the check below when starting to support
+// PPC64BE that has VCRYPTO capability. In that case, add `|| defined(OPENSSL_PPC64BE)`
+// to `#if defined(OPENSSL_PPC64LE)` wherever it occurs.
 #if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_PPC32BE) && !defined(OPENSSL_PPC64BE)
-// TODO: Do we need to implement this for PPC BE architectures?
   OPENSSL_cpuid_setup();
 #endif
 

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -228,7 +228,8 @@ static void BORINGSSL_bcm_power_on_self_test(void) __attribute__ ((constructor))
 #endif
 
 static void BORINGSSL_bcm_power_on_self_test(void) {
-#if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_PPC32BE)
+#if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_PPC32BE) && !defined(OPENSSL_PPC64BE)
+// TODO: Do we need to implement this for PPC BE architectures?
   OPENSSL_cpuid_setup();
 #endif
 
@@ -273,7 +274,7 @@ int BORINGSSL_integrity_test(void) {
   assert_not_within(start, OPENSSL_ia32cap_P, end);
 #elif defined(OPENSSL_AARCH64)
   assert_not_within(start, &OPENSSL_armcap_P, end);
-#endif  
+#endif
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
   const uint8_t *const rodata_start = BORINGSSL_bcm_rodata_start;

--- a/crypto/fipsmodule/bn/bytes.c
+++ b/crypto/fipsmodule/bn/bytes.c
@@ -148,6 +148,7 @@ BIGNUM *BN_le2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
   unsigned m;
 
   m = (len - 1) % BN_BYTES;
+  // size_t is unsigned so i >= 0 is always true
   for (size_t i = len - 1; i < len; i--) {
     word = (word << 8) | in[i];
     if (m-- == 0) {

--- a/crypto/fipsmodule/bn/bytes.c
+++ b/crypto/fipsmodule/bn/bytes.c
@@ -243,7 +243,6 @@ int BN_bn2le_padded(uint8_t *out, size_t len, const BIGNUM *in) {
   return 1;
 }
 
-// Need to reverse the overall word order but not byte order
 int BN_bn2bin_padded(uint8_t *out, size_t len, const BIGNUM *in) {
   if (!fits_in_bytes(in->d, in->width, len)) {
     return 0;

--- a/crypto/fipsmodule/bn/bytes.c
+++ b/crypto/fipsmodule/bn/bytes.c
@@ -143,9 +143,22 @@ BIGNUM *BN_le2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
   // Make sure the top bytes will be zeroed.
   ret->d[num_words - 1] = 0;
 
-  // We only support little-endian platforms, so we can simply memcpy the
-  // internal representation.
+#ifdef OPENSSL_BIG_ENDIAN
+  BN_ULONG word = 0;
+  unsigned m;
+
+  m = (len - 1) % BN_BYTES;
+  for (size_t i = len - 1; i < len; i--) {
+    word = (word << 8) | in[i];
+    if (m-- == 0) {
+      ret->d[--num_words] = word;
+      word = 0;
+      m = BN_BYTES - 1;
+    }
+  }
+#else
   OPENSSL_memcpy(ret->d, in, len);
+#endif
   return ret;
 }
 
@@ -153,12 +166,26 @@ BIGNUM *BN_le2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
 // represented in |num_bytes| bytes.
 static int fits_in_bytes(const BN_ULONG *words, size_t num_words,
                          size_t num_bytes) {
+  uint8_t mask = 0;
+#ifdef OPENSSL_BIG_ENDIAN
+  for (size_t i = num_bytes / BN_BYTES; i < num_words; i++) {
+    BN_ULONG word = words[i];
+    for (size_t j = 0; j < BN_BYTES; j++) {
+      if ((i * BN_BYTES) + j < num_bytes) {
+        // For the first word we don't need to check any bytes shorter than len
+        continue ;
+      } else {
+        mask |= (word >> (j * 8)) & 0xff;
+      }
+    }
+  }
+#else
   const uint8_t *bytes = (const uint8_t *)words;
   size_t tot_bytes = num_words * sizeof(BN_ULONG);
-  uint8_t mask = 0;
   for (size_t i = num_bytes; i < tot_bytes; i++) {
     mask |= bytes[i];
   }
+#endif
   return mask == 0;
 }
 
@@ -166,18 +193,22 @@ void bn_words_to_big_endian(uint8_t *out, size_t out_len, const BN_ULONG *in,
                             size_t in_len) {
   // The caller should have selected an output length without truncation.
   assert(fits_in_bytes(in, in_len, out_len));
-
-  // We only support little-endian platforms, so the internal representation is
-  // also little-endian as bytes. We can simply copy it in reverse.
-  const uint8_t *bytes = (const uint8_t *)in;
   size_t num_bytes = in_len * sizeof(BN_ULONG);
   if (out_len < num_bytes) {
     num_bytes = out_len;
   }
 
+#ifdef OPENSSL_BIG_ENDIAN
+  for (size_t i = 0; i < num_bytes; i++) {
+    BN_ULONG l = in[i / BN_BYTES];
+    out[out_len - i - 1] = (uint8_t)(l >> (8 * (i % BN_BYTES))) & 0xff;
+  }
+#else
+  const uint8_t *bytes = (const uint8_t *)in;
   for (size_t i = 0; i < num_bytes; i++) {
     out[out_len - i - 1] = bytes[i];
   }
+#endif
   // Pad out the rest of the buffer with zeroes.
   OPENSSL_memset(out, 0, out_len - num_bytes);
 }
@@ -193,20 +224,26 @@ int BN_bn2le_padded(uint8_t *out, size_t len, const BIGNUM *in) {
     return 0;
   }
 
-  // We only support little-endian platforms, so we can simply memcpy into the
-  // internal representation.
-  const uint8_t *bytes = (const uint8_t *)in->d;
   size_t num_bytes = in->width * BN_BYTES;
   if (len < num_bytes) {
     num_bytes = len;
   }
-
+#ifdef OPENSSL_BIG_ENDIAN
+  BN_ULONG l;
+  for (size_t i = 0; i < num_bytes; i++) {
+    l = in->d[i / BN_BYTES];
+    out[i] = (uint8_t)(l >> (8 * (i % BN_BYTES))) & 0xff;
+  }
+#else
+  const uint8_t *bytes = (const uint8_t *)in->d;
   OPENSSL_memcpy(out, bytes, num_bytes);
+#endif
   // Pad out the rest of the buffer with zeroes.
   OPENSSL_memset(out + num_bytes, 0, len - num_bytes);
   return 1;
 }
 
+// Need to reverse the overall word order but not byte order
 int BN_bn2bin_padded(uint8_t *out, size_t len, const BIGNUM *in) {
   if (!fits_in_bytes(in->d, in->width, len)) {
     return 0;

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -734,7 +734,7 @@ static inline uint32_t CRYPTO_bswap4(uint32_t x) {
 static inline uint64_t CRYPTO_bswap8(uint64_t x) {
   return __builtin_bswap64(x);
 }
-static inline uint64_t CRYPTO_bswap_word(uint64_t x) {
+static inline crypto_word_t CRYPTO_bswap_word(crypto_word_t x) {
 #if defined(OPENSSL_64_BIT)
   return CRYPTO_bswap8(x);
 #else

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -734,6 +734,15 @@ static inline uint32_t CRYPTO_bswap4(uint32_t x) {
 static inline uint64_t CRYPTO_bswap8(uint64_t x) {
   return __builtin_bswap64(x);
 }
+static inline uint64_t CRYPTO_bswap_word(uint64_t x) {
+#if defined(OPENSSL_64_BIT)
+  return CRYPTO_bswap8(x);
+#else
+  return CRYPTO_bswap4(x);
+#endif
+}
+
+
 #elif defined(_MSC_VER)
 OPENSSL_MSVC_PRAGMA(warning(push, 3))
 #include <stdlib.h>
@@ -855,58 +864,104 @@ static inline void *OPENSSL_memset(void *dst, int c, size_t n) {
 static inline uint32_t CRYPTO_load_u32_le(const void *in) {
   uint32_t v;
   OPENSSL_memcpy(&v, in, sizeof(v));
+#if defined(OPENSSL_BIG_ENDIAN)
+  return CRYPTO_bswap4(v);
+#else
   return v;
+#endif
 }
 
 static inline void CRYPTO_store_u32_le(void *out, uint32_t v) {
+#if defined(OPENSSL_BIG_ENDIAN)
+  v = CRYPTO_bswap4(v);
+#endif
   OPENSSL_memcpy(out, &v, sizeof(v));
+
 }
 
 static inline uint32_t CRYPTO_load_u32_be(const void *in) {
   uint32_t v;
   OPENSSL_memcpy(&v, in, sizeof(v));
+#if defined(OPENSSL_BIG_ENDIAN)
+  return v;
+#else
   return CRYPTO_bswap4(v);
+#endif
 }
 
 static inline void CRYPTO_store_u32_be(void *out, uint32_t v) {
+
+#if !defined(OPENSSL_BIG_ENDIAN)
   v = CRYPTO_bswap4(v);
+#endif
   OPENSSL_memcpy(out, &v, sizeof(v));
+
 }
 
 static inline uint64_t CRYPTO_load_u64_le(const void *in) {
   uint64_t v;
   OPENSSL_memcpy(&v, in, sizeof(v));
+#if defined(OPENSSL_BIG_ENDIAN)
+  return CRYPTO_bswap8(v);
+#else
   return v;
+#endif
 }
 
 static inline void CRYPTO_store_u64_le(void *out, uint64_t v) {
+#if defined(OPENSSL_BIG_ENDIAN)
+  v = CRYPTO_bswap8(v);
+#endif
   OPENSSL_memcpy(out, &v, sizeof(v));
+
 }
 
 static inline uint64_t CRYPTO_load_u64_be(const void *ptr) {
   uint64_t ret;
   OPENSSL_memcpy(&ret, ptr, sizeof(ret));
+#if defined(OPENSSL_BIG_ENDIAN)
+  return ret;
+#else
   return CRYPTO_bswap8(ret);
+#endif
 }
 
 static inline void CRYPTO_store_u64_be(void *out, uint64_t v) {
+#if defined(OPENSSL_BIG_ENDIAN)
+#else
   v = CRYPTO_bswap8(v);
+#endif
   OPENSSL_memcpy(out, &v, sizeof(v));
+
 }
 
 static inline crypto_word_t CRYPTO_load_word_le(const void *in) {
+
   crypto_word_t v;
   OPENSSL_memcpy(&v, in, sizeof(v));
+#if defined(OPENSSL_BIG_ENDIAN)
+  return CRYPTO_bswap_word(v);
+#else
   return v;
+#endif
 }
 
 static inline void CRYPTO_store_word_le(void *out, crypto_word_t v) {
+
+
+#if defined(OPENSSL_BIG_ENDIAN)
+  v = CRYPTO_bswap_word(v);
+#endif
   OPENSSL_memcpy(out, &v, sizeof(v));
+
 }
 
 static inline crypto_word_t CRYPTO_load_word_be(const void *in) {
   crypto_word_t v;
   OPENSSL_memcpy(&v, in, sizeof(v));
+#if defined(OPENSSL_BIG_ENDIAN)
+  return v;
+#else
 #if defined(OPENSSL_64_BIT)
   assert(sizeof(v) == 8);
   return CRYPTO_bswap8(v);
@@ -914,8 +969,8 @@ static inline crypto_word_t CRYPTO_load_word_be(const void *in) {
   assert(sizeof(v) == 4);
   return CRYPTO_bswap4(v);
 #endif
+#endif
 }
-
 
 // Bit rotation functions.
 //

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -84,7 +84,6 @@ extern "C" {
 #if defined(BORINGSSL_FIPS)
 #define AWSLC_FIPS
 #endif
-
 #if defined(__x86_64) || defined(_M_AMD64) || defined(_M_X64)
 #define OPENSSL_64_BIT
 #define OPENSSL_X86_64

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -100,6 +100,14 @@ extern "C" {
 #elif (defined(__PPC64__) || defined(__powerpc64__)) && defined(_LITTLE_ENDIAN)
 #define OPENSSL_64_BIT
 #define OPENSSL_PPC64LE
+#elif (defined(__PPC64__) || defined(__powerpc64__)) && defined(_BIG_ENDIAN)
+#define OPENSSL_64_BIT
+#define OPENSSL_PPC64BE
+#define OPENSSL_BIG_ENDIAN
+#elif (defined(__PPC__) || defined(__powerpc__)) && defined(_BIG_ENDIAN)
+#define OPENSSL_32_BIT
+#define OPENSSL_PPC32BE
+#define OPENSSL_BIG_ENDIAN
 #elif defined(__MIPSEL__) && !defined(__LP64__)
 #define OPENSSL_32_BIT
 #define OPENSSL_MIPS
@@ -113,7 +121,7 @@ extern "C" {
 #define OPENSSL_32_BIT
 #elif defined(__loongarch_lp64)
 #define OPENSSL_64_BIT
-#define OPENSSL_LOONGARCH64	
+#define OPENSSL_LOONGARCH64
 #elif defined(__pnacl__)
 #define OPENSSL_32_BIT
 #define OPENSSL_PNACL

--- a/util/fipstools/acvp/modulewrapper/main.cc
+++ b/util/fipstools/acvp/modulewrapper/main.cc
@@ -39,6 +39,8 @@ int main(int argc, char **argv) {
     puts("aarch64 (64-bit)");
 #elif defined(OPENSSL_PPC64LE)
     puts("PPC64LE (64-bit)");
+#elif defined(OPENSSL_PPC32BE)
+    puts("PPC32BE (32-bit)");
 #else
 #error "FIPS build not supported on this architecture"
 #endif


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Updates work done on previous PR: https://github.com/aws/aws-lc/pull/1133
* Adds `EndianTest` to test our support for little- and big-endian architectures.
* Adds macros for `OPENSSL_PPC64BE` and `OPENSSL_PPC32BE`.

### Call-outs:
* The FIPS build for ppc64be is failing - delocator.go cannot parse the assembly code.
* There's a lot more work to fully support big-endian

### Testing:
For ppc64be:
* All `EndianTest.*` tests pass except `EndianTest.AES`.
```
...
[----------] 16 tests from EndianTest (18 ms total)

[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (23 ms total)
[  PASSED  ] 15 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] EndianTest.AES

 1 FAILED TEST
```
* All 'BNTest.*` tests pass.
```
...
[----------] 36 tests from BNTest (935247 ms total)

[----------] Global test environment tear-down
[==========] 36 tests from 1 test suite ran. (935252 ms total)
[  PASSED  ] 36 tests

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
