### PR TITLE
Add back OCSP integration test executing

### DIFF
--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -96,6 +96,9 @@
     "cmd": ["ssl/ssl_test"]
   },
   {
+    "cmd": ["ssl/integration_test"]
+  },
+  {
     "cmd": ["crypto/mem_test"]
   },
   {


### PR DESCRIPTION
### Description of changes: 
I didn't notice this until touching the file in the upstream merge, but it seems like the OCSP integration test didn't get added to `all_tests.json`.

### Call-outs:
N/A

### Testing:
New test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
