### PR TITLE
Fix build error on Apple devices on 1MU branch

### DIFF
--- a/tool/digest.cc
+++ b/tool/digest.cc
@@ -226,7 +226,6 @@ static bool Check(const CheckModeArguments &args, const EVP_MD *md,
   unsigned bad_lines = 0;
   unsigned parsed_lines = 0;
   unsigned error_lines = 0;
-  unsigned bad_hash_lines = 0;
   unsigned line_no = 0;
   bool ok = true;
   bool draining_overlong_line = false;
@@ -297,7 +296,6 @@ static bool Check(const CheckModeArguments &args, const EVP_MD *md,
     }
 
     if (calculated_hex_digest != std::string(line, hex_size)) {
-      bad_hash_lines++;
       if (!args.status) {
         printf("%s: FAILED\n", target_filename.c_str());
       }


### PR DESCRIPTION
### Description of changes: 
For whatever reason while I was producing vectors for iOS and MacOS on the 1MU branch, I got the following build error:
```
error: variable 'bad_hash_lines' set but not used [-Werror,-Wunused-but-set-variable]
  unsigned bad_hash_lines = 0;
```

I took a look and it appears this is cruft in one of the included tools, which is outside of the FIPS boundaries.

### Call-outs:
N/A

### Testing:
Changes build locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
