### PR TITLE
Fix Spake25519 for big-endian

### DIFF
--- a/crypto/curve25519/spake25519.c
+++ b/crypto/curve25519/spake25519.c
@@ -384,7 +384,8 @@ int SPAKE2_generate_msg(SPAKE2_CTX *ctx, uint8_t *out, size_t *out_len,
   // bit and so one for all the bottom three bits.
 
   scalar password_scalar;
-  OPENSSL_memcpy(&password_scalar, password_tmp, sizeof(password_scalar));
+  bn_little_endian_to_words(password_scalar.words, sizeof(password_scalar) / BN_BYTES,
+                            password_tmp, sizeof(password_scalar));
 
   // |password_scalar| is the result of |x25519_sc_reduce| and thus is, at
   // most, $l-1$ (where $l$ is |kOrder|, the order of the prime-order subgroup
@@ -414,9 +415,8 @@ int SPAKE2_generate_msg(SPAKE2_CTX *ctx, uint8_t *out, size_t *out_len,
 
     assert((password_scalar.words[0] & 7) == 0);
   }
-
-  OPENSSL_memcpy(ctx->password_scalar, password_scalar.words,
-                 sizeof(ctx->password_scalar));
+  bn_words_to_little_endian(ctx->password_scalar, sizeof(ctx->password_scalar),
+                            password_scalar.words, sizeof(password_scalar) / BN_BYTES);
 
   ge_p3 mask;
   x25519_ge_scalarmult_small_precomp(&mask, ctx->password_scalar,


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Fix Spake25519 for big-endian

### Call-outs:
N/A

### Testing:
PPC32
```
❯ ppc-qemu.sh ./crypto/crypto_test --gtest_filter="SPAKE25519Test.*"
Note: Google Test filter = SPAKE25519Test.*
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from SPAKE25519Test
[ RUN      ] SPAKE25519Test.SPAKE2
[       OK ] SPAKE25519Test.SPAKE2 (823 ms)
[ RUN      ] SPAKE25519Test.OldAlice
[       OK ] SPAKE25519Test.OldAlice (786 ms)
[ RUN      ] SPAKE25519Test.OldBob
[       OK ] SPAKE25519Test.OldBob (833 ms)
[ RUN      ] SPAKE25519Test.WrongPassword
[       OK ] SPAKE25519Test.WrongPassword (38 ms)
[ RUN      ] SPAKE25519Test.WrongNames
[       OK ] SPAKE25519Test.WrongNames (42 ms)
[ RUN      ] SPAKE25519Test.CorruptMessages
[       OK ] SPAKE25519Test.CorruptMessages (9315 ms)
[----------] 6 tests from SPAKE25519Test (11840 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (11848 ms total)
[  PASSED  ] 6 tests.
```

PPC64
```
❯ ppc64-qemu.sh ./crypto/crypto_test --gtest_filter="SPAKE25519Test.*"
Note: Google Test filter = SPAKE25519Test.*
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from SPAKE25519Test
[ RUN      ] SPAKE25519Test.SPAKE2
[       OK ] SPAKE25519Test.SPAKE2 (418 ms)
[ RUN      ] SPAKE25519Test.OldAlice
[       OK ] SPAKE25519Test.OldAlice (423 ms)
[ RUN      ] SPAKE25519Test.OldBob
[       OK ] SPAKE25519Test.OldBob (441 ms)
[ RUN      ] SPAKE25519Test.WrongPassword
[       OK ] SPAKE25519Test.WrongPassword (21 ms)
[ RUN      ] SPAKE25519Test.WrongNames
[       OK ] SPAKE25519Test.WrongNames (18 ms)
[ RUN      ] SPAKE25519Test.CorruptMessages
[       OK ] SPAKE25519Test.CorruptMessages (3953 ms)
[----------] 6 tests from SPAKE25519Test (5279 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (5291 ms total)
[  PASSED  ] 6 tests.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
