### PR TITLE
Fix XChaCha20Poly1305 for big-endian

### DIFF
--- a/crypto/chacha/chacha.c
+++ b/crypto/chacha/chacha.c
@@ -24,8 +24,13 @@
 
 
 // sigma contains the ChaCha constants, which happen to be an ASCII string.
-static const uint8_t sigma[16] = { 'e', 'x', 'p', 'a', 'n', 'd', ' ', '3',
-                                   '2', '-', 'b', 'y', 't', 'e', ' ', 'k' };
+// "expand 32-byte k"
+static const uint32_t sigma_words[4] = {
+        0x61707865, // 'e' 0x65, 'x' 0x78, 'p' 0x70, 'a' 0x61,
+        0x3320646e, // 'n' 0x6E, 'd' 0x64, ' ' 0x20, '3' 0x33,
+        0x79622d32, // '2' 0x32, '-' 0x2D, 'b' 0x62, 'y' 0x79,
+        0x6b206574  // 't' 0x74, 'e' 0x65, ' ' 0x20, 'k' 0x6B
+};
 
 // QUARTERROUND updates a, b, c, d with a ChaCha "quarter" round.
 #define QUARTERROUND(a, b, c, d)           \
@@ -41,10 +46,8 @@ static const uint8_t sigma[16] = { 'e', 'x', 'p', 'a', 'n', 'd', ' ', '3',
 void CRYPTO_hchacha20(uint8_t out[32], const uint8_t key[32],
                       const uint8_t nonce[16]) {
   uint32_t x[16];
+  OPENSSL_memcpy(x, sigma_words, sizeof(sigma_words));
 #ifdef OPENSSL_BIG_ENDIAN
-  for(size_t i = 0; i < 4; i++) {
-    x[i] = CRYPTO_load_u32_le(sigma + i * sizeof(uint32_t));
-  }
   for(size_t i = 4; i < 12; i++) {
     x[i] = CRYPTO_load_u32_le(key + (i-4) * sizeof(uint32_t));
   }
@@ -52,7 +55,6 @@ void CRYPTO_hchacha20(uint8_t out[32], const uint8_t key[32],
     x[i] = CRYPTO_load_u32_le(nonce + (i-12) * sizeof(uint32_t));
   }
 #else
-  OPENSSL_memcpy(x, sigma, sizeof(sigma));
   OPENSSL_memcpy(&x[4], key, 32);
   OPENSSL_memcpy(&x[12], nonce, 16);
 #endif
@@ -70,7 +72,7 @@ void CRYPTO_hchacha20(uint8_t out[32], const uint8_t key[32],
 
 #ifdef OPENSSL_BIG_ENDIAN
   for(size_t i = 0; i < 4; i++) {
-    CRYPTO_store_u32_le(out + i*sizeof(uint32_t), x[i]);
+    CRYPTO_store_u32_le(out + i * sizeof(uint32_t), x[i]);
   }
   for(size_t i = 12; i < 16; i++) {
     CRYPTO_store_u32_le(out + (i-8) * sizeof(uint32_t), x[i]);
@@ -170,10 +172,10 @@ void CRYPTO_chacha_20(uint8_t *out, const uint8_t *in, size_t in_len,
   uint8_t buf[64];
   size_t todo, i;
 
-  input[0] = CRYPTO_load_u32_le(sigma + 0);
-  input[1] = CRYPTO_load_u32_le(sigma + 4);
-  input[2] = CRYPTO_load_u32_le(sigma + 8);
-  input[3] = CRYPTO_load_u32_le(sigma + 12);
+  input[0] = sigma_words[0];
+  input[1] = sigma_words[1];
+  input[2] = sigma_words[2];
+  input[3] = sigma_words[3];
 
   input[4] = CRYPTO_load_u32_le(key + 0);
   input[5] = CRYPTO_load_u32_le(key + 4);


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Fix big-endian issue with (AEAD) XChaCha20Poly1305.
* When combined with #1213, all of our `PerAEADTest.TestVector` tests succeed.

### Call-outs:
N/A

### Testing:
PPC32:
```
❯ ppc-qemu.sh  ./crypto/crypto_test --gtest_filter="*/PerAEADTest.TestVector/*"
Note: Google Test filter = */PerAEADTest.TestVector/*
[==========] Running 24 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 24 tests from All/PerAEADTest
[ RUN      ] All/PerAEADTest.TestVector/AES_128_GCM
[       OK ] All/PerAEADTest.TestVector/AES_128_GCM (667 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_GCM_NIST
[       OK ] All/PerAEADTest.TestVector/AES_128_GCM_NIST (32982 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_192_GCM
[       OK ] All/PerAEADTest.TestVector/AES_192_GCM (391 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_GCM
[       OK ] All/PerAEADTest.TestVector/AES_256_GCM (773 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_GCM_NIST
[       OK ] All/PerAEADTest.TestVector/AES_256_GCM_NIST (40476 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_GCM_SIV
[       OK ] All/PerAEADTest.TestVector/AES_128_GCM_SIV (1020 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_GCM_SIV
[       OK ] All/PerAEADTest.TestVector/AES_256_GCM_SIV (1443 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_GCM_RandomNonce
[       OK ] All/PerAEADTest.TestVector/AES_128_GCM_RandomNonce (11 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_GCM_RandomNonce
[       OK ] All/PerAEADTest.TestVector/AES_256_GCM_RandomNonce (12 ms)
[ RUN      ] All/PerAEADTest.TestVector/ChaCha20Poly1305
[       OK ] All/PerAEADTest.TestVector/ChaCha20Poly1305 (81 ms)
[ RUN      ] All/PerAEADTest.TestVector/XChaCha20Poly1305
[       OK ] All/PerAEADTest.TestVector/XChaCha20Poly1305 (42 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CBC_SHA1_TLS
[       OK ] All/PerAEADTest.TestVector/AES_128_CBC_SHA1_TLS (1775 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CBC_SHA1_TLSImplicitIV
[       OK ] All/PerAEADTest.TestVector/AES_128_CBC_SHA1_TLSImplicitIV (1776 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CBC_SHA256_TLS
[       OK ] All/PerAEADTest.TestVector/AES_128_CBC_SHA256_TLS (2150 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CBC_SHA256_TLSImplicitIV
[       OK ] All/PerAEADTest.TestVector/AES_128_CBC_SHA256_TLSImplicitIV (1888 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_CBC_SHA1_TLS
[       OK ] All/PerAEADTest.TestVector/AES_256_CBC_SHA1_TLS (2694 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_CBC_SHA1_TLSImplicitIV
[       OK ] All/PerAEADTest.TestVector/AES_256_CBC_SHA1_TLSImplicitIV (2930 ms)
[ RUN      ] All/PerAEADTest.TestVector/DES_EDE3_CBC_SHA1_TLS
[       OK ] All/PerAEADTest.TestVector/DES_EDE3_CBC_SHA1_TLS (808 ms)
[ RUN      ] All/PerAEADTest.TestVector/DES_EDE3_CBC_SHA1_TLSImplicitIV
[       OK ] All/PerAEADTest.TestVector/DES_EDE3_CBC_SHA1_TLSImplicitIV (846 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CTR_HMAC_SHA256
[       OK ] All/PerAEADTest.TestVector/AES_128_CTR_HMAC_SHA256 (99 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_CTR_HMAC_SHA256
[       OK ] All/PerAEADTest.TestVector/AES_256_CTR_HMAC_SHA256 (114 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CCM_BLUETOOTH
[       OK ] All/PerAEADTest.TestVector/AES_128_CCM_BLUETOOTH (76 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CCM_BLUETOOTH_8
[       OK ] All/PerAEADTest.TestVector/AES_128_CCM_BLUETOOTH_8 (31 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CCM_Matter
[       OK ] All/PerAEADTest.TestVector/AES_128_CCM_Matter (31 ms)
[----------] 24 tests from All/PerAEADTest (93139 ms total)

[----------] Global test environment tear-down
[==========] 24 tests from 1 test suite ran. (93147 ms total)
[  PASSED  ] 24 tests.
```

PPC64:
```
❯ ppc64-qemu.sh crypto/crypto_test --gtest_filter="*/PerAEADTest.TestVector/*" 
Note: Google Test filter = */PerAEADTest.TestVector/*
[==========] Running 24 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 24 tests from All/PerAEADTest
[ RUN      ] All/PerAEADTest.TestVector/AES_128_GCM
[       OK ] All/PerAEADTest.TestVector/AES_128_GCM (705 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_GCM_NIST
[       OK ] All/PerAEADTest.TestVector/AES_128_GCM_NIST (36329 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_192_GCM
[       OK ] All/PerAEADTest.TestVector/AES_192_GCM (328 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_GCM
[       OK ] All/PerAEADTest.TestVector/AES_256_GCM (587 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_GCM_NIST
[       OK ] All/PerAEADTest.TestVector/AES_256_GCM_NIST (38893 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_GCM_SIV
[       OK ] All/PerAEADTest.TestVector/AES_128_GCM_SIV (1033 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_GCM_SIV
[       OK ] All/PerAEADTest.TestVector/AES_256_GCM_SIV (1428 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_GCM_RandomNonce
[       OK ] All/PerAEADTest.TestVector/AES_128_GCM_RandomNonce (9 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_GCM_RandomNonce
[       OK ] All/PerAEADTest.TestVector/AES_256_GCM_RandomNonce (11 ms)
[ RUN      ] All/PerAEADTest.TestVector/ChaCha20Poly1305
[       OK ] All/PerAEADTest.TestVector/ChaCha20Poly1305 (83 ms)
[ RUN      ] All/PerAEADTest.TestVector/XChaCha20Poly1305
[       OK ] All/PerAEADTest.TestVector/XChaCha20Poly1305 (45 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CBC_SHA1_TLS
[       OK ] All/PerAEADTest.TestVector/AES_128_CBC_SHA1_TLS (1346 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CBC_SHA1_TLSImplicitIV
[       OK ] All/PerAEADTest.TestVector/AES_128_CBC_SHA1_TLSImplicitIV (1314 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CBC_SHA256_TLS
[       OK ] All/PerAEADTest.TestVector/AES_128_CBC_SHA256_TLS (1403 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CBC_SHA256_TLSImplicitIV
[       OK ] All/PerAEADTest.TestVector/AES_128_CBC_SHA256_TLSImplicitIV (1416 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_CBC_SHA1_TLS
[       OK ] All/PerAEADTest.TestVector/AES_256_CBC_SHA1_TLS (1669 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_CBC_SHA1_TLSImplicitIV
[       OK ] All/PerAEADTest.TestVector/AES_256_CBC_SHA1_TLSImplicitIV (1644 ms)
[ RUN      ] All/PerAEADTest.TestVector/DES_EDE3_CBC_SHA1_TLS
[       OK ] All/PerAEADTest.TestVector/DES_EDE3_CBC_SHA1_TLS (700 ms)
[ RUN      ] All/PerAEADTest.TestVector/DES_EDE3_CBC_SHA1_TLSImplicitIV
[       OK ] All/PerAEADTest.TestVector/DES_EDE3_CBC_SHA1_TLSImplicitIV (710 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CTR_HMAC_SHA256
[       OK ] All/PerAEADTest.TestVector/AES_128_CTR_HMAC_SHA256 (106 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_256_CTR_HMAC_SHA256
[       OK ] All/PerAEADTest.TestVector/AES_256_CTR_HMAC_SHA256 (96 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CCM_BLUETOOTH
[       OK ] All/PerAEADTest.TestVector/AES_128_CCM_BLUETOOTH (64 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CCM_BLUETOOTH_8
[       OK ] All/PerAEADTest.TestVector/AES_128_CCM_BLUETOOTH_8 (25 ms)
[ RUN      ] All/PerAEADTest.TestVector/AES_128_CCM_Matter
[       OK ] All/PerAEADTest.TestVector/AES_128_CCM_Matter (25 ms)
[----------] 24 tests from All/PerAEADTest (89985 ms total)

[----------] Global test environment tear-down
[==========] 24 tests from 1 test suite ran. (89996 ms total)
[  PASSED  ] 24 tests.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
