### PR TITLE
Fix bad cast in SSHKDF

### DIFF
--- a/crypto/fipsmodule/sshkdf/sshkdf.c
+++ b/crypto/fipsmodule/sshkdf/sshkdf.c
@@ -23,7 +23,7 @@ int SSHKDF(const EVP_MD *evp_md,
 {
   EVP_MD_CTX *md = NULL;
   uint8_t digest[EVP_MAX_MD_SIZE];
-  size_t digest_size = 0;
+  unsigned int digest_size = 0;
   size_t cursize = 0;
   int ret = 0;
 
@@ -72,7 +72,7 @@ int SSHKDF(const EVP_MD *evp_md,
     goto out;
   }
 
-  if (!EVP_DigestFinal_ex(md, digest, (unsigned int *)&digest_size)) {
+  if (!EVP_DigestFinal_ex(md, digest, &digest_size)) {
     goto out;
   }
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Bad cast was causing SSHKDF to break on ppc64be.
   * The [third parameter of `EVP_DigestFinal_ex`]https://github.com/aws/aws-lc/blob/bb1aabad676ccb61e195917452d8d90c86d73217/include/openssl/digest.h#L184 is expected to be an `unsigned int *`, but a `size_t*` was being passed.

### Call-outs:
N/A

### Testing:
```
❯ ppc64-qemu.sh ./crypto/crypto_test --gtest_filter="SSHKDFTest.*"  
Note: Google Test filter = SSHKDFTest.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from SSHKDFTest
[ RUN      ] SSHKDFTest.SSHKDF_INPUT_INSANITY
[       OK ] SSHKDFTest.SSHKDF_INPUT_INSANITY (3 ms)
[ RUN      ] SSHKDFTest.KAT
[       OK ] SSHKDFTest.KAT (388 ms)
[----------] 2 tests from SSHKDFTest (393 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (401 ms total)
[  PASSED  ] 2 tests.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
