### PR TITLE
Ensure array length assumption agree

### DIFF
--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -316,6 +316,12 @@ static int rdrand(uint8_t *buf, size_t len) {
 #if defined(BORINGSSL_FIPS)
 
 #if defined(FIPS_ENTROPY_SOURCE_PASSIVE)
+
+// Currently, we assume that the length of externally loaded entropy has the
+// same length as the seed used in the ctr-drbg.
+OPENSSL_STATIC_ASSERT(CTR_DRBG_ENTROPY_LEN == PASSIVE_ENTROPY_LOAD_LENGTH,
+  passive_entropy_load_length_different_from_ctr_drbg_seed_length)
+
 void RAND_load_entropy(uint8_t out_entropy[CTR_DRBG_ENTROPY_LEN],
                        uint8_t entropy[PASSIVE_ENTROPY_LOAD_LENGTH]) {
   OPENSSL_memcpy(out_entropy, entropy, CTR_DRBG_ENTROPY_LEN);


### PR DESCRIPTION
### Description of changes: 

`PASSIVE_ENTROPY_LOAD_LENGTH` and `CTR_DRBG_ENTROPY_LEN` are currently equal. This assumption is used implicitly in `RAND_load_entropy()`. Statically ensure this continues to be true while assumed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
