### PR TITLE
Silence warning on CMP0116

### DIFF
--- a/cmake/go.cmake
+++ b/cmake/go.cmake
@@ -41,9 +41,11 @@ function(go_executable dest package)
     string(SUBSTRING "${CMAKE_CURRENT_BINARY_DIR}" ${root_dir_length} -1 target)
     set(target "${target}/${dest}")
 
-    # Silences warning about CMP0116:
-    # https://cmake.org/cmake/help/latest/policy/CMP0116.html
-    cmake_policy(SET CMP0116 OLD)
+    if(CMAKE_VERSION VERSION_GREATER "3.19")
+      # Silences warning about CMP0116:
+      # https://cmake.org/cmake/help/latest/policy/CMP0116.html
+      cmake_policy(SET CMP0116 OLD)
+    endif()
 
     set(depfile "${CMAKE_CURRENT_BINARY_DIR}/${dest}.d")
     add_custom_command(OUTPUT ${dest}

--- a/cmake/go.cmake
+++ b/cmake/go.cmake
@@ -41,6 +41,10 @@ function(go_executable dest package)
     string(SUBSTRING "${CMAKE_CURRENT_BINARY_DIR}" ${root_dir_length} -1 target)
     set(target "${target}/${dest}")
 
+    # Silences warning about CMP0116:
+    # https://cmake.org/cmake/help/latest/policy/CMP0116.html
+    cmake_policy(SET CMP0116 OLD)
+
     set(depfile "${CMAKE_CURRENT_BINARY_DIR}/${dest}.d")
     add_custom_command(OUTPUT ${dest}
                        COMMAND ${GO_EXECUTABLE} build


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Currently the setup of the FIPS build produces the following warning when using recent versions (> 3.19) of CMake:
```
CMake Warning (dev) at cmake/go.cmake:49 (add_custom_command):
  Policy CMP0116 is not set: Ninja generators transform DEPFILEs from
  add_custom_command().  Run "cmake --help-policy CMP0116" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.
```
* This change explicitly sets the expected policy.

### Call-outs:
N/A

### Testing:
I successfully performed a FIPS build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
