### PR TITLE
Revert "Give up on qsort for sk_FOO_sort"

### DIFF
--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -393,52 +393,20 @@ err:
   return NULL;
 }
 
-static size_t parent_idx(size_t idx) {
-  assert(idx > 0);
-  return (idx - 1) / 2;
+#if defined(_MSC_VER)
+struct sort_compare_ctx {
+  OPENSSL_sk_call_cmp_func call_cmp_func;
+  OPENSSL_sk_cmp_func cmp_func;
+};
+
+static int sort_compare(void *ctx_v, const void *a, const void *b) {
+  struct sort_compare_ctx *ctx = ctx_v;
+  // |a| and |b| point to |void*| pointers which contain the actual values.
+  const void *const *a_ptr = a;
+  const void *const *b_ptr = b;
+  return ctx->call_cmp_func(ctx->cmp_func, *a_ptr, *b_ptr);
 }
-
-static size_t left_idx(size_t idx) {
-  // The largest possible index is |PTRDIFF_MAX|, not |SIZE_MAX|. If
-  // |ptrdiff_t|, a signed type, is the same size as |size_t|, this cannot
-  // overflow.
-  assert(idx <= PTRDIFF_MAX);
-  OPENSSL_STATIC_ASSERT(PTRDIFF_MAX <= (SIZE_MAX - 1) / 2, 2_times_idx_plus_1_may_oveflow);
-  return 2 * idx + 1;
-}
-
-// down_heap fixes the subtree rooted at |i|. |i|'s children must each satisfy
-// the heap property. Only the first |num| elements of |sk| are considered.
-static void down_heap(OPENSSL_STACK *sk, OPENSSL_sk_call_cmp_func call_cmp_func,
-                      size_t i, size_t num) {
-  assert(i < num && num <= sk->num);
-  for (;;) {
-    size_t left = left_idx(i);
-    if (left >= num) {
-      break;  // No left child.
-    }
-
-    // Swap |i| with the largest of its children.
-    size_t next = i;
-    if (call_cmp_func(sk->comp, sk->data[next], sk->data[left]) < 0) {
-      next = left;
-    }
-    size_t right = left + 1;  // Cannot overflow because |left < num|.
-    if (right < num &&
-        call_cmp_func(sk->comp, sk->data[next], sk->data[right]) < 0) {
-      next = right;
-    }
-
-    if (i == next) {
-      break;  // |i| is already larger than its children.
-    }
-
-    void *tmp = sk->data[i];
-    sk->data[i] = sk->data[next];
-    sk->data[next] = tmp;
-    i = next;
-  }
-}
+#endif
 
 void OPENSSL_sk_sort(OPENSSL_STACK *sk,
                      OPENSSL_sk_call_cmp_func call_cmp_func) {
@@ -447,25 +415,25 @@ void OPENSSL_sk_sort(OPENSSL_STACK *sk,
   }
 
   if (sk->num >= 2) {
-    // |qsort| lacks a context parameter in the comparison function for us to
-    // pass in |call_cmp_func| and |sk->comp|. While we could cast |sk->comp| to
-    // the expected type, it is undefined behavior in C can trip sanitizers.
-    // |qsort_r| and |qsort_s| avoid this, but using them is impractical. See
-    // https://stackoverflow.com/a/39561369
+#if defined(_MSC_VER)
+    // MSVC's |qsort_s| is different from the C11 one.
+    // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/qsort-s?view=msvc-170
+    struct sort_compare_ctx ctx = {call_cmp_func, sk->comp};
+    qsort_s(sk->data, sk->num, sizeof(void *), sort_compare, &ctx);
+#else
+    // sk->comp is a function that takes pointers to pointers to elements, but
+    // qsort take a comparison function that just takes pointers to elements.
+    // However, since we're passing an array of pointers to qsort, we can just
+    // cast the comparison function and everything works.
     //
-    // Use our own heap sort instead. This is not performance-sensitive, so we
-    // optimize for simplicity and size. First, build a max-heap in place.
-    for (size_t i = parent_idx(sk->num - 1); i < sk->num; i--) {
-      down_heap(sk, call_cmp_func, i, sk->num);
-    }
-
-    // Iteratively remove the maximum element to populate the result in reverse.
-    for (size_t i = sk->num - 1; i > 0; i--) {
-      void *tmp = sk->data[0];
-      sk->data[0] = sk->data[i];
-      sk->data[i] = tmp;
-      down_heap(sk, call_cmp_func, 0, i);
-    }
+    // TODO(davidben): This is undefined behavior, but the call is in libc so,
+    // e.g., CFI does not notice. |qsort| is missing a void* parameter in its
+    // callback, while no one defines |qsort_r| or |qsort_s| consistently. See
+    // https://stackoverflow.com/a/39561369
+    int (*comp_func)(const void *, const void *) =
+        (int (*)(const void *, const void *))(sk->comp);
+    qsort(sk->data, sk->num, sizeof(void *), comp_func);
+#endif
   }
   sk->sorted = 1;
 }

--- a/crypto/stack/stack_test.cc
+++ b/crypto/stack/stack_test.cc
@@ -24,7 +24,6 @@
 #include <gtest/gtest.h>
 
 #include <openssl/mem.h>
-#include <openssl/rand.h>
 
 
 // Define a custom stack type for testing.
@@ -481,39 +480,4 @@ TEST(StackTest, IsSorted) {
   // Without a comparison function, the list cannot be sorted.
   sk_TEST_INT_set_cmp_func(sk.get(), nullptr);
   EXPECT_FALSE(sk_TEST_INT_is_sorted(sk.get()));
-}
-
-TEST(StackTest, Sort) {
-  constexpr size_t kMaxLength = 100;
-  constexpr int kIterations = 500;
-  for (size_t len = 0; len < kMaxLength; len++) {
-    SCOPED_TRACE(len);
-    for (int iter = 0; iter < kIterations; iter++) {
-      // Make a random input list.
-      std::vector<int> vec(len);
-      RAND_bytes(reinterpret_cast<uint8_t *>(vec.data()),
-                 sizeof(int) * vec.size());
-      SCOPED_TRACE(testing::PrintToString(vec));
-
-      // Convert it to a |STACK_OF(TEST_INT)|.
-      bssl::UniquePtr<STACK_OF(TEST_INT)> sk(sk_TEST_INT_new(compare));
-      ASSERT_TRUE(sk);
-      for (int v : vec) {
-        auto value = TEST_INT_new(v);
-        ASSERT_TRUE(value);
-        ASSERT_TRUE(bssl::PushToStack(sk.get(), std::move(value)));
-      }
-
-      // Sort it with our sort implementation.
-      sk_TEST_INT_sort(sk.get());
-      std::vector<int> result;
-      for (const TEST_INT *v : sk.get()) {
-        result.push_back(*v);
-      }
-
-      // The result must match the STL's version.
-      std::sort(vec.begin(), vec.end());
-      EXPECT_EQ(vec, result);
-    }
-  }
 }

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -4584,8 +4584,15 @@ TEST(X509Test, ExpiredCandidate) {
       CertsToStack({intermediate1.get(), intermediate2.get()}));
   bssl::UniquePtr<X509_STORE_CTX> ctx(X509_STORE_CTX_new());
   bssl::UniquePtr<X509_STORE> store(X509_STORE_new());
+
+  // TODO: Remove this ifdef when we pull in google/boringssl@1340a5b.
+#if defined(OPENSSL_WINDOWS)
   ASSERT_TRUE(X509_STORE_add_cert(store.get(), intermediate1.get()));
   ASSERT_TRUE(X509_STORE_add_cert(store.get(), intermediate2.get()));
+#else
+  ASSERT_TRUE(X509_STORE_add_cert(store.get(), intermediate2.get()));
+  ASSERT_TRUE(X509_STORE_add_cert(store.get(), intermediate1.get()));
+#endif
   ASSERT_TRUE(X509_STORE_CTX_init(ctx.get(), store.get(), leaf.get(),
                            intermediates_stack.get()));
 

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2495,6 +2495,16 @@ OPENSSL_EXPORT int X509_REVOKED_add1_ext_i2d(X509_REVOKED *x, int nid,
 // NOTE:
 //   1. Applications rarely call this function directly, but it is used
 //      internally for certificate validation.
+//   2. |X509_verify_cert| and other related functions call
+//      |sk_X509_OBJECT_sort| internally, which rearranges the certificate
+//      ordering. There will be cases where two certs have an identical
+//      |subject| and |X509_OBJECT_cmp| will return 0, but one is a valid cert
+//      and the other is invalid.
+//      Due to https://github.com/openssl/openssl/issues/18708, certificate
+//      verification could fail if an invalid cert is checked before the valid
+//      cert. What we do with sorting behavior when certs are identical is
+//      considered "unstable" and certain sorting expectations shouldn't be
+//      depended on.
 OPENSSL_EXPORT int X509_verify_cert(X509_STORE_CTX *ctx);
 
 // PKCS#8 utilities


### PR DESCRIPTION
This reverts commit 1b87d59d7fdbcefc096965efb4af22068c491a08.

### Issues:
Resolves `P104663041`

### Description of changes: 
There's the [existing issue](https://github.com/openssl/openssl/issues/18708) in AWS-LC/OpenSSL where certificate verification will fail depending on an invalid certificate in the trust store coming first. The new sorting introduced a rearrangement of identical certificates within the trust store. This could technically increase the chance of teams running into the existing AWS-LC/OpenSSL issue mentioned earlier, if their invalid identical certificate is rearranged to the top of the stack.

We will have to introduce this change sooner or later to get around the UB sanitizer issue this commit was trying to resolve. But we should do additional verification to make sure we aren't changing the original certificate ordering. To be fair, sorting behavior has always been considered "unstable" and certain sorting expectations shouldn't be depended on. We can clarify this within the "revert" commit.

### Testing:
Apparently one of the new tests I had written was being effected as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
