### PR TITLE
Fix 32-bit big-endian p521 bug

### DIFF
--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -2332,10 +2332,6 @@ TEST(ECTest, HashToScalar) {
 }
 
 TEST(ECTest, FelemBytes) {
-  EC_FELEM test_felem;
-  EC_FELEM test2_felem;
-  size_t out_len = 0;
-  uint8_t buffer[EC_MAX_BYTES];
   std::tuple<int,int, int>  test_cases[2] = {
           std::make_tuple(NID_secp384r1, P384_EC_FELEM_BYTES, P384_EC_FELEM_WORDS),
           std::make_tuple(NID_secp521r1, P521_EC_FELEM_BYTES, P521_EC_FELEM_WORDS)
@@ -2357,17 +2353,5 @@ TEST(ECTest, FelemBytes) {
     bssl::UniquePtr<EC_GROUP> test_group(EC_GROUP_new_by_curve_name(nid));
     ASSERT_TRUE(test_group);
     ASSERT_EQ(test_group.get()->field.width, expected_felem_words);
-
-    bssl::UniquePtr<BIGNUM> a(BN_new());
-    ASSERT_TRUE(a);
-
-    ASSERT_TRUE(EC_GROUP_get_curve_GFp(test_group.get(), nullptr, a.get(), nullptr, nullptr));
-    ASSERT_TRUE(ec_bignum_to_felem(test_group.get(), &test_felem, a.get()));
-    out_len = 0;
-    ec_felem_to_bytes(test_group.get(), buffer, &out_len, &test_felem);
-    ASSERT_EQ((size_t)expected_felem_bytes, out_len);
-
-    ASSERT_TRUE(ec_felem_from_bytes(test_group.get(), &test2_felem, buffer, expected_felem_bytes));
-    ASSERT_TRUE(ec_felem_equal(test_group.get(), &test_felem, &test2_felem));
   }
 }

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -2331,18 +2331,29 @@ TEST(ECTest, HashToScalar) {
       p224.get(), &scalar, kDST, sizeof(kDST), kMessage, sizeof(kMessage)));
 }
 
