### PR TITLE
Flag so compiler warnings do not fail build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,9 @@ if (GCC)
   endif ()
 endif ()
 
+# Private build configuration. Subject to deprecation at any time.
 if(AWS_LC_WARNINGS_ARE_NOT_ERRORS)
+  message(WARNING "Compiler warning-diagnostics will not fail the build")
   set(AWS_LC_WERROR "")
 else()
   set(AWS_LC_WERROR "-Werror")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,12 @@ if (GCC)
   endif ()
 endif ()
 
+if(AWS_LC_WARNINGS_ARE_NOT_ERRORS)
+  set(AWS_LC_WERROR "")
+else()
+  set(AWS_LC_WERROR "-Werror")
+endif()
+
 if(GCC OR CLANG)
   # Note clang-cl is odd and sets both CLANG and MSVC. We base our configuration
   # primarily on our normal Clang one.
@@ -316,7 +322,7 @@ if(GCC OR CLANG)
   # TODO(CryptoAlg-759): enable '-Wpedantic' if awslc has to follow c99 spec.
   if(CLANG OR (GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "4.1.3"))
     # GCC 4.1.3 and below do not support all of these flags or they raise false positives.
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Werror")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter ${AWS_LC_WERROR}")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wwrite-strings -Wformat-security -Wunused-result")
     set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wvla -Wtype-limits")
@@ -327,7 +333,7 @@ if(GCC OR CLANG)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-cast-function-type")
   endif()
 
-  set(C_CXX_FLAGS "${C_CXX_FLAGS} -Werror -Wformat=2 -Wsign-compare -Wmissing-field-initializers -Wwrite-strings")
+  set(C_CXX_FLAGS "${C_CXX_FLAGS} ${AWS_LC_WERROR} -Wformat=2 -Wsign-compare -Wmissing-field-initializers -Wwrite-strings")
   if(MSVC)
     # clang-cl sets different default warnings than clang. It also treats -Wall
     # as -Weverything, to match MSVC. Instead -W3 is the alias for -Wall.


### PR DESCRIPTION
### Issues:
Addresses #1185

### Description of changes: 
* Accept flag to allow warnings to not fail the build.

### Call-outs:
N/A

### Testing:
* I set a commonly used function as deprecated, then verified that build would succeed with flag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
