### PR TITLE
Refactor ED25519_verify into hw and nohw backend

### DIFF
--- a/crypto/curve25519/internal.h
+++ b/crypto/curve25519/internal.h
@@ -135,6 +135,19 @@ void ed25519_sign_nohw(
   uint8_t r[SHA512_DIGEST_LENGTH], const uint8_t *s, const uint8_t *A,
   const void *message, size_t message_len);
 
+// Computes the SHA512 of three input pairs: (|input1|, |len1|),
+// (|input2|, |len2|), (|input3|, |len3|). Specifically, the hash is computed
+// over the concatenation: |input1| || |input2| || |input3|.
+// The final pair might have |len3| == 0, meaning this input will be ignored.
+// The result is written to |out|.
+void ed25519_sha512(uint8_t out[SHA512_DIGEST_LENGTH],
+  const void *input1, size_t len1, const void *input2, size_t len2,
+  const void *input3, size_t len3);
+
+int ed25519_verify_nohw(uint8_t R_have_encoded[32],
+  const uint8_t public_key[ED25519_PUBLIC_KEY_LEN], uint8_t R_expected[32],
+  uint8_t S[32], const uint8_t *message, size_t message_len);
+
 // Port to internal linkage in curve25519_nohw.c when adding implementation
 // from s2n-bignum ed25519
 void ge_p3_tobytes(uint8_t s[32], const ge_p3 *h);

--- a/crypto/curve25519/internal.h
+++ b/crypto/curve25519/internal.h
@@ -135,15 +135,6 @@ void ed25519_sign_nohw(
   uint8_t r[SHA512_DIGEST_LENGTH], const uint8_t *s, const uint8_t *A,
   const void *message, size_t message_len);
 
-// Computes the SHA512 of three input pairs: (|input1|, |len1|),
-// (|input2|, |len2|), (|input3|, |len3|). Specifically, the hash is computed
-// over the concatenation: |input1| || |input2| || |input3|.
-// The final pair might have |len3| == 0, meaning this input will be ignored.
-// The result is written to |out|.
-void ed25519_sha512(uint8_t out[SHA512_DIGEST_LENGTH],
-  const void *input1, size_t len1, const void *input2, size_t len2,
-  const void *input3, size_t len3);
-
 int ed25519_verify_nohw(uint8_t R_have_encoded[32],
   const uint8_t public_key[ED25519_PUBLIC_KEY_LEN], uint8_t R_expected[32],
   uint8_t S[32], const uint8_t *message, size_t message_len);


### PR DESCRIPTION
### Description of changes: 

Refactors `ED25519_verify` into a no-hardware and a hardware path. Existing backend is the former. Preparation for s2n-bignum Ed25519.

s2n-bignum is lacking SHA512. So unfortunately, I can't punt this computation to s2n-bignum. 

PR chain:
1. refactor `ED25519_keypair` https://github.com/aws/aws-lc/pull/1271
2. refactor `ED25519_sign` https://github.com/aws/aws-lc/pull/1276
3. (this PR) refactor `ED25519_verify`
4. various small changes to improve code quality
5. import s2n-bignum Ed25519 routines
6. connect s2n-bignum Ed25519 backend to frontend

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
