### PR TITLE
Update the integrity hash calculation in bcm.c to handle big/little endian platforms

### DIFF
--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -325,11 +325,14 @@ int BORINGSSL_integrity_test(void) {
 #endif
 #if defined(BORINGSSL_SHARED_LIBRARY)
   uint64_t length = end - start;
-  HMAC_Update(&hmac_ctx, (const uint8_t *) &length, sizeof(length));
+  uint8_t buffer[sizeof(length)];
+  CRYPTO_store_u64_le(buffer, length);
+  HMAC_Update(&hmac_ctx, buffer, sizeof(length));
   HMAC_Update(&hmac_ctx, start, length);
 
   length = rodata_end - rodata_start;
-  HMAC_Update(&hmac_ctx, (const uint8_t *) &length, sizeof(length));
+  CRYPTO_store_u64_le(buffer, length);
+  HMAC_Update(&hmac_ctx, buffer, sizeof(length));
   HMAC_Update(&hmac_ctx, rodata_start, length);
 #else
   HMAC_Update(&hmac_ctx, start, end - start);


### PR DESCRIPTION
### Description of changes: 
Previously bcm.c and inject_hash.go assumed both would run on little endian platforms. [inject_hash.go is explicit and always encoded the length in little](https://github.com/aws/aws-lc/blob/main/util/fipstools/inject_hash/inject_hash.go#L383), but [bcm.c would do whatever the host CPU was running in](https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/bcm.c#L327-L328). 

This change updates bcm.c to always hash the little endian encoded value of the length of the text/rodata sections.

### Call-outs:
This is a no-op for little endian platforms.

### Testing:
With this change in a BE PPC emulator `bssl isfips` works as expected, on little endian it continues to work. All of crypto_test built in FIPS mode is still running locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
