### PR TITLE
Don't use expired certificates if possible.

### DIFF
--- a/crypto/x509/internal.h
+++ b/crypto/x509/internal.h
@@ -373,6 +373,8 @@ int X509_CERT_AUX_print(BIO *bp, X509_CERT_AUX *x, int indent);
 // caller must not free the result after use.
 EVP_PKEY *X509_PUBKEY_get0(X509_PUBKEY *key);
 
+int x509_check_cert_time(X509_STORE_CTX *ctx, X509 *x, int suppress_error);
+
 // RSA-PSS functions.
 
 // x509_rsa_pss_to_ctx configures |ctx| for an RSA-PSS operation based on

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -643,7 +643,7 @@ int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x) {
   }
   CRYPTO_MUTEX_unlock_write(&ctx->ctx->objs_lock);
   if(*issuer) {
-    CRYPTO_refcount_inc(&(*issuer)->references);
+    X509_up_ref(*issuer);
   }
   return ret;
 }

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -604,8 +604,10 @@ int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x) {
   }
   // If certificate matches all OK
   if (ctx->check_issued(ctx, x, obj.data.x509)) {
-    *issuer = obj.data.x509;
-    return 1;
+    if (x509_check_cert_time(ctx, obj.data.x509, /*suppress_error*/1)) {
+      *issuer = obj.data.x509;
+      return 1;
+    }
   }
   X509_OBJECT_free_contents(&obj);
 
@@ -627,13 +629,21 @@ int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x) {
       }
       if (ctx->check_issued(ctx, x, pobj->data.x509)) {
         *issuer = pobj->data.x509;
-        X509_OBJECT_up_ref_count(pobj);
         ret = 1;
-        break;
+        // Break the loop with a match if the time check is valid, otherwise
+        // we continue searching. We leave the last tested issuer certificate in
+        // |issuer| on purpose. This returns the closest match if none of the
+        // candidate issuer certificates' timestamps were valid.
+        if (x509_check_cert_time(ctx, *issuer, /*suppress_error*/1)) {
+          break;
+        }
       }
     }
   }
   CRYPTO_MUTEX_unlock_write(&ctx->ctx->objs_lock);
+  if(*issuer) {
+    CRYPTO_refcount_inc(&(*issuer)->references);
+  }
   return ret;
 }
 

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -598,6 +598,7 @@ int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x) {
   X509_OBJECT obj, *pobj;
   int idx, ret;
   size_t i;
+  *issuer = NULL;
   xn = X509_get_issuer_name(x);
   if (!X509_STORE_CTX_get_by_subject(ctx, X509_LU_X509, xn, &obj)) {
     return 0;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -491,7 +491,10 @@ end:
 }
 
 // Given a STACK_OF(X509) find the issuer of cert (if any)
-
+//
+// |find_issuer| will directly return the pointer of the corresponding index
+// within |sk|. Callers of |find_issuer| should remember to bump the reference
+// count of the returned |X509| if the call is successful.
 static X509 *find_issuer(X509_STORE_CTX *ctx, STACK_OF(X509) *sk, X509 *x) {
   size_t i;
   X509 *issuer, *candidate = NULL;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -494,14 +494,17 @@ end:
 
 static X509 *find_issuer(X509_STORE_CTX *ctx, STACK_OF(X509) *sk, X509 *x) {
   size_t i;
-  X509 *issuer;
+  X509 *issuer, *candidate = NULL;
   for (i = 0; i < sk_X509_num(sk); i++) {
     issuer = sk_X509_value(sk, i);
     if (ctx->check_issued(ctx, x, issuer)) {
-      return issuer;
+      candidate = issuer;
+      if (x509_check_cert_time(ctx, candidate, /*suppress_error*/1)) {
+        break;
+      }
     }
   }
-  return NULL;
+  return candidate;
 }
 
 // Given a possible certificate and issuer check them
@@ -1641,7 +1644,7 @@ static int check_policy(X509_STORE_CTX *ctx) {
   return 1;
 }
 
-static int check_cert_time(X509_STORE_CTX *ctx, X509 *x) {
+int x509_check_cert_time(X509_STORE_CTX *ctx, X509 *x509, int suppress_error) {
   if (ctx->param->flags & X509_V_FLAG_NO_CHECK_TIME) {
     return 1;
   }
@@ -1653,35 +1656,47 @@ static int check_cert_time(X509_STORE_CTX *ctx, X509 *x) {
     ptime = time(NULL);
   }
 
-  int i = X509_cmp_time_posix(X509_get_notBefore(x), ptime);
+  int i = X509_cmp_time_posix(X509_get_notBefore(x509), ptime);
   if (i == 0) {
+    if (suppress_error != 0) {
+      return 0;
+    }
     ctx->error = X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD;
-    ctx->current_cert = x;
+    ctx->current_cert = x509;
     if (!ctx->verify_cb(0, ctx)) {
       return 0;
     }
   }
 
   if (i > 0) {
+    if (suppress_error != 0) {
+      return 0;
+    }
     ctx->error = X509_V_ERR_CERT_NOT_YET_VALID;
-    ctx->current_cert = x;
+    ctx->current_cert = x509;
     if (!ctx->verify_cb(0, ctx)) {
       return 0;
     }
   }
 
-  i = X509_cmp_time_posix(X509_get_notAfter(x), ptime);
+  i = X509_cmp_time_posix(X509_get_notAfter(x509), ptime);
   if (i == 0) {
+    if (suppress_error != 0) {
+      return 0;
+    }
     ctx->error = X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD;
-    ctx->current_cert = x;
+    ctx->current_cert = x509;
     if (!ctx->verify_cb(0, ctx)) {
       return 0;
     }
   }
 
   if (i < 0) {
+    if (suppress_error != 0) {
+      return 0;
+    }
     ctx->error = X509_V_ERR_CERT_HAS_EXPIRED;
-    ctx->current_cert = x;
+    ctx->current_cert = x509;
     if (!ctx->verify_cb(0, ctx)) {
       return 0;
     }
@@ -1748,7 +1763,7 @@ static int internal_verify(X509_STORE_CTX *ctx) {
     }
 
   check_cert:
-    ok = check_cert_time(ctx, xs);
+    ok = x509_check_cert_time(ctx, xs, /*suppress_error*/0);
     if (!ok) {
       goto end;
     }

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2495,11 +2495,6 @@ OPENSSL_EXPORT int X509_REVOKED_add1_ext_i2d(X509_REVOKED *x, int nid,
 // NOTE:
 //   1. Applications rarely call this function directly, but it is used
 //      internally for certificate validation.
-//   2. When looking for the issuer of a certificate, if the current candidate
-//      issuer matches the subject certificate, but is expired, AWS-LC will fail
-//      verification and reject the expired cert. This is inherently different
-//      from OpenSSL 1.1.1, where they will continue searching until they find a
-//      non-expired cert to use.
 OPENSSL_EXPORT int X509_verify_cert(X509_STORE_CTX *ctx);
 
 // PKCS#8 utilities


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2052`

### Description of changes: 
Some internal teams have ran into unsuspecting issues when migrating over to AWS-LC. If an expired cert was placed before a possible valid cert within the stack, AWS-LC would break and fail certificate verification. This would not happen if the valid certificate was placed first. The behavioral difference was pinned down to an older commit from OpenSSL 1.0.2 -> OpenSSL 1.1.1: https://github.com/openssl/openssl/commit/0930251df814f3993bf2c598761e0c7c6d0d62a2, that we didn't have support for.

### Call-outs:
Logic was applied from the original commit. 

### Testing:
New certificate test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
