### PR TITLE
 Fix SipHash for big-endian

### DIFF
--- a/crypto/siphash/siphash.c
+++ b/crypto/siphash/siphash.c
@@ -77,6 +77,5 @@ uint64_t SIPHASH_24(const uint64_t key[2], const uint8_t *input,
   siphash_round(v);
   siphash_round(v);
 
-  uint64_t b = v[0] ^ v[1] ^ v[2] ^ v[3];
-  return CRYPTO_load_u64_le(&b);
+  return v[0] ^ v[1] ^ v[2] ^ v[3];
 }

--- a/crypto/siphash/siphash.c
+++ b/crypto/siphash/siphash.c
@@ -42,8 +42,13 @@ uint64_t SIPHASH_24(const uint64_t key[2], const uint8_t *input,
   const size_t orig_input_len = input_len;
 
   uint64_t v[4], k0, k1;
-  CRYPTO_store_u64_le(&k0, key[0]);
-  CRYPTO_store_u64_le(&k1, key[1]);
+#ifdef OPENSSL_BIG_ENDIAN
+  k0 = CRYPTO_bswap8(key[0]);
+  k1 = CRYPTO_bswap8(key[1]);
+#else
+  k0 = key[0];
+  k1 = key[1];
+#endif
   v[0] = k0 ^ UINT64_C(0x736f6d6570736575);
   v[1] = k1 ^ UINT64_C(0x646f72616e646f6d);
   v[2] = k0 ^ UINT64_C(0x6c7967656e657261);

--- a/crypto/siphash/siphash.c
+++ b/crypto/siphash/siphash.c
@@ -41,11 +41,13 @@ uint64_t SIPHASH_24(const uint64_t key[2], const uint8_t *input,
                     size_t input_len) {
   const size_t orig_input_len = input_len;
 
-  uint64_t v[4];
-  v[0] = key[0] ^ UINT64_C(0x736f6d6570736575);
-  v[1] = key[1] ^ UINT64_C(0x646f72616e646f6d);
-  v[2] = key[0] ^ UINT64_C(0x6c7967656e657261);
-  v[3] = key[1] ^ UINT64_C(0x7465646279746573);
+  uint64_t v[4], k0, k1;
+  CRYPTO_store_u64_le(&k0, key[0]);
+  CRYPTO_store_u64_le(&k1, key[1]);
+  v[0] = k0 ^ UINT64_C(0x736f6d6570736575);
+  v[1] = k1 ^ UINT64_C(0x646f72616e646f6d);
+  v[2] = k0 ^ UINT64_C(0x6c7967656e657261);
+  v[3] = k1 ^ UINT64_C(0x7465646279746573);
 
   while (input_len >= sizeof(uint64_t)) {
     uint64_t m = CRYPTO_load_u64_le(input);
@@ -75,5 +77,6 @@ uint64_t SIPHASH_24(const uint64_t key[2], const uint8_t *input,
   siphash_round(v);
   siphash_round(v);
 
-  return v[0] ^ v[1] ^ v[2] ^ v[3];
+  uint64_t b = v[0] ^ v[1] ^ v[2] ^ v[3];
+  return CRYPTO_load_u64_le(&b);
 }

--- a/crypto/siphash/siphash_test.cc
+++ b/crypto/siphash/siphash_test.cc
@@ -34,8 +34,8 @@ TEST(SipHash, Basic) {
   for (unsigned i = 0; i < sizeof(input); i++) {
     input[i] = i;
   }
-
-  EXPECT_EQ(UINT64_C(0xa129ca6149be45e5),
+  uint64_t expected = UINT64_C(0xa129ca6149be45e5);
+  EXPECT_EQ(CRYPTO_load_u64_le(&expected),
             SIPHASH_24(key, input, sizeof(input)));
 }
 

--- a/crypto/siphash/siphash_test.cc
+++ b/crypto/siphash/siphash_test.cc
@@ -34,24 +34,24 @@ TEST(SipHash, Basic) {
   for (unsigned i = 0; i < sizeof(input); i++) {
     input[i] = i;
   }
-  uint64_t expected = UINT64_C(0xa129ca6149be45e5);
-  EXPECT_EQ(CRYPTO_load_u64_le(&expected),
+
+  EXPECT_EQ(UINT64_C(0xa129ca6149be45e5),
             SIPHASH_24(key, input, sizeof(input)));
 }
 
 TEST(SipHash, Vectors) {
   FileTestGTest("crypto/siphash/siphash_tests.txt", [](FileTest *t) {
-    std::vector<uint8_t> key, msg, hash;
+    std::vector<uint8_t> key, msg, hash_bytes;
     ASSERT_TRUE(t->GetBytes(&key, "KEY"));
     ASSERT_TRUE(t->GetBytes(&msg, "IN"));
-    ASSERT_TRUE(t->GetBytes(&hash, "HASH"));
+    ASSERT_TRUE(t->GetBytes(&hash_bytes, "HASH"));
     ASSERT_EQ(16u, key.size());
-    ASSERT_EQ(8u, hash.size());
+    ASSERT_EQ(8u, hash_bytes.size());
+    uint64_t hash = CRYPTO_load_u64_le(hash_bytes.data());
 
     uint64_t key_words[2];
     memcpy(key_words, key.data(), key.size());
     uint64_t result = SIPHASH_24(key_words, msg.data(), msg.size());
-    EXPECT_EQ(Bytes(reinterpret_cast<uint8_t *>(&result), sizeof(result)),
-              Bytes(hash));
+    EXPECT_EQ(result, hash);
   });
 }


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Fix SipHash implementation for big-endian architectures.

### Call-outs:
N/A

### Testing:
`SipHash.*` test pass for both ppc32 and ppc64.

ppc32:
```
❯ ppc-qemu.sh ./crypto/crypto_test --gtest_filter="SipHash.*"
Note: Google Test filter = SipHash.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from SipHash
[ RUN      ] SipHash.Basic
[       OK ] SipHash.Basic (3 ms)
[ RUN      ] SipHash.Vectors
[       OK ] SipHash.Vectors (115 ms)
[----------] 2 tests from SipHash (120 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (129 ms total)
[  PASSED  ] 2 tests.
```

ppc64:
```
❯ ppc64-qemu.sh ./crypto/crypto_test --gtest_filter="SipHash.*"   
Note: Google Test filter = SipHash.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from SipHash
[ RUN      ] SipHash.Basic
[       OK ] SipHash.Basic (2 ms)
[ RUN      ] SipHash.Vectors
[       OK ] SipHash.Vectors (122 ms)
[----------] 2 tests from SipHash (126 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (133 ms total)
[  PASSED  ] 2 tests.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
