### PR TITLE
Replace s2n-bignum's Montgomery reduction with its latest, faster version

### DIFF
--- a/crypto/fipsmodule/bn/montgomery.c
+++ b/crypto/fipsmodule/bn/montgomery.c
@@ -518,8 +518,13 @@ static void montgomery_s2n_bignum_mul_mont(BN_ULONG *rp, const BN_ULONG *ap,
   //    A. The result of step 1 >= 2^(64*num), meaning that bignum_emontredc_8n
   //       returned 1. Since m is less than 2^(64*num), (result of step 1) >= m holds.
   //    B. The result of step 1 fits in 2^(64*num), and the result >= m.
+
+  // temp's size is 12 * (num / 4 - 1) where num's upperbound is
+  // BN_MONTGOMERY_MAX_WORDS (caller's assertion), and num is divisible by 8
+  // by montgomery_use_s2n_bignum(num).
+  uint64_t temp[12 * (BN_MONTGOMERY_MAX_WORDS / 4 - 1)];
   uint64_t c = CRYPTO_is_NEON_capable() ? 
-               bignum_emontredc_8n_neon(num, mulres, np, w) :
+               bignum_emontredc_8n_neon(num, mulres, np, w, temp) :
                bignum_emontredc_8n(num, mulres, np, w); // c: case A
   c |= bignum_ge(num, mulres + num, num, np);  // c: case B
   // Optionally subtract and store the result at rp

--- a/third_party/s2n-bignum/arm/fastmul/bignum_emontredc_8n_neon.S
+++ b/third_party/s2n-bignum/arm/fastmul/bignum_emontredc_8n_neon.S
@@ -30,18 +30,18 @@
 
 // Some immediate offsets for cached differences+carry used
 // in the inner ADK multiplications
-#define cache_a01 (32+0*16)
-#define cache_a02 (32+1*16)
-#define cache_a03 (32+2*16)
-#define cache_a12 (32+3*16)
-#define cache_a13 (32+4*16)
-#define cache_a23 (32+5*16)
-#define cache_m10 (0*16)
-#define cache_m20 (1*16)
-#define cache_m30 (2*16)
-#define cache_m21 (3*16)
-#define cache_m31 (4*16)
-#define cache_m32 (5*16)
+#define cache_a01 32
+#define cache_a02 48
+#define cache_a03 64
+#define cache_a12 80
+#define cache_a13 96
+#define cache_a23 112
+#define cache_m10 0
+#define cache_m20 16
+#define cache_m30 32
+#define cache_m21 48
+#define cache_m31 64
+#define cache_m32 80
 
 #define a0 x4
 #define a1 x5
@@ -63,24 +63,24 @@ S2N_BN_SYMBOL(bignum_emontredc_8n_neon):
         cmp x0, #12
         ble bignum_emontredc_8n_neon_bignum_emontredc_8n
 
-        sub sp, sp, #(14*16)
-        stp x19, x20, [sp, #(13*16)]
-        stp x21, x22, [sp, #(12*16)]
-        stp x23, x24, [sp, #(11*16)]
-        stp x25, x26, [sp, #(10*16)]
-        stp x27, x28, [sp, #(9*16)]
-        stp x29, x30, [sp, #(8*16)]
-        str q8, [sp, #16*0]
-        str q9, [sp, #16*1]
-        str q10, [sp, #16*2]
-        str q11, [sp, #16*3]
-        str q12, [sp, #16*4]
-        str q13, [sp, #16*5]
-        str q14, [sp, #16*6]
-        str q15, [sp, #16*7]
+        sub sp, sp, #224
+        stp x19, x20, [sp, #208]
+        stp x21, x22, [sp, #192]
+        stp x23, x24, [sp, #176]
+        stp x25, x26, [sp, #160]
+        stp x27, x28, [sp, #144]
+        stp x29, x30, [sp, #128]
+        str q8, [sp]
+        str q9, [sp, #16]
+        str q10, [sp, #32]
+        str q11, [sp, #48]
+        str q12, [sp, #64]
+        str q13, [sp, #80]
+        str q14, [sp, #96]
+        str q15, [sp, #112]
 
         // Leave space for cached differences of words of a in inner loop
-        sub sp, sp, #(6*16)
+        sub sp, sp, #96
 
         sub sp, sp, #32
         lsr x0, x0, #2
@@ -658,12 +658,12 @@ bignum_emontredc_8n_neon_end:
         ldr q13, [sp, #16*5]
         ldr q14, [sp, #16*6]
         ldr q15, [sp, #16*7]
-        ldp x29, x30, [sp, #(8*16)]
-        ldp x27, x28, [sp, #(9*16)]
-        ldp x25, x26, [sp, #(10*16)]
-        ldp x23, x24, [sp, #(11*16)]
-        ldp x21, x22, [sp, #(12*16)]
-        ldp x19, x20, [sp, #(13*16)]
+        ldp x29, x30, [sp, #8*16]
+        ldp x27, x28, [sp, #9*16]
+        ldp x25, x26, [sp, #10*16]
+        ldp x23, x24, [sp, #11*16]
+        ldp x21, x22, [sp, #12*16]
+        ldp x19, x20, [sp, #13*16]
         add sp, sp, #(14*16)
 
         ret

--- a/third_party/s2n-bignum/arm/fastmul/bignum_emontredc_8n_neon.S
+++ b/third_party/s2n-bignum/arm/fastmul/bignum_emontredc_8n_neon.S
@@ -60,6 +60,9 @@
 
 S2N_BN_SYMBOL(bignum_emontredc_8n_neon):
 
+        cmp x0, #12
+        ble bignum_emontredc_8n_neon_bignum_emontredc_8n
+
         sub sp, sp, #(14*16)
         stp x19, x20, [sp, #(13*16)]
         stp x21, x22, [sp, #(12*16)]
@@ -664,3 +667,269 @@ bignum_emontredc_8n_neon_end:
         add sp, sp, #(14*16)
 
         ret
+
+bignum_emontredc_8n_neon_bignum_emontredc_8n:
+ 	stp	x19, x20, [sp, #-16]!
+ 	stp	x21, x22, [sp, #-16]!
+ 	stp	x23, x24, [sp, #-16]!
+ 	stp	x25, x26, [sp, #-16]!
+ 	stp	x27, x28, [sp, #-16]!
+ 	lsr	x0, x0, #2
+ 	mov	x26, x0
+ 	subs	x12, x0, #0x1
+ 	bcc	bignum_emontredc_8n_neon_bignum_emontredc_8n_end
+ 	mov	x28, xzr
+ 	lsl	x0, x12, #5
+
+bignum_emontredc_8n_neon_bignum_emontredc_8n_outerloop:
+  	ldp	x17, x19, [x1]
+  	ldp	x20, x21, [x1, #16]
+  	ldp	x8, x9, [x2]
+  	ldp	x10, x11, [x2, #16]
+  	mul	x4, x17, x3
+  	mul	x12, x4, x8
+  	mul	x13, x4, x9
+  	mul	x14, x4, x10
+  	mul	x15, x4, x11
+  	adds	x17, x17, x12
+  	umulh	x12, x4, x8
+  	adcs	x19, x19, x13
+  	umulh	x13, x4, x9
+  	adcs	x20, x20, x14
+  	umulh	x14, x4, x10
+  	adcs	x21, x21, x15
+  	umulh	x15, x4, x11
+  	adc	x22, xzr, xzr
+  	adds	x19, x19, x12
+  	adcs	x20, x20, x13
+  	adcs	x21, x21, x14
+  	adc	x22, x22, x15
+  	mul	x5, x19, x3
+  	mul	x12, x5, x8
+  	mul	x13, x5, x9
+  	mul	x14, x5, x10
+  	mul	x15, x5, x11
+  	adds	x19, x19, x12
+  	umulh	x12, x5, x8
+  	adcs	x20, x20, x13
+  	umulh	x13, x5, x9
+  	adcs	x21, x21, x14
+  	umulh	x14, x5, x10
+  	adcs	x22, x22, x15
+  	umulh	x15, x5, x11
+  	adc	x23, xzr, xzr
+  	adds	x20, x20, x12
+  	adcs	x21, x21, x13
+  	adcs	x22, x22, x14
+  	adc	x23, x23, x15
+  	mul	x6, x20, x3
+  	mul	x12, x6, x8
+  	mul	x13, x6, x9
+  	mul	x14, x6, x10
+  	mul	x15, x6, x11
+  	adds	x20, x20, x12
+  	umulh	x12, x6, x8
+  	adcs	x21, x21, x13
+  	umulh	x13, x6, x9
+  	adcs	x22, x22, x14
+  	umulh	x14, x6, x10
+  	adcs	x23, x23, x15
+  	umulh	x15, x6, x11
+  	adc	x24, xzr, xzr
+  	adds	x21, x21, x12
+  	adcs	x22, x22, x13
+  	adcs	x23, x23, x14
+  	adc	x24, x24, x15
+  	mul	x7, x21, x3
+  	mul	x12, x7, x8
+  	mul	x13, x7, x9
+  	mul	x14, x7, x10
+  	mul	x15, x7, x11
+  	adds	x21, x21, x12
+  	umulh	x12, x7, x8
+  	adcs	x22, x22, x13
+  	umulh	x13, x7, x9
+  	adcs	x23, x23, x14
+  	umulh	x14, x7, x10
+  	adcs	x24, x24, x15
+  	umulh	x15, x7, x11
+  	adc	x25, xzr, xzr
+  	adds	x12, x22, x12
+  	adcs	x13, x23, x13
+  	adcs	x14, x24, x14
+  	adc	x15, x25, x15
+  	stp	x4, x5, [x1]
+  	stp	x6, x7, [x1, #16]
+  	cbz	x0, bignum_emontredc_8n_neon_bignum_emontredc_8n_madddone
+  	mov	x27, x0
+
+bignum_emontredc_8n_neon_bignum_emontredc_8n_maddloop:
+ 	add	x2, x2, #0x20
+ 	add	x1, x1, #0x20
+ 	ldp	x8, x9, [x2]
+ 	ldp	x10, x11, [x2, #16]
+ 	mul	x17, x4, x8
+ 	mul	x22, x5, x9
+ 	mul	x23, x6, x10
+ 	mul	x24, x7, x11
+ 	umulh	x16, x4, x8
+ 	adds	x22, x22, x16
+ 	umulh	x16, x5, x9
+ 	adcs	x23, x23, x16
+ 	umulh	x16, x6, x10
+ 	adcs	x24, x24, x16
+ 	umulh	x16, x7, x11
+ 	adc	x25, x16, xzr
+ 	ldp	x20, x21, [x1]
+ 	adds	x12, x12, x20
+ 	adcs	x13, x13, x21
+ 	ldp	x20, x21, [x1, #16]
+ 	adcs	x14, x14, x20
+ 	adcs	x15, x15, x21
+ 	adc	x16, xzr, xzr
+ 	adds	x19, x22, x17
+ 	adcs	x22, x23, x22
+ 	adcs	x23, x24, x23
+ 	adcs	x24, x25, x24
+ 	adc	x25, xzr, x25
+ 	adds	x20, x22, x17
+ 	adcs	x21, x23, x19
+ 	adcs	x22, x24, x22
+ 	adcs	x23, x25, x23
+ 	adcs	x24, xzr, x24
+ 	adc	x25, xzr, x25
+ 	adds	x17, x17, x12
+ 	adcs	x19, x19, x13
+ 	adcs	x20, x20, x14
+ 	adcs	x21, x21, x15
+ 	adcs	x22, x22, x16
+ 	adcs	x23, x23, xzr
+ 	adcs	x24, x24, xzr
+ 	adc	x25, x25, xzr
+ 	subs	x15, x6, x7
+ 	cneg	x15, x15, cc  // cc = lo, ul, last
+ 	csetm	x12, cc  // cc = lo, ul, last
+ 	subs	x13, x11, x10
+ 	cneg	x13, x13, cc  // cc = lo, ul, last
+ 	mul	x14, x15, x13
+ 	umulh	x13, x15, x13
+ 	cinv	x12, x12, cc  // cc = lo, ul, last
+ 	cmn	x12, #0x1
+ 	eor	x14, x14, x12
+ 	adcs	x23, x23, x14
+ 	eor	x13, x13, x12
+ 	adcs	x24, x24, x13
+ 	adc	x25, x25, x12
+ 	subs	x15, x4, x5
+ 	cneg	x15, x15, cc  // cc = lo, ul, last
+ 	csetm	x12, cc  // cc = lo, ul, last
+ 	subs	x13, x9, x8
+ 	cneg	x13, x13, cc  // cc = lo, ul, last
+ 	mul	x14, x15, x13
+ 	umulh	x13, x15, x13
+ 	cinv	x12, x12, cc  // cc = lo, ul, last
+ 	cmn	x12, #0x1
+ 	eor	x14, x14, x12
+ 	adcs	x19, x19, x14
+ 	eor	x13, x13, x12
+ 	adcs	x20, x20, x13
+ 	adcs	x21, x21, x12
+ 	adcs	x22, x22, x12
+ 	adcs	x23, x23, x12
+ 	adcs	x24, x24, x12
+ 	adc	x25, x25, x12
+ 	subs	x15, x5, x7
+ 	cneg	x15, x15, cc  // cc = lo, ul, last
+ 	csetm	x12, cc  // cc = lo, ul, last
+ 	subs	x13, x11, x9
+ 	cneg	x13, x13, cc  // cc = lo, ul, last
+ 	mul	x14, x15, x13
+ 	umulh	x13, x15, x13
+ 	cinv	x12, x12, cc  // cc = lo, ul, last
+ 	cmn	x12, #0x1
+ 	eor	x14, x14, x12
+ 	adcs	x22, x22, x14
+ 	eor	x13, x13, x12
+ 	adcs	x23, x23, x13
+ 	adcs	x24, x24, x12
+ 	adc	x25, x25, x12
+ 	subs	x15, x4, x6
+ 	cneg	x15, x15, cc  // cc = lo, ul, last
+ 	csetm	x12, cc  // cc = lo, ul, last
+ 	subs	x13, x10, x8
+ 	cneg	x13, x13, cc  // cc = lo, ul, last
+ 	mul	x14, x15, x13
+ 	umulh	x13, x15, x13
+ 	cinv	x12, x12, cc  // cc = lo, ul, last
+ 	cmn	x12, #0x1
+ 	eor	x14, x14, x12
+ 	adcs	x20, x20, x14
+ 	eor	x13, x13, x12
+ 	adcs	x21, x21, x13
+ 	adcs	x22, x22, x12
+ 	adcs	x23, x23, x12
+ 	adcs	x24, x24, x12
+ 	adc	x25, x25, x12
+ 	subs	x15, x4, x7
+ 	cneg	x15, x15, cc  // cc = lo, ul, last
+ 	csetm	x12, cc  // cc = lo, ul, last
+ 	subs	x13, x11, x8
+ 	cneg	x13, x13, cc  // cc = lo, ul, last
+ 	mul	x14, x15, x13
+ 	umulh	x13, x15, x13
+ 	cinv	x12, x12, cc  // cc = lo, ul, last
+ 	cmn	x12, #0x1
+ 	eor	x14, x14, x12
+ 	adcs	x21, x21, x14
+ 	eor	x13, x13, x12
+ 	adcs	x22, x22, x13
+ 	adcs	x23, x23, x12
+ 	adcs	x24, x24, x12
+ 	adc	x25, x25, x12
+ 	subs	x15, x5, x6
+ 	cneg	x15, x15, cc  // cc = lo, ul, last
+ 	csetm	x12, cc  // cc = lo, ul, last
+ 	subs	x13, x10, x9
+ 	cneg	x13, x13, cc  // cc = lo, ul, last
+ 	mul	x14, x15, x13
+ 	umulh	x13, x15, x13
+ 	cinv	x12, x12, cc  // cc = lo, ul, last
+ 	cmn	x12, #0x1
+ 	eor	x14, x14, x12
+ 	adcs	x21, x21, x14
+ 	eor	x13, x13, x12
+ 	adcs	x22, x22, x13
+ 	adcs	x13, x23, x12
+ 	adcs	x14, x24, x12
+ 	adc	x15, x25, x12
+ 	mov	x12, x22
+ 	stp	x17, x19, [x1]
+ 	stp	x20, x21, [x1, #16]
+ 	subs	x27, x27, #0x20
+ 	bne	bignum_emontredc_8n_neon_bignum_emontredc_8n_maddloop
+
+bignum_emontredc_8n_neon_bignum_emontredc_8n_madddone:
+ 	ldp	x17, x19, [x1, #32]
+ 	ldp	x20, x21, [x1, #48]
+ 	cmn	x28, x28
+ 	adcs	x17, x17, x12
+ 	adcs	x19, x19, x13
+ 	adcs	x20, x20, x14
+ 	adcs	x21, x21, x15
+ 	csetm	x28, cs  // cs = hs, nlast
+ 	stp	x17, x19, [x1, #32]
+ 	stp	x20, x21, [x1, #48]
+ 	sub	x1, x1, x0
+ 	sub	x2, x2, x0
+ 	add	x1, x1, #0x20
+ 	subs	x26, x26, #0x1
+ 	bne	bignum_emontredc_8n_neon_bignum_emontredc_8n_outerloop
+ 	neg	x0, x28
+
+bignum_emontredc_8n_neon_bignum_emontredc_8n_end:
+ 	ldp	x27, x28, [sp], #16
+ 	ldp	x25, x26, [sp], #16
+ 	ldp	x23, x24, [sp], #16
+ 	ldp	x21, x22, [sp], #16
+ 	ldp	x19, x20, [sp], #16
+ 	ret

--- a/third_party/s2n-bignum/arm/fastmul/bignum_emontredc_8n_neon.S
+++ b/third_party/s2n-bignum/arm/fastmul/bignum_emontredc_8n_neon.S
@@ -3,1091 +3,664 @@
 
 // ----------------------------------------------------------------------------
 // Extend Montgomery reduce in 8-digit blocks, results in input-output buffer
-// Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
+// Inputs z[2*k], m[k], w;
+// Outputs function return (extra result bit) and z[2*k]
+// Temporary buffer m_precalc[12*(k/4-1)]
 //
 //    extern uint64_t bignum_emontredc_8n_neon
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w);
+//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w, uint64_t *m_precalc);
 //
-// Functionally equivalent to bignum_emontredc (see that file for more detail).
-// But in general assumes that the input k is a multiple of 8.
+// The main loop of this code is an output of SLOTHY, a superoptimizer for ARM.
 //
-// Standard ARM ABI: X0 = k, X1 = z, X2 = m, X3 = w, returns X0
+// Standard ARM ABI: X0 = k, X1 = z, X2 = m, X3 = w, X4 = m_precalc
+//                   returns X0
 // ----------------------------------------------------------------------------
 #include "_internal_s2n_bignum.h"
 
-					S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_emontredc_8n_neon)
-					S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_emontredc_8n_neon)
-					.text
-					.balign 4
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_emontredc_8n_neon)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_emontredc_8n_neon)
+        .text
+        .balign 4
 
+
+#define count x27
+
+// Helper macro for the pre-computations
+#define cdiff(t, c, x, y) subs t, x, y; cneg t, t, cc; csetm c, cc
+
+// Some immediate offsets for cached differences+carry used
+// in the inner ADK multiplications
+#define cache_a01 (32+0*16)
+#define cache_a02 (32+1*16)
+#define cache_a03 (32+2*16)
+#define cache_a12 (32+3*16)
+#define cache_a13 (32+4*16)
+#define cache_a23 (32+5*16)
+#define cache_m10 (0*16)
+#define cache_m20 (1*16)
+#define cache_m30 (2*16)
+#define cache_m21 (3*16)
+#define cache_m31 (4*16)
+#define cache_m32 (5*16)
+
+#define a0 x4
+#define a1 x5
+#define a2 x6
+#define a3 x7
+
+// Registers for precalculation
+#define vpre00 v30
+#define vpre01 v28
+#define vpre02 v17
+#define vpre10 v18
+#define vpre11 v19
+#define vpre12 v20
+
+#define m x2
 
 S2N_BN_SYMBOL(bignum_emontredc_8n_neon):
-           stp x19, x20, [sp, #-16]!
-           stp x21, x22, [sp, #-16]!
-           stp x23, x24, [sp, #-16]!
-           stp x25, x26, [sp, #-16]!
-           stp x27, x28, [sp, #-16]!
-           sub sp, sp, #32
-           lsr x0, x0, #2
-           mov x26, x0
-           subs x12, x0, #1
-           bcc bignum_emontredc_8n_neon_end
 
-           stp x3, xzr, [sp]
-           stp x26, xzr, [sp, #16]
-           mov x28, xzr
-           lsl x0, x12, #5
+        sub sp, sp, #(14*16)
+        stp x19, x20, [sp, #(13*16)]
+        stp x21, x22, [sp, #(12*16)]
+        stp x23, x24, [sp, #(11*16)]
+        stp x25, x26, [sp, #(10*16)]
+        stp x27, x28, [sp, #(9*16)]
+        stp x29, x30, [sp, #(8*16)]
+        str q8, [sp, #16*0]
+        str q9, [sp, #16*1]
+        str q10, [sp, #16*2]
+        str q11, [sp, #16*3]
+        str q12, [sp, #16*4]
+        str q13, [sp, #16*5]
+        str q14, [sp, #16*6]
+        str q15, [sp, #16*7]
+
+        // Leave space for cached differences of words of a in inner loop
+        sub sp, sp, #(6*16)
+
+        sub sp, sp, #32
+        lsr x0, x0, #2
+        mov x26, x0
+        subs x12, x0, #1
+        bcc bignum_emontredc_8n_neon_end
+
+        //
+        // Start of precomputation of m
+        //
+        // Precompute and cache signed differences of modulus components
+        // used in the ADK multiplication in the inner loop.
+        //
+        // THIS SHOULD BE HOISTED OUT
+        // (and until then, comment out for benchmarking to get accurate estimates)
+        //
+
+        // Number of extra limbs required:
+        // 6 * (number of limbs / 4 - 1) * 2 = 12 * (number_of_limbs/4 - 1)
+        //
+        mov x24, x4
+        mov x30, x4
+
+        // Save modulus pointer
+        mov x25, m
+
+        mov count, x12
+
+bignum_emontredc_8n_neon_precomp:
+        ldp a0, a1, [m, #32]!
+        ldp a2, a3, [m, #16]
+
+#define t x28
+#define c x29
+
+        cdiff(t, c, a1, a0)
+        stp   t, c, [x30, #cache_m10]
+        cdiff(t, c, a2, a0)
+        stp   t, c, [x30, #cache_m20]
+        cdiff(t, c, a3, a0)
+        stp   t, c, [x30, #cache_m30]
+        cdiff(t, c, a2, a1)
+        stp   t, c, [x30, #cache_m21]
+        cdiff(t, c, a3, a1)
+        stp   t, c, [x30, #cache_m31]
+        cdiff(t, c, a3, a2)
+        stp   t, c, [x30, #cache_m32]
+
+        add x30, x30, #(6*16)
+
+        subs count, count, #1
+        cbnz count, bignum_emontredc_8n_neon_precomp
+
+        // Set modulus pointer and buffer pointer back to its original value
+        mov m, x25
+        mov x30, x24
+
+        //
+        // End of precomputation
+        //
+
+        stp x3, x30, [sp]
+        //stp x3, xzr, [sp]
+        stp x26, xzr, [sp, #16]
+        mov x28, xzr
+        lsl x0, x12, #5
+
+        movi    v29.2d, #0x000000ffffffff
 
 bignum_emontredc_8n_neon_outerloop:
-          ldp x3, xzr, [sp]
-          ldp x17, x19, [x1]
-          ldp x20, x21, [x1, #16]
-          ldp x8, x9, [x2]
-          ldp x10, x11, [x2, #16]
-          ldr q21, [x2, #16]
-
-          // Montgomery step 0
-
-          mul x4, x17, x3
-// NEON: Calculate x4 * (x10, x11) that does two 64x64->128-bit multiplications.
-dup v0.2d, x4
-uzp2    v3.4s, v21.4s, v0.4s
-xtn     v4.2s, v0.2d
-xtn     v5.2s, v21.2d
-          mul	x12, x4, x8
-          adds x17, x17, x12
-          umulh x12, x4, x8
-          mul	x13, x4, x9
-rev64   v1.4s, v21.4s
-umull   v6.2d, v4.2s, v5.2s
-umull   v7.2d, v4.2s, v3.2s
-uzp2    v16.4s, v0.4s, v0.4s
-mul     v0.4s, v1.4s, v0.4s
-movi    v2.2d, #0x000000ffffffff
-usra    v7.2d, v6.2d, #32
-umull   v1.2d, v16.2s, v3.2s
-uaddlp  v0.2d, v0.4s
-and     v2.16b, v7.16b, v2.16b
-umlal   v2.2d, v16.2s, v5.2s
-shl     v0.2d, v0.2d, #32
-usra    v1.2d, v7.2d, #32
-umlal   v0.2d, v4.2s, v5.2s
-mov x14, v0.d[0]
-mov x15, v0.d[1]
-          adcs x19, x19, x13
-          umulh x13, x4, x9
-          adcs x20, x20, x14
-usra    v1.2d, v2.2d, #32
-mov x14, v1.d[0]
-          adcs x21, x21, x15
-mov x15, v1.d[1]
-          adc x22, xzr, xzr
-          adds x19, x19, x12
-          mul x5, x19, x3 // hoisted from step 1
-          adcs x20, x20, x13
-          adcs x21, x21, x14
-          adc x22, x22, x15
-
-          // Montgomery step 1
-
-// NEON: Calculate x5 * (x10, x11) that does two 64x64->128-bit multiplications.
-dup v0.2d, x5
-uzp2    v3.4s, v21.4s, v0.4s
-xtn     v4.2s, v0.2d
-xtn     v5.2s, v21.2d
-
-          mul	x12, x5, x8
-          adds	x19, x19, x12
-          umulh	x12, x5, x8
-          mul	x13, x5, x9
-
-rev64   v1.4s, v21.4s
-umull   v6.2d, v4.2s, v5.2s
-umull   v7.2d, v4.2s, v3.2s
-uzp2    v16.4s, v0.4s, v0.4s
-mul     v0.4s, v1.4s, v0.4s
-movi    v2.2d, #0x000000ffffffff
-usra    v7.2d, v6.2d, #32
-umull   v1.2d, v16.2s, v3.2s
-uaddlp  v0.2d, v0.4s
-and     v2.16b, v7.16b, v2.16b
-umlal   v2.2d, v16.2s, v5.2s
-shl     v0.2d, v0.2d, #32
-usra    v1.2d, v7.2d, #32
-umlal   v0.2d, v4.2s, v5.2s
-mov x14, v0.d[0]
-mov x15, v0.d[1]
-          adcs	x20, x20, x13
-          umulh	x13, x5, x9
-          adcs x21, x21, x14
-usra    v1.2d, v2.2d, #32
-mov x14, v1.d[0]
-          adcs x22, x22, x15
-mov x15, v1.d[1]
-          adc x23, xzr, xzr
-          adds x20, x20, x12
-          mul	x6, x20, x3 // hoisted from step 2
-
-// NEON: For montgomery step 2,
-// calculate x6 * (x10, x11) that does two 64x64->128-bit multiplications.
-dup v0.2d, x6
-#define in1  v21
-#define in2  v0
-#define out_lo v0
-#define out_hi v1
-uzp2    v3.4s, in2.4s, in1.4s
-xtn     v4.2s, in1.2d
-xtn     v5.2s, in2.2d
-
-          adcs x21, x21, x13
-          adcs x22, x22, x14
-          adc x23, x23, x15
-
-          stp x4, x5, [x1]
-
-// hoisted from maddloop_neon_firstitr
-ldr q20, [x1]
-// q21 will be loaded later.
-
-ldr q22, [x2, #32]
-ldr q23, [x2, #48]
-
-        // Montgomery step 2
-
-rev64   v1.4s, in2.4s
-umull   v6.2d, v4.2s, v5.2s
-umull   v7.2d, v4.2s, v3.2s
-uzp2    v16.4s, in1.4s, in1.4s
-
-        mul	x12, x6, x8
-        adds	x20, x20, x12
-
-mul     v0.4s, v1.4s, in1.4s
-movi    v2.2d, #0x000000ffffffff
-usra    v7.2d, v6.2d, #32
-umull   out_hi.2d, v16.2s, v3.2s
-
-        umulh	x12, x6, x8
-        mul	x13, x6, x9
-
-uaddlp  v0.2d, v0.4s
-and     v2.16b, v7.16b, v2.16b
-umlal   v2.2d, v16.2s, v5.2s
-shl     out_lo.2d, v0.2d, #32
-
-        adcs	x21, x21, x13
-        umulh	x13, x6, x9
-
-usra    out_hi.2d, v7.2d, #32
-umlal   out_lo.2d, v4.2s, v5.2s
-mov x14, out_lo.d[0]
-mov x15, out_lo.d[1]
-
-usra    out_hi.2d, v2.2d, #32
-#undef in1
-#undef in2
-#undef out_lo
-#undef out_hi
-
-          adcs x22, x22, x14
-          adcs x23, x23, x15
-
-mov x14, v1.d[0]
-mov x15, v1.d[1]
-
-          adc	x24, xzr, xzr
-          adds	x21, x21, x12
-          mul	x7, x21, x3
-          adcs	x22, x22, x13
-          adcs	x23, x23, x14
-          adc	x24, x24, x15
-
-          stp x6, x7, [x1, #16]
-
-// hoisted from maddloop_neon_firstitr
-ldr q21, [x1, #16]
-
-// pre-calculate 2mul+2umulhs in maddloop_neon_firstitr
-// v25++v24 = hi and lo of (x4 * x8, x5 * x9)
-#define in1  v20
-#define in2  v22
-#define out_lo v24
-#define out_hi v25
-uzp2    v3.4s, in2.4s, in1.4s
-xtn     v4.2s, in1.2d
-
-          // Montgomery step 3
-
-           mul	x12, x7, x8
-           mul	x13, x7, x9
-
-xtn     v5.2s, in2.2d
-rev64   v1.4s, in2.4s
-umull   v6.2d, v4.2s, v5.2s
-umull   v7.2d, v4.2s, v3.2s
-
-           mul	x14, x7, x10
-           mul	x15, x7, x11
-
-uzp2    v16.4s, in1.4s, in1.4s
-mul     v0.4s, v1.4s, in1.4s
-movi    v2.2d, #0x000000ffffffff
-usra    v7.2d, v6.2d, #32
-umull   out_hi.2d, v16.2s, v3.2s
-uaddlp  v0.2d, v0.4s
-and     v2.16b, v7.16b, v2.16b
-umlal   v2.2d, v16.2s, v5.2s
-
-           adds	x21, x21, x12
-           umulh	x12, x7, x8
-           adcs	x22, x22, x13
-           umulh	x13, x7, x9
-
-shl     out_lo.2d, v0.2d, #32
-usra    out_hi.2d, v7.2d, #32
-umlal   out_lo.2d, v4.2s, v5.2s
-usra    out_hi.2d, v2.2d, #32
-#undef in1
-#undef in2
-#undef out_lo
-#undef out_hi
-
-           adcs	x23, x23, x14
-           umulh	x14, x7, x10
-           adcs	x24, x24, x15
-           umulh	x15, x7, x11
-
-// v27++v26 = hi and lo of (x6 * x10, x7 * x11)
-#define in1  v21
-#define in2  v23
-#define out_lo v26
-#define out_hi v27
-uzp2    v3.4s, in2.4s, in1.4s
-xtn     v4.2s, in1.2d
-xtn     v5.2s, in2.2d
-rev64   v1.4s, in2.4s
-
-// hoisted from maddloop_neon_firstitr and maddloop_x0one
-          ldp x8, x9, [x2, #32]
-          ldp x10, x11, [x2, #48]
-
-umull   v6.2d, v4.2s, v5.2s
-umull   v7.2d, v4.2s, v3.2s
-uzp2    v16.4s, in1.4s, in1.4s
-mul     v0.4s, v1.4s, in1.4s
-
-          adc	x25, xzr, xzr
-          adds	x12, x22, x12
-          adcs	x13, x23, x13
-          adcs	x14, x24, x14
-          adc	x15, x25, x15
-
-movi    v2.2d, #0x000000ffffffff
-usra    v7.2d, v6.2d, #32
-umull   out_hi.2d, v16.2s, v3.2s
-uaddlp  v0.2d, v0.4s
-and     v2.16b, v7.16b, v2.16b
-umlal   v2.2d, v16.2s, v5.2s
-shl     out_lo.2d, v0.2d, #32
-usra    out_hi.2d, v7.2d, #32
-umlal   out_lo.2d, v4.2s, v5.2s
-usra    out_hi.2d, v2.2d, #32
-#undef in1
-#undef in2
-#undef out_lo
-#undef out_hi
-
-          cbz x0, bignum_emontredc_8n_neon_madddone
-          mov x27, x0
-          cmp x0, #32
-          bne bignum_emontredc_8n_neon_maddloop_neon_firstitr
-
-bignum_emontredc_8n_neon_maddloop_x0one:
-         	add	x2, x2, #0x20
-         	add	x1, x1, #0x20
-         	mul	x17, x4, x8
-         	mul	x22, x5, x9
-         	mul	x23, x6, x10
-         	mul	x24, x7, x11
-         	umulh	x16, x4, x8
-         	adds	x22, x22, x16
-         	umulh	x16, x5, x9
-         	adcs	x23, x23, x16
-         	umulh	x16, x6, x10
-         	adcs	x24, x24, x16
-         	umulh	x16, x7, x11
-         	adc	x25, x16, xzr
-         	ldp	x20, x21, [x1]
-         	adds	x12, x12, x20
-         	adcs	x13, x13, x21
-         	ldp	x20, x21, [x1, #16]
-         	adcs	x14, x14, x20
-         	adcs	x15, x15, x21
-         	adc	x16, xzr, xzr
-         	adds	x19, x22, x17
-         	adcs	x22, x23, x22
-         	adcs	x23, x24, x23
-         	adcs	x24, x25, x24
-         	adc	x25, xzr, x25
-         	adds	x20, x22, x17
-         	adcs	x21, x23, x19
-         	adcs	x22, x24, x22
-         	adcs	x23, x25, x23
-         	adcs	x24, xzr, x24
-         	adc	x25, xzr, x25
-         	adds	x17, x17, x12
-         	adcs	x19, x19, x13
-         	adcs	x20, x20, x14
-         	adcs	x21, x21, x15
-         	adcs	x22, x22, x16
-         	adcs	x23, x23, xzr
-         	adcs	x24, x24, xzr
-         	adc	x25, x25, xzr
-         	subs	x15, x6, x7
-         	cneg	x15, x15, cc  // cc = lo, ul, last
-         	csetm	x12, cc  // cc = lo, ul, last
-         	subs	x13, x11, x10
-         	cneg	x13, x13, cc  // cc = lo, ul, last
-         	mul	x14, x15, x13
-         	umulh	x13, x15, x13
-         	cinv	x12, x12, cc  // cc = lo, ul, last
-         	cmn	x12, #0x1
-         	eor	x14, x14, x12
-         	adcs	x23, x23, x14
-         	eor	x13, x13, x12
-         	adcs	x24, x24, x13
-         	adc	x25, x25, x12
-         	subs	x15, x4, x5
-         	cneg	x15, x15, cc  // cc = lo, ul, last
-         	csetm	x12, cc  // cc = lo, ul, last
-         	subs	x13, x9, x8
-         	cneg	x13, x13, cc  // cc = lo, ul, last
-         	mul	x14, x15, x13
-         	umulh	x13, x15, x13
-         	cinv	x12, x12, cc  // cc = lo, ul, last
-         	cmn	x12, #0x1
-         	eor	x14, x14, x12
-         	adcs	x19, x19, x14
-         	eor	x13, x13, x12
-         	adcs	x20, x20, x13
-         	adcs	x21, x21, x12
-         	adcs	x22, x22, x12
-         	adcs	x23, x23, x12
-         	adcs	x24, x24, x12
-         	adc	x25, x25, x12
-         	subs	x15, x5, x7
-         	cneg	x15, x15, cc  // cc = lo, ul, last
-         	csetm	x12, cc  // cc = lo, ul, last
-         	subs	x13, x11, x9
-         	cneg	x13, x13, cc  // cc = lo, ul, last
-         	mul	x14, x15, x13
-         	umulh	x13, x15, x13
-         	cinv	x12, x12, cc  // cc = lo, ul, last
-         	cmn	x12, #0x1
-         	eor	x14, x14, x12
-         	adcs	x22, x22, x14
-         	eor	x13, x13, x12
-         	adcs	x23, x23, x13
-         	adcs	x24, x24, x12
-         	adc	x25, x25, x12
-         	subs	x15, x4, x6
-         	cneg	x15, x15, cc  // cc = lo, ul, last
-         	csetm	x12, cc  // cc = lo, ul, last
-         	subs	x13, x10, x8
-         	cneg	x13, x13, cc  // cc = lo, ul, last
-         	mul	x14, x15, x13
-         	umulh	x13, x15, x13
-         	cinv	x12, x12, cc  // cc = lo, ul, last
-         	cmn	x12, #0x1
-         	eor	x14, x14, x12
-         	adcs	x20, x20, x14
-         	eor	x13, x13, x12
-         	adcs	x21, x21, x13
-         	adcs	x22, x22, x12
-         	adcs	x23, x23, x12
-         	adcs	x24, x24, x12
-         	adc	x25, x25, x12
-         	subs	x15, x4, x7
-         	cneg	x15, x15, cc  // cc = lo, ul, last
-         	csetm	x12, cc  // cc = lo, ul, last
-         	subs	x13, x11, x8
-         	cneg	x13, x13, cc  // cc = lo, ul, last
-         	mul	x14, x15, x13
-         	umulh	x13, x15, x13
-         	cinv	x12, x12, cc  // cc = lo, ul, last
-         	cmn	x12, #0x1
-         	eor	x14, x14, x12
-         	adcs	x21, x21, x14
-         	eor	x13, x13, x12
-         	adcs	x22, x22, x13
-         	adcs	x23, x23, x12
-         	adcs	x24, x24, x12
-         	adc	x25, x25, x12
-         	subs	x15, x5, x6
-         	cneg	x15, x15, cc  // cc = lo, ul, last
-         	csetm	x12, cc  // cc = lo, ul, last
-         	subs	x13, x10, x9
-         	cneg	x13, x13, cc  // cc = lo, ul, last
-         	mul	x14, x15, x13
-         	umulh	x13, x15, x13
-         	cinv	x12, x12, cc  // cc = lo, ul, last
-         	cmn	x12, #0x1
-         	eor	x14, x14, x12
-         	adcs	x21, x21, x14
-         	eor	x13, x13, x12
-         	adcs	x22, x22, x13
-         	adcs	x13, x23, x12
-         	adcs	x14, x24, x12
-         	adc	x15, x25, x12
-         	mov	x12, x22
-         	stp	x17, x19, [x1]
-         	stp	x20, x21, [x1, #16]
-         	sub	x27, x27, #0x20
-          b bignum_emontredc_8n_neon_madddone
-
-
-bignum_emontredc_8n_neon_maddloop_neon_firstitr:
-
-mov x16, v25.d[0] //umulh x16,x4,x8
-mov x22, v24.d[1] //mul x22, x5, x9
-
-mov x20, v25.d[1] //umulh x20,x5,x9
-mov x23, v26.d[0] //mul x23, x6, x10
-
-mov x21, v27.d[0] //umulh x21,x6,x10
-mov x24, v26.d[1] //mul x24, x7, x11
-
-mov x3, v27.d[1] //umulh x3,x7,x11
-mov x17, v24.d[0] //mul x17, x4, x8
-
-          adds x22,x22,x16
-          adcs x23,x23,x20
-          adcs x24,x24,x21
-          adc x25,x3,xzr
-
-// pre-calculate the multiplications for the next iter.
-// v25 ++ v24 = hi, lo of (x4 * x8, x5 * x9)
-ldr q22, [x2, #64]
-ldr q23, [x2, #80]
-
-          add x2, x2, #32
-          add x1, x1, #32
-
-#define in1  v20
-#define in2  v22
-#define out_lo v24
-#define out_hi v25
-uzp2    v3.4s, in2.4s, in1.4s
-xtn     v4.2s, in1.2d
-xtn     v5.2s, in2.2d
-rev64   v1.4s, in2.4s
-
-          ldp x20,x21,[x1]
-          adds x12,x12,x20
-          adcs x13,x13,x21
-          ldp x20,x21,[x1,#16]
-
-umull   v6.2d, v4.2s, v5.2s
-umull   v7.2d, v4.2s, v3.2s
-uzp2    v16.4s, in1.4s, in1.4s
-mul     v0.4s, v1.4s, in1.4s
-
-          adcs x14,x14,x20
-          adcs x15,x15,x21
-          adc x16,xzr,xzr
-          adds x19,x22,x17
-
-movi    v2.2d, #0x000000ffffffff
-usra    v7.2d, v6.2d, #32
-umull   out_hi.2d, v16.2s, v3.2s
-uaddlp  v0.2d, v0.4s
-
-          adcs x22,x23,x22
-          adcs x23,x24,x23
-          adcs x24,x25,x24
-          adc x25,xzr,x25
-
-and     v2.16b, v7.16b, v2.16b
-umlal   v2.2d, v16.2s, v5.2s
-shl     out_lo.2d, v0.2d, #32
-usra    out_hi.2d, v7.2d, #32
-
-          adds x20,x22,x17
-          adcs x21,x23,x19
-          adcs x22,x24,x22
-          adcs x23,x25,x23
-
-umlal   out_lo.2d, v4.2s, v5.2s
-usra    out_hi.2d, v2.2d, #32
-#undef in1
-#undef in2
-#undef out_lo
-#undef out_hi
-
-          adcs x24,xzr,x24
-          adc x25,xzr,x25
-          adds x17,x17,x12
-          adcs x19,x19,x13
-
-#define in1  v21
-#define in2  v23
-#define out_lo v26
-#define out_hi v27
-uzp2    v3.4s, in2.4s, in1.4s
-xtn     v4.2s, in1.2d
-xtn     v5.2s, in2.2d
-rev64   v1.4s, in2.4s
-
-          adcs x20,x20,x14
-          adcs x21,x21,x15
-          adcs x22,x22,x16
-          adcs x23,x23,xzr
-
-umull   v6.2d, v4.2s, v5.2s
-umull   v7.2d, v4.2s, v3.2s
-uzp2    v16.4s, in1.4s, in1.4s
-mul     v0.4s, v1.4s, in1.4s
-
-          adcs x24,x24,xzr
-          adc x25,x25,xzr
-          subs x15,x6,x7
-          cneg x15,x15,cc
-
-movi    v2.2d, #0x000000ffffffff
-usra    v7.2d, v6.2d, #32
-umull   out_hi.2d, v16.2s, v3.2s
-uaddlp  v0.2d, v0.4s
-
-          csetm x12,cc
-          subs x13,x11,x10
-          cneg x13,x13,cc
-          mul x14,x15,x13
-
-and     v2.16b, v7.16b, v2.16b
-umlal   v2.2d, v16.2s, v5.2s
-shl     out_lo.2d, v0.2d, #32
-usra    out_hi.2d, v7.2d, #32
-
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-
-umlal   out_lo.2d, v4.2s, v5.2s
-usra    out_hi.2d, v2.2d, #32
-#undef in1
-#undef in2
-#undef out_lo
-#undef out_hi
-
-          adcs x23,x23,x14
-          eor x13,x13,x12
-          adcs x24,x24,x13
-          adc x25,x25,x12
-          subs x15,x4,x5
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x9,x8
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x19,x19,x14
-          eor x13,x13,x12
-          adcs x20,x20,x13
-          adcs x21,x21,x12
-          adcs x22,x22,x12
-          adcs x23,x23,x12
-          adcs x24,x24,x12
-          adc x25,x25,x12
-
-          stp x17,x19,[x1]
-
-mov x16, v25.d[0] // hi bits of (x4 * x8)
-mov x26, v27.d[0] // hi bits of (x6 * x10)
-mov x3, v25.d[1] // hi bits of (x5 * x9)
-mov x17, v27.d[1] // hi bits of (x6 * x10)
-
-          subs x15,x5,x7
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x11,x9
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x22,x22,x14
-          eor x13,x13,x12
-          adcs x23,x23,x13
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x4,x6
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x10,x8
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x20,x20,x14
-          eor x13,x13,x12
-          adcs x21,x21,x13
-          adcs x22,x22,x12
-          adcs x23,x23,x12
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x4,x7
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x11,x8
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x21,x21,x14
-          eor x13,x13,x12
-          adcs x22,x22,x13
-          adcs x23,x23,x12
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x5,x6
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x10,x9
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x21,x21,x14
-
-          stp x20,x21,[x1,#16]
-mov x20, v24.d[1] // lo bits of (x5 * x9)
-mov x21, v26.d[0] // lo bits of (x6 * x10)
-
-          eor x13,x13,x12
-          adcs x22,x22,x13
-          adcs x13,x23,x12
-          adcs x14,x24,x12
-          adc x15,x25,x12
-          mov x12,x22
-
-mov x24, v26.d[1] // lo bits of (x7 * x11)
-
-           sub x27, x27, #32
-           cmp x27, #32
-           beq bignum_emontredc_8n_neon_maddloop_neon_last
-
-
-bignum_emontredc_8n_neon_maddloop_neon:
-          ldp x8, x9, [x2, #32]
-          ldp x10, x11, [x2, #48]
-
-// pre-calculate the multiplications for the next iter.
-// v25 ++ v24 = hi, lo of (x4 * x8, x5 * x9)
-ldr q22, [x2, #64]
-ldr q23, [x2, #80]
-
-          add x2, x2, #32
-          add x1, x1, #32
-
-          adds x22,x20,x16
-          adcs x23,x21,x3
-          adcs x24,x24,x26
-          adc x25,x17,xzr
-mov x17, v24.d[0] // lo bits of (x4 * x8)
-
-#define in1  v20
-#define in2  v22
-#define out_lo v24
-#define out_hi v25
-uzp2    v3.4s, in2.4s, in1.4s
-xtn     v4.2s, in1.2d
-xtn     v5.2s, in2.2d
-rev64   v1.4s, in2.4s
-
-          ldp x20,x21,[x1]
-          adds x12,x12,x20
-          adcs x13,x13,x21
-          ldp x20,x21,[x1,#16]
-
-umull   v6.2d, v4.2s, v5.2s
-umull   v7.2d, v4.2s, v3.2s
-uzp2    v16.4s, in1.4s, in1.4s
-mul     v0.4s, v1.4s, in1.4s
-
-          adcs x14,x14,x20
-          adcs x15,x15,x21
-          adc x16,xzr,xzr
-          adds x19,x22,x17
-
-movi    v2.2d, #0x000000ffffffff
-usra    v7.2d, v6.2d, #32
-umull   out_hi.2d, v16.2s, v3.2s
-uaddlp  v0.2d, v0.4s
-
-          adcs x22,x23,x22
-          adcs x23,x24,x23
-          adcs x24,x25,x24
-          adc x25,xzr,x25
-
-and     v2.16b, v7.16b, v2.16b
-umlal   v2.2d, v16.2s, v5.2s
-shl     out_lo.2d, v0.2d, #32
-usra    out_hi.2d, v7.2d, #32
-
-          adds x20,x22,x17
-          adcs x21,x23,x19
-          adcs x22,x24,x22
-          adcs x23,x25,x23
-
-umlal   out_lo.2d, v4.2s, v5.2s
-usra    out_hi.2d, v2.2d, #32
-#undef in1
-#undef in2
-#undef out_lo
-#undef out_hi
-
-          adcs x24,xzr,x24
-          adc x25,xzr,x25
-          adds x17,x17,x12
-          adcs x19,x19,x13
-
-#define in1  v21
-#define in2  v23
-#define out_lo v26
-#define out_hi v27
-uzp2    v3.4s, in2.4s, in1.4s
-xtn     v4.2s, in1.2d
-xtn     v5.2s, in2.2d
-rev64   v1.4s, in2.4s
-
-          adcs x20,x20,x14
-          adcs x21,x21,x15
-          adcs x22,x22,x16
-          adcs x23,x23,xzr
-
-umull   v6.2d, v4.2s, v5.2s
-umull   v7.2d, v4.2s, v3.2s
-uzp2    v16.4s, in1.4s, in1.4s
-mul     v0.4s, v1.4s, in1.4s
-
-          adcs x24,x24,xzr
-          adc x25,x25,xzr
-          subs x15,x6,x7
-          cneg x15,x15,cc
-
-movi    v2.2d, #0x000000ffffffff
-usra    v7.2d, v6.2d, #32
-umull   out_hi.2d, v16.2s, v3.2s
-uaddlp  v0.2d, v0.4s
-
-          csetm x12,cc
-          subs x13,x11,x10
-          cneg x13,x13,cc
-          mul x14,x15,x13
-
-and     v2.16b, v7.16b, v2.16b
-umlal   v2.2d, v16.2s, v5.2s
-shl     out_lo.2d, v0.2d, #32
-usra    out_hi.2d, v7.2d, #32
-
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-
-umlal   out_lo.2d, v4.2s, v5.2s
-usra    out_hi.2d, v2.2d, #32
-#undef in1
-#undef in2
-#undef out_lo
-#undef out_hi
-
-          adcs x23,x23,x14
-          eor x13,x13,x12
-          adcs x24,x24,x13
-          adc x25,x25,x12
-          subs x15,x4,x5
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x9,x8
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x19,x19,x14
-          eor x13,x13,x12
-          adcs x20,x20,x13
-          adcs x21,x21,x12
-          adcs x22,x22,x12
-          adcs x23,x23,x12
-          adcs x24,x24,x12
-          adc x25,x25,x12
-
-          stp x17,x19,[x1]
-
-mov x16, v25.d[0] // hi bits of (x4 * x8)
-mov x26, v27.d[0] // hi bits of (x6 * x10)
-mov x3, v25.d[1] // hi bits of (x5 * x9)
-mov x17, v27.d[1] // hi bits of (x6 * x10)
-
-          subs x15,x5,x7
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x11,x9
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x22,x22,x14
-          eor x13,x13,x12
-          adcs x23,x23,x13
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x4,x6
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x10,x8
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x20,x20,x14
-          eor x13,x13,x12
-          adcs x21,x21,x13
-          adcs x22,x22,x12
-          adcs x23,x23,x12
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x4,x7
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x11,x8
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x21,x21,x14
-          eor x13,x13,x12
-          adcs x22,x22,x13
-          adcs x23,x23,x12
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x5,x6
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x10,x9
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x21,x21,x14
-
-          stp x20,x21,[x1,#16]
-mov x20, v24.d[1] // lo bits of (x5 * x9)
-mov x21, v26.d[0] // lo bits of (x6 * x10)
-
-          eor x13,x13,x12
-          adcs x22,x22,x13
-          adcs x13,x23,x12
-          adcs x14,x24,x12
-          adc x15,x25,x12
-          mov x12,x22
-
-mov x24, v26.d[1] // lo bits of (x7 * x11)
-
-           sub x27, x27, #32
-           cmp x27, #32
-           bne bignum_emontredc_8n_neon_maddloop_neon
-
-
-bignum_emontredc_8n_neon_maddloop_neon_last:
-          ldp x8, x9, [x2, #32]
-          ldp x10, x11, [x2, #48]
-
-          add x2, x2, #32
-          add x1, x1, #32
-
-          adds x22,x20,x16
-          adcs x23,x21,x3
-          adcs x24,x24,x26
-          adc x25,x17,xzr
-mov x17, v24.d[0] // lo bits of (x4 * x8)
-
-          ldp x20,x21,[x1]
-          adds x12,x12,x20
-          adcs x13,x13,x21
-          ldp x20,x21,[x1,#16]
-          adcs x14,x14,x20
-          adcs x15,x15,x21
-          adc x16,xzr,xzr
-          adds x19,x22,x17
-          adcs x22,x23,x22
-          adcs x23,x24,x23
-          adcs x24,x25,x24
-          adc x25,xzr,x25
-          adds x20,x22,x17
-          adcs x21,x23,x19
-          adcs x22,x24,x22
-          adcs x23,x25,x23
-          adcs x24,xzr,x24
-          adc x25,xzr,x25
-          adds x17,x17,x12
-          adcs x19,x19,x13
-          adcs x20,x20,x14
-          adcs x21,x21,x15
-          adcs x22,x22,x16
-          adcs x23,x23,xzr
-          adcs x24,x24,xzr
-          adc x25,x25,xzr
-          subs x15,x6,x7
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x11,x10
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x23,x23,x14
-          eor x13,x13,x12
-          adcs x24,x24,x13
-          adc x25,x25,x12
-          subs x15,x4,x5
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x9,x8
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x19,x19,x14
-          eor x13,x13,x12
-          adcs x20,x20,x13
-          adcs x21,x21,x12
-          adcs x22,x22,x12
-          adcs x23,x23,x12
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x5,x7
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x11,x9
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x22,x22,x14
-          eor x13,x13,x12
-          adcs x23,x23,x13
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x4,x6
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x10,x8
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x20,x20,x14
-          eor x13,x13,x12
-          adcs x21,x21,x13
-          adcs x22,x22,x12
-          adcs x23,x23,x12
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x4,x7
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x11,x8
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x21,x21,x14
-          eor x13,x13,x12
-          adcs x22,x22,x13
-          adcs x23,x23,x12
-          adcs x24,x24,x12
-          adc x25,x25,x12
-          subs x15,x5,x6
-          cneg x15,x15,cc
-          csetm x12,cc
-          subs x13,x10,x9
-          cneg x13,x13,cc
-          mul x14,x15,x13
-          umulh x13,x15,x13
-          cinv x12,x12,cc
-          adds xzr,x12,#1
-          eor x14,x14,x12
-          adcs x21,x21,x14
-          eor x13,x13,x12
-          adcs x22,x22,x13
-          adcs x13,x23,x12
-          adcs x14,x24,x12
-          adc x15,x25,x12
-          mov x12,x22
-          stp x17,x19,[x1]
-          stp x20,x21,[x1,#16]
-           subs x27, x27, #64
-
-bignum_emontredc_8n_neon_madddone:
-           ldp x17, x19, [x1, #32]
-           ldp x20, x21, [x1, #48]
-           ldp x26, xzr, [sp, #16]
-           adds xzr, x28, x28
-           adcs x17, x17, x12
-           adcs x19, x19, x13
-           adcs x20, x20, x14
-           adcs x21, x21, x15
-           csetm x28, cs
-           stp x17, x19, [x1, #32]
-           stp x20, x21, [x1, #48]
-           sub x1, x1, x0
-           sub x2, x2, x0
-           add x1, x1, #32
-           subs x26, x26, #1
-           stp x26, xzr, [sp, #16]
-           bne bignum_emontredc_8n_neon_outerloop
-           neg x0, x28
+        ldp x9, x13, [x1, #0]
+        ldr x3, [sp]
+        lsr x27, x0, #5
+        sub x27, x27, #1
+        ldp x10, x12, [x1, #16]
+        ldp x4, x15, [x2, #0]
+        ldr q1, [x2, #16]
+        mul x11, x9, x3
+        uzp2 v18.4S, v1.4S, v1.4S
+        dup v27.2D, x11
+        xtn v13.2S, v1.2D
+        rev64 v9.4S, v1.4S
+        mul x7, x11, x4
+        rev64 v2.4S, v1.4S
+        uzp2 v20.4S, v1.4S, v1.4S
+        mul v31.4S, v9.4S, v27.4S
+        xtn v14.2S, v1.2D
+        uzp2 v21.4S, v1.4S, v1.4S
+        umulh x22, x11, x15
+        xtn v17.2S, v27.2D
+        adds x19, x9, x7
+        umull v28.2D, v17.2S, v13.2S
+        umull v26.2D, v17.2S, v18.2S
+        uaddlp v8.2D, v31.4S
+        umulh x8, x11, x4
+        shl v7.2D, v8.2D, #32
+        uzp2 v30.4S, v27.4S, v27.4S
+        umlal v7.2D, v17.2S, v13.2S
+        mul x14, x11, x15
+        usra v26.2D, v28.2D, #32
+        umull v12.2D, v30.2S, v18.2S
+        mov x24, v7.d[0]
+        adcs x29, x13, x14
+        and v4.16B, v26.16B, v29.16B
+        mov x17, v7.d[1]
+        rev64 v27.4S, v1.4S
+        adcs x5, x10, x24
+        umlal v4.2D, v30.2S, v13.2S
+        usra v12.2D, v26.2D, #32
+        adcs x14, x12, x17
+        adc x23, xzr, xzr
+        adds x8, x29, x8
+        adcs x7, x5, x22
+        mul x25, x8, x3
+        usra v12.2D, v4.2D, #32
+        dup v8.2D, x25
+        stp x11, x25, [x1, #0]
+        mul x22, x25, x4
+        mov x16, v12.d[1]
+        ldr q16, [x1, #0]
+        mov x21, v12.d[0]
+        mul v31.4S, v27.4S, v8.4S
+        adcs x20, x14, x21
+        xtn v27.2S, v8.2D
+        adc x10, x23, x16
+        subs x14, x11, x25
+        rev64 v17.4S, v16.4S
+        cneg x17, x14, cc
+        csetm x26, cc
+        uaddlp v26.2D, v31.4S
+        mul x6, x25, x15
+        stp x17, x26, [sp, #cache_a01]
+        umull v24.2D, v27.2S, v14.2S
+        uzp2 v30.4S, v16.4S, v16.4S
+        shl v4.2D, v26.2D, #32
+        uzp2 v5.4S, v8.4S, v8.4S
+        umulh x17, x25, x4
+        umlal v4.2D, v27.2S, v14.2S
+        umull v8.2D, v27.2S, v21.2S
+        mov x21, v4.d[0]
+        adds x8, x8, x22
+        mov x12, v4.d[1]
+        ldp x23, x14, [x2, #16]
+        adcs x29, x7, x6
+        umulh x13, x25, x15
+        usra v8.2D, v24.2D, #32
+        ldp x8, x24, [x30, #cache_m20]
+        adcs x9, x20, x21
+        ldr q9, [x2, #32]!
+        xtn v28.2S, v16.2D
+        adcs x19, x10, x12
+        ldr q13, [x2, #16]
+        umull v18.2D, v5.2S, v21.2S
+        adc x7, xzr, xzr
+        adds x5, x29, x17
+        xtn v21.2S, v1.2D
+        mul x12, x5, x3
+        and v4.16B, v8.16B, v29.16B
+        adcs x21, x9, x13
+        uzp2 v31.4S, v9.4S, v9.4S
+        xtn v23.2S, v9.2D
+        usra v18.2D, v8.2D, #32
+        umlal v4.2D, v5.2S, v14.2S
+        dup v5.2D, x12
+        umull v16.2D, v23.2S, v30.2S
+        umull v1.2D, v23.2S, v28.2S
+        umulh x29, x12, x15
+        umull v8.2D, v31.2S, v30.2S
+        xtn v24.2S, v13.2D
+        mul v25.4S, v2.4S, v5.4S
+        usra v18.2D, v4.2D, #32
+        xtn v3.2S, v5.2D
+        uzp2 v19.4S, v5.4S, v5.4S
+        mul x10, x12, x15
+        umull v26.2D, v3.2S, v20.2S
+        mov x22, v18.d[0]
+        umull v10.2D, v3.2S, v21.2S
+        uaddlp v11.2D, v25.4S
+        mov x6, v18.d[1]
+        mul x16, x12, x4
+        umull v4.2D, v19.2S, v20.2S
+        usra v16.2D, v1.2D, #32
+        adcs x13, x19, x22
+        shl v11.2D, v11.2D, #32
+        adc x6, x7, x6
+        subs x7, x11, x12
+        usra v26.2D, v10.2D, #32
+        csetm x26, cc
+        cneg x20, x7, cc
+        subs x19, x25, x12
+        umlal v11.2D, v3.2S, v21.2S
+        cneg x9, x19, cc
+        stp x20, x26, [sp, #cache_a02]
+        umulh x7, x12, x4
+        usra v8.2D, v16.2D, #32
+        mul v7.4S, v17.4S, v9.4S
+        csetm x26, cc
+        adds x19, x5, x16
+        and v1.16B, v16.16B, v29.16B
+        adcs x21, x21, x10
+        stp x9, x26, [sp, #cache_a12]
+        ldp x17, x20, [sp, #cache_a02]
+        usra v4.2D, v26.2D, #32
+        and v18.16B, v26.16B, v29.16B
+        umlal v1.2D, v31.2S, v28.2S
+        mov x22, v11.d[0]
+        mov x16, v11.d[1]
+        umlal v18.2D, v19.2S, v21.2S
+        adcs x19, x13, x22
+        mul x22, x17, x8
+        uaddlp v5.2D, v7.4S
+        adcs x13, x6, x16
+        usra v8.2D, v1.2D, #32
+        adc x9, xzr, xzr
+        adds x5, x21, x7
+        usra v4.2D, v18.2D, #32
+        adcs x6, x19, x29
+        mul x19, x5, x3
+        shl v15.2D, v5.2D, #32
+        mov x3, v8.d[1]
+        umlal v15.2D, v23.2S, v28.2S
+        mov x21, v4.d[0]
+        mul x7, x19, x23
+        stp x12, x19, [x1, #16]
+        mov x10, v4.d[1]
+        ldr q9, [x1, #16]
+        adcs x13, x13, x21
+        mov x21, v15.d[1]
+        mul x16, x19, x4
+        adc x9, x9, x10
+        subs x29, x25, x19
+        csetm x26, cc
+        cneg x10, x29, cc
+        subs x29, x12, x19
+        stp x10, x26, [sp, #cache_a13]
+        uzp2 v18.4S, v9.4S, v9.4S
+        mul x12, x19, x15
+        rev64 v20.4S, v9.4S
+        xtn v19.2S, v9.2D
+        umull v25.2D, v24.2S, v18.2S
+        csetm x26, cc
+        umull v14.2D, v24.2S, v19.2S
+        cneg x29, x29, cc
+        umulh x10, x19, x23
+        adds x25, x5, x16
+        mul v7.4S, v20.4S, v13.4S
+        adcs x12, x6, x12
+        ldp x6, x5, [sp, #cache_a01]
+        mov x16, v8.d[0]
+        adcs x25, x13, x7
+        stp x29, x26, [sp, #cache_a23]
+        usra v25.2D, v14.2D, #32
+        mul x29, x19, x14
+        uzp2 v1.4S, v13.4S, v13.4S
+        uaddlp v7.2D, v7.4S
+        umull v0.2D, v1.2S, v18.2S
+        umulh x13, x19, x4
+        and v10.16B, v25.16B, v29.16B
+        shl v13.2D, v7.2D, #32
+        adcs x4, x9, x29
+        umlal v10.2D, v1.2S, v19.2S
+        adc x9, xzr, xzr
+        subs x29, x11, x19
+        usra v0.2D, v25.2D, #32
+        eor x11, x20, x24
+        umulh x15, x19, x15
+        umlal v13.2D, v24.2S, v19.2S
+        cneg x7, x29, cc
+        ldp x20, x29, [x1, #32]!
+        csetm x26, cc
+        usra v0.2D, v10.2D, #32
+        umulh x19, x19, x14
+        mov x23, v13.d[1]
+        stp x7, x26, [sp, #cache_a03]
+        adds x12, x12, x13
+        adcs x13, x25, x15
+        mov x26, v0.d[0]
+        umulh x8, x17, x8
+        adcs x14, x4, x10
+        mov x17, v13.d[0]
+        adc x15, x9, x19
+        ldp x24, x10, [x30], #96
+
+bignum_emontredc_8n_neon_maddloop:
+        ldr q14, [x2, #32]!
+        ldr q25, [x2, #16]
+        eor x19, x5, x10
+        adds x25, x21, x16
+        mov x16, v0.d[1]
+        ldp x4, x7, [x1, #16]
+        adcs x21, x17, x3
+        eor x22, x22, x11
+        adcs x23, x23, x26
+        adc x17, x16, xzr
+        adds x16, x12, x20
+        mul x5, x6, x24
+        xtn v21.2S, v14.2D
+        xtn v31.2S, v25.2D
+        adcs x9, x13, x29
+        uzp2 v24.4S, v25.4S, v25.4S
+        mov x29, v15.d[0]
+        adcs x4, x14, x4
+        ldp x10, x13, [sp, #cache_a23]
+        umull v5.2D, v21.2S, v30.2S
+        umulh x20, x6, x24
+        adcs x24, x15, x7
+        ldp x12, x7, [x30, #cache_m32 - 96]
+        umull v16.2D, v31.2S, v18.2S
+        adc x6, xzr, xzr
+        adds x14, x25, x29
+        umull v13.2D, v21.2S, v28.2S
+        uzp2 v10.4S, v14.4S, v14.4S
+        eor x15, x8, x11
+        adcs x25, x21, x25
+        umull v1.2D, v31.2S, v19.2S
+        adcs x8, x23, x21
+        mul v6.4S, v20.4S, v25.4S
+        eor x7, x13, x7
+        adcs x23, x17, x23
+        eor x21, x5, x19
+        adc x13, xzr, x17
+        adds x17, x25, x29
+        umull v0.2D, v24.2S, v18.2S
+        usra v5.2D, v13.2D, #32
+        adcs x5, x8, x14
+        umull v2.2D, v10.2S, v30.2S
+        adcs x25, x23, x25
+        usra v16.2D, v1.2D, #32
+        adcs x8, x13, x8
+        uaddlp v13.2D, v6.4S
+        adcs x23, xzr, x23
+        and v7.16B, v5.16B, v29.16B
+        adc x13, xzr, x13
+        adds x29, x29, x16
+        mul x16, x10, x12
+        usra v2.2D, v5.2D, #32
+        adcs x9, x14, x9
+        and v25.16B, v16.16B, v29.16B
+        adcs x17, x17, x4
+        umlal v7.2D, v10.2S, v28.2S
+        umulh x12, x10, x12
+        adcs x10, x5, x24
+        usra v0.2D, v16.2D, #32
+        eor x5, x16, x7
+        ldp x16, x14, [x30, #cache_m31 - 96]
+        adcs x6, x25, x6
+        shl v16.2D, v13.2D, #32
+        eor x24, x20, x19
+        adcs x4, x8, xzr
+        ldp x20, x25, [sp, #cache_a13]
+        umlal v25.2D, v24.2S, v19.2S
+        adcs x23, x23, xzr
+        usra v2.2D, v7.2D, #32
+        umlal v16.2D, v31.2S, v19.2S
+        adc x8, x13, xzr
+        adds xzr, x7, #1
+        mul v7.4S, v17.4S, v14.4S
+        adcs x4, x4, x5
+        eor x5, x12, x7
+        adcs x23, x23, x5
+        mul x12, x20, x16
+        adc x5, x8, x7
+        adds xzr, x19, #1
+        adcs x21, x9, x21
+        eor x8, x25, x14
+        usra v0.2D, v25.2D, #32
+        adcs x13, x17, x24
+        stp x29, x21, [x1, #0]
+        umulh x20, x20, x16
+        uaddlp v10.2D, v7.4S
+        adcs x17, x10, x19
+        mov x3, v2.d[1]
+        ldp x29, x24, [sp, #cache_a03]
+        adcs x25, x6, x19
+        ldp x6, x21, [x30, #cache_m30 - 96]
+        eor x10, x12, x8
+        adcs x9, x4, x19
+        mov x26, v0.d[0]
+        ldp x4, x16, [x30, #cache_m21 - 96]
+        adcs x12, x23, x19
+        adc x5, x5, x19
+        adds xzr, x8, #1
+        ldp x7, x19, [sp, #cache_a12]
+        adcs x14, x25, x10
+        mul x25, x29, x6
+        eor x20, x20, x8
+        adcs x23, x9, x20
+        ldp x9, x20, [sp, #cache_a02]
+        eor x24, x24, x21
+        adcs x12, x12, x8
+        adc x10, x5, x8
+        adds xzr, x11, #1
+        umulh x5, x29, x6
+        shl v15.2D, v10.2D, #32
+        adcs x8, x13, x22
+        eor x13, x25, x24
+        adcs x29, x17, x15
+        umlal v15.2D, v21.2S, v28.2S
+        adcs x22, x14, x11
+        mov x17, v16.d[0]
+        adcs x21, x23, x11
+        mul x23, x7, x4
+        adcs x14, x12, x11
+        eor x12, x19, x16
+        mov x16, v2.d[0]
+        adc x15, x10, x11
+        adds xzr, x24, #1
+        eor x19, x5, x24
+        adcs x11, x29, x13
+        umulh x29, x7, x4
+        adcs x13, x22, x19
+        ldp x6, x5, [sp, #cache_a01]
+        ldp x7, x25, [x30, #cache_m20]
+        adcs x19, x21, x24
+        mov x21, v15.d[1]
+        eor x22, x23, x12
+        adcs x14, x14, x24
+        mov x23, v16.d[1]
+        adc x15, x15, x24
+        adds xzr, x12, #1
+        ldp x24, x10, [x30], #96
+        adcs x11, x11, x22
+        mul x22, x9, x7
+        eor x4, x29, x12
+        adcs x4, x13, x4
+        stp x8, x11, [x1, #16]
+        adcs x13, x19, x12
+        eor x11, x20, x25
+        ldp x20, x29, [x1, #32]!
+        adcs x14, x14, x12
+        adc x15, x15, x12
+        mov x12, x4
+        umulh x8, x9, x7
+
+        sub count, count, #1
+        cbnz count, bignum_emontredc_8n_neon_maddloop
+
+bignum_emontredc_8n_neon_inner_loop_postamble:
+        umulh x19, x6, x24
+        ldp x7, x9, [sp, #cache_a23]
+        adds x4, x21, x16
+        mov x25, v0.d[1]
+        eor x5, x5, x10
+        adcs x17, x17, x3
+        ldp x16, x10, [x1, #16]
+        adcs x21, x23, x26
+        eor x8, x8, x11
+        adc x23, x25, xzr
+        adds x20, x12, x20
+        adcs x12, x13, x29
+        mov x25, v15.d[0]
+        adcs x13, x14, x16
+        eor x16, x19, x5
+        adcs x29, x15, x10
+        ldp x14, x19, [x30, #cache_m32 - 96]
+        mul x15, x6, x24
+        adc x24, xzr, xzr
+        adds x6, x4, x25
+        adcs x10, x17, x4
+        eor x4, x22, x11
+        adcs x17, x21, x17
+        eor x22, x9, x19
+        adcs x9, x23, x21
+        adc x21, xzr, x23
+        adds x23, x10, x25
+        eor x15, x15, x5
+        adcs x19, x17, x6
+        ldp x26, xzr, [sp, #16]
+        sub x2, x2, x0
+        adcs x10, x9, x10
+        adcs x17, x21, x17
+        adcs x9, xzr, x9
+        adc x21, xzr, x21
+        adds x25, x25, x20
+        mul x20, x7, x14
+        adcs x6, x6, x12
+        adcs x23, x23, x13
+        adcs x13, x19, x29
+        umulh x19, x7, x14
+        ldp x14, x29, [x30, #cache_m31 - 96]
+        adcs x10, x10, x24
+        ldp x12, x7, [sp, #cache_a13]
+        adcs x17, x17, xzr
+        adcs x24, x9, xzr
+        adc x9, x21, xzr
+        adds xzr, x22, #1
+        eor x21, x20, x22
+        adcs x20, x17, x21
+        eor x17, x19, x22
+        mul x19, x12, x14
+        eor x29, x7, x29
+        adcs x17, x24, x17
+        adc x9, x9, x22
+        adds xzr, x5, #1
+        umulh x21, x12, x14
+        ldp x14, x24, [sp, #cache_a03]
+        adcs x6, x6, x15
+        adcs x7, x23, x16
+        ldp x15, x12, [x30, #cache_m30 - 96]
+        eor x19, x19, x29
+        adcs x13, x13, x5
+        stp x25, x6, [x1, #0]
+        adcs x16, x10, x5
+        ldp x10, x6, [x30, #cache_m21 - 96]
+        adcs x23, x20, x5
+        adcs x25, x17, x5
+        umulh x30, x14, x15
+        ldp x17, x22, [sp, #cache_a12]
+        adc x9, x9, x5
+        adds xzr, x29, #1
+        eor x21, x21, x29
+        adcs x16, x16, x19
+        adcs x5, x23, x21
+        eor x23, x24, x12
+        mul x12, x17, x10
+        adcs x19, x25, x29
+        adc x29, x9, x29
+        adds xzr, x11, #1
+        adcs x7, x7, x4
+        adcs x21, x13, x8
+        mul x4, x14, x15
+        eor x9, x30, x23
+        adcs x30, x16, x11
+        adcs x24, x5, x11
+        adcs x16, x19, x11
+        adc x19, x29, x11
+        adds xzr, x23, #1
+        eor x8, x4, x23
+        adcs x4, x21, x8
+        umulh x21, x17, x10
+        adcs x8, x30, x9
+        ldp x10, x30, [x1, #32]
+        adcs x25, x24, x23
+        eor x11, x22, x6
+        adcs x22, x16, x23
+        eor x5, x12, x11
+        adc x29, x19, x23
+        adds xzr, x11, #1
+        eor x14, x21, x11
+        adcs x9, x4, x5
+        stp x7, x9, [x1, #16]
+        adcs x9, x8, x14
+        adcs x19, x25, x11
+        ldp x8, x21, [x1, #48]
+        mov x24, x9
+        adcs x5, x22, x11
+        adc x16, x29, x11
+        adds xzr, x28, x28
+        adcs x17, x10, x24
+        adcs x14, x30, x19
+        ldr x30, [sp, #8]
+        adcs x8, x8, x5
+        stp x17, x14, [x1, #32]
+        adcs x9, x21, x16
+        csetm x28, cs
+        stp x8, x9, [x1, #48]
+        subs x26, x26, #1
+        sub x1, x1, x0
+        stp x26, xzr, [sp, #16]
+        add x1, x1, #32
+
+bignum_emontredc_8n_neon_outer_loop_end:
+        bne bignum_emontredc_8n_neon_outerloop
+        neg x0, x28
 
 bignum_emontredc_8n_neon_end:
-           add sp, sp, #32
+        add sp, sp, #32
+        add sp, sp, #(6*16)
 
-           ldp x27, x28, [sp], #16
-           ldp x25, x26, [sp], #16
-           ldp x23, x24, [sp], #16
-           ldp x21, x22, [sp], #16
-           ldp x19, x20, [sp], #16
-           ret
+        ldr q8, [sp, #16*0]
+        ldr q9, [sp, #16*1]
+        ldr q10, [sp, #16*2]
+        ldr q11, [sp, #16*3]
+        ldr q12, [sp, #16*4]
+        ldr q13, [sp, #16*5]
+        ldr q14, [sp, #16*6]
+        ldr q15, [sp, #16*7]
+        ldp x29, x30, [sp, #(8*16)]
+        ldp x27, x28, [sp, #(9*16)]
+        ldp x25, x26, [sp, #(10*16)]
+        ldp x23, x24, [sp, #(11*16)]
+        ldp x21, x22, [sp, #(12*16)]
+        ldp x19, x20, [sp, #(13*16)]
+        add sp, sp, #(14*16)
 
+        ret

--- a/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
+++ b/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
@@ -192,8 +192,11 @@ bignum_kmul_16_32_neon(uint64_t z[static 32], const uint64_t x[static 16],
 // Inputs: z[2*k], m[k], w; outputs: function return (extra result bit) and z[2*k]
 extern uint64_t bignum_emontredc_8n(uint64_t k, uint64_t *z, const uint64_t *m,
                                     uint64_t w);
+// Neon version of bignum_emontredc_8n.
+// Takes an additional temporary buffer to hold differences used in ADK.
+// temp is uint64_t[12*(k/4-1)].
 extern uint64_t bignum_emontredc_8n_neon(uint64_t k, uint64_t *z, const uint64_t *m,
-                                         uint64_t w);
+                                         uint64_t w, uint64_t *temp);
 
 // Optionally subtract, z := x - y (if p nonzero) or z := x (if p zero)
 // Inputs: x[k], p, y[k]; outputs: function return (carry-out) and z[k]


### PR DESCRIPTION
### Description of changes: 

This is going to be the last patch for improving RSA signatures on Graviton 2.
This patch replaces s2n-bignum's bignum_emontredc_8n_neon with its latest, faster version in s2n-bignum.
(At the moment, the code is not verified yet; once verification is done, I will deliver the verified code to s2n-bignum first, and switch this PR from draft to ready.)
The faster version uses two techniques: (1) Cache differences used in Arbitrary Degree Karatsuba and store it in a temporary buffer to reuse it in its innermost loop (2) Schedule Arm instructions in the main loop using [SLOTHY](https://github.com/slothy-optimizer/slothy) (a superoptimization tool for Arm).

```
| RSA signing bits | baseline (b405bb9) | new  | speedup |
|------------------|--------------------|------|---------|
| 2048             | 540                | 583  | 8.0%    |
| 3072             | 128.6              | 139  | 8.1%    |
| 4096             | 81                 | 91.4 | 12.8%   |
| 8192             | 7.6                | 8.4  | 10.5%   |
```

To store the differences, a temporary buffer of `uint64_t[12 * (BN_MONTGOMERY_MAX_WORDS / 4 - 1)]` is created at stack.
Since `BN_MONTGOMERY_MAX_WORDS` is set to `8192 / 8 = 1024`, this will use 255 * 12 * `size_of(uint64_t)` ~= 24 KB.
A question is whether allocating this size on stack is acceptable. If this is too big, I can make this PR use this newer montgomery reduction only when the montgomery multiplication's bitwidth is sufficiently small (which will still cover the major use cases).

### Testing:
`bssl speed -filter RSA`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
