### PR TITLE
EVP_PKEY assert that method is  found

### DIFF
--- a/crypto/fipsmodule/evp/evp.c
+++ b/crypto/fipsmodule/evp/evp.c
@@ -251,7 +251,9 @@ int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, RSA *key) {
 }
 
 int EVP_PKEY_assign_RSA(EVP_PKEY *pkey, RSA *key) {
-  evp_pkey_set_method(pkey, evp_pkey_asn1_find(EVP_PKEY_RSA));
+  const EVP_PKEY_ASN1_METHOD *meth = evp_pkey_asn1_find(EVP_PKEY_RSA);
+  assert(meth != NULL);
+  evp_pkey_set_method(pkey, meth);
   pkey->pkey.ptr = key;
   return key != NULL;
 }
@@ -281,7 +283,9 @@ int EVP_PKEY_set1_DSA(EVP_PKEY *pkey, DSA *key) {
 }
 
 int EVP_PKEY_assign_DSA(EVP_PKEY *pkey, DSA *key) {
-  evp_pkey_set_method(pkey, evp_pkey_asn1_find(EVP_PKEY_DSA));
+  const EVP_PKEY_ASN1_METHOD *meth = evp_pkey_asn1_find(EVP_PKEY_DSA);
+  assert(meth != NULL);
+  evp_pkey_set_method(pkey, meth);
   pkey->pkey.ptr = key;
   return key != NULL;
 }
@@ -311,7 +315,9 @@ int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) {
 }
 
 int EVP_PKEY_assign_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) {
-  evp_pkey_set_method(pkey, evp_pkey_asn1_find(EVP_PKEY_EC));
+  const EVP_PKEY_ASN1_METHOD *meth = evp_pkey_asn1_find(EVP_PKEY_EC);
+  assert(meth != NULL);
+  evp_pkey_set_method(pkey, meth);
   pkey->pkey.ptr = key;
   return key != NULL;
 }

--- a/ssl/test/bssl_shim.cc
+++ b/ssl/test/bssl_shim.cc
@@ -105,8 +105,10 @@ class OwnedSocket {
   OwnedSocket(OwnedSocket &&other) { *this = std::move(other); }
   ~OwnedSocket() { reset(); }
   OwnedSocket &operator=(OwnedSocket &&other) {
-    drain_on_close_ = other.drain_on_close_;
-    reset(other.release());
+    if (this != &other) {
+      drain_on_close_ = other.drain_on_close_;
+      reset(other.release());
+    }
     return *this;
   }
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Add assertions that EVP_PKEY methods are found. (This should always be true in a sane build.)
* Handle potential self-assignment of `OwnedSocket`

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
