### PR TITLE
self destruct ec2 instances after certain amount of time

### DIFF
--- a/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
+++ b/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
@@ -10,6 +10,9 @@ mainSteps:
     inputs:
       timeoutSeconds: '7200'
       runCommand:
+        # Fallback plan to shut down the ec2 instance in 60 minutes in case it's not terminated.
+        # Codebuild just "stops" the instance calling the script, so "trap cleanup" is not executed.
+        - shutdown -P +60
         - sudo -i
         - export DEBIAN_FRONTEND=noninteractive
         - export CPU_TYPE=$(dpkg --print-architecture)

--- a/tests/ci/run_ec2_test_framework.sh
+++ b/tests/ci/run_ec2_test_framework.sh
@@ -36,6 +36,7 @@ create_ec2_instances() {
     --tag-specifications 'ResourceType="instance",Tags=[{Key="aws-lc",Value="aws-lc-ci-ec2-test-framework-ec2-x86-instance"}]' \
     --iam-instance-profile Name=aws-lc-ci-ec2-test-framework-ec2-profile \
     --placement 'AvailabilityZone=us-west-2a' \
+    --instance-initiated-shutdown-behavior terminate \
     --query Instances[*].InstanceId --output text)"
   echo "${instance_id}"
 }


### PR DESCRIPTION
### Description of changes: 
The new ec2 test framework doesn't mesh well with our job pruner. Codebuild just "stops" the instance without giving a signal to the executing script, so `trap cleanup` is not executed. This lets the ec2 self-terminate once a certain amount of time has passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
