### PR TITLE
Refactor ED25519_keypair into hw and nohw backend

### DIFF
--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -31,6 +31,25 @@
 #include "../internal.h"
 #include "../fipsmodule/cpucap/internal.h"
 
+// X25519 [1] and Ed25519 [2] is an ECDHE protocol and signature scheme,
+// respectively. This file contains an implementation of both using two
+// different backends:
+// 1) One backed is a pure C backend that should work on any platform.
+// 2) The other backend is machine-optimized using s2n-bignum [3] as backend.
+//
+// [1]: https://datatracker.ietf.org/doc/html/rfc7748
+// [2]: https://datatracker.ietf.org/doc/html/rfc8032
+// [3]: https://github.com/awslabs/s2n-bignum
+//
+// "Clamping":
+// Both X25519 and Ed25519 contain "clamping" steps; bit-twiddling, masking or
+// setting specific bits. Generally, the bit-twiddling is to avoid common
+// implementation errors and weak instances. Details can be found through the
+// following two references:
+// * https://mailarchive.ietf.org/arch/msg/cfrg/pt2bt3fGQbNF8qdEcorp-rJSJrc/
+// * https://neilmadden.blog/2020/05/28/whats-the-curve25519-clamping-all-about
+
+
 // If (1) x86_64 or aarch64, (2) linux or apple, and (3) OPENSSL_NO_ASM is not
 // set, s2n-bignum path is capable.
 #if ((defined(OPENSSL_X86_64) &&                                               \

