### PR TITLE
Completely remove Jitter CPU from library artifact if not enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(FIPS)
 
   if(ENABLE_FIPS_ENTROPY_CPU_JITTER)
     add_definitions(-DFIPS_ENTROPY_SOURCE_JITTER_CPU)
+    add_subdirectory(third_party/jitterentropy)
     message(STATUS "FIPS entropy source method configured: CPU Jitter")
   else()
     add_definitions(-DFIPS_ENTROPY_SOURCE_PASSIVE)
@@ -646,8 +647,6 @@ if(FIPS)
   if(WIN32 AND CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
     message(FATAL_ERROR "Windows Debug build is not supported with FIPS, use Release or RelWithDebInfo")
   endif()
-
-  add_subdirectory(third_party/jitterentropy)
 
   add_definitions(-DBORINGSSL_FIPS)
   if(FIPS_BREAK_TEST)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -532,7 +532,9 @@ target_include_directories(crypto_objects BEFORE PRIVATE ${PROJECT_BINARY_DIR}/s
 target_include_directories(crypto_objects PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
 function(build_libcrypto name module_source)
-  if(FIPS)
+  if(FIPS AND ENABLE_FIPS_ENTROPY_CPU_JITTER)
+    # If the jitter cpu entropy source is enabled add an object dependency to
+    # the libcrypto target.
     add_library(${name} $<TARGET_OBJECTS:crypto_objects> ${CRYPTO_FIPS_OBJECTS} ${module_source} $<TARGET_OBJECTS:jitterentropy>)
   else()
     add_library(${name} $<TARGET_OBJECTS:crypto_objects> ${CRYPTO_FIPS_OBJECTS} ${module_source})
@@ -678,13 +680,6 @@ if(BUILD_TESTING)
     ${RANDOM_TEST_EXEC}
     fipsmodule/rand/urandom_test.cc
   )
-
-  # When using CPU Jitter as the entropy source (only in FIPS build)
-  # urandom_test should not be performed so we pass the compilation flag
-  # and handle it in urandom_test.cc
-  if(JITTER_ENTROPY)
-    target_compile_options(${RANDOM_TEST_EXEC} PUBLIC -DJITTER_ENTROPY)
-  endif()
 
   add_dependencies(${RANDOM_TEST_EXEC} boringssl_prefix_symbols)
   target_link_libraries(${RANDOM_TEST_EXEC} test_support_lib boringssl_gtest crypto)

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -235,10 +235,12 @@ static void BORINGSSL_bcm_power_on_self_test(void) {
   OPENSSL_cpuid_setup();
 #endif
 
+#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
   if (jent_entropy_init()) {
     fprintf(stderr, "CPU Jitter entropy RNG initialization failed.\n");
     goto err;
   }
+#endif
 
 #if !defined(OPENSSL_ASAN)
   // Integrity tests cannot run under ASAN because it involves reading the full

--- a/crypto/fipsmodule/rand/cpu_jitter_test.cc
+++ b/crypto/fipsmodule/rand/cpu_jitter_test.cc
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-#if defined(BORINGSSL_FIPS)
+#if defined(BORINGSSL_FIPS) && defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
 
 #include <gtest/gtest.h>
 

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2252,6 +2252,7 @@ static bool SpeedSelfTest(const std::string &selected) {
   return true;
 }
 
+#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
 static bool SpeedJitter(size_t chunk_size) {
   struct rand_data *jitter_ec = jent_entropy_collector_alloc(0, JENT_FORCE_FIPS);
 
@@ -2287,6 +2288,7 @@ static bool SpeedJitter(std::string selected) {
   }
   return true;
 }
+#endif
 #endif
 
 static bool SpeedDHcheck(size_t prime_bit_length) {
@@ -2682,10 +2684,14 @@ bool Speed(const std::vector<std::string> &args) {
     }
 
 #if defined(AWSLC_FIPS)
-    if (!SpeedSelfTest(selected) ||
-        !SpeedJitter(selected)) {
+    if (!SpeedSelfTest(selected)) {
       return false;
     }
+#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
+    if (!SpeedJitter(selected)) {
+      return false;
+    }
+#endif
 #endif
   }
 


### PR DESCRIPTION
### Description of changes: 

Previously, we disabled jitter cpu by default; instead enabling the passive strategy by default. This is a build-time configuration. That is, if jitter cpu is not explicitly enabled, jitter cpu is not used as the source in FIPS mode and is redundant.

However, the previous work didn't completely remove jitter cpu object code from resulting library artifacts when FIPS is enabled:
```
$ ar -t crypto/libcrypto.a | grep jitter
jitterentropy-base.c.o
jitterentropy-gcd.c.o
jitterentropy-health.c.o
jitterentropy-noise.c.o
jitterentropy-sha3.c.o
jitterentropy-timer.c.o
```

There is no escaped issue, but it takes up space in the library artifact. In additional, it imposes jitter cpu latency at power-on time since the initialisation function is executed in `BORINGSSL_bcm_power_on_self_test()`.

The last point above also means that the linker doesn't even elide the jitter cpu object code at link-editor time when using the static aws-lc libcrypto; Because `bcm.o` has a dependency on the jitter cpu object in the aws-lc static archive...

Hence, this change will:
* improve library size slightly.
* improve power-on since we no longer (accidentally) initialise jitter cpu even though it's unused.

### Call-outs:

Unfortunately, this is a bit of an annoying issue to resolve; it requires several code changes in the build and source code adding more pre-processing logic.

Firstly, I originally made jitter cpu build independent of FIPS (i.e. always build it) such that I could simplify the speed tool (remove macro's etc). But I ended up reverting it, since it would increase the set of platforms jitter cpu would be build on. Currently, the number of platforms is reduced since it's only ever build in the FIPS configuration. There is definitely a likelihood of a build regression if increasing scope. I'm not ready to make that change.

Secondly, the prng modeling test actually supports jitter entropy now (since https://github.com/aws/aws-lc/commit/6ba258c31a16d6f5eead6cfb572f836e08e956cd). I removed the cmake script stuff dealing with it (it was also unused at this point).

Finally, I need pre-processing logic in the power-on workflow. We still need to support initialising jitter cpu if enabled.

### Testing:

No longer any lingering jitter cpu object code:
```
$ ar -t crypto/libcrypto.a | grep jitter
<empty>
$ objdump -d crypto/libcrypto.a | grep jitter
<empty>
```

If enabling jitter cpu, we can successfully run tests:
```
$ ./crypto/crypto_test --gtest_filter=CPUJitterEntropyTest.*
Note: Google Test filter = CPUJitterEntropyTest.*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CPUJitterEntropyTest
[ RUN      ] CPUJitterEntropyTest.Basic
[       OK ] CPUJitterEntropyTest.Basic (81 ms)
[----------] 1 test from CPUJitterEntropyTest (81 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (81 ms total)
[  PASSED  ] 1 test.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
