### PR TITLE
Ensure rand_thread_state is always zerod in the event that CRYPTO_set_thread_local needs to call the deconstructor

### DIFF
--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -413,6 +413,9 @@ void RAND_bytes_with_additional_data(uint8_t *out, size_t out_len,
 
   if (state == NULL) {
     state = OPENSSL_malloc(sizeof(struct rand_thread_state));
+    if (state != NULL) {
+      OPENSSL_memset(state, 0, sizeof(struct rand_thread_state));
+    }
     if (state == NULL ||
         !CRYPTO_set_thread_local(OPENSSL_THREAD_LOCAL_RAND, state,
                                  rand_thread_state_free)) {


### PR DESCRIPTION
### Testing:
* Verified that the [aws-cpp-sdk-core](https://github.com/aws/aws-sdk-cpp/tree/main/tests/aws-cpp-sdk-core-tests) tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
