### PR TITLE
Improve Codecov reporting

### DIFF
--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -18,7 +18,6 @@ jobs:
         run: ./util/codecov-ci.sh ${{ runner.temp }}/build
       - name: Upload code coverage report to Codecov
         uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ${{ runner.temp }}/build/coverage.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: "${{ runner.temp }}/build/coverage-default.info,${{ runner.temp }}/build/coverage-no-asm.info"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,8 +630,8 @@ if(UBSAN)
 endif()
 
 if(GCOV)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -O0")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -O0")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 endif()
 

--- a/util/codecov-ci.sh
+++ b/util/codecov-ci.sh
@@ -45,7 +45,11 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
 else
   LCOV_PARAMS+=(--exclude '/usr/*')
   LCOV_PARAMS+=(--exclude '/lib/*')
-  LCOV_IGNORE_ERRORS="negative,mismatch,unused"
+  if lcov --version | grep --silent 'LCOV version 1.'; then
+    LCOV_IGNORE_ERRORS="gcov,source,graph"
+  else
+    LCOV_IGNORE_ERRORS="negative,mismatch,unused"
+  fi
   GENHTML_IGNORE_ERRORS="inconsistent,unmapped"
 fi
 LCOV_PARAMS+=(--ignore-errors ${LCOV_IGNORE_ERRORS})

--- a/util/codecov-ci.sh
+++ b/util/codecov-ci.sh
@@ -18,11 +18,9 @@ fi
 
 BUILD="$1"
 if [ -n "$BUILD" ]; then
-  if [ ! -e "$BUILD" ]; then
-    mkdir -p "$BUILD/default"
-    mkdir -p "$BUILD/no_asm"
-    mkdir -p "$BUILD/html"
-  fi
+  mkdir -p "$BUILD/default"
+  mkdir -p "$BUILD/no_asm"
+  mkdir -p "$BUILD/html"
   BUILD=$(readlink -f "$BUILD")
   BUILD_DEFAULT=$(readlink -f "$BUILD/default")
   BUILD_NO_ASM=$(readlink -f "$BUILD/no_asm")
@@ -32,37 +30,43 @@ else
   exit 1
 fi
 
+LCOV_PARAMS=()
+LCOV_PARAMS+=(--exclude '*/third_party/*')
+LCOV_PARAMS+=(--exclude '*/tool/*')
+LCOV_PARAMS+=(--exclude '*_test.*')
+LCOV_PARAMS+=(--exclude '*/test_*')
+LCOV_PARAMS+=(--exclude '*_test_*')
+LCOV_PARAMS+=(--exclude '*/gtest_*')
+LCOV_PARAMS+=(--exclude '*/wycheproof_*')
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  LCOV_PARAMS+=(--exclude '/Applications/*')
+  LCOV_IGNORE_ERRORS="inconsistent,inconsistent,gcov,gcov"
+  GENHTML_IGNORE_ERRORS="inconsistent,unmapped"
+else
+  LCOV_PARAMS+=(--exclude '/usr/*')
+  LCOV_PARAMS+=(--exclude '/lib/*')
+  LCOV_IGNORE_ERRORS="negative,mismatch,unused"
+  GENHTML_IGNORE_ERRORS="inconsistent,unmapped"
+fi
+LCOV_PARAMS+=(--ignore-errors ${LCOV_IGNORE_ERRORS})
+
 # Default x86-64 build/test
 cmake -DGCOV=1 -DDISABLE_PERL=1 -DBUILD_TESTING=1 -DBUILD_LIBSSL=1 -DCMAKE_BUILD_TYPE=Debug -S "${SRC}" -B "${BUILD_DEFAULT}"
 cmake --build "${BUILD_DEFAULT}" --target all_tests
+lcov --capture "${LCOV_PARAMS[@]}" --initial --directory "${BUILD_DEFAULT}" --output-file "${BUILD}/initial-default.info"
 cmake --build "${BUILD_DEFAULT}" --target run_tests
 
 # No Assembly x86-64 build/test
 cmake -DGCOV=1 -DOPENSSL_NO_ASM=1 -DDISABLE_PERL=1 -DBUILD_TESTING=1 -DBUILD_LIBSSL=1 -DCMAKE_BUILD_TYPE=Debug -S "${SRC}" -B "${BUILD_NO_ASM}"
 cmake --build "${BUILD_NO_ASM}" --target all_tests
