### PR TITLE
Add integration ci for Monit

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -176,3 +176,13 @@ batch:
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:ubuntu-22.04_gcc-12x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_sslproxy_integration.sh"
+
+    - identifier: monit_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_SMALL
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_monit_integration.sh"

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
@@ -48,6 +48,7 @@ RUN set -ex && \
     liblua5.4-dev \
     libnet-dev \
     libnet-ssleay-perl \
+    libpam0g-dev \
     libpcap-dev \
     libperl-dev \
     libpcre2-dev \

--- a/tests/ci/integration/run_monit_integration.sh
+++ b/tests/ci/integration/run_monit_integration.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -exu
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# SYS_ROOT
+#  - SRC_ROOT(aws-lc)
+#    - SCRATCH_FOLDER
+#      - monit
+#      - AWS_LC_BUILD_FOLDER
+#      - AWS_LC_INSTALL_FOLDER
+#      - MONIT_BUILD_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER="${SRC_ROOT}/MONIT_BUILD_ROOT"
+MONIT_SRC_FOLDER="${SCRATCH_FOLDER}/monit"
+MONIT_BUILD_FOLDER="${SCRATCH_FOLDER}/monit-aws-lc"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+
+function monit_build() {
+  ./bootstrap  
+  ./configure --with-ssl-static="${AWS_LC_INSTALL_FOLDER}"
+  make -j ${NUM_CPU_THREADS}
+}
+
+# Monit doesn't run any tests verifying ssl behavior, but it shouldn't hurt to run the brief tests.
+function monit_run_tests() {
+  pushd libmonit
+  # TimeTest will fail on a machine not in CET timezone.
+  # https://bitbucket.org/tildeslash/monit/src/def6b462259586358be3c86d76a299c80744df39/libmonit/test/TimeTest.c#lines-24
+  sed -i 's/TimeTest && //g' test/test.sh
+  make verify
+  popd
+}
+
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf ${SCRATCH_FOLDER}/*
+cd ${SCRATCH_FOLDER}
+
+git clone https://bitbucket.org/tildeslash/monit.git ${MONIT_SRC_FOLDER} --depth 1
+mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${MONIT_BUILD_FOLDER}
+ls
+
+aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
+
+# Build monit from source.
+pushd ${MONIT_SRC_FOLDER}
+
+monit_build
+monit_run_tests
+popd
+

--- a/tests/ci/integration/run_monit_integration.sh
+++ b/tests/ci/integration/run_monit_integration.sh
@@ -45,7 +45,7 @@ git clone https://bitbucket.org/tildeslash/monit.git ${MONIT_SRC_FOLDER} --depth
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${MONIT_BUILD_FOLDER}
 ls
 
-aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
+aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_TESTING=OFF
 
 # Build monit from source.
 pushd ${MONIT_SRC_FOLDER}


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2167`

### Description of changes: 
Adding an integration CI for our recent support for Monit.

### Call-outs:
N/A

### Testing:
New CI dimension, time tests will fail on a non-CET timezone machine, so I removed the test. It's non-relevant to AWS-LC functionality.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
