### PR TITLE
Use OPENSSL_DEPRECATED

### DIFF
--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -180,3 +180,12 @@ TEST(Crypto, OnDemandIntegrityTest) {
   BORINGSSL_integrity_test();
 }
 #endif
+
+OPENSSL_DEPRECATED static void DeprecatedFunction() {}
+
+OPENSSL_BEGIN_ALLOW_DEPRECATED
+TEST(CryptoTest, DeprecatedFunction) {
+  // This is deprecated, but should not trigger any warnings.
+  DeprecatedFunction();
+}
+OPENSSL_END_ALLOW_DEPRECATED

--- a/crypto/x509v3/v3_lib.c
+++ b/crypto/x509v3/v3_lib.c
@@ -141,6 +141,7 @@ int X509V3_EXT_free(int nid, void *ext_data) {
 }
 
 int X509V3_EXT_add_alias(int nid_to, int nid_from) {
+OPENSSL_BEGIN_ALLOW_DEPRECATED
   const X509V3_EXT_METHOD *ext;
   X509V3_EXT_METHOD *tmpext;
 
@@ -159,6 +160,7 @@ int X509V3_EXT_add_alias(int nid_to, int nid_from) {
     return 0;
   }
   return 1;
+OPENSSL_END_ALLOW_DEPRECATED
 }
 
 // Legacy function: we don't need to add standard extensions any more because

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -165,8 +165,9 @@ extern "C" {
   __pragma(warning(push)) __pragma(warning(disable : 4996))
 #define OPENSSL_END_ALLOW_DEPRECATED __pragma(warning(pop))
 
-#elif defined(__GNUC__) || defined(__clang__)
-
+#elif (defined(__GNUC__) && ((__GNUC__ > 4) ||  (__GNUC_MINOR__ >= 6))) || defined(__clang__)
+// `_Pragma("GCC diagnostic push")` was added in GCC 4.6
+// http://gcc.gnu.org/gcc-4.6/changes.html
 #define OPENSSL_DEPRECATED __attribute__((__deprecated__))
 #define OPENSSL_BEGIN_ALLOW_DEPRECATED \
   _Pragma("GCC diagnostic push")       \

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -387,17 +387,6 @@ typedef struct x509_trust_st X509_TRUST;
 
 typedef void *OPENSSL_BLOCK;
 
-#ifndef __has_attribute
-#define __has_attribute(x) 0
-#endif
-#if __STDC_VERSION__ > 202300L
-#define AWS_LC_DEPRECATED [[deprecated]]
-#elif __has_attribute(deprecated)
-#define AWS_LC_DEPRECATED __attribute__((deprecated))
-#else
-#define AWS_LC_DEPRECATED /* deprecated */
-#endif
-
 #if defined(__cplusplus)
 }  // extern C
 #elif !defined(BORINGSSL_NO_CXX)

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -154,6 +154,33 @@ extern "C" {
 
 #endif  // defined(BORINGSSL_SHARED_LIBRARY)
 
+#if defined(_MSC_VER)
+
+// OPENSSL_DEPRECATED is used to mark a function as deprecated. Use
+// of any functions so marked in caller code will produce a warning.
+// OPENSSL_BEGIN_ALLOW_DEPRECATED and OPENSSL_END_ALLOW_DEPRECATED
+// can be used to suppress the warning in regions of caller code.
+#define OPENSSL_DEPRECATED __declspec(deprecated)
+#define OPENSSL_BEGIN_ALLOW_DEPRECATED \
+  __pragma(warning(push)) __pragma(warning(disable : 4996))
+#define OPENSSL_END_ALLOW_DEPRECATED __pragma(warning(pop))
+
+#elif defined(__GNUC__) || defined(__clang__)
+
+#define OPENSSL_DEPRECATED __attribute__((__deprecated__))
+#define OPENSSL_BEGIN_ALLOW_DEPRECATED \
+  _Pragma("GCC diagnostic push")       \
+      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define OPENSSL_END_ALLOW_DEPRECATED _Pragma("GCC diagnostic pop")
+
+#else
+
+#define OPENSSL_DEPRECATED
+#define OPENSSL_BEGIN_ALLOW_DEPRECATED
+#define OPENSSL_END_ALLOW_DEPRECATED
+
+#endif
+
 
 #if defined(__GNUC__) || defined(__clang__)
 // MinGW has two different printf implementations. Ensure the format macro

--- a/include/openssl/cipher.h
+++ b/include/openssl/cipher.h
@@ -541,10 +541,10 @@ OPENSSL_EXPORT const EVP_CIPHER *EVP_bf_cbc(void);
 OPENSSL_EXPORT const EVP_CIPHER *EVP_bf_cfb(void);
 
 // EVP_cast5_ecb is CAST5 in ECB mode and is deprecated.
-AWS_LC_DEPRECATED OPENSSL_EXPORT const EVP_CIPHER *EVP_cast5_ecb(void);
+OPENSSL_DEPRECATED OPENSSL_EXPORT const EVP_CIPHER *EVP_cast5_ecb(void);
 
 // EVP_cast5_cbc is CAST5 in CBC mode and is deprecated.
-AWS_LC_DEPRECATED OPENSSL_EXPORT const EVP_CIPHER *EVP_cast5_cbc(void);
+OPENSSL_DEPRECATED OPENSSL_EXPORT const EVP_CIPHER *EVP_cast5_cbc(void);
 
 // The following flags do nothing and are included only to make it easier to
 // compile code with AWS-LC.

--- a/include/openssl/cipher.h
+++ b/include/openssl/cipher.h
@@ -541,10 +541,10 @@ OPENSSL_EXPORT const EVP_CIPHER *EVP_bf_cbc(void);
 OPENSSL_EXPORT const EVP_CIPHER *EVP_bf_cfb(void);
 
 // EVP_cast5_ecb is CAST5 in ECB mode and is deprecated.
-OPENSSL_DEPRECATED OPENSSL_EXPORT const EVP_CIPHER *EVP_cast5_ecb(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const EVP_CIPHER *EVP_cast5_ecb(void);
 
 // EVP_cast5_cbc is CAST5 in CBC mode and is deprecated.
-OPENSSL_DEPRECATED OPENSSL_EXPORT const EVP_CIPHER *EVP_cast5_cbc(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const EVP_CIPHER *EVP_cast5_cbc(void);
 
 // The following flags do nothing and are included only to make it easier to
 // compile code with AWS-LC.

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -377,7 +377,7 @@ OPENSSL_EXPORT int EC_GROUP_set_generator(EC_GROUP *group,
 // On success, it returns the BIGNUM pointer supplied or, if |ret| is NULL,
 // allocates and returns a fresh |BIGNUM|. On error, it returns NULL. The |ctx|
 // argument may be used if not NULL.
-AWS_LC_DEPRECATED OPENSSL_EXPORT BIGNUM *EC_POINT_point2bn(
+OPENSSL_DEPRECATED OPENSSL_EXPORT BIGNUM *EC_POINT_point2bn(
     const EC_GROUP *group, const EC_POINT *point, point_conversion_form_t form,
     BIGNUM *ret, BN_CTX *ctx);
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -377,7 +377,7 @@ OPENSSL_EXPORT int EC_GROUP_set_generator(EC_GROUP *group,
 // On success, it returns the BIGNUM pointer supplied or, if |ret| is NULL,
 // allocates and returns a fresh |BIGNUM|. On error, it returns NULL. The |ctx|
 // argument may be used if not NULL.
-OPENSSL_DEPRECATED OPENSSL_EXPORT BIGNUM *EC_POINT_point2bn(
+OPENSSL_EXPORT OPENSSL_DEPRECATED BIGNUM *EC_POINT_point2bn(
     const EC_GROUP *group, const EC_POINT *point, point_conversion_form_t form,
     BIGNUM *ret, BN_CTX *ctx);
 

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -151,7 +151,7 @@ OPENSSL_EXPORT void ERR_load_BIO_strings(void);
 OPENSSL_EXPORT void ERR_load_ERR_strings(void);
 
 // ERR_load_CRYPTO_strings does nothing.
-OPENSSL_DEPRECATED OPENSSL_EXPORT void ERR_load_CRYPTO_strings(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void ERR_load_CRYPTO_strings(void);
 
 // ERR_load_crypto_strings does nothing.
 OPENSSL_EXPORT void ERR_load_crypto_strings(void);

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -151,7 +151,7 @@ OPENSSL_EXPORT void ERR_load_BIO_strings(void);
 OPENSSL_EXPORT void ERR_load_ERR_strings(void);
 
 // ERR_load_CRYPTO_strings does nothing.
-AWS_LC_DEPRECATED OPENSSL_EXPORT void ERR_load_CRYPTO_strings(void);
+OPENSSL_DEPRECATED OPENSSL_EXPORT void ERR_load_CRYPTO_strings(void);
 
 // ERR_load_crypto_strings does nothing.
 OPENSSL_EXPORT void ERR_load_crypto_strings(void);

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -707,7 +707,7 @@ OPENSSL_EXPORT char *i2s_ASN1_ENUMERATED(const X509V3_EXT_METHOD *meth,
 // callers should simply handle the custom extension with the byte-based
 // |X509_EXTENSION| APIs directly. Registering |ext| with the library has little
 // practical value.
-OPENSSL_EXPORT int X509V3_EXT_add(X509V3_EXT_METHOD *ext);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int X509V3_EXT_add(X509V3_EXT_METHOD *ext);
 
 // X509V3_EXT_add_list calls |X509V3_EXT_add| on |&extlist[0]|, |&extlist[1]|,
 // and so on, until some |extlist[i]->ext_nid| is -1. It returns one on success
@@ -721,7 +721,8 @@ OPENSSL_EXPORT int X509V3_EXT_add_list(X509V3_EXT_METHOD *extlist);
 // and zero on error.
 //
 // WARNING: Do not use this function. See |X509V3_EXT_add|.
-OPENSSL_EXPORT int X509V3_EXT_add_alias(int nid_to, int nid_from);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int X509V3_EXT_add_alias(int nid_to,
+                                                           int nid_from);
 
 // X509V3_EXT_cleanup removes all custom extensions registered with
 // |X509V3_EXT_add*|.


### PR DESCRIPTION
### Issues:
N/A

### Description of changes:
* Use same deprecation macros as BoringSSL.  This mechanism is superior as it also provides macros that allow use of a deprecated function w/o triggering the warning.
   * Cherry-picked [commit from BoringSSL](https://github.com/google/boringssl/commit/ac6d55859a61f1316010890eee451f6b0930301d).
   * Migrated existing uses of `AWS_LC_DEPRECATED` to `OPENSSL_DEPRECATED`.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
