### PR TITLE
EC support for PPC64 big endian 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,6 @@ cmake-build-debug/
 symbols.txt
 
 .DS_Store
-.idea
+.idea/
+.fleet/
+.cache/

--- a/crypto/ec_extra/hash_to_curve.c
+++ b/crypto/ec_extra/hash_to_curve.c
@@ -158,19 +158,6 @@ static int num_bytes_to_derive(size_t *out, const BIGNUM *modulus, unsigned k) {
   return 1;
 }
 
-// big_endian_to_words decodes |in| as a big-endian integer and writes the
-// result to |out|. |num_words| must be large enough to contain the output.
-static void big_endian_to_words(BN_ULONG *out, size_t num_words,
-                                const uint8_t *in, size_t len) {
-  assert(len <= num_words * sizeof(BN_ULONG));
-  // Ensure any excess bytes are zeroed.
-  OPENSSL_memset(out, 0, num_words * sizeof(BN_ULONG));
-  uint8_t *out_u8 = (uint8_t *)out;
-  for (size_t i = 0; i < len; i++) {
-    out_u8[len - 1 - i] = in[i];
-  }
-}
-
 // hash_to_field implements the operation described in section 5.2
 // of draft-irtf-cfrg-hash-to-curve-16, with count = 2. |k| is the security
 // factor.
@@ -186,9 +173,9 @@ static int hash_to_field2(const EC_GROUP *group, const EVP_MD *md,
   }
   BN_ULONG words[2 * EC_MAX_WORDS];
   size_t num_words = 2 * group->field.width;
-  big_endian_to_words(words, num_words, buf, L);
+  bn_big_endian_to_words(words, num_words, buf, L);
   group->meth->felem_reduce(group, out1, words, num_words);
-  big_endian_to_words(words, num_words, buf + L, L);
+  bn_big_endian_to_words(words, num_words, buf + L, L);
   group->meth->felem_reduce(group, out2, words, num_words);
   return 1;
 }
@@ -207,7 +194,7 @@ static int hash_to_scalar(const EC_GROUP *group, const EVP_MD *md,
 
   BN_ULONG words[2 * EC_MAX_WORDS];
   size_t num_words = 2 * group->order.width;
-  big_endian_to_words(words, num_words, buf, L);
+  bn_big_endian_to_words(words, num_words, buf, L);
   ec_scalar_reduce(group, out, words, num_words);
   return 1;
 }

--- a/crypto/fipsmodule/bn/bytes.c
+++ b/crypto/fipsmodule/bn/bytes.c
@@ -235,7 +235,7 @@ size_t BN_bn2bin(const BIGNUM *in, uint8_t *out) {
   return n;
 }
 
