### PR TITLE
Fix Blake2b for BigEndian

### DIFF
--- a/crypto/blake2/blake2.c
+++ b/crypto/blake2/blake2.c
@@ -59,6 +59,19 @@ static uint64_t blake2b_load(const uint8_t block[BLAKE2B_CBLOCK], size_t i) {
   return CRYPTO_load_u64_le(block + 8 * i);
 }
 
+static void copy_digest_words_to_dest(uint8_t* dest, uint64_t* src, size_t word_count) {
+#ifdef OPENSSL_BIG_ENDIAN
+  for(size_t i = 0; i < word_count; i++) {
+    uint64_t word = src[i];
+    for(size_t j = 0; j < sizeof(uint64_t); j++) {
+      dest[i * sizeof(uint64_t) + j] = (word >> (j * 8)) & 0xFF;
+    }
+  }
+#else
+  OPENSSL_memcpy(dest, src, word_count * sizeof(uint64_t));
+#endif
+}
+
 static void blake2b_transform(BLAKE2B_CTX *b2b,
                               const uint8_t block[BLAKE2B_CBLOCK],
                               size_t num_bytes, int is_final_block) {
@@ -158,7 +171,7 @@ void BLAKE2B256_Final(uint8_t out[BLAKE2B256_DIGEST_LENGTH], BLAKE2B_CTX *b2b) {
   blake2b_transform(b2b, b2b->block, b2b->block_used,
                     /*is_final_block=*/1);
   OPENSSL_STATIC_ASSERT(BLAKE2B256_DIGEST_LENGTH <= sizeof(b2b->h), _)
-  memcpy(out, b2b->h, BLAKE2B256_DIGEST_LENGTH);
+  copy_digest_words_to_dest(out, b2b->h, 4);
 }
 
 void BLAKE2B256(const uint8_t *data, size_t len,

--- a/crypto/blake2/blake2.c
+++ b/crypto/blake2/blake2.c
@@ -171,7 +171,7 @@ void BLAKE2B256_Final(uint8_t out[BLAKE2B256_DIGEST_LENGTH], BLAKE2B_CTX *b2b) {
   blake2b_transform(b2b, b2b->block, b2b->block_used,
                     /*is_final_block=*/1);
   OPENSSL_STATIC_ASSERT(BLAKE2B256_DIGEST_LENGTH <= sizeof(b2b->h), _)
-  copy_digest_words_to_dest(out, b2b->h, 4);
+  copy_digest_words_to_dest(out, b2b->h, BLAKE2B256_DIGEST_LENGTH / 8);
 }
 
 void BLAKE2B256(const uint8_t *data, size_t len,

--- a/crypto/blake2/blake2.c
+++ b/crypto/blake2/blake2.c
@@ -62,10 +62,7 @@ static uint64_t blake2b_load(const uint8_t block[BLAKE2B_CBLOCK], size_t i) {
 static void copy_digest_words_to_dest(uint8_t* dest, uint64_t* src, size_t word_count) {
 #ifdef OPENSSL_BIG_ENDIAN
   for(size_t i = 0; i < word_count; i++) {
-    uint64_t word = src[i];
-    for(size_t j = 0; j < sizeof(uint64_t); j++) {
-      dest[i * sizeof(uint64_t) + j] = (word >> (j * 8)) & 0xFF;
-    }
+    CRYPTO_store_u64_le(&dest[i * sizeof(uint64_t)], src[i]);
   }
 #else
   OPENSSL_memcpy(dest, src, word_count * sizeof(uint64_t));


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Fixes the Blake2b digest for big-endian architectures.
  * The problem was only with the final copying of the bytes to the destination buffer.

### Call-outs:
N/A

### Testing:
`DigestTest.*` and `BLAKE2B256Test.*` succeed for ppc and ppc64.

PPC64:
```
❯ file crypto/crypto_test  
crypto/crypto_test: ELF 64-bit MSB executable, 64-bit PowerPC or cisco 7500, Power ELF V1 ABI, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld64.so.1, for GNU/Linux 6.4.0, with debug_info, not stripped
...
❯ ppc64-qemu.sh ./crypto/crypto_test --gtest_filter="BLAKE2B256Test.*"
Note: Google Test filter = BLAKE2B256Test.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from BLAKE2B256Test
[ RUN      ] BLAKE2B256Test.ABC
[       OK ] BLAKE2B256Test.ABC (3 ms)
[ RUN      ] BLAKE2B256Test.TestVectors
[       OK ] BLAKE2B256Test.TestVectors (171 ms)
[----------] 2 tests from BLAKE2B256Test (175 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (183 ms total)
[  PASSED  ] 2 tests.
...
❯ ppc64-qemu.sh ./crypto/crypto_test --gtest_filter="DigestTest.*"
Note: Google Test filter = DigestTest.*
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from DigestTest
[ RUN      ] DigestTest.TestVectors
[       OK ] DigestTest.TestVectors (19112 ms)
[ RUN      ] DigestTest.Getters
[       OK ] DigestTest.Getters (4 ms)
[ RUN      ] DigestTest.TestXOF
[       OK ] DigestTest.TestXOF (1 ms)
[ RUN      ] DigestTest.ASN1
[       OK ] DigestTest.ASN1 (2 ms)
[ RUN      ] DigestTest.TransformBlocks
[       OK ] DigestTest.TransformBlocks (1 ms)
[----------] 5 tests from DigestTest (19121 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (19131 ms total)
[  PASSED  ] 5 tests.
```

PPC:
```
❯ file crypto/crypto_test 
crypto/crypto_test: ELF 32-bit MSB executable, PowerPC or cisco 4500, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld.so.1, for GNU/Linux 6.1.35, with debug_info, not stripped
...
❯ ppc-qemu.sh ./crypto/crypto_test --gtest_filter="BLAKE2B256Test.*"
Note: Google Test filter = BLAKE2B256Test.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from BLAKE2B256Test
[ RUN      ] BLAKE2B256Test.ABC
[       OK ] BLAKE2B256Test.ABC (5 ms)
[ RUN      ] BLAKE2B256Test.TestVectors
[       OK ] BLAKE2B256Test.TestVectors (159 ms)
[----------] 2 tests from BLAKE2B256Test (167 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (179 ms total)
[  PASSED  ] 2 tests.
...
❯ ppc-qemu.sh ./crypto/crypto_test --gtest_filter="DigestTest.*"    
Note: Google Test filter = DigestTest.*
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from DigestTest
[ RUN      ] DigestTest.TestVectors
[       OK ] DigestTest.TestVectors (19167 ms)
[ RUN      ] DigestTest.Getters
[       OK ] DigestTest.Getters (5 ms)
[ RUN      ] DigestTest.TestXOF
[       OK ] DigestTest.TestXOF (1 ms)
[ RUN      ] DigestTest.ASN1
[       OK ] DigestTest.ASN1 (2 ms)
[ RUN      ] DigestTest.TransformBlocks
[       OK ] DigestTest.TransformBlocks (1 ms)
[----------] 5 tests from DigestTest (19180 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (19193 ms total)
[  PASSED  ] 5 tests.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
