### PR TITLE
For Issue-1185: Avoid 'may be used uninitialized' warning

### DIFF
--- a/crypto/fipsmodule/ec/simple_mul.c
+++ b/crypto/fipsmodule/ec/simple_mul.c
@@ -120,6 +120,9 @@ static void ec_GFp_mont_batch_get_window(const EC_GROUP *group,
 
   // Negate if necessary.
   EC_FELEM neg_Y;
+  // Initialize |out| to avoid "may be used uninitialized" warning below.
+  // https://github.com/aws/aws-lc/issues/1185
+  OPENSSL_memset(&neg_Y, 0, sizeof(EC_FELEM));
   ec_felem_neg(group, &neg_Y, &out->Y);
   crypto_word_t sign_mask = sign;
   sign_mask = 0u - sign_mask;


### PR DESCRIPTION
### Issues:
Addresses: #1185 

### Description of changes: 
Some compilers (erroneously) warn that `neg_Y` might not be initialized prior to an in-place bit-wise operation on the value.
```
[00:20:47] In file included from /workspace/srcdir/aws-lc/crypto/fipsmodule/bcm.c:96:0:
[00:20:47] /workspace/srcdir/aws-lc/crypto/fipsmodule/ec/simple_mul.c: In function ‘ec_GFp_mont_batch_get_window’:
[00:20:47] /workspace/srcdir/aws-lc/crypto/fipsmodule/ec/felem.c:65:19: error: ‘neg_Y.words[0]’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
[00:20:47]      out->words[i] &= mask;
[00:20:47]                    ^~
[00:20:47] cc1: all warnings being treated as errors
```

### Call-outs:
* I've not yet setup a host to test 32-bit ARM, so more changes might be needed to correct the build on the affected platform.
* The requester asks about mechanism to disable treating all warning as error.  This is also not addressed.

### Testing:
* crypto_test passes locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