-void bn_words_to_little_endian(uint8_t *out, size_t out_len, const BN_ULONG *in, size_t in_len) {
+void bn_words_to_little_endian(uint8_t *out, size_t out_len, const BN_ULONG *in, const size_t in_len) {
   // The caller should have selected an output length without truncation.
   assert(fits_in_bytes(in, in_len, out_len));
   size_t num_bytes = in_len * sizeof(BN_ULONG);

--- a/crypto/fipsmodule/bn/bytes.c
+++ b/crypto/fipsmodule/bn/bytes.c
@@ -140,27 +140,42 @@ BIGNUM *BN_le2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
   }
   ret->width = (int)num_words;
 
-  // Make sure the top bytes will be zeroed.
-  ret->d[num_words - 1] = 0;
+  bn_little_endian_to_words(ret->d, ret->width, in, len);
 
-#ifdef OPENSSL_BIG_ENDIAN
-  BN_ULONG word = 0;
-  unsigned m;
-
-  m = (len - 1) % BN_BYTES;
-  // size_t is unsigned so i >= 0 is always true
-  for (size_t i = len - 1; i < len; i--) {
-    word = (word << 8) | in[i];
-    if (m-- == 0) {
-      ret->d[--num_words] = word;
-      word = 0;
-      m = BN_BYTES - 1;
-    }
-  }
-#else
-  OPENSSL_memcpy(ret->d, in, len);
-#endif
   return ret;
+}
+
+void bn_little_endian_to_words(BN_ULONG *out, size_t out_len, const uint8_t *in, const size_t in_len) {
+  assert(out_len > 0);
+#ifdef OPENSSL_BIG_ENDIAN
+  size_t in_index = 0;
+  for (size_t i = 0; i < out_len; i++) {
+    if ((in_len-in_index) < sizeof(BN_ULONG)) {
+      // Load the last partial word.
+      BN_ULONG word = 0;
+      // size_t is unsigned, so j >= 0 is always true.
+      for (size_t j = in_len-1; j >= in_index && j < in_len; j--) {
+        word = (word << 8) | in[j];
+      }
+      in_index = in_len;
+      out[i] = word;
+
+      // Fill the remainder with zeros.
+      OPENSSL_memset(out + i + 1, 0, (out_len - i - 1) * sizeof(BN_ULONG));
+      break;
+    }
+
+    out[i] = CRYPTO_load_word_le(in + in_index);
+    in_index += sizeof(BN_ULONG);
+  }
+
+  // The caller should have sized the output to avoid truncation.
+  assert(in_index == in_len);
+#else
+  OPENSSL_memcpy(out, in, in_len);
+  // Fill the remainder with zeros.
+  OPENSSL_memset( ((uint8_t*)out) + in_len, 0, sizeof(BN_ULONG)*out_len - in_len);
+#endif
 }
 
 // fits_in_bytes returns one if the |num_words| words in |words| can be
@@ -220,27 +235,36 @@ size_t BN_bn2bin(const BIGNUM *in, uint8_t *out) {
   return n;
 }
 
+void bn_words_to_little_endian(uint8_t *out, size_t out_len, const BN_ULONG *in, size_t in_len) {
+  // The caller should have selected an output length without truncation.
+  assert(fits_in_bytes(in, in_len, out_len));
+  size_t num_bytes = in_len * sizeof(BN_ULONG);
+  if (out_len < num_bytes) {
+    num_bytes = out_len;
+  }
+#ifdef OPENSSL_BIG_ENDIAN
+  size_t byte_idx = 0;
+  for (size_t word_idx = 0; word_idx < in_len; word_idx++) {
+    BN_ULONG l = in[word_idx];
+    for(size_t j = 0; j < BN_BYTES && byte_idx < num_bytes; j++) {
+      out[byte_idx] = (uint8_t)(l & 0xff);
+      l >>= 8;
+      byte_idx++;
+    }
+  }
+#else
+  const uint8_t *bytes = (const uint8_t *)in;
+  OPENSSL_memcpy(out, bytes, num_bytes);
+#endif
+  // Fill the remainder with zeros.
+  OPENSSL_memset(out + num_bytes, 0, out_len - num_bytes);
+}
+
 int BN_bn2le_padded(uint8_t *out, size_t len, const BIGNUM *in) {
   if (!fits_in_bytes(in->d, in->width, len)) {
     return 0;
   }
-
-  size_t num_bytes = in->width * BN_BYTES;
-  if (len < num_bytes) {
-    num_bytes = len;
-  }
-#ifdef OPENSSL_BIG_ENDIAN
-  BN_ULONG l;
-  for (size_t i = 0; i < num_bytes; i++) {
-    l = in->d[i / BN_BYTES];
-    out[i] = (uint8_t)(l >> (8 * (i % BN_BYTES))) & 0xff;
-  }
-#else
-  const uint8_t *bytes = (const uint8_t *)in->d;
-  OPENSSL_memcpy(out, bytes, num_bytes);
-#endif
-  // Pad out the rest of the buffer with zeroes.
-  OPENSSL_memset(out + num_bytes, 0, len - num_bytes);
+  bn_words_to_little_endian(out, len, in->d, in->width);
   return 1;
 }
 

