### PR TITLE
Add support for building with pkgconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1112,3 +1112,14 @@ FILE(STRINGS "include/openssl/opensslv.h"
 if(NOT ${BASE_VERSION_NUMBER} MATCHES ${OPENSSLV_VERSION_NUMBER})
   message( FATAL_ERROR "OPENSSL_VERSION_NUMBER in base.h and opensslv.h should match.")
 endif()
+
+# TODO: Find a way to make this automatically align with OPENSSL_VERSION_NUMBER in base.h.
+set(VERSION 1.1.1)
+
+file(GLOB OPENSSL_PKGCONFIGS "pkgconfig/*.pc.in")
+foreach(in_file ${OPENSSL_PKGCONFIGS})
+  file(RELATIVE_PATH in_file ${PROJECT_SOURCE_DIR} ${in_file})
+  string(REPLACE ".in" "" pc_file ${in_file})
+  configure_file(${in_file} ${CMAKE_CURRENT_BINARY_DIR}/${pc_file} @ONLY)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${pc_file} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1116,6 +1116,9 @@ endif()
 # TODO: Find a way to make this automatically align with OPENSSL_VERSION_NUMBER in base.h.
 set(VERSION 1.1.1)
 
+# AWS-LC may be installed in a non-standard prefix. If OpenSSL exists in the standard path,
+# the downstream integration may build with the system's OpenSSL version instead.
+# Consider adjusting the PKG_CONFIG_PATH environment to get around this.
 file(GLOB OPENSSL_PKGCONFIGS "pkgconfig/*.pc.in")
 foreach(in_file ${OPENSSL_PKGCONFIGS})
   file(RELATIVE_PATH in_file ${PROJECT_SOURCE_DIR} ${in_file})

--- a/pkgconfig/libcrypto.pc.in
+++ b/pkgconfig/libcrypto.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: AWS-LC-libcrypto
+Description: AWS-LC cryptography library
+Version: @VERSION@
+Libs: -L${libdir} -lcrypto
+Cflags: -I${includedir}

--- a/pkgconfig/libssl.pc.in
+++ b/pkgconfig/libssl.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: AWS-LC-libssl
+Description: AWS-LC (OpenSSL SHIM)
+Version: @VERSION@
+Requires.private: libcrypto
+Libs: -L${libdir} -lssl
+Cflags: -I${includedir}

--- a/pkgconfig/openssl.pc.in
+++ b/pkgconfig/openssl.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: AWS-LC
+Description: AWS-LC (OpenSSL SHIM)
+Version: @VERSION@
+Requires: libssl libcrypto


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2164`

### Description of changes: 
librelp, bind, and other libraries use package config to detect OpenSSL support. This lets these projects find AWS-LC with their existing configuration.

### Call-outs:
Versioning still needs ironing out

### Testing:
This can be tested once we add CI for librelp. This passes locally but we haven't ironed out all the details for librelp just yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
