### PR TITLE
Only update thread_states_list if freed state is head when prev is NULL

### DIFF
--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -251,7 +251,7 @@ static void rand_thread_state_free(void *state_in) {
 
   if (state->prev != NULL) {
     state->prev->next = state->next;
-  } else {
+  } else if (*thread_states_list_bss_get() == state) {
     *thread_states_list_bss_get() = state->next;
   }
 

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4276,7 +4276,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.17.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.17.3");
 }
 
 #else
@@ -4319,6 +4319,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.17.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.17.3");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -232,7 +232,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.17.2"
+#define AWSLC_VERSION_NUMBER_STRING "1.17.3"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Per David Benjamin's [comment](https://boringssl-review.googlesource.com/c/boringssl/+/63885/comment/5b05d928_cc807f04/) on the BoringSSL patch, there is an edge case around managing the invariant of the doubly linked-list of process rand_thread_state's. This list is maintained so that the state can be zerod on process exit, as the normal thread-local de-constructors aren't called on process exit. The invariant expected is that if `state->prev == NULL` then it must be the head of the list. This patch validates that when `rand_thread_state` is freed, if `state->prev == NULL` then it only updates the head of the list if the state pointed to is itself. Otherwise this implies that we are freeing a zerod / just initialized `rand_thread_state` that has not been added to the state list yet.

Invariant logic: https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/rand/rand.c#L452C9-L460

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