+lcov --capture "${LCOV_PARAMS[@]}" --initial --directory "${BUILD_NO_ASM}" --output-file "${BUILD}/initial-no-asm.info"
 cmake --build "${BUILD_NO_ASM}" --target run_tests
 
-LCOV_EXCLUDE_PARAMS=()
-LCOV_EXCLUDE_PARAMS+=(--exclude '*/third_party/*')
-LCOV_EXCLUDE_PARAMS+=(--exclude '*/tool/*')
-LCOV_EXCLUDE_PARAMS+=(--exclude '*_test.*')
-LCOV_EXCLUDE_PARAMS+=(--exclude '*/test_*')
-LCOV_EXCLUDE_PARAMS+=(--exclude '*_test_*')
-LCOV_EXCLUDE_PARAMS+=(--exclude '*/gtest_*')
-LCOV_EXCLUDE_PARAMS+=(--exclude '*/wycheproof_')
+lcov --capture "${LCOV_PARAMS[@]}" --directory "${BUILD_DEFAULT}" --output-file "${BUILD}/test-default.info"
+lcov "${LCOV_PARAMS[@]}" --add-tracefile "${BUILD}/initial-default.info" --add-tracefile "${BUILD}/test-default.info" --output-file "${BUILD}/coverage-default.info"
+lcov --capture "${LCOV_PARAMS[@]}" --directory "${BUILD_NO_ASM}" --output-file "${BUILD}/test-no-asm.info"
+lcov "${LCOV_PARAMS[@]}" --add-tracefile "${BUILD}/initial-no-asm.info" --add-tracefile "${BUILD}/test-no-asm.info" --output-file "${BUILD}/coverage-no-asm.info"
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  LCOV_EXCLUDE_PARAMS+=(--exclude '/Applications/*')
-  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --ignore-errors inconsistent,inconsistent,gcov,gcov --directory "${BUILD_DEFAULT}" --output-file "${BUILD}/coverage-default.info"
-  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --ignore-errors inconsistent,inconsistent,gcov,gcov --directory "${BUILD_NO_ASM}" --output-file "${BUILD}/coverage-no-asm.info"
+#genhtml --ignore-errors ${GENHTML_IGNORE_ERRORS} --output-directory "${BUILD_HTML}" "${BUILD}"/coverage-*.info
+#open "${BUILD_HTML}"/index.html
 
-  #genhtml --ignore-errors inconsistent,inconsistent,unmapped --output-directory "${BUILD_HTML}" "${BUILD}"/coverage-*.info
-  #open "${BUILD_HTML}"/index.html
-else
-  LCOV_EXCLUDE_PARAMS+=(--exclude '/usr/*')
-  LCOV_EXCLUDE_PARAMS+=(--exclude '/lib/*')
-  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --ignore-errors negative,mismatch,unused --directory "${BUILD_DEFAULT}" --output-file "${BUILD}/coverage-default.info"
-  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --ignore-errors negative,mismatch,unused --directory "${BUILD_NO_ASM}" --output-file "${BUILD}/coverage-no-asm.info"
-
-  #genhtml --output-directory "${BUILD_HTML}" "${BUILD}"/coverage-*.info
-fi

--- a/util/codecov-ci.sh
+++ b/util/codecov-ci.sh
@@ -7,6 +7,7 @@
 set -xe
 
 SRC=$(pwd)
+SRC=$(readlink -f "$SRC")
 
 # Sanity check
 DIRNAME=$(basename -- "${SRC}")
@@ -18,25 +19,48 @@ fi
 BUILD="$1"
 if [ -n "$BUILD" ]; then
   if [ ! -e "$BUILD" ]; then
-    mkdir -p "$BUILD"
+    mkdir -p "$BUILD/default"
+    mkdir -p "$BUILD/no_asm"
+    mkdir -p "$BUILD/html"
   fi
   BUILD=$(readlink -f "$BUILD")
+  BUILD_DEFAULT=$(readlink -f "$BUILD/default")
+  BUILD_NO_ASM=$(readlink -f "$BUILD/no_asm")
+  BUILD_HTML=$(readlink -f "$BUILD/html")
 else
   echo "Must specify a build directory."
   exit 1
 fi
 
