### PR TITLE
Document Ed25519 verification operation

### DIFF
--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -364,7 +364,7 @@ int ED25519_verify(const uint8_t *message, size_t message_len,
   // First negate A'. Point negation for the twisted edwards curve when points
   // are represented in the extended coordinate system is simply:
   //   -(X,Y,Z,T) = (-X,Y,Z,-T).
-  // See "Twisted Edwards curves revisited" http://eprint.iacr.org/2008/522.
+  // See "Twisted Edwards curves revisited" https://ia.cr/2008/522.
   fe_loose t;
   fe_neg(&t, &A.X);
   fe_carry(&A.X, &t);


### PR DESCRIPTION
### Description of changes: 

Document Ed25519 workflow with respect to https://datatracker.ietf.org/doc/html/rfc8032.

### Call-outs:

Swapped the order of a few (data independent) operations. I see no cache impact.

Renamed few variables to align with naming in rfc8032.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
