### PR TITLE
Update bio_info_cb to align with OpenSSL 3.x

### DIFF
--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -696,4 +696,23 @@ TEST_P(BIOPairTest, TestCallbacks) {
   ASSERT_EQ(param_len_ex[0], 0u);
 }
 
+static long callback(BIO *b, int state, int res) {
+  EXPECT_EQ(state, 0);
+  EXPECT_EQ(res, -1);
+  return 0;
+}
+
+TEST(BIOTest, InvokeConnectCallback) {
+  BIO *bio = BIO_new(BIO_s_connect());
+  ASSERT_NE(bio, nullptr);
+
+  ASSERT_TRUE(BIO_set_conn_hostname(bio, "localhost"));
+  ASSERT_TRUE(BIO_set_conn_port(bio, "8080"));
+  ASSERT_TRUE(BIO_callback_ctrl(bio, BIO_CTRL_SET_CALLBACK, callback));
+
+  ASSERT_EQ(BIO_do_connect(bio), 0);
+
+  ASSERT_TRUE(BIO_free(bio));
+}
+
 INSTANTIATE_TEST_SUITE_P(All, BIOPairTest, testing::Values(false, true));

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -696,23 +696,31 @@ TEST_P(BIOPairTest, TestCallbacks) {
   ASSERT_EQ(param_len_ex[0], 0u);
 }
 
-static long callback(BIO *b, int state, int res) {
-  EXPECT_EQ(state, 0);
-  EXPECT_EQ(res, -1);
-  return 0;
-}
+namespace {
+  static int callback_invoked = 0;
 
-TEST(BIOTest, InvokeConnectCallback) {
-  BIO *bio = BIO_new(BIO_s_connect());
-  ASSERT_NE(bio, nullptr);
+  static long callback(BIO *b, int state, int res) {
+    callback_invoked = 1;
+    EXPECT_EQ(state, 0);
+    EXPECT_EQ(res, -1);
+    return 0;
+  }
 
-  ASSERT_TRUE(BIO_set_conn_hostname(bio, "localhost"));
-  ASSERT_TRUE(BIO_set_conn_port(bio, "8080"));
-  ASSERT_TRUE(BIO_callback_ctrl(bio, BIO_CTRL_SET_CALLBACK, callback));
+  TEST(BIOTest, InvokeConnectCallback) {
 
-  ASSERT_EQ(BIO_do_connect(bio), 0);
+    ASSERT_EQ(callback_invoked, 0);
+    BIO *bio = BIO_new(BIO_s_connect());
+    ASSERT_NE(bio, nullptr);
 
-  ASSERT_TRUE(BIO_free(bio));
+    ASSERT_TRUE(BIO_set_conn_hostname(bio, "localhost"));
+    ASSERT_TRUE(BIO_set_conn_port(bio, "8080"));
+    ASSERT_TRUE(BIO_callback_ctrl(bio, BIO_CTRL_SET_CALLBACK, callback));
+
+    ASSERT_EQ(BIO_do_connect(bio), 0);
+    ASSERT_EQ(callback_invoked, 1);
+
+    ASSERT_TRUE(BIO_free(bio));
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(All, BIOPairTest, testing::Values(false, true));

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -244,13 +244,12 @@ OPENSSL_EXPORT int BIO_method_type(const BIO *bio);
 // The BIO_CB_RETURN flag indicates if it is after the call
 #define BIO_CB_RETURN 0x80
 
-// bio_info_cb is the type of a callback function that can be called for most
-// BIO operations. The |event| argument is one of |BIO_CB_*| and can be ORed
-// with |BIO_CB_RETURN| if the callback is being made after the operation in
-// question. In that case, |return_value| will contain the return value from
-// the operation.
-typedef long (*bio_info_cb)(BIO *bio, int event, const char *parg, int cmd,
-                            long larg, long return_value);
+// |bio_info_cb| is a type of callback function providing information about a
+// BIO operation. |state| identifies the current state of the BIO
+// object, such as |BIO_CONN_S_BEFORE|. |res| represent the result of the
+// operation that triggered the callback. This can be a positive value, zero,
+// or a negative value depending on the operation and its outcome.
+typedef long (*bio_info_cb)(BIO *b, int state, int res);
 
 // |BIO_callback_fn_ex| parameters have the following meaning:
 //    |bio| the bio that made the call


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Fixes compile warning from GCC 13.2:
```
/tmp/aws-lc/crypto/bio/connect.c: In function 'conn_callback_ctrl':
/tmp/aws-lc/crypto/bio/connect.c:493:29: error: cast between incompatible function types from 'bio_info_cb' {aka 'long int (*)(struct bio_st *, int,  const char *, int,  long int,  long int)'} to 'int (*)(const struct bio_st *, int,  int)' [-Werror=cast-function-type]
  493 |       data->info_callback = (int (*)(const struct bio_st *, int, int))fp;
      |                             ^
```
* Updates `bio_info_cb` to align with its definition in OpenSSL 1.1.1 (and later).

### Call-outs:
N/A

### Testing:
* Added test to very callback function can successfully be invoked.
* Verified compilation succeeds with GCC 13.2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
