### PR TITLE
Add CRT integration test

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -22,7 +22,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_SMALL
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:amazonlinux-2_gcc-7x_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:amazonlinux-2023_gcc-11x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_crt_integration.sh"
 
@@ -32,7 +32,7 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_SMALL
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2_gcc-7x_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2023_gcc-11x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_crt_integration.sh"
 

--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -16,6 +16,26 @@ batch:
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_s2n_integration.sh"
 
+    - identifier: crt_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_SMALL
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:amazonlinux-2_gcc-7x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_crt_integration.sh"
+
+    - identifier: crt_integration_aarch64
+      buildspec: tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_SMALL
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2_gcc-7x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_crt_integration.sh"
+
     - identifier: openssh_integration_x86_64
       buildspec: tests/ci/codebuild/common/run_simple_target.yml
       env:

--- a/tests/ci/integration/run_crt_integration.sh
+++ b/tests/ci/integration/run_crt_integration.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -exu
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+source tests/ci/common_posix_setup.sh
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER=${SYS_ROOT}/"SCRATCH_AWSLC_CRT_TEST"
+
+# Make script execution idempotent.
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf ${SCRATCH_FOLDER}/*
+cd ${SCRATCH_FOLDER}
+
+git clone --recursive https://github.com/awslabs/aws-crt-cpp.git
+
+cd aws-crt-cpp
+# The CRT has a submodule for AWS-LC, overwrite that with the local version
+rm -rf crt/aws-lc/*
+cp -r ${SRC_ROOT}/* crt/aws-lc/
+
+# Don't pre-build AWS-LC, the CRT will build all of it's dependencies how it wants them built
+mkdir build && cd build
+cmake -GNinja ../
+ninja
+ninja test

--- a/tests/ci/integration/run_crt_integration.sh
+++ b/tests/ci/integration/run_crt_integration.sh
@@ -1,11 +1,12 @@
-#!/bin/bash -exu
+#!/usr/bin/env bash
+set -exu
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
 source tests/ci/common_posix_setup.sh
 
 # Assumes script is executed from the root of aws-lc directory
-SCRATCH_FOLDER=${SYS_ROOT}/"SCRATCH_AWSLC_CRT_TEST"
+SCRATCH_FOLDER=${SYS_ROOT}/SCRATCH_AWSLC_CRT_TEST
 
 # Make script execution idempotent.
 mkdir -p ${SCRATCH_FOLDER}
@@ -21,6 +22,6 @@ cp -r ${SRC_ROOT}/* crt/aws-lc/
 
 # Don't pre-build AWS-LC, the CRT will build all of it's dependencies how it wants them built
 mkdir build && cd build
-cmake -GNinja ../
+${CMAKE_COMMAND} -GNinja ../
 ninja
 ninja test


### PR DESCRIPTION
### Description of changes: 
The CRT uses AWS-LC indirectly though s2n-tls, and directly though the aws-c-cal. This adds a CI integration test to make sure everything works together. 

### Testing:
Built locally, CodeBuild will check the yaml is correct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
