### PR TITLE
Update create_image.sh for formal verification to fetch the updated Dockerfile

### DIFF
--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_clang-10x_formal-verification/create_image.sh
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_clang-10x_formal-verification/create_image.sh
@@ -10,6 +10,6 @@ fi
 rm -rf aws-lc-verification
 git clone https://github.com/awslabs/aws-lc-verification.git
 cd aws-lc-verification
-docker build --pull --no-cache -t ${docker_tag} .
+docker build --pull --no-cache -f Dockerfile.saw -t ${docker_tag} .
 cd ..
 rm -rf aws-lc-verification


### PR DESCRIPTION
### Issues:
None

### Description of changes: 
A recent AWS-LC-verification [PR](https://github.com/awslabs/aws-lc-verification/pull/115) divides a single `Dockerfile` into two (`Dockerfile.saw` for the SAW proofs and `Dockerfile.coq` for the Coq proofs). `Dockerfile` file is no longer used. Update the create_image.sh script for formal verification to use the updated file `Dockerfile.saw`.

### Call-outs:
None

### Testing:
I tested that the current create_image.sh script will fail with the following error message:
```
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /.../aws-lc/tests/ci/docker_images/linux-x86/ubuntu-20.04_clang-10x_formal-verification/aws-lc-verification/Dockerfile: no such file or directory
```
By updating to `Dockerfile.saw`, the run was successful.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
