### PR TITLE
Add missing NULL check in conf test

### DIFF
--- a/crypto/conf/conf_test.cc
+++ b/crypto/conf/conf_test.cc
@@ -57,6 +57,7 @@ static void ExpectConfEquals(const CONF *conf, const ConfModel &model) {
       const std::string &value = pair.second[i].second;
 
       const CONF_VALUE *v = sk_CONF_VALUE_value(values, i);
+      ASSERT_NE(v, nullptr);
       EXPECT_EQ(v->section, section);
       EXPECT_EQ(v->name, name);
       EXPECT_EQ(v->value, value);


### PR DESCRIPTION
### Issues:

V1027818360

### Description of changes: 

Micro sanity check that we do not dereference NULL in test case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