-cmake -DGCOV=1 -DDISABLE_PERL=1 -DBUILD_TESTING=1 -DBUILD_LIBSSL=1 -DCMAKE_BUILD_TYPE=Debug -S "${SRC}" -B "${BUILD}"
-cmake --build "${BUILD}" --target all_tests
-cmake --build "${BUILD}" --target run_tests
+# Default x86-64 build/test
+cmake -DGCOV=1 -DDISABLE_PERL=1 -DBUILD_TESTING=1 -DBUILD_LIBSSL=1 -DCMAKE_BUILD_TYPE=Debug -S "${SRC}" -B "${BUILD_DEFAULT}"
+cmake --build "${BUILD_DEFAULT}" --target all_tests
+cmake --build "${BUILD_DEFAULT}" --target run_tests
 
-#TODO: Use callgrind
-#mkdir "$BUILD/callgrind/"
-#go run "$SRC/util/all_tests.go" -build-dir "$BUILD" -callgrind -num-workers 16
+# No Assembly x86-64 build/test
+cmake -DGCOV=1 -DOPENSSL_NO_ASM=1 -DDISABLE_PERL=1 -DBUILD_TESTING=1 -DBUILD_LIBSSL=1 -DCMAKE_BUILD_TYPE=Debug -S "${SRC}" -B "${BUILD_NO_ASM}"
+cmake --build "${BUILD_NO_ASM}" --target all_tests
+cmake --build "${BUILD_NO_ASM}" --target run_tests
 
-shopt -s globstar
+LCOV_EXCLUDE_PARAMS=()
+LCOV_EXCLUDE_PARAMS+=(--exclude '*/third_party/*')
+LCOV_EXCLUDE_PARAMS+=(--exclude '*/tool/*')
+LCOV_EXCLUDE_PARAMS+=(--exclude '*_test.*')
+LCOV_EXCLUDE_PARAMS+=(--exclude '*/test_*')
+LCOV_EXCLUDE_PARAMS+=(--exclude '*_test_*')
+LCOV_EXCLUDE_PARAMS+=(--exclude '*/gtest_*')
+LCOV_EXCLUDE_PARAMS+=(--exclude '*/wycheproof_')
 
-pushd "${BUILD}"
-gcov --source-prefix "${SRC}" **/*.gcda
-lcov --capture --exclude "/Applications/*" --exclude "/usr/*" --exclude "/lib/*" --directory . --output-file coverage.info
-popd
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  LCOV_EXCLUDE_PARAMS+=(--exclude '/Applications/*')
+  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --ignore-errors inconsistent,inconsistent,gcov,gcov --directory "${BUILD_DEFAULT}" --output-file "${BUILD}/coverage-default.info"
+  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --ignore-errors inconsistent,inconsistent,gcov,gcov --directory "${BUILD_NO_ASM}" --output-file "${BUILD}/coverage-no-asm.info"
+
+  #genhtml --ignore-errors inconsistent,inconsistent,unmapped --output-directory "${BUILD_HTML}" "${BUILD}"/coverage-*.info
+  #open "${BUILD_HTML}"/index.html
+else
+  LCOV_EXCLUDE_PARAMS+=(--exclude '/usr/*')
+  LCOV_EXCLUDE_PARAMS+=(--exclude '/lib/*')
+  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --directory "${BUILD_DEFAULT}" --output-file "${BUILD}/coverage-default.info"
+  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --directory "${BUILD_NO_ASM}" --output-file "${BUILD}/coverage-no-asm.info"
+fi

--- a/util/codecov-ci.sh
+++ b/util/codecov-ci.sh
@@ -61,6 +61,8 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
 else
   LCOV_EXCLUDE_PARAMS+=(--exclude '/usr/*')
   LCOV_EXCLUDE_PARAMS+=(--exclude '/lib/*')
-  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --directory "${BUILD_DEFAULT}" --output-file "${BUILD}/coverage-default.info"
-  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --directory "${BUILD_NO_ASM}" --output-file "${BUILD}/coverage-no-asm.info"
+  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --ignore-errors negative,mismatch,unused --directory "${BUILD_DEFAULT}" --output-file "${BUILD}/coverage-default.info"
+  lcov --capture "${LCOV_EXCLUDE_PARAMS[@]}" --ignore-errors negative,mismatch,unused --directory "${BUILD_NO_ASM}" --output-file "${BUILD}/coverage-no-asm.info"
+
+  #genhtml --output-directory "${BUILD_HTML}" "${BUILD}"/coverage-*.info
 fi


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Include a `-DOPENSSL_NO_ASM=1` build in the coverage report.
* Include files that had no test coverage.
* Exclude test files from the coverage report.
* Improve support for running coverage report locally on Mac/Linux.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
