### PR TITLE
Don't build FFDH benchmarks with AWS-LC API versions less than 22

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1635,7 +1635,8 @@ static bool SpeedECMUL(const std::string &selected) {
 
 #endif // !defined(OPENSSL_1_0_BENCHMARK)
 
-#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK)) || AWSLC_API_VERSION >= 22
+// Only new AWS-LC (>= 22) and new OpenSSL (>= 1.1.1) support FFDH
+#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >= 22
 static bool SpeedFFDHGroup(const std::string &name, int nid,
                            const std::string &selected) {
   if (!selected.empty() && name.find(selected) == std::string::npos) {
@@ -1668,7 +1669,7 @@ static bool SpeedFFDH(const std::string &selected) {
   return SpeedFFDHGroup("FFDH 2048", NID_ffdhe2048, selected) &&
          SpeedFFDHGroup("FFDH 4096", NID_ffdhe4096, selected);
 }
-#endif //(!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK)) || AWSLC_API_VERSION >= 22
+#endif //(!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >= 22
 
 #if !defined(OPENSSL_BENCHMARK)
 static bool Speed25519(const std::string &selected) {
@@ -2625,7 +2626,7 @@ bool Speed(const std::vector<std::string> &args) {
        // OpenSSL 1.0 doesn't support Scrypt
        !SpeedScrypt(selected) ||
 #endif
-#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK)) || AWSLC_API_VERSION >= 22
+#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >= 22
        // OpenSSL 1.0 and BoringSSL don't support DH_new_by_nid, NID_ffdhe2048, or NID_ffdhe4096
        !SpeedFFDH(selected) ||
 #endif


### PR DESCRIPTION
### Description of changes: 
Previously older versions of AWS-LC with API versions less than 22 would incorrectly attempt to build the FFDH benchmakrs. This is because it passed the first part of the or statement: `!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK)`. This fixes that so the canary can resume building the current version of speed.cc with older versions of AWS-LC. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
