### PR TITLE
Add Github actions job pruner

### DIFF
--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -2,6 +2,9 @@ name: AWS-LC ABI Diff
 on:
   pull_request:
     branches: [ '*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 env:
   DOCKER_BUILDKIT: 1
   GOPROXY: https://proxy.golang.org,direct

--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -4,6 +4,9 @@ on:
     branches: [ '*' ]
   pull_request:
     branches: [ '*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org,direct
 jobs:

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -4,6 +4,9 @@ on:
     branches: [ '*' ]
   pull_request:
     branches: [ '*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 env:
   CC: gcc
 jobs:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   PACKAGE_NAME: aws-lc
   # Used to enable ASAN test dimension.


### PR DESCRIPTION
### Description of changes: 
Our wondrous Codebuild job pruner has been saving us quite a lot. I noticed Github Actions had something similar so I thought it'd be nice to apply here as well.

### Testing:
Tested in local fork: https://github.com/samuel40791765/aws-lc/actions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
