### PR TITLE
Bump version to 1.17.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4276,7 +4276,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.16.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.17.0");
 }
 
 #else
@@ -4319,6 +4319,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.16.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.17.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -224,7 +224,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.16.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.17.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Add a FFDH benchmark to demonstrate how slow it is by @andrewhop in https://github.com/aws/aws-lc/pull/1202
* Add missing NULL check in conf test by @torben-hansen in https://github.com/aws/aws-lc/pull/1208
* Add EVP support for SHA512-224 by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1170
* Handle x30 target register in delocator for aarch64 to avoid clobbering the register by @torben-hansen in https://github.com/aws/aws-lc/pull/1204
* Elaborate on whiten factor for passive entropy by @torben-hansen in https://github.com/aws/aws-lc/pull/1209
* Implement SSL_get_client_ciphers by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1159
* Add ARM dimensions for integration test CI  by @samuel40791765 in https://github.com/aws/aws-lc/pull/1206
* Add back support for SSL_build_cert_chain by @samuel40791765 in https://github.com/aws/aws-lc/pull/1200
* Add BIGNUM support for big-endian architectures by @justsmth in https://github.com/aws/aws-lc/pull/1205
* For Issue-1185: Avoid 'may be used uninitialized' warning by @justsmth in https://github.com/aws/aws-lc/pull/1212
* Use s2n-bignum's constant-time table lookup for copy_from_prebuf by @aqjune-aws in https://github.com/aws/aws-lc/pull/1189
* No external conditioning by @torben-hansen in https://github.com/aws/aws-lc/pull/1216
* Don't build FFDH benchmarks with AWS-LC API versions less than 22 by @andrewhop in https://github.com/aws/aws-lc/pull/1218
* Add TLS Transfer Support Caller Responsibilities by @skmcgrail in https://github.com/aws/aws-lc/pull/1223
* EC support for PPC64 big endian  by @justsmth in https://github.com/aws/aws-lc/pull/1214
* Update bio_info_cb to align with OpenSSL 3.x by @justsmth in https://github.com/aws/aws-lc/pull/1222
* bump version to 2.0 for FIPS by @samuel40791765 in https://github.com/aws/aws-lc/pull/1225
* Revert "Bump version to 2.0 for FIPS" by @samuel40791765 in https://github.com/aws/aws-lc/pull/1227
* Abstract some ec2 CI logic and add support for c7g by @samuel40791765 in https://github.com/aws/aws-lc/pull/1220
* Fix AppleClang 15 FIPS Shared Library Build by @skmcgrail in https://github.com/aws/aws-lc/pull/1224
* Update rsa service indicator test vectors by @billbo-yang in https://github.com/aws/aws-lc/pull/1230
* Expose SHAKE through the EVP API by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1199
* Add support for RSA KeyGen AFT tests for FIPS186-5 to ACVP tool by @billbo-yang in https://github.com/aws/aws-lc/pull/1234
* Fix Blake2b for BigEndian by @justsmth in https://github.com/aws/aws-lc/pull/1235
* Upstream merge 2023-10-02 by @dkostic in https://github.com/aws/aws-lc/pull/1221
* self destruct ec2 instances after certain amount of time by @samuel40791765 in https://github.com/aws/aws-lc/pull/1233
* Fix bad cast in SSHKDF by @justsmth in https://github.com/aws/aws-lc/pull/1241
* Add Github actions job pruner by @samuel40791765 in https://github.com/aws/aws-lc/pull/1242
* Ensure array length assumption agree by @torben-hansen in https://github.com/aws/aws-lc/pull/1246
* Use scoped version of EVP_MD_CTX in test by @samuel40791765 in https://github.com/aws/aws-lc/pull/1244
* Resolve aws-lc-rs CI build issues by @skmcgrail in https://github.com/aws/aws-lc/pull/1231
* Completely remove Jitter CPU from library artifact if not enabled by @torben-hansen in https://github.com/aws/aws-lc/pull/1249
* Fix Spake25519 for big-endian by @justsmth in https://github.com/aws/aws-lc/pull/1243
* Slight build fix and migrate to GHA for MacOS ARM CI by @samuel40791765 in https://github.com/aws/aws-lc/pull/1245
* Fix 32-bit big-endian p521 bug by @justsmth in https://github.com/aws/aws-lc/pull/1240
* Add support for BIO_FP_TEXT in file BIOs by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1153
* Fix GCC 13.x compiler error by @justsmth in https://github.com/aws/aws-lc/pull/1259
* Fix XChaCha20Poly1305 for big-endian by @justsmth in https://github.com/aws/aws-lc/pull/1257
* Fix scrypt for big-endian by @justsmth in https://github.com/aws/aws-lc/pull/1253
* Fix SipHash for big-endian by @justsmth in https://github.com/aws/aws-lc/pull/1251
* Upstream merge 2023-10-15 by @andrewhop in https://github.com/aws/aws-lc/pull/1250
* Add CRT integration test by @andrewhop in https://github.com/aws/aws-lc/pull/1248
* Update patch for nginx integration CI by @samuel40791765 in https://github.com/aws/aws-lc/pull/1260
* Add SDE+ASAN CI dimension by @samuel40791765 in https://github.com/aws/aws-lc/pull/1254
* Add CI for Windows MSVC2019, MSVC2022, and SDE 32/64-bit by @samuel40791765 in https://github.com/aws/aws-lc/pull/1228
* Test fixes by @nebeid in https://github.com/aws/aws-lc/pull/1263
* Add a build option to the assembler to retain local symbols. by @nebeid in https://github.com/aws/aws-lc/pull/1252
* Remove -mavx512vbmi2 clang compiler argument by @skmcgrail in https://github.com/aws/aws-lc/pull/1266
* 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
