### PR TITLE
Add support for RSA KeyGen AFT tests for FIPS186-5 to ACVP tool

### DIFF
--- a/util/fipstools/acvp/acvptool/subprocess/rsa.go
+++ b/util/fipstools/acvp/acvptool/subprocess/rsa.go
@@ -126,10 +126,9 @@ func processKeyGen(vectorSet []byte, m Transactable) (any, error) {
 	var ret []rsaKeyGenTestGroupResponse
 
 	for _, group := range parsed.Groups {
-		// GDT means "Generated data test", i.e. "please generate an RSA key".
-		const expectedType = "GDT"
-		if group.Type != expectedType {
-			return nil, fmt.Errorf("RSA KeyGen test group has type %q, but only generation tests (%q) are supported", group.Type, expectedType)
+		// We support both GDT and AFT tests, which are formatted the same and expect the same output.
+		if !(group.Type == "GDT" || group.Type == "AFT") {
+			return nil, fmt.Errorf("RSA KeyGen test group has type %q, but only GDT and AFT tests are supported", group.Type)
 		}
 
 		response := rsaKeyGenTestGroupResponse{


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-1838

### Description of changes: 
[FIPS 186-5](https://csrc.nist.gov/pubs/fips/186-5/final) updates some things related to RSA. For ACVP, it introduces a new capabilities registration. Luckily, the format of the vectors is largely the same, but we need to enable support for "AFT" tests in order to correctly parse FIPS 186-5 compatible test vectors.

### Call-outs:
N/A

### Testing:
Tool passes when running against ACVP demo server.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
