### PR TITLE
Bump version to 1.17.2

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4276,7 +4276,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.17.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.17.2");
 }
 
 #else
@@ -4319,6 +4319,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.17.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.17.2");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -224,7 +224,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.17.1"
+#define AWSLC_VERSION_NUMBER_STRING "1.17.2"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* EVP_PKEY assert that method is  found by @justsmth in https://github.com/aws/aws-lc/pull/1279
* Rearrange X509 symbols for Monit support by @samuel40791765 in https://github.com/aws/aws-lc/pull/1272
* Update gha windows instance type names by @samuel40791765 in https://github.com/aws/aws-lc/pull/1283
* Use uint8_t not u_int8_t by @justsmth in https://github.com/aws/aws-lc/pull/1287
* Update create_image.sh for formal verification to fetch the updated Dockerfile by @pennyannn in https://github.com/aws/aws-lc/pull/1281
* Ensure rand_thread_state is always zerod in the event that CRYPTO_set_thread_local needs to call the deconstructor by @skmcgrail in https://github.com/aws/aws-lc/pull/1288


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
