### PR TITLE
Rearrange X509 symbols for Monit support

### DIFF
--- a/crypto/x509/internal.h
+++ b/crypto/x509/internal.h
@@ -361,6 +361,8 @@ struct x509_store_ctx_st {
   CRYPTO_EX_DATA ex_data;
 } /* X509_STORE_CTX */;
 
+void X509_OBJECT_free_contents(X509_OBJECT *a);
+
 ASN1_TYPE *ASN1_generate_v3(const char *str, const X509V3_CTX *cnf);
 
 int X509_CERT_AUX_print(BIO *bp, X509_CERT_AUX *x, int indent);

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -279,7 +279,7 @@ X509_LOOKUP *X509_STORE_add_lookup(X509_STORE *v, X509_LOOKUP_METHOD *m) {
   }
 }
 
-int X509_STORE_get_by_subject(X509_STORE_CTX *vs, int type, X509_NAME *name,
+int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs, int type, X509_NAME *name,
                               X509_OBJECT *ret) {
   X509_STORE *ctx = vs->ctx;
   X509_LOOKUP *lu;
@@ -492,7 +492,7 @@ STACK_OF(X509) *X509_STORE_get1_certs(X509_STORE_CTX *ctx, X509_NAME *nm) {
     // cache
     X509_OBJECT xobj;
     CRYPTO_MUTEX_unlock_write(&ctx->ctx->objs_lock);
-    if (!X509_STORE_get_by_subject(ctx, X509_LU_X509, nm, &xobj)) {
+    if (!X509_STORE_CTX_get_by_subject(ctx, X509_LU_X509, nm, &xobj)) {
       sk_X509_free(sk);
       return NULL;
     }
@@ -530,7 +530,7 @@ STACK_OF(X509_CRL) *X509_STORE_get1_crls(X509_STORE_CTX *ctx, X509_NAME *nm) {
   }
 
   // Always do lookup to possibly add new CRLs to cache.
-  if (!X509_STORE_get_by_subject(ctx, X509_LU_CRL, nm, &xobj)) {
+  if (!X509_STORE_CTX_get_by_subject(ctx, X509_LU_CRL, nm, &xobj)) {
     sk_X509_CRL_free(sk);
     return NULL;
   }
@@ -599,7 +599,7 @@ int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x) {
   int idx, ret;
   size_t i;
   xn = X509_get_issuer_name(x);
-  if (!X509_STORE_get_by_subject(ctx, X509_LU_X509, xn, &obj)) {
+  if (!X509_STORE_CTX_get_by_subject(ctx, X509_LU_X509, xn, &obj)) {
     return 0;
   }
   // If certificate matches all OK

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -359,6 +359,15 @@ int X509_STORE_add_crl(X509_STORE *ctx, X509_CRL *x) {
   return x509_store_add(ctx, x, /*is_crl=*/1);
 }
 
+X509_OBJECT *X509_OBJECT_new(void) {
+  X509_OBJECT *ret = OPENSSL_malloc(sizeof(X509_OBJECT));
+  if (ret == NULL) {
+    return NULL;
+  }
+  OPENSSL_memset(ret, 0, sizeof(X509_OBJECT));
+  return ret;
+}
+
 int X509_OBJECT_up_ref_count(X509_OBJECT *a) {
   switch (a->type) {
     case X509_LU_X509:
@@ -380,6 +389,11 @@ void X509_OBJECT_free_contents(X509_OBJECT *a) {
       X509_CRL_free(a->data.crl);
       break;
   }
+}
+
+void X509_OBJECT_free(X509_OBJECT *a) {
+  X509_OBJECT_free_contents(a);
+  OPENSSL_free(a);
 }
 
 int X509_OBJECT_get_type(const X509_OBJECT *a) { return a->type; }

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -6629,3 +6629,9 @@ TEST(X509Test, TestDecode) {
   ASSERT_TRUE(pkey2);
   ASSERT_TRUE(X509_verify(cert.get(), pkey2.get()));
 }
+
+TEST(X509Test, X509_OBJECT_heap) {
+  X509_OBJECT *x509_object = X509_OBJECT_new();
+  ASSERT_TRUE(x509_object);
+  X509_OBJECT_free(x509_object);
+}

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2906,9 +2906,6 @@ OPENSSL_EXPORT X509_LOOKUP_METHOD *X509_LOOKUP_file(void);
 OPENSSL_EXPORT int X509_STORE_add_cert(X509_STORE *ctx, X509 *x);
 OPENSSL_EXPORT int X509_STORE_add_crl(X509_STORE *ctx, X509_CRL *x);
 
-OPENSSL_EXPORT int X509_STORE_get_by_subject(X509_STORE_CTX *vs, int type,
-                                             X509_NAME *name, X509_OBJECT *ret);
-
 OPENSSL_EXPORT int X509_LOOKUP_ctrl(X509_LOOKUP *ctx, int cmd, const char *argc,
                                     long argl, char **ret);
 

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2778,6 +2778,12 @@ OPENSSL_EXPORT void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
   (X509_V_FLAG_POLICY_CHECK | X509_V_FLAG_EXPLICIT_POLICY | \
    X509_V_FLAG_INHIBIT_ANY | X509_V_FLAG_INHIBIT_MAP)
 
+// X509_OBJECT_new allocates an |X509_OBJECT| on the heap.
+OPENSSL_EXPORT X509_OBJECT *X509_OBJECT_new(void);
+
+// X509_OBJECT_new frees an |X509_OBJECT| from the heap.
+OPENSSL_EXPORT void X509_OBJECT_free(X509_OBJECT *a);
+
 OPENSSL_EXPORT int X509_OBJECT_idx_by_subject(STACK_OF(X509_OBJECT) *h,
                                               int type, X509_NAME *name);
 OPENSSL_EXPORT X509_OBJECT *X509_OBJECT_retrieve_by_subject(
@@ -2785,7 +2791,6 @@ OPENSSL_EXPORT X509_OBJECT *X509_OBJECT_retrieve_by_subject(
 OPENSSL_EXPORT X509_OBJECT *X509_OBJECT_retrieve_match(STACK_OF(X509_OBJECT) *h,
                                                        X509_OBJECT *x);
 OPENSSL_EXPORT int X509_OBJECT_up_ref_count(X509_OBJECT *a);
-OPENSSL_EXPORT void X509_OBJECT_free_contents(X509_OBJECT *a);
 OPENSSL_EXPORT int X509_OBJECT_get_type(const X509_OBJECT *a);
 OPENSSL_EXPORT X509 *X509_OBJECT_get0_X509(const X509_OBJECT *a);
 // X509_OBJECT_get0_X509_CRL returns the |X509_CRL| associated with |a|

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2781,7 +2781,7 @@ OPENSSL_EXPORT void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
 // X509_OBJECT_new allocates an |X509_OBJECT| on the heap.
 OPENSSL_EXPORT X509_OBJECT *X509_OBJECT_new(void);
 
-// X509_OBJECT_new frees an |X509_OBJECT| from the heap.
+// X509_OBJECT_free frees an |X509_OBJECT| from the heap.
 OPENSSL_EXPORT void X509_OBJECT_free(X509_OBJECT *a);
 
 OPENSSL_EXPORT int X509_OBJECT_idx_by_subject(STACK_OF(X509_OBJECT) *h,
@@ -3001,6 +3001,19 @@ OPENSSL_EXPORT void X509_STORE_CTX_set0_param(X509_STORE_CTX *ctx,
                                               X509_VERIFY_PARAM *param);
 OPENSSL_EXPORT int X509_STORE_CTX_set_default(X509_STORE_CTX *ctx,
                                               const char *name);
+
+// X509_STORE_get_by_subject is an alias to |X509_STORE_CTX_get_by_subject| in
+// OpenSSL 1.1.1.
+#define X509_STORE_get_by_subject X509_STORE_CTX_get_by_subject
+
+// X509_STORE_CTX_get_by_subject tries to find an object of a given type, which
+// may be |X509_LU_X509| or |X509_LU_CRL|, and the subject name from the store
+// in |vs|. If found and |ret| is not NULL, it increments the reference count
+// and stores the object in |ret|.
+OPENSSL_EXPORT int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs,
+                                                 int type,
+                                                 X509_NAME *name,
+                                                 X509_OBJECT *ret);
 
 // X509_VERIFY_PARAM functions
 


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2167`

### Description of changes: 
* Monit depends on [these symbols](https://bitbucket.org/tildeslash/monit/src/a869c3aad38f34a3b24e9b510b9ee48e3d7b3d9f/src/ssl/Ssl.c?at=master#lines-436:448).
* `X509_OBJECT_free_contents` was removed from OpenSSL 1.0.2 -> 1.1.1 in https://github.com/openssl/openssl/commit/6ddbb4cd92ad8c9ebf874e5d9920c122696b7477. We already expose our version string as 1.1.1, so we can remove this.
* OpenSSL 1.1.1 renamed `X509_STORE_get_by_subject` to `X509_STORE_CTX_get_by_subject` and made an alias to the original: https://github.com/openssl/openssl/commit/6ddbb4cd92ad8c9ebf874e5d9920c122696b7477

### Call-outs:
N/A

### Testing:
Minor new test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