--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -241,12 +241,14 @@ static void x25519_s2n_bignum_public_from_private(
 
 // Stub function until ED25519 lands in s2n-bignum
 static void ed25519_public_key_from_hashed_seed_s2n_bignum(
-  uint8_t out_public_key[32], uint8_t az[SHA512_DIGEST_LENGTH]) {
+  uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
+  uint8_t az[SHA512_DIGEST_LENGTH]) {
   abort();
 }
 
 void ED25519_keypair_from_seed(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
-  uint8_t out_private_key[64], const uint8_t seed[ED25519_SEED_LEN]) {
+  uint8_t out_private_key[ED25519_PRIVATE_KEY_LEN],
+  const uint8_t seed[ED25519_SEED_LEN]) {
 
   // Step: rfc8032 5.1.5.1
   // Compute SHA512(seed).
@@ -268,13 +270,14 @@ void ED25519_keypair_from_seed(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
 
   // Encoded public key is a suffix in the private key. Avoids having to
   // generate the public key from the private key when signing. 
-  OPENSSL_STATIC_ASSERT(64 == (ED25519_SEED_LEN + ED25519_PUBLIC_KEY_LEN), ed25519_parameter_length_mismatch)
+  OPENSSL_STATIC_ASSERT(ED25519_PRIVATE_KEY_LEN == (ED25519_SEED_LEN + ED25519_PUBLIC_KEY_LEN), ed25519_parameter_length_mismatch)
   OPENSSL_memcpy(out_private_key, seed, ED25519_SEED_LEN);
   OPENSSL_memcpy(out_private_key + ED25519_SEED_LEN, out_public_key,
     ED25519_PUBLIC_KEY_LEN);
 }
 
-void ED25519_keypair(uint8_t out_public_key[32], uint8_t out_private_key[64]) {
+void ED25519_keypair(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
+  uint8_t out_private_key[ED25519_PRIVATE_KEY_LEN]) {
 
   // Ed25519 key generation: rfc8032 5.1.5
   // Private key is 32 octets of random data.

--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -34,7 +34,7 @@
 // X25519 [1] and Ed25519 [2] is an ECDHE protocol and signature scheme,
 // respectively. This file contains an implementation of both using two
 // different backends:
-// 1) One backed is a pure C backend that should work on any platform.
+// 1) One backend is a pure C backend that should work on any platform.
 // 2) The other backend is machine-optimized using s2n-bignum [3] as backend.
 //
 // [1]: https://datatracker.ietf.org/doc/html/rfc7748

--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -254,14 +254,9 @@ void ED25519_keypair_from_seed(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
   SHA512(seed, ED25519_SEED_LEN, az);
 
   // Step: rfc8032 5.1.5.2
-  // 248 = 11111000_2 clears lowest 3 bits.
-  // For last octet: clear highest highest bit and set second highest bit,
-  // respectively.
-  // 127 = 01111111_2
-  // 64 = 01000000_2
-  az[0] &= 248;
-  az[31] &= 127;
-  az[31] |= 64;
+  az[0] &= 248; // 11111000_2
+  az[31] &= 127; // 01111111_2
+  az[31] |= 64; // 01000000_2
 
   // Step: rfc8032 5.1.5.[3,4]
   // Compute [az]B and encode public key to a 32 byte octet.

--- a/crypto/curve25519/curve25519_nohw.c
+++ b/crypto/curve25519/curve25519_nohw.c
@@ -1969,7 +1969,7 @@ void x25519_public_from_private_nohw(uint8_t out_public_value[32],
   CONSTTIME_DECLASSIFY(out_public_value, 32);
 }
 
-void ed25519_keypair_from_seed_nohw(uint8_t out_public_key[32],
+void ed25519_public_key_from_hashed_seed_nohw(uint8_t out_public_key[32],
     uint8_t az[SHA512_DIGEST_LENGTH]) {
   ge_p3 A;
   x25519_ge_scalarmult_base(&A, az);

--- a/crypto/curve25519/curve25519_nohw.c
+++ b/crypto/curve25519/curve25519_nohw.c
@@ -1968,3 +1968,10 @@ void x25519_public_from_private_nohw(uint8_t out_public_value[32],
   fe_tobytes(out_public_value, &zminusy_inv);
   CONSTTIME_DECLASSIFY(out_public_value, 32);
 }
+
+void ed25519_keypair_from_seed_nohw(uint8_t out_public_key[32],
+    uint8_t az[SHA512_DIGEST_LENGTH]) {
+  ge_p3 A;
+  x25519_ge_scalarmult_base(&A, az);
+  ge_p3_tobytes(out_public_key, &A);
+}

--- a/crypto/curve25519/internal.h
+++ b/crypto/curve25519/internal.h
@@ -20,6 +20,7 @@ extern "C" {
 #endif
 
 #include <openssl/base.h>
+#include <openssl/curve25519.h>
 
 #include "../internal.h"
 
@@ -114,6 +115,8 @@ void x25519_scalar_mult_generic_nohw(uint8_t out[32],
                                       const uint8_t point[32]);
 void x25519_public_from_private_nohw(uint8_t out_public_value[32],
                                       const uint8_t private_key[32]);
+void ed25519_keypair_from_seed_nohw(uint8_t out_public_key[32],
+                               uint8_t az[SHA512_DIGEST_LENGTH]);
 
 // Port to internal linkage in curve25519_nohw.c when adding implementation
 // from s2n-bignum ed25519

--- a/crypto/curve25519/internal.h
+++ b/crypto/curve25519/internal.h
@@ -115,8 +115,9 @@ void x25519_scalar_mult_generic_nohw(uint8_t out[32],
                                       const uint8_t point[32]);
 void x25519_public_from_private_nohw(uint8_t out_public_value[32],
                                       const uint8_t private_key[32]);
-void ed25519_public_key_from_hashed_seed_nohw(uint8_t out_public_key[32],
-                                      uint8_t az[SHA512_DIGEST_LENGTH]);
+void ed25519_public_key_from_hashed_seed_nohw(
+  uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
+  uint8_t az[SHA512_DIGEST_LENGTH]);
 
 // Port to internal linkage in curve25519_nohw.c when adding implementation
 // from s2n-bignum ed25519

--- a/crypto/curve25519/internal.h
+++ b/crypto/curve25519/internal.h
@@ -115,8 +115,8 @@ void x25519_scalar_mult_generic_nohw(uint8_t out[32],
                                       const uint8_t point[32]);
 void x25519_public_from_private_nohw(uint8_t out_public_value[32],
                                       const uint8_t private_key[32]);
-void ed25519_keypair_from_seed_nohw(uint8_t out_public_key[32],
-                               uint8_t az[SHA512_DIGEST_LENGTH]);
+void ed25519_public_key_from_hashed_seed_nohw(uint8_t out_public_key[32],
+                                      uint8_t az[SHA512_DIGEST_LENGTH]);
 
 // Port to internal linkage in curve25519_nohw.c when adding implementation
 // from s2n-bignum ed25519


### PR DESCRIPTION
### Description of changes: 

Refactors `ED25519_keypair` into a no-hardware and a hardware path. Existing backend is the former. Preparation for s2n-bignum ED25519.

s2n-bignum is lacking SHA512. So unfortunately, I can't punt this computation to s2n-bignum. 

PR chain:
1. (this PR) refactor `ED25519_keypair`
2. refactor `ED25519_sign`
3. refactor `ED25519_verify`
4. various small changes to improve code quality
5. import s2n-bignum Ed25519 routines
6. connect s2n-bignum Ed25519 backend to frontend

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
