### PR TITLE
Bump version to v1.17.1

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4276,7 +4276,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.17.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.17.1");
 }
 
 #else
@@ -4319,6 +4319,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.17.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.17.1");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -224,7 +224,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.17.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.17.1"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
Release patch version update

### Description of changes: 
* Document Ed25519 verification operation by @torben-hansen in https://github.com/aws/aws-lc/pull/1256
* Fix AES on PPCBE (32-bit and 64-bit). by @nebeid in https://github.com/aws/aws-lc/pull/1213
* Upstream merge 2023-10-23 by @nebeid in https://github.com/aws/aws-lc/pull/1262
* Create dirs in cmake build dir with default permissions by @sfod in https://github.com/aws/aws-lc/pull/1269
* Refactor ED25519_keypair into hw and nohw backend by @torben-hansen in https://github.com/aws/aws-lc/pull/1271
* Run basic test run in GHA before using expensive runners by @samuel40791765 in https://github.com/aws/aws-lc/pull/1270


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