-TEST(ECTest, Macros) {
+TEST(ECTest, FelemBytes) {
   EC_FELEM test_felem;
+  EC_FELEM test2_felem;
   size_t out_len = 0;
   uint8_t buffer[EC_MAX_BYTES];
-  std::pair<int,int>  test_cases[2] = {
-          std::make_pair(NID_secp384r1, P384_EC_FELEM_BYTES),
-          std::make_pair(NID_secp521r1, P521_EC_FELEM_BYTES)
+  std::tuple<int,int, int>  test_cases[2] = {
+          std::make_tuple(NID_secp384r1, P384_EC_FELEM_BYTES, P384_EC_FELEM_WORDS),
+          std::make_tuple(NID_secp521r1, P521_EC_FELEM_BYTES, P521_EC_FELEM_WORDS)
   };
 
-  for(size_t i = 0; i < sizeof(test_cases)/sizeof(std::pair<int,int>); i++) {
-    int nid = test_cases[i].first;
-    int expected_felem_bytes = test_cases[i].second;
+  for(size_t i = 0; i < sizeof(test_cases)/sizeof(std::tuple<int,int,int>); i++) {
+    int nid = std::get<0>(test_cases[i]);
+    int expected_felem_bytes = std::get<1>(test_cases[i]);
+    int expected_felem_words = std::get<2>(test_cases[i]);
+
+    ASSERT_TRUE(expected_felem_bytes <= EC_MAX_BYTES);
+    ASSERT_TRUE(expected_felem_words <= EC_MAX_WORDS);
+    if( 0 == (expected_felem_bytes % BN_BYTES)) {
+      ASSERT_EQ(expected_felem_words, expected_felem_bytes / BN_BYTES);
+    } else {
+      ASSERT_EQ(expected_felem_words, 1 + (expected_felem_bytes / BN_BYTES));
+    }
+
     bssl::UniquePtr<EC_GROUP> test_group(EC_GROUP_new_by_curve_name(nid));
     ASSERT_TRUE(test_group);
 
@@ -2354,5 +2365,8 @@ TEST(ECTest, Macros) {
     out_len = 0;
     ec_felem_to_bytes(test_group.get(), buffer, &out_len, &test_felem);
     ASSERT_EQ((size_t)expected_felem_bytes, out_len);
+
+    ASSERT_TRUE(ec_felem_from_bytes(test_group.get(), &test2_felem, buffer, expected_felem_bytes));
+    ASSERT_TRUE(ec_felem_equal(test_group.get(), &test_felem, &test2_felem));
   }
 }

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -2356,6 +2356,7 @@ TEST(ECTest, FelemBytes) {
 
     bssl::UniquePtr<EC_GROUP> test_group(EC_GROUP_new_by_curve_name(nid));
     ASSERT_TRUE(test_group);
+    ASSERT_EQ(test_group.get()->field.width, expected_felem_words);
 
     bssl::UniquePtr<BIGNUM> a(BN_new());
     ASSERT_TRUE(a);

--- a/crypto/fipsmodule/ec/internal.h
+++ b/crypto/fipsmodule/ec/internal.h
@@ -109,7 +109,7 @@ OPENSSL_STATIC_ASSERT(EC_MAX_WORDS <= BN_SMALL_MAX_WORDS,
 // An EC_SCALAR is an integer fully reduced modulo the order. Only the first
 // |order->width| words are used. An |EC_SCALAR| is specific to an |EC_GROUP|
 // and must not be mixed between groups.
-typedef union {
+typedef struct {
   // words is the representation of the scalar in little-endian order.
   BN_ULONG words[EC_MAX_WORDS];
 } EC_SCALAR;

--- a/crypto/fipsmodule/ec/internal.h
+++ b/crypto/fipsmodule/ec/internal.h
@@ -196,6 +196,12 @@ void ec_scalar_select(const EC_GROUP *group, EC_SCALAR *out, BN_ULONG mask,
 
 // Field elements.
 
+#define P384_EC_FELEM_BYTES (48)
+#define P384_EC_FELEM_WORDS ((P384_EC_FELEM_BYTES + BN_BYTES - 1) / BN_BYTES)
+
+#define P521_EC_FELEM_BYTES (66)
+#define P521_EC_FELEM_WORDS ((P521_EC_FELEM_BYTES + BN_BYTES - 1) / BN_BYTES)
+
 // An EC_FELEM represents a field element. Only the first |field->width| words
 // are used. An |EC_FELEM| is specific to an |EC_GROUP| and must not be mixed
 // between groups. Additionally, the representation (whether or not elements are

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -143,8 +143,6 @@ static p384_limb_t p384_felem_nz(const p384_limb_t in1[P384_NLIMBS]) {
 
 #endif // P384_USE_S2N_BIGNUM_FIELD_ARITH
 
-#define P384_FELEM_BYTES (48)
-#define P384_FELEM_WORDS ((P384_FELEM_BYTES + BN_BYTES - 1) / BN_BYTES)
 
 static void p384_felem_copy(p384_limb_t out[P384_NLIMBS],
                            const p384_limb_t in1[P384_NLIMBS]) {
@@ -164,10 +162,9 @@ static void p384_felem_cmovznz(p384_limb_t out[P384_NLIMBS],
 }
 
 static void p384_from_generic(p384_felem out, const EC_FELEM *in) {
-  assert(P384_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[P384_FELEM_BYTES];
-  bn_words_to_little_endian(tmp, P384_FELEM_BYTES, in->words, P384_FELEM_WORDS);
+  uint8_t tmp[P384_EC_FELEM_BYTES];
+  bn_words_to_little_endian(tmp, P384_EC_FELEM_BYTES, in->words, P384_EC_FELEM_WORDS);
   p384_felem_from_bytes(out, tmp);
 #else
   p384_felem_from_bytes(out, (const uint8_t *)in->words);
@@ -180,21 +177,19 @@ static void p384_to_generic(EC_FELEM *out, const p384_felem in) {
   OPENSSL_STATIC_ASSERT(
       384 / 8 == sizeof(BN_ULONG) * ((384 + BN_BITS2 - 1) / BN_BITS2),
       p384_felem_to_bytes_leaves_bytes_uninitialized);
-  assert(P384_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[P384_FELEM_BYTES];
+  uint8_t tmp[P384_EC_FELEM_BYTES];
   p384_felem_to_bytes(tmp, in);
-  bn_little_endian_to_words(out->words, P384_FELEM_WORDS, tmp, P384_FELEM_BYTES);
+  bn_little_endian_to_words(out->words, P384_EC_FELEM_WORDS, tmp, P384_EC_FELEM_BYTES);
 #else
   p384_felem_to_bytes((uint8_t *)out->words, in);
 #endif
 }
 
 static void p384_from_scalar(p384_felem out, const EC_SCALAR *in) {
-  assert(P384_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[P384_FELEM_BYTES];
-  bn_words_to_little_endian(tmp, P384_FELEM_BYTES, in->words, P384_FELEM_WORDS);
+  uint8_t tmp[P384_EC_FELEM_BYTES];
+  bn_words_to_little_endian(tmp, P384_EC_FELEM_BYTES, in->words, P384_EC_FELEM_WORDS);
   p384_felem_from_bytes(out, tmp);
 #else
   p384_felem_from_bytes(out, (const uint8_t *)in->words);

--- a/crypto/fipsmodule/ec/p384.c
+++ b/crypto/fipsmodule/ec/p384.c
@@ -144,6 +144,7 @@ static p384_limb_t p384_felem_nz(const p384_limb_t in1[P384_NLIMBS]) {
 #endif // P384_USE_S2N_BIGNUM_FIELD_ARITH
 
 #define P384_FELEM_BYTES (48)
+#define P384_FELEM_WORDS ((P384_FELEM_BYTES + BN_BYTES - 1) / BN_BYTES)
 
 static void p384_felem_copy(p384_limb_t out[P384_NLIMBS],
                            const p384_limb_t in1[P384_NLIMBS]) {
@@ -163,9 +164,10 @@ static void p384_felem_cmovznz(p384_limb_t out[P384_NLIMBS],
 }
 
 static void p384_from_generic(p384_felem out, const EC_FELEM *in) {
+  assert(P384_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P384_FELEM_BYTES];
-  bn_words_to_little_endian(tmp, P384_FELEM_BYTES, in->words, P384_NLIMBS);
+  bn_words_to_little_endian(tmp, P384_FELEM_BYTES, in->words, P384_FELEM_WORDS);
   p384_felem_from_bytes(out, tmp);
 #else
   p384_felem_from_bytes(out, (const uint8_t *)in->words);
@@ -178,20 +180,21 @@ static void p384_to_generic(EC_FELEM *out, const p384_felem in) {
   OPENSSL_STATIC_ASSERT(
       384 / 8 == sizeof(BN_ULONG) * ((384 + BN_BITS2 - 1) / BN_BITS2),
       p384_felem_to_bytes_leaves_bytes_uninitialized);
-
+  assert(P384_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P384_FELEM_BYTES];
   p384_felem_to_bytes(tmp, in);
-  bn_little_endian_to_words(out->words, P384_NLIMBS, tmp, P384_FELEM_BYTES);
+  bn_little_endian_to_words(out->words, P384_FELEM_WORDS, tmp, P384_FELEM_BYTES);
 #else
   p384_felem_to_bytes((uint8_t *)out->words, in);
 #endif
 }
 
 static void p384_from_scalar(p384_felem out, const EC_SCALAR *in) {
+  assert(P384_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P384_FELEM_BYTES];
-  bn_words_to_little_endian(tmp, P384_FELEM_BYTES, in->words, P384_NLIMBS);
+  bn_words_to_little_endian(tmp, P384_FELEM_BYTES, in->words, P384_FELEM_WORDS);
   p384_felem_from_bytes(out, tmp);
 #else
   p384_felem_from_bytes(out, (const uint8_t *)in->words);

--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -177,6 +177,7 @@ static const p521_limb_t p521_felem_p[P521_NLIMBS] = {
 #endif // P521_USE_S2N_BIGNUM_FIELD_ARITH
 
 #define P521_FELEM_BYTES (66)
+#define P521_FELEM_WORDS ((P521_FELEM_BYTES + BN_BYTES - 1) / BN_BYTES)
 
 static p521_limb_t p521_felem_nz(const p521_limb_t in1[P521_NLIMBS]) {
   p521_limb_t is_not_zero = 0;
@@ -218,9 +219,10 @@ static void p521_felem_cmovznz(p521_limb_t out[P521_NLIMBS],
 
 // NOTE: the input and output are in little-endian representation.
 static void p521_from_generic(p521_felem out, const EC_FELEM *in) {
+  assert(P521_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P521_FELEM_BYTES];
-  bn_words_to_little_endian(tmp, P521_FELEM_BYTES, in->words, EC_MAX_WORDS);
+  bn_words_to_little_endian(tmp, P521_FELEM_BYTES, in->words, P521_FELEM_WORDS);
   p521_felem_from_bytes(out, tmp);
 #else
   p521_felem_from_bytes(out, (const uint8_t *)in->words);
@@ -237,10 +239,11 @@ static void p521_to_generic(EC_FELEM *out, const p521_felem in) {
   // translate to 72 bytes, which means that we have to make sure that the
   // extra 6 bytes are zeroed out. To avoid confusion over 32 vs. 64 bit
   // systems and Fiat's vs. ours representation we zero out the whole element.
+  assert(P521_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P521_FELEM_BYTES];
   p521_felem_to_bytes(tmp, in);
-  bn_little_endian_to_words(out->words, EC_MAX_WORDS, tmp, P521_FELEM_BYTES);
+  bn_little_endian_to_words(out->words, P521_FELEM_WORDS, tmp, P521_FELEM_BYTES);
 #else
   OPENSSL_memset((uint8_t*)out->words, 0, sizeof(out->words));
   // Convert the element to bytes.

--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -176,9 +176,6 @@ static const p521_limb_t p521_felem_p[P521_NLIMBS] = {
 
 #endif // P521_USE_S2N_BIGNUM_FIELD_ARITH
 
-#define P521_FELEM_BYTES (66)
-#define P521_FELEM_WORDS ((P521_FELEM_BYTES + BN_BYTES - 1) / BN_BYTES)
-
 static p521_limb_t p521_felem_nz(const p521_limb_t in1[P521_NLIMBS]) {
   p521_limb_t is_not_zero = 0;
   for (int i = 0; i < P521_NLIMBS; i++) {
@@ -219,10 +216,9 @@ static void p521_felem_cmovznz(p521_limb_t out[P521_NLIMBS],
 
 // NOTE: the input and output are in little-endian representation.
 static void p521_from_generic(p521_felem out, const EC_FELEM *in) {
-  assert(P521_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[P521_FELEM_BYTES];
-  bn_words_to_little_endian(tmp, P521_FELEM_BYTES, in->words, P521_FELEM_WORDS);
+  uint8_t tmp[P521_EC_FELEM_BYTES];
+  bn_words_to_little_endian(tmp, P521_EC_FELEM_BYTES, in->words, P521_EC_FELEM_WORDS);
   p521_felem_from_bytes(out, tmp);
 #else
   p521_felem_from_bytes(out, (const uint8_t *)in->words);
@@ -239,11 +235,10 @@ static void p521_to_generic(EC_FELEM *out, const p521_felem in) {
   // translate to 72 bytes, which means that we have to make sure that the
   // extra 6 bytes are zeroed out. To avoid confusion over 32 vs. 64 bit
   // systems and Fiat's vs. ours representation we zero out the whole element.
-  assert(P521_FELEM_WORDS <= EC_MAX_WORDS);
 #ifdef OPENSSL_BIG_ENDIAN
-  uint8_t tmp[P521_FELEM_BYTES];
+  uint8_t tmp[P521_EC_FELEM_BYTES];
   p521_felem_to_bytes(tmp, in);
-  bn_little_endian_to_words(out->words, P521_FELEM_WORDS, tmp, P521_FELEM_BYTES);
+  bn_little_endian_to_words(out->words, P521_EC_FELEM_WORDS, tmp, P521_EC_FELEM_BYTES);
 #else
   OPENSSL_memset((uint8_t*)out->words, 0, sizeof(out->words));
   // Convert the element to bytes.

--- a/crypto/fipsmodule/ec/p521.c
+++ b/crypto/fipsmodule/ec/p521.c
@@ -220,7 +220,7 @@ static void p521_felem_cmovznz(p521_limb_t out[P521_NLIMBS],
 static void p521_from_generic(p521_felem out, const EC_FELEM *in) {
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P521_FELEM_BYTES];
-  bn_words_to_little_endian(tmp, P521_FELEM_BYTES, in->words, P521_NLIMBS);
+  bn_words_to_little_endian(tmp, P521_FELEM_BYTES, in->words, EC_MAX_WORDS);
   p521_felem_from_bytes(out, tmp);
 #else
   p521_felem_from_bytes(out, (const uint8_t *)in->words);
@@ -240,7 +240,7 @@ static void p521_to_generic(EC_FELEM *out, const p521_felem in) {
 #ifdef OPENSSL_BIG_ENDIAN
   uint8_t tmp[P521_FELEM_BYTES];
   p521_felem_to_bytes(tmp, in);
-  bn_little_endian_to_words(out->words, P521_NLIMBS, tmp, P521_FELEM_BYTES);
+  bn_little_endian_to_words(out->words, EC_MAX_WORDS, tmp, P521_FELEM_BYTES);
 #else
   OPENSSL_memset((uint8_t*)out->words, 0, sizeof(out->words));
   // Convert the element to bytes.


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Fixes 32-bit big-endian bug in P521.
  * `P521_NLIMBS` is 19, but the `EC_FELEM` type only contains `EC_MAX_WORDS` (= 17) words.

### Call-outs:
N/A

### Testing:
```
❮ ppc-qemu.sh ./crypto/crypto_test --gtest_filter="EC*.*:*/EC*.*"                         
Note: Google Test filter = EC*.*:*/EC*.*
[==========] Running 156 tests from 6 test suites.
[----------] Global test environment set-up.
[----------] 7 tests from ECDHTest
...
[----------] 80 tests from All/ECCurveTest (7543 ms total)

[----------] Global test environment tear-down
[==========] 156 tests from 6 test suites ran. (407363 ms total)
[  PASSED  ] 156 tests.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