--- a/crypto/fipsmodule/bn/internal.h
+++ b/crypto/fipsmodule/bn/internal.h
@@ -767,7 +767,7 @@ void bn_words_to_big_endian(uint8_t *out, size_t out_len, const BN_ULONG *in,
 // is in little-endian word order with |out[0]| being the least-significant word.
 // |out_len| must be large enough to represent any |in_len|-byte value. That is,
 // |out_len| must be at least |BN_BYTES * in_len|.
-void bn_little_endian_to_words(BN_ULONG *out, size_t out_len, const uint8_t *in, size_t in_len);
+void bn_little_endian_to_words(BN_ULONG *out, size_t out_len, const uint8_t *in, const size_t in_len);
 
 // bn_words_to_little_endian represents |in_len| words from |in| (in little-endian
 // word order) as a little-endian, unsigned integer in |out_len| bytes. It
@@ -776,7 +776,7 @@ void bn_little_endian_to_words(BN_ULONG *out, size_t out_len, const uint8_t *in,
 //
 // Note |out_len| may be less than |BN_BYTES * in_len| if |in| is known to have
 // leading zeros.
-void bn_words_to_little_endian(uint8_t *out, size_t out_len, const BN_ULONG *in, size_t in_len);
+void bn_words_to_little_endian(uint8_t *out, size_t out_len, const BN_ULONG *in, const size_t in_len);
 
 #if defined(__cplusplus)
 }  // extern C

--- a/crypto/fipsmodule/bn/internal.h
+++ b/crypto/fipsmodule/bn/internal.h
@@ -745,21 +745,38 @@ void bn_mod_inverse0_prime_mont_small(BN_ULONG *r, const BN_ULONG *a,
 // Word-based byte conversion functions.
 
 // bn_big_endian_to_words interprets |in_len| bytes from |in| as a big-endian,
-// unsigned integer and writes the result to |out_len| words in |out|. |out_len|
-// must be large enough to represent any |in_len|-byte value. That is, |out_len|
-// must be at least |BN_BYTES * in_len|.
+// unsigned integer and writes the result to |out_len| words in |out|. The output
+// is in little-endian word order with |out[0]| being the least-significant word.
+// |out_len| must be large enough to represent any |in_len|-byte value. That is,
+// |out_len| must be at least |BN_BYTES * in_len|.
 void bn_big_endian_to_words(BN_ULONG *out, size_t out_len, const uint8_t *in,
                             size_t in_len);
 
-// bn_words_to_big_endian represents |in_len| words from |in| as a big-endian,
-// unsigned integer in |out_len| bytes. It writes the result to |out|. |out_len|
-// must be large enough to represent |in| without truncation.
+// bn_words_to_big_endian represents |in_len| words from |in| (in little-endian
+// word order) as a big-endian, unsigned integer in |out_len| bytes. It writes
+// the result to |out|. |out_len| must be large enough to represent |in| without
+// truncation.
 //
 // Note |out_len| may be less than |BN_BYTES * in_len| if |in| is known to have
 // leading zeros.
 void bn_words_to_big_endian(uint8_t *out, size_t out_len, const BN_ULONG *in,
                             size_t in_len);
 
+// bn_little_endian_to_words interprets |in_len| bytes from |in| as a little-endian,
+// unsigned integer and writes the result to |out_len| words in |out|.  The output
+// is in little-endian word order with |out[0]| being the least-significant word.
+// |out_len| must be large enough to represent any |in_len|-byte value. That is,
+// |out_len| must be at least |BN_BYTES * in_len|.
+void bn_little_endian_to_words(BN_ULONG *out, size_t out_len, const uint8_t *in, size_t in_len);
+
+// bn_words_to_little_endian represents |in_len| words from |in| (in little-endian
+// word order) as a little-endian, unsigned integer in |out_len| bytes. It
+// writes the result to |out|. |out_len| must be large enough to represent |in|
+// without truncation.
+//
+// Note |out_len| may be less than |BN_BYTES * in_len| if |in| is known to have
+// leading zeros.
+void bn_words_to_little_endian(uint8_t *out, size_t out_len, const BN_ULONG *in, size_t in_len);
 
 #if defined(__cplusplus)
 }  // extern C

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1886,7 +1886,6 @@ TEST(ECTest, LargeXCoordinateVectors) {
     bssl::UniquePtr<EC_POINT> pub_key(EC_POINT_new(group.get()));
     ASSERT_TRUE(pub_key);
 
-    size_t len = BN_num_bytes(&group.get()->field); // Modulus byte-length
     ASSERT_TRUE(EC_KEY_set_group(key.get(), group.get()));
 
     // |EC_POINT_set_affine_coordinates_GFp| sets given (x, y) according to the
@@ -1900,10 +1899,10 @@ TEST(ECTest, LargeXCoordinateVectors) {
     // Set the raw point directly with the BIGNUM coordinates.
     // Note that both are in little-endian byte order.
     OPENSSL_memcpy(key.get()->pub_key->raw.X.words,
-                   x.get()->d, len);
+                   x.get()->d, BN_BYTES * group->field.width);
     OPENSSL_memcpy(key.get()->pub_key->raw.Y.words,
-                   y.get()->d, len);
-    OPENSSL_memset(key.get()->pub_key->raw.Z.words, 0, len);
+                   y.get()->d, BN_BYTES * group->field.width);
+    OPENSSL_memset(key.get()->pub_key->raw.Z.words, 0, BN_BYTES * group->field.width);
     key.get()->pub_key->raw.Z.words[0] = 1;
 
     // |EC_KEY_check_fips| first calls the |EC_KEY_check_key| function that

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1922,7 +1922,7 @@ TEST(ECTest, LargeXCoordinateVectors) {
 
     // Now replace the x-coordinate with the larger one, x+p.
     OPENSSL_memcpy(key.get()->pub_key->raw.X.words,
-                   xpp.get()->d, len);
+                   xpp.get()->d, BN_BYTES * group->field.width);
     // We expect |EC_KEY_check_fips| to always fail when given key with x > p.
     ASSERT_FALSE(EC_KEY_check_fips(key.get()));
 

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -98,9 +98,7 @@ static inline uint8_t p384_use_s2n_bignum_alt(void) {
 #define p384_felem_add(out, in0, in1)   bignum_add_p384(out, in0, in1)
 #define p384_felem_sub(out, in0, in1)   bignum_sub_p384(out, in0, in1)
 #define p384_felem_opp(out, in0)        bignum_neg_p384(out, in0)
-// TODO: convert to p384_felem_to_words
 #define p384_felem_to_bytes(out, in0)   bignum_tolebytes_6(out, in0)
-// TODO: convert to p384_felem_from_words
 #define p384_felem_from_bytes(out, in0) bignum_fromlebytes_6(out, in0)
 
 // The following four functions need bmi2 and adx support.
@@ -134,9 +132,7 @@ static p384_limb_t p384_felem_nz(const p384_limb_t in1[P384_NLIMBS]) {
 #define p384_felem_sqr(out, in0)        fiat_p384_square(out, in0)
 #define p384_felem_to_mont(out, in0)    fiat_p384_to_montgomery(out, in0)
 #define p384_felem_from_mont(out, in0)  fiat_p384_from_montgomery(out, in0)
-// TODO: convert to p384_felem_to_words
 #define p384_felem_to_bytes(out, in0)   fiat_p384_to_bytes(out, in0)
-// TODO: convert to p384_felem_from_words
 #define p384_felem_from_bytes(out, in0) fiat_p384_from_bytes(out, in0)
 
 static p384_limb_t p384_felem_nz(const p384_limb_t in1[P384_NLIMBS]) {
@@ -164,19 +160,40 @@ static void p384_felem_cmovznz(p384_limb_t out[P384_NLIMBS],
   }
 }
 
-// NOTE: the input and output are in little-endian representation.
 static void p384_from_generic(p384_felem out, const EC_FELEM *in) {
+#ifdef OPENSSL_BIG_ENDIAN
+  uint8_t tmp[48];
+  bn_words_to_little_endian(tmp, 48, in->words, P384_NLIMBS);
+  p384_felem_from_bytes(out, tmp);
+#else
   p384_felem_from_bytes(out, (const uint8_t *)in->words);
+#endif
 }
 
-// NOTE: the input and output are in little-endian representation.
 static void p384_to_generic(EC_FELEM *out, const p384_felem in) {
   // This works because 384 is a multiple of 64, so there are no excess bytes to
   // zero when rounding up to |BN_ULONG|s.
   OPENSSL_STATIC_ASSERT(
       384 / 8 == sizeof(BN_ULONG) * ((384 + BN_BITS2 - 1) / BN_BITS2),
       p384_felem_to_bytes_leaves_bytes_uninitialized);
+
+#ifdef OPENSSL_BIG_ENDIAN
+  uint8_t tmp[48];
+  p384_felem_to_bytes(tmp, in);
+  bn_little_endian_to_words(out->words, 6, tmp, 48);
+#else
   p384_felem_to_bytes((uint8_t *)out->words, in);
+#endif
+}
+
+static void p384_from_scalar(p384_felem out, const EC_SCALAR *in) {
+#ifdef OPENSSL_BIG_ENDIAN
+  uint8_t tmp[48];
+  bn_words_to_little_endian(tmp, 48, in->words, P384_NLIMBS);
+  p384_felem_from_bytes(out, tmp);
+#else
+  p384_felem_from_bytes(out, (const uint8_t *)in->words);
+#endif
 }
 
 // p384_inv_square calculates |out| = |in|^{-2}
@@ -586,7 +603,7 @@ static int ec_GFp_nistp384_cmp_x_coordinate(const EC_GROUP *group,
   p384_felem_mul(Z2_mont, Z2_mont, Z2_mont);
 
   p384_felem r_Z2;
-  p384_felem_from_bytes(r_Z2, (const uint8_t*)r->words);  // r < order < p, so this is valid.
+  p384_from_scalar(r_Z2, r);  // r < order < p, so this is valid.
   p384_felem_mul(r_Z2, r_Z2, Z2_mont);
 
   p384_felem X;

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -182,7 +182,7 @@ static void p384_to_generic(EC_FELEM *out, const p384_felem in) {
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P384_FELEM_BYTES];
   p384_felem_to_bytes(tmp, in);
-  bn_little_endian_to_words(out->words, EC_MAX_WORDS, tmp, P384_FELEM_BYTES);
+  bn_little_endian_to_words(out->words, P384_NLIMBS, tmp, P384_FELEM_BYTES);
 #else
   p384_felem_to_bytes((uint8_t *)out->words, in);
 #endif

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -143,6 +143,8 @@ static p384_limb_t p384_felem_nz(const p384_limb_t in1[P384_NLIMBS]) {
 
 #endif // P384_USE_S2N_BIGNUM_FIELD_ARITH
 
+#define P384_FELEM_BYTES (48)
+
 static void p384_felem_copy(p384_limb_t out[P384_NLIMBS],
                            const p384_limb_t in1[P384_NLIMBS]) {
   for (size_t i = 0; i < P384_NLIMBS; i++) {
@@ -162,8 +164,8 @@ static void p384_felem_cmovznz(p384_limb_t out[P384_NLIMBS],
 
 static void p384_from_generic(p384_felem out, const EC_FELEM *in) {
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[48];
-  bn_words_to_little_endian(tmp, 48, in->words, P384_NLIMBS);
+  uint8_t tmp[P384_FELEM_BYTES];
+  bn_words_to_little_endian(tmp, P384_FELEM_BYTES, in->words, P384_NLIMBS);
   p384_felem_from_bytes(out, tmp);
 #else
   p384_felem_from_bytes(out, (const uint8_t *)in->words);
@@ -178,9 +180,9 @@ static void p384_to_generic(EC_FELEM *out, const p384_felem in) {
       p384_felem_to_bytes_leaves_bytes_uninitialized);
 
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[48];
+  uint8_t tmp[P384_FELEM_BYTES];
   p384_felem_to_bytes(tmp, in);
-  bn_little_endian_to_words(out->words, 6, tmp, 48);
+  bn_little_endian_to_words(out->words, EC_MAX_WORDS, tmp, P384_FELEM_BYTES);
 #else
   p384_felem_to_bytes((uint8_t *)out->words, in);
 #endif
@@ -188,8 +190,8 @@ static void p384_to_generic(EC_FELEM *out, const p384_felem in) {
 
 static void p384_from_scalar(p384_felem out, const EC_SCALAR *in) {
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[48];
-  bn_words_to_little_endian(tmp, 48, in->words, P384_NLIMBS);
+  uint8_t tmp[P384_FELEM_BYTES];
+  bn_words_to_little_endian(tmp, P384_FELEM_BYTES, in->words, P384_NLIMBS);
   p384_felem_from_bytes(out, tmp);
 #else
   p384_felem_from_bytes(out, (const uint8_t *)in->words);

--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -176,6 +176,8 @@ static const p521_limb_t p521_felem_p[P521_NLIMBS] = {
 
 #endif // P521_USE_S2N_BIGNUM_FIELD_ARITH
 
+#define P521_FELEM_BYTES (66)
+
 static p521_limb_t p521_felem_nz(const p521_limb_t in1[P521_NLIMBS]) {
   p521_limb_t is_not_zero = 0;
   for (int i = 0; i < P521_NLIMBS; i++) {
@@ -217,8 +219,8 @@ static void p521_felem_cmovznz(p521_limb_t out[P521_NLIMBS],
 // NOTE: the input and output are in little-endian representation.
 static void p521_from_generic(p521_felem out, const EC_FELEM *in) {
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[66];
-  bn_words_to_little_endian(tmp, 66, in->words, EC_MAX_WORDS);
+  uint8_t tmp[P521_FELEM_BYTES];
+  bn_words_to_little_endian(tmp, P521_FELEM_BYTES, in->words, EC_MAX_WORDS);
   p521_felem_from_bytes(out, tmp);
 #else
   p521_felem_from_bytes(out, (const uint8_t *)in->words);
@@ -236,9 +238,9 @@ static void p521_to_generic(EC_FELEM *out, const p521_felem in) {
   // extra 6 bytes are zeroed out. To avoid confusion over 32 vs. 64 bit
   // systems and Fiat's vs. ours representation we zero out the whole element.
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[66];
+  uint8_t tmp[P521_FELEM_BYTES];
   p521_felem_to_bytes(tmp, in);
-  bn_little_endian_to_words(out->words, EC_MAX_WORDS, tmp, 66);
+  bn_little_endian_to_words(out->words, EC_MAX_WORDS, tmp, P521_FELEM_BYTES);
 #else
   OPENSSL_memset((uint8_t*)out->words, 0, sizeof(out->words));
   // Convert the element to bytes.

--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -220,7 +220,7 @@ static void p521_felem_cmovznz(p521_limb_t out[P521_NLIMBS],
 static void p521_from_generic(p521_felem out, const EC_FELEM *in) {
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P521_FELEM_BYTES];
-  bn_words_to_little_endian(tmp, P521_FELEM_BYTES, in->words, EC_MAX_WORDS);
+  bn_words_to_little_endian(tmp, P521_FELEM_BYTES, in->words, P521_NLIMBS);
   p521_felem_from_bytes(out, tmp);
 #else
   p521_felem_from_bytes(out, (const uint8_t *)in->words);
@@ -240,7 +240,7 @@ static void p521_to_generic(EC_FELEM *out, const p521_felem in) {
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P521_FELEM_BYTES];
   p521_felem_to_bytes(tmp, in);
-  bn_little_endian_to_words(out->words, EC_MAX_WORDS, tmp, P521_FELEM_BYTES);
+  bn_little_endian_to_words(out->words, P521_NLIMBS, tmp, P521_FELEM_BYTES);
 #else
   OPENSSL_memset((uint8_t*)out->words, 0, sizeof(out->words));
   // Convert the element to bytes.

--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -100,9 +100,7 @@ static inline uint8_t p521_use_s2n_bignum_alt(void) {
 #define p521_felem_add(out, in0, in1)   bignum_add_p521(out, in0, in1)
 #define p521_felem_sub(out, in0, in1)   bignum_sub_p521(out, in0, in1)
 #define p521_felem_opp(out, in0)        bignum_neg_p521(out, in0)
-// TODO: Convert to p521_felem_to_words
 #define p521_felem_to_bytes(out, in0)   bignum_tolebytes_p521(out, in0)
-// TODO: Convert to p521_felem_from_words
 #define p521_felem_from_bytes(out, in0) bignum_fromlebytes_p521(out, in0)
 
 // The following two functions need bmi2 and adx support.
@@ -173,9 +171,7 @@ static const p521_limb_t p521_felem_p[P521_NLIMBS] = {
 #define p521_felem_opp(out, in0)        fiat_secp521r1_carry_opp(out, in0)
 #define p521_felem_mul(out, in0, in1)   fiat_secp521r1_carry_mul(out, in0, in1)
 #define p521_felem_sqr(out, in0)        fiat_secp521r1_carry_square(out, in0)
-// TODO: Convert to p521_felem_to_words
 #define p521_felem_to_bytes(out, in0)   fiat_secp521r1_to_bytes(out, in0)
-// TODO: Convert to p521_felem_from_words
 #define p521_felem_from_bytes(out, in0) fiat_secp521r1_from_bytes(out, in0)
 
 #endif // P521_USE_S2N_BIGNUM_FIELD_ARITH
@@ -220,7 +216,13 @@ static void p521_felem_cmovznz(p521_limb_t out[P521_NLIMBS],
 
 // NOTE: the input and output are in little-endian representation.
 static void p521_from_generic(p521_felem out, const EC_FELEM *in) {
+#ifdef OPENSSL_BIG_ENDIAN
+  uint8_t tmp[66];
+  bn_words_to_little_endian(tmp, 66, in->words, EC_MAX_WORDS);
+  p521_felem_from_bytes(out, tmp);
+#else
   p521_felem_from_bytes(out, (const uint8_t *)in->words);
+#endif
 }
 
 // NOTE: the input and output are in little-endian representation.
@@ -233,9 +235,15 @@ static void p521_to_generic(EC_FELEM *out, const p521_felem in) {
   // translate to 72 bytes, which means that we have to make sure that the
   // extra 6 bytes are zeroed out. To avoid confusion over 32 vs. 64 bit
   // systems and Fiat's vs. ours representation we zero out the whole element.
+#ifdef OPENSSL_BIG_ENDIAN
+  uint8_t tmp[66];
+  p521_felem_to_bytes(tmp, in);
+  bn_little_endian_to_words(out->words, EC_MAX_WORDS, tmp, 66);
+#else
   OPENSSL_memset((uint8_t*)out->words, 0, sizeof(out->words));
   // Convert the element to bytes.
   p521_felem_to_bytes((uint8_t *)out->words, in);
+#endif
 }
 
 // Finite field inversion using Fermat Little Theorem.


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-2021

### Description of changes:
* Due to being a big-endian CPU architecture, most of AWS-LC's algorithms are broken for PPC64.
* This PR addresses many of the issues related to Elliptic Curve algorithms when running on PPC64.

### Call-outs:
* AES for PPC64 will be address on this PR: #1213

### Testing:
I ran elliptic curve and bignum-related tests using qemu.  All tests pass except AES (which will be addressed on this PR: #1213)

PowerPC-64:
```
> ppc64-qemu.sh ./crypto/crypto_test --gtest_filter="*/EC*:EC*:Ed*:BNTest.*:EndianTest.*" 
Note: Google Test filter = */EC*:EC*:Ed*:BNTest.*:EndianTest.*
[==========] Running 211 tests from 9 test suites.
[----------] Global test environment set-up.
...
[----------] Global test environment tear-down
[==========] 211 tests from 9 test suites ran. (1036017 ms total)
[  PASSED  ] 210 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] EndianTest.AES
```

PowerPC-32:
```
❯ ppc-qemu.sh ./crypto/crypto_test --gtest_filter="*/EC*:EC*:Ed*:BNTest.*:EndianTest.*"
Note: Google Test filter = */EC*:EC*:Ed*:BNTest.*:EndianTest.*
[==========] Running 213 tests from 9 test suites.
[----------] Global test environment set-up.
...

[----------] Global test environment tear-down
[==========] 213 tests from 9 test suites ran. (2189312 ms total)
[  PASSED  ] 212 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] EndianTest.AES
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
