### PR TITLE
Include Codecov in CI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+comment:
+  require_base: false
+  require_changes: false
+  require_head: true
+  hide_project_coverage: false

--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Install lcov
         run: sudo apt-get -y install lcov
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Code Coverage Build
         run: ./util/codecov-ci.sh ${{ runner.temp }}/build
       - name: Upload code coverage report to Codecov

--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -1,0 +1,24 @@
+name: Code Coverage
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+concurrency:
+  group: code-cov-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  codecov-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install lcov
+        run: sudo apt-get -y install lcov
+      - uses: actions/checkout@master
+      - name: Run Code Coverage Build
+        run: ./util/codecov-ci.sh ${{ runner.temp }}/build
+      - name: Upload code coverage report to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          file: ${{ runner.temp }}/build/coverage.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,8 +630,9 @@ if(UBSAN)
 endif()
 
 if(GCOV)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 endif()
 
 if(KEEP_ASM_LOCAL_SYMBOLS)

--- a/util/codecov-ci.sh
+++ b/util/codecov-ci.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright Amazon.com Inc. or its affiliates.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+#
+
+set -xe
+
+SRC=$(pwd)
+
+# Sanity check
+DIRNAME=$(basename -- "${SRC}")
+if [[ "${DIRNAME}" != 'aws-lc' ]]; then
+  echo "Script must be executed from aws-lc directory"
+  exit 1
+fi
+
+BUILD="$1"
+if [ -n "$BUILD" ]; then
+  if [ ! -e "$BUILD" ]; then
+    mkdir -p "$BUILD"
+  fi
+  BUILD=$(readlink -f "$BUILD")
+else
+  echo "Must specify a build directory."
+  exit 1
+fi
+
+cmake -DGCOV=1 -DDISABLE_PERL=1 -DBUILD_TESTING=1 -DBUILD_LIBSSL=1 -DCMAKE_BUILD_TYPE=Debug -S "${SRC}" -B "${BUILD}"
+cmake --build "${BUILD}" --target all_tests
+cmake --build "${BUILD}" --target run_tests
+
+#TODO: Use callgrind
+#mkdir "$BUILD/callgrind/"
+#go run "$SRC/util/all_tests.go" -build-dir "$BUILD" -callgrind -num-workers 16
+
+shopt -s globstar
+
+pushd "${BUILD}"
+gcov --source-prefix "${SRC}" **/*.gcda
+lcov --capture --exclude "/Applications/*" --exclude "/usr/*" --exclude "/lib/*" --directory . --output-file coverage.info
+popd


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Generates coverage data using `gcov` and uploads it to Codecov.

### Call-outs:
N/A

### Testing:
Initial testing produced this data: https://app.codecov.io/github/aws/aws-lc/tree/codecov-ci/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
