### PR TITLE
Update s2n-bignum subtree 2023-11-19

### DIFF
--- a/third_party/s2n-bignum/arm/curve25519/bignum_madd_n25519.S
+++ b/third_party/s2n-bignum/arm/curve25519/bignum_madd_n25519.S
@@ -1,0 +1,284 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// ----------------------------------------------------------------------------
+// Multiply-add modulo the order of the curve25519/edwards25519 basepoint
+// Inputs x[4], y[4], c[4]; output z[4]
+//
+//    extern void bignum_madd_n25519
+//     (uint64_t z[static 4], uint64_t x[static 4],
+//      uint64_t y[static 4], uint64_t c[static 4]);
+//
+// Performs z := (x * y + c) mod n_25519, where the modulus is
+// n_25519 = 2^252 + 27742317777372353535851937790883648493, the
+// order of the curve25519/edwards25519 basepoint. The result z
+// and the inputs x, y and c are all 4 digits (256 bits).
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y, X3 = c
+// ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
+
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_madd_n25519)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_madd_n25519)
+        .text
+        .balign 4
+
+// Backup of the input pointer so we can modify x0
+
+#define z x19
+
+// Temporaries for reduction phase
+
+#define q   x2
+#define n0  x3
+#define n1  x4
+#define t0  x5
+#define t1  x6
+#define t2  x7
+
+// Loading large constants
+
+#define movbig(nn,n3,n2,n1,n0)                                      \
+        movz    nn, n0;                                             \
+        movk    nn, n1, lsl #16;                                    \
+        movk    nn, n2, lsl #32;                                    \
+        movk    nn, n3, lsl #48
+
+// Single round of modular reduction mod_n25519, mapping
+// [m4;m3;m2;m1;m0] = m to [m3;m2;m1;m0] = m mod n_25519,
+// *assuming* the input m < 2^64 * n_25519. This is very
+// close to the loop body of the bignum_mod_n25519 function.
+
+#define reduce(m4,m3,m2,m1,m0)                          \
+        extr    q, m4, m3, #60;                         \
+        and     m3, m3, #0x0FFFFFFFFFFFFFFF;            \
+        sub     q, q, m4, lsr #60;                      \
+        and     t0, m4, #0xF000000000000000;            \
+        add     m3, m3, t0;                             \
+        mul     t0, n0, q;                              \
+        mul     t1, n1, q;                              \
+        umulh   t2, n0, q;                              \
+        adds    t1, t1, t2;                             \
+        umulh   t2, n1, q;                              \
+        adc     t2, t2, xzr;                            \
+        subs    m0, m0, t0;                             \
+        sbcs    m1, m1, t1;                             \
+        sbcs    m2, m2, t2;                             \
+        sbcs    m3, m3, xzr;                            \
+        csel    t0, n0, xzr, cc;                        \
+        csel    t1, n1, xzr, cc;                        \
+        adds    m0, m0, t0;                             \
+        and     t2, t0, #0x1000000000000000;            \
+        adcs    m1, m1, t1;                             \
+        adcs    m2, m2, xzr;                            \
+        adc     m3, m3, t2
+
+// Special case of "reduce" with m4 = 0. As well as not using m4,
+// the quotient selection is slightly simpler, just floor(m/2^252)
+// versus min (floor(m/2^252)) (2^63-1).
+
+#define reduce0(m3,m2,m1,m0)                            \
+        lsr     q, m3, #60;                             \
+        and     m3, m3, #0x0FFFFFFFFFFFFFFF;            \
+        mul     t0, n0, q;                              \
+        mul     t1, n1, q;                              \
+        umulh   t2, n0, q;                              \
+        adds    t1, t1, t2;                             \
+        umulh   t2, n1, q;                              \
+        adc     t2, t2, xzr;                            \
+        subs    m0, m0, t0;                             \
+        sbcs    m1, m1, t1;                             \
+        sbcs    m2, m2, t2;                             \
+        sbcs    m3, m3, xzr;                            \
+        csel    t0, n0, xzr, cc;                        \
+        csel    t1, n1, xzr, cc;                        \
+        adds    m0, m0, t0;                             \
+        and     t2, t0, #0x1000000000000000;            \
+        adcs    m1, m1, t1;                             \
+        adcs    m2, m2, xzr;                            \
+        adc     m3, m3, t2
+
+S2N_BN_SYMBOL(bignum_madd_n25519):
+
+        stp     x19, x20, [sp, -16]!
+
+// Back up the result pointer so we can overwrite x0 in intermediate steps
+
+        mov     z, x0
+
+// First compute [x15;x14;x13;x12;x11;x10;x9;x8] = x * y. This is
+// a basic 2-level Karatsuba multiplier, similar to the start of
+// bignum_mul_p25519, but with changes to the register allocation,
+// which in particular preserve x3/w3 for the next step.
+
+        ldp     x0, x4, [x1]
+        ldp     x5, x6, [x2]
+        umull   x8, w0, w5
+        lsr     x17, x0, #32
+        umull   x7, w17, w5
+        lsr     x16, x5, #32
+        umull   x9, w16, w17
+        umull   x16, w0, w16
+        adds    x8, x8, x7, lsl #32
+        lsr     x7, x7, #32
+        adc     x9, x9, x7
+        adds    x8, x8, x16, lsl #32
+        lsr     x16, x16, #32
+        adc     x9, x9, x16
+        mul     x10, x4, x6
+        umulh   x11, x4, x6
+        subs    x4, x4, x0
+        cneg    x4, x4, cc
+        csetm   x16, cc
+        adds    x10, x10, x9
+        adc     x11, x11, xzr
+        subs    x0, x5, x6
+        cneg    x0, x0, cc
+        cinv    x16, x16, cc
+        mul     x7, x4, x0
+        umulh   x0, x4, x0
+        adds    x9, x8, x10
+        adcs    x10, x10, x11
+        adc     x11, x11, xzr
+        cmn     x16, #0x1
+        eor     x7, x7, x16
+        adcs    x9, x7, x9
+        eor     x0, x0, x16
+        adcs    x10, x0, x10
+        adc     x11, x11, x16
+        ldp     x0, x4, [x1, #16]
+        ldp     x5, x6, [x2, #16]
+        umull   x12, w0, w5
+        lsr     x17, x0, #32
+        umull   x7, w17, w5
+        lsr     x16, x5, #32
+        umull   x13, w16, w17
+        umull   x16, w0, w16
+        adds    x12, x12, x7, lsl #32
+        lsr     x7, x7, #32
+        adc     x13, x13, x7
+        adds    x12, x12, x16, lsl #32
+        lsr     x16, x16, #32
+        adc     x13, x13, x16
+        mul     x14, x4, x6
+        umulh   x15, x4, x6
+        subs    x4, x4, x0
+        cneg    x4, x4, cc
+        csetm   x16, cc
+        adds    x14, x14, x13
+        adc     x15, x15, xzr
+        subs    x0, x5, x6
+        cneg    x0, x0, cc
+        cinv    x16, x16, cc
+        mul     x7, x4, x0
+        umulh   x0, x4, x0
+        adds    x13, x12, x14
+        adcs    x14, x14, x15
+        adc     x15, x15, xzr
+        cmn     x16, #0x1
+        eor     x7, x7, x16
+        adcs    x13, x7, x13
+        eor     x0, x0, x16
+        adcs    x14, x0, x14
+        adc     x15, x15, x16
+        ldp     x0, x4, [x1, #16]
+        ldp     x7, x16, [x1]
+        subs    x0, x0, x7
+        sbcs    x4, x4, x16
+        csetm   x16, cc
+        ldp     x7, x17, [x2]
+        subs    x5, x7, x5
+        sbcs    x6, x17, x6
+        csetm   x17, cc
+        eor     x0, x0, x16
+        subs    x0, x0, x16
+        eor     x4, x4, x16
+        sbc     x4, x4, x16
+        eor     x5, x5, x17
+        subs    x5, x5, x17
+        eor     x6, x6, x17
+        sbc     x6, x6, x17
+        eor     x16, x17, x16
+        adds    x12, x12, x10
+        adcs    x13, x13, x11
+        adcs    x14, x14, xzr
+        adc     x15, x15, xzr
+        mul     x2, x0, x5
+        umulh   x17, x0, x5
+        mul     x7, x4, x6
+        umulh   x1, x4, x6
+        subs    x4, x4, x0
+        cneg    x4, x4, cc
+        csetm   x10, cc
+        adds    x7, x7, x17
+        adc     x1, x1, xzr
+        subs    x6, x5, x6
+        cneg    x6, x6, cc
+        cinv    x10, x10, cc
+        mul     x5, x4, x6
+        umulh   x6, x4, x6
+        adds    x17, x2, x7
+        adcs    x7, x7, x1
+        adc     x1, x1, xzr
+        cmn     x10, #0x1
+        eor     x5, x5, x10
+        adcs    x17, x5, x17
+        eor     x6, x6, x10
+        adcs    x7, x6, x7
+        adc     x1, x1, x10
+        adds    x10, x12, x8
+        adcs    x11, x13, x9
+        adcs    x12, x14, x12
+        adcs    x13, x15, x13
+        adcs    x14, x14, xzr
+        adc     x15, x15, xzr
+        cmn     x16, #0x1
+        eor     x2, x2, x16
+        adcs    x10, x2, x10
+        eor     x17, x17, x16
+        adcs    x11, x17, x11
+        eor     x7, x7, x16
+        adcs    x12, x7, x12
+        eor     x1, x1, x16
+        adcs    x13, x1, x13
+        adcs    x14, x14, x16
+        adc     x15, x15, x16
+
+// Add the constant term, so [x15;x14;x13;x12;x11;x10;x9;x8] = x * y + c
+// It's easier to just do this now versus incorporating it into the
+// Karatsuba steps above or deferring it until partway through the
+// reduction, though it does result in a long carry propagation here.
+
+        ldp     x0, x1, [x3]
+        adds    x8, x8, x0
+        adcs    x9, x9, x1
+        ldp     x0, x1, [x3, #16]
+        adcs    x10, x10, x0
+        adcs    x11, x11, x1
+        adcs    x12, x12, xzr
+        adcs    x13, x13, xzr
+        adcs    x14, x14, xzr
+        adc     x15, x15, xzr
+
+// Now do the modular reduction and write back
+
+        movbig( n0, #0x5812, #0x631a, #0x5cf5, #0xd3ed)
+        movbig( n1, #0x14de, #0xf9de, #0xa2f7, #0x9cd6)
+
+        reduce0(x15,x14,x13,x12)
+        reduce(x15,x14,x13,x12,x11)
+        reduce(x14,x13,x12,x11,x10)
+        reduce(x13,x12,x11,x10,x9)
+        reduce(x12,x11,x10,x9,x8)
+
+        stp     x8, x9, [z]
+        stp     x10, x11, [z, #16]
+
+// Restore registers and return
+
+        ldp     x19, x20, [sp], 16
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stacz,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/curve25519/bignum_madd_n25519_alt.S
+++ b/third_party/s2n-bignum/arm/curve25519/bignum_madd_n25519_alt.S
@@ -1,0 +1,210 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// ----------------------------------------------------------------------------
+// Multiply-add modulo the order of the curve25519/edwards25519 basepoint
+// Inputs x[4], y[4], c[4]; output z[4]
+//
+//    extern void bignum_madd_n25519_alt
+//     (uint64_t z[static 4], uint64_t x[static 4],
+//      uint64_t y[static 4], uint64_t c[static 4]);
+//
+// Performs z := (x * y + c) mod n_25519, where the modulus is
+// n_25519 = 2^252 + 27742317777372353535851937790883648493, the
+// order of the curve25519/edwards25519 basepoint. The result z
+// and the inputs x, y and c are all 4 digits (256 bits).
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y, X3 = c
+// ----------------------------------------------------------------------------
+#include "_internal_s2n_bignum.h"
+
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_madd_n25519_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_madd_n25519_alt)
+        .text
+        .balign 4
+
+// Backup of the input pointer so we can modify x0
+
+#define z x19
+
+// Temporaries for reduction phase
+
+#define q   x2
+#define n0  x3
+#define n1  x4
+#define t0  x5
+#define t1  x6
+#define t2  x7
+
+// Loading large constants
+
+#define movbig(nn,n3,n2,n1,n0)                                      \
+        movz    nn, n0;                                             \
+        movk    nn, n1, lsl #16;                                    \
+        movk    nn, n2, lsl #32;                                    \
+        movk    nn, n3, lsl #48
+
+// Single round of modular reduction mod_n25519, mapping
+// [m4;m3;m2;m1;m0] = m to [m3;m2;m1;m0] = m mod n_25519,
+// *assuming* the input m < 2^64 * n_25519. This is very
+// close to the loop body of the bignum_mod_n25519 function.
+
+#define reduce(m4,m3,m2,m1,m0)                          \
+        extr    q, m4, m3, #60;                         \
+        and     m3, m3, #0x0FFFFFFFFFFFFFFF;            \
+        sub     q, q, m4, lsr #60;                      \
+        and     t0, m4, #0xF000000000000000;            \
+        add     m3, m3, t0;                             \
+        mul     t0, n0, q;                              \
+        mul     t1, n1, q;                              \
+        umulh   t2, n0, q;                              \
+        adds    t1, t1, t2;                             \
+        umulh   t2, n1, q;                              \
+        adc     t2, t2, xzr;                            \
+        subs    m0, m0, t0;                             \
+        sbcs    m1, m1, t1;                             \
+        sbcs    m2, m2, t2;                             \
+        sbcs    m3, m3, xzr;                            \
+        csel    t0, n0, xzr, cc;                        \
+        csel    t1, n1, xzr, cc;                        \
+        adds    m0, m0, t0;                             \
+        and     t2, t0, #0x1000000000000000;            \
+        adcs    m1, m1, t1;                             \
+        adcs    m2, m2, xzr;                            \
+        adc     m3, m3, t2
+
+// Special case of "reduce" with m4 = 0. As well as not using m4,
+// the quotient selection is slightly simpler, just floor(m/2^252)
+// versus min (floor(m/2^252)) (2^63-1).
+
+#define reduce0(m3,m2,m1,m0)                            \
+        lsr     q, m3, #60;                             \
+        and     m3, m3, #0x0FFFFFFFFFFFFFFF;            \
+        mul     t0, n0, q;                              \
+        mul     t1, n1, q;                              \
+        umulh   t2, n0, q;                              \
+        adds    t1, t1, t2;                             \
+        umulh   t2, n1, q;                              \
+        adc     t2, t2, xzr;                            \
+        subs    m0, m0, t0;                             \
+        sbcs    m1, m1, t1;                             \
+        sbcs    m2, m2, t2;                             \
+        sbcs    m3, m3, xzr;                            \
+        csel    t0, n0, xzr, cc;                        \
+        csel    t1, n1, xzr, cc;                        \
+        adds    m0, m0, t0;                             \
+        and     t2, t0, #0x1000000000000000;            \
+        adcs    m1, m1, t1;                             \
+        adcs    m2, m2, xzr;                            \
+        adc     m3, m3, t2
+
+S2N_BN_SYMBOL(bignum_madd_n25519_alt):
+
+        stp     x19, x20, [sp, -16]!
+
+// Back up the result pointer so we can overwrite x0 in intermediate steps
+
+        mov     z, x0
+
+// First compute [x15;x14;x13;x12;x11;x10;x9;x8] = x * y + c. This
+// is a basic schoolbook multiplier similar to the start of
+// bignum_mul_p25519_alt except for different registers, but it
+// also adds in the c term after the first row accumulation.
+
+        ldp     x13, x14, [x1]
+        ldp     x7, x0, [x2]
+        mul     x8, x13, x7
+        umulh   x9, x13, x7
+        mul     x16, x13, x0
+        umulh   x10, x13, x0
+        adds    x9, x9, x16
+        ldp     x4, x5, [x2, #16]
+        mul     x16, x13, x4
+        umulh   x11, x13, x4
+        adcs    x10, x10, x16
+        mul     x16, x13, x5
+        umulh   x12, x13, x5
+        adcs    x11, x11, x16
+        adc     x12, x12, xzr
+        ldp     x15, x6, [x3]
+        adds    x8, x8, x15
+        adcs    x9, x9, x6
+        ldp     x15, x6, [x3, #16]
+        adcs    x10, x10, x15
+        adcs    x11, x11, x6
+        adc     x12, x12, xzr
+        ldp     x15, x6, [x1, #16]
+        mul     x16, x14, x7
+        adds    x9, x9, x16
+        mul     x16, x14, x0
+        adcs    x10, x10, x16
+        mul     x16, x14, x4
+        adcs    x11, x11, x16
+        mul     x16, x14, x5
+        adcs    x12, x12, x16
+        umulh   x13, x14, x5
+        adc     x13, x13, xzr
+        umulh   x16, x14, x7
+        adds    x10, x10, x16
+        umulh   x16, x14, x0
+        adcs    x11, x11, x16
+        umulh   x16, x14, x4
+        adcs    x12, x12, x16
+        adc     x13, x13, xzr
+        mul     x16, x15, x7
+        adds    x10, x10, x16
+        mul     x16, x15, x0
+        adcs    x11, x11, x16
+        mul     x16, x15, x4
+        adcs    x12, x12, x16
+        mul     x16, x15, x5
+        adcs    x13, x13, x16
+        umulh   x14, x15, x5
+        adc     x14, x14, xzr
+        umulh   x16, x15, x7
+        adds    x11, x11, x16
+        umulh   x16, x15, x0
+        adcs    x12, x12, x16
+        umulh   x16, x15, x4
+        adcs    x13, x13, x16
+        adc     x14, x14, xzr
+        mul     x16, x6, x7
+        adds    x11, x11, x16
+        mul     x16, x6, x0
+        adcs    x12, x12, x16
+        mul     x16, x6, x4
+        adcs    x13, x13, x16
+        mul     x16, x6, x5
+        adcs    x14, x14, x16
+        umulh   x15, x6, x5
+        adc     x15, x15, xzr
+        umulh   x16, x6, x7
+        adds    x12, x12, x16
+        umulh   x16, x6, x0
+        adcs    x13, x13, x16
+        umulh   x16, x6, x4
+        adcs    x14, x14, x16
+        adc     x15, x15, xzr
+
+// Now do the modular reduction and write back
+
+        movbig( n0, #0x5812, #0x631a, #0x5cf5, #0xd3ed)
+        movbig( n1, #0x14de, #0xf9de, #0xa2f7, #0x9cd6)
+
+        reduce0(x15,x14,x13,x12)
+        reduce(x15,x14,x13,x12,x11)
+        reduce(x14,x13,x12,x11,x10)
+        reduce(x13,x12,x11,x10,x9)
+        reduce(x12,x11,x10,x9,x8)
+
+        stp     x8, x9, [z]
+        stp     x10, x11, [z, #16]
+
+// Restore registers and return
+
+        ldp     x19, x20, [sp], 16
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stacz,"",%progbits
+#endif

--- a/third_party/s2n-bignum/arm/curve25519/edwards25519_scalarmulbase.S
+++ b/third_party/s2n-bignum/arm/curve25519/edwards25519_scalarmulbase.S
@@ -577,7 +577,7 @@ S2N_BN_SYMBOL(edwards25519_scalarmulbase):
 // (X,Y,Z,T), representing an affine point on the edwards25519 curve
 // (x,y) via x = X/Z, y = Y/Z and x * y = T/Z (so X * Y = T * Z).
 // In comments B means the standard basepoint (x,4/5) =
-// (0x216....f25d51a,0x0x6666..666658).
+// (0x216....f25d51a,0x6666..666658).
 //
 // Initialize accumulator "acc" to either 0 or 2^251 * B depending on
 // bit 251 of the (reduced) scalar. That leaves bits 0..250 to handle.

--- a/third_party/s2n-bignum/arm/curve25519/edwards25519_scalarmulbase_alt.S
+++ b/third_party/s2n-bignum/arm/curve25519/edwards25519_scalarmulbase_alt.S
@@ -419,7 +419,7 @@ S2N_BN_SYMBOL(edwards25519_scalarmulbase_alt):
 // (X,Y,Z,T), representing an affine point on the edwards25519 curve
 // (x,y) via x = X/Z, y = Y/Z and x * y = T/Z (so X * Y = T * Z).
 // In comments B means the standard basepoint (x,4/5) =
-// (0x216....f25d51a,0x0x6666..666658).
+// (0x216....f25d51a,0x6666..666658).
 //
 // Initialize accumulator "acc" to either 0 or 2^251 * B depending on
 // bit 251 of the (reduced) scalar. That leaves bits 0..250 to handle.

--- a/third_party/s2n-bignum/arm/curve25519/edwards25519_scalarmuldouble.S
+++ b/third_party/s2n-bignum/arm/curve25519/edwards25519_scalarmuldouble.S
@@ -1514,7 +1514,7 @@ edwards25519_scalarmuldouble_loop:
 // form amounts to swapping the first two fields and negating the third.
 // The negation does not always fully reduce even mod 2^256-38 in the zero
 // case, instead giving -0 = 2^256-38. But that is fine since the result is
-// always fed to a multipliction inside the "pepadd" function below that
+// always fed to a multiplication inside the "pepadd" function below that
 // handles any 256-bit input.
 
         cmp     cf, xzr

--- a/third_party/s2n-bignum/arm/curve25519/edwards25519_scalarmuldouble_alt.S
+++ b/third_party/s2n-bignum/arm/curve25519/edwards25519_scalarmuldouble_alt.S
@@ -1298,7 +1298,7 @@ edwards25519_scalarmuldouble_alt_loop:
 // form amounts to swapping the first two fields and negating the third.
 // The negation does not always fully reduce even mod 2^256-38 in the zero
 // case, instead giving -0 = 2^256-38. But that is fine since the result is
-// always fed to a multipliction inside the "pepadd" function below that
+// always fed to a multiplication inside the "pepadd" function below that
 // handles any 256-bit input.
 
         cmp     cf, xzr

--- a/third_party/s2n-bignum/arm/p384/Makefile
+++ b/third_party/s2n-bignum/arm/p384/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 #############################################################################
 
-# If actually on an ARM8 machine, just use the GNU assmbler (as). Otherwise
+# If actually on an ARM8 machine, just use the GNU assembler (as). Otherwise
 # use a cross-assembling version so that the code can still be assembled
 # and the proofs checked against the object files (though you won't be able
 # to run code without additional emulation infrastructure). The aarch64

--- a/third_party/s2n-bignum/arm/p521/Makefile
+++ b/third_party/s2n-bignum/arm/p521/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 #############################################################################
 
-# If actually on an ARM8 machine, just use the GNU assmbler (as). Otherwise
+# If actually on an ARM8 machine, just use the GNU assembler (as). Otherwise
 # use a cross-assembling version so that the code can still be assembled
 # and the proofs checked against the object files (though you won't be able
 # to run code without additional emulation infrastructure). The aarch64

--- a/third_party/s2n-bignum/x86_att/curve25519/bignum_madd_n25519.S
+++ b/third_party/s2n-bignum/x86_att/curve25519/bignum_madd_n25519.S
@@ -1,0 +1,219 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// ----------------------------------------------------------------------------
+// Multiply-add modulo the order of the curve25519/edwards25519 basepoint
+// Inputs x[4], y[4], c[4]; output z[4]
+//
+//    extern void bignum_madd_n25519
+//     (uint64_t z[static 4], uint64_t x[static 4],
+//      uint64_t y[static 4], uint64_t c[static 4]);
+//
+// Performs z := (x * y + c) mod n_25519, where the modulus is
+// n_25519 = 2^252 + 27742317777372353535851937790883648493, the
+// order of the curve25519/edwards25519 basepoint. The result z
+// and the inputs x, y and c are all 4 digits (256 bits).
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y, RCX = c
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y, R9 = c
+// ----------------------------------------------------------------------------
+
+#include "_internal_s2n_bignum.h"
+
+
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_madd_n25519)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_madd_n25519)
+        .text
+
+// Single round of modular reduction mod_n25519, mapping
+// [m4;m3;m2;m1;m0] = m to [m3;m2;m1;m0] = m mod n_25519,
+// *assuming* the input m < 2^64 * n_25519. This is very
+// close to the loop body of the bignum_mod_n25519 function.
+
+#define reduce(m4,m3,m2,m1,m0)                                  \
+        movq    m4, %rbx ;                                        \
+        shldq   $0x4, m3, %rbx ;                                   \
+        shrq    $0x3c, m4 ;                                       \
+        subq    m4, %rbx ;                                        \
+        shlq    $0x4, m3 ;                                        \
+        shrdq   $0x4, m4, m3 ;                                    \
+        movabsq $0x5812631a5cf5d3ed, %rax ;                        \
+        mulq    %rbx;                                            \
+        movq    %rax, %rbp ;                                       \
+        movq    %rdx, %rcx ;                                       \
+        movabsq $0x14def9dea2f79cd6, %rax ;                        \
+        mulq    %rbx;                                            \
+        addq    %rax, %rcx ;                                       \
+        adcq    $0x0, %rdx ;                                       \
+        subq    %rbp, m0 ;                                        \
+        sbbq    %rcx, m1 ;                                        \
+        sbbq    %rdx, m2 ;                                        \
+        sbbq    $0x0, m3 ;                                        \
+        sbbq    %rbx, %rbx ;                                       \
+        movabsq $0x5812631a5cf5d3ed, %rax ;                        \
+        andq    %rbx, %rax ;                                       \
+        movabsq $0x14def9dea2f79cd6, %rdx ;                        \
+        andq    %rbx, %rdx ;                                       \
+        movabsq $0x1000000000000000, %rbx ;                        \
+        andq    %rax, %rbx ;                                       \
+        addq    %rax, m0 ;                                        \
+        adcq    %rdx, m1 ;                                        \
+        adcq    $0x0, m2 ;                                        \
+        adcq    %rbx, m3
+
+// Special case of "reduce" with m4 = 0. As well as not using m4,
+// the quotient selection is slightly simpler, just floor(m/2^252)
+// versus min (floor(m/2^252)) (2^63-1).
+
+#define reduce0(m3,m2,m1,m0)                                    \
+        movq    m3, %rbx ;                                        \
+        shrq    $60, %rbx ;                                        \
+        shlq    $4, m3 ;                                          \
+        shrq    $4, m3 ;                                          \
+        movabsq $0x5812631a5cf5d3ed, %rax ;                        \
+        mulq    %rbx;                                            \
+        movq    %rax, %rbp ;                                       \
+        movq    %rdx, %rcx ;                                       \
+        movabsq $0x14def9dea2f79cd6, %rax ;                        \
+        mulq    %rbx;                                            \
+        addq    %rax, %rcx ;                                       \
+        adcq    $0x0, %rdx ;                                       \
+        subq    %rbp, m0 ;                                        \
+        sbbq    %rcx, m1 ;                                        \
+        sbbq    %rdx, m2 ;                                        \
+        sbbq    $0x0, m3 ;                                        \
+        sbbq    %rbx, %rbx ;                                       \
+        movabsq $0x5812631a5cf5d3ed, %rax ;                        \
+        andq    %rbx, %rax ;                                       \
+        movabsq $0x14def9dea2f79cd6, %rdx ;                        \
+        andq    %rbx, %rdx ;                                       \
+        movabsq $0x1000000000000000, %rbx ;                        \
+        andq    %rax, %rbx ;                                       \
+        addq    %rax, m0 ;                                        \
+        adcq    %rdx, m1 ;                                        \
+        adcq    $0x0, m2 ;                                        \
+        adcq    %rbx, m3
+
+S2N_BN_SYMBOL(bignum_madd_n25519):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+        movq    %r9, %rcx
+#endif
+
+// Save some additional registers for use
+
+        pushq   %rbx
+        pushq   %rbp
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// First compute [%r15;%r14;%r13;%r12;%r11;%r10;%r9;%r8] = x * y + c. This is
+// a multiply-add variant of an ADCX/ADOX-based schoolbook multiplier,
+// starting the accumulation with the c term and doing the zeroth row
+// in the same uniform fashion, otherwise similar to the start of
+// bignum_mul_p256k1.
+
+        movq    (%rcx), %r8
+        movq    8(%rcx), %r9
+        movq    16(%rcx), %r10
+        movq    24(%rcx), %r11
+        movq    %rdx, %rcx
+        xorl    %ebp, %ebp
+        movq    (%rcx), %rdx
+        mulxq   (%rsi), %rax, %rbx
+        adcxq   %rax, %r8
+        adoxq   %rbx, %r9
+        mulxq   0x8(%rsi), %rax, %rbx
+        adcxq   %rax, %r9
+        adoxq   %rbx, %r10
+        mulxq   0x10(%rsi), %rax, %rbx
+        adcxq   %rax, %r10
+        adoxq   %rbx, %r11
+        mulxq   0x18(%rsi), %rax, %r12
+        adcxq   %rax, %r11
+        adoxq   %rbp, %r12
+        adcxq   %rbp, %r12
+        xorl    %ebp, %ebp
+        movq    0x8(%rcx), %rdx
+        mulxq   (%rsi), %rax, %rbx
+        adcxq   %rax, %r9
+        adoxq   %rbx, %r10
+        mulxq   0x8(%rsi), %rax, %rbx
+        adcxq   %rax, %r10
+        adoxq   %rbx, %r11
+        mulxq   0x10(%rsi), %rax, %rbx
+        adcxq   %rax, %r11
+        adoxq   %rbx, %r12
+        mulxq   0x18(%rsi), %rax, %r13
+        adcxq   %rax, %r12
+        adoxq   %rbp, %r13
+        adcxq   %rbp, %r13
+        xorl    %ebp, %ebp
+        movq    0x10(%rcx), %rdx
+        mulxq   (%rsi), %rax, %rbx
+        adcxq   %rax, %r10
+        adoxq   %rbx, %r11
+        mulxq   0x8(%rsi), %rax, %rbx
+        adcxq   %rax, %r11
+        adoxq   %rbx, %r12
+        mulxq   0x10(%rsi), %rax, %rbx
+        adcxq   %rax, %r12
+        adoxq   %rbx, %r13
+        mulxq   0x18(%rsi), %rax, %r14
+        adcxq   %rax, %r13
+        adoxq   %rbp, %r14
+        adcxq   %rbp, %r14
+        xorl    %ebp, %ebp
+        movq    0x18(%rcx), %rdx
+        mulxq   (%rsi), %rax, %rbx
+        adcxq   %rax, %r11
+        adoxq   %rbx, %r12
+        mulxq   0x8(%rsi), %rax, %rbx
+        adcxq   %rax, %r12
+        adoxq   %rbx, %r13
+        mulxq   0x10(%rsi), %rax, %rbx
+        adcxq   %rax, %r13
+        adoxq   %rbx, %r14
+        mulxq   0x18(%rsi), %rax, %r15
+        adcxq   %rax, %r14
+        adoxq   %rbp, %r15
+        adcxq   %rbp, %r15
+
+// Now do the modular reduction and write back
+
+        reduce0(%r15,%r14,%r13,%r12)
+        reduce(%r15,%r14,%r13,%r12,%r11)
+        reduce(%r14,%r13,%r12,%r11,%r10)
+        reduce(%r13,%r12,%r11,%r10,%r9)
+        reduce(%r12,%r11,%r10,%r9,%r8)
+
+        movq    %r8, (%rdi)
+        movq    %r9, 8(%rdi)
+        movq    %r10, 16(%rdi)
+        movq    %r11, 24(%rdi)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbp
+        popq    %rbx
+
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/curve25519/bignum_madd_n25519_alt.S
+++ b/third_party/s2n-bignum/x86_att/curve25519/bignum_madd_n25519_alt.S
@@ -1,0 +1,245 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// ----------------------------------------------------------------------------
+// Multiply-add modulo the order of the curve25519/edwards25519 basepoint
+// Inputs x[4], y[4], c[4]; output z[4]
+//
+//    extern void bignum_madd_n25519_alt
+//     (uint64_t z[static 4], uint64_t x[static 4],
+//      uint64_t y[static 4], uint64_t c[static 4]);
+//
+// Performs z := (x * y + c) mod n_25519, where the modulus is
+// n_25519 = 2^252 + 27742317777372353535851937790883648493, the
+// order of the curve25519/edwards25519 basepoint. The result z
+// and the inputs x, y and c are all 4 digits (256 bits).
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y, RCX = c
+// Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y, R9 = c
+// ----------------------------------------------------------------------------
+
+#include "_internal_s2n_bignum.h"
+
+
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_madd_n25519_alt)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_madd_n25519_alt)
+        .text
+
+// Single round of modular reduction mod_n25519, mapping
+// [m4;m3;m2;m1;m0] = m to [m3;m2;m1;m0] = m mod n_25519,
+// *assuming* the input m < 2^64 * n_25519. This is very
+// close to the loop body of the bignum_mod_n25519 function.
+
+#define reduce(m4,m3,m2,m1,m0)                                  \
+        movq    m4, %rbx ;                                        \
+        shldq   $0x4, m3, %rbx ;                                   \
+        shrq    $0x3c, m4 ;                                       \
+        subq    m4, %rbx ;                                        \
+        shlq    $0x4, m3 ;                                        \
+        shrdq   $0x4, m4, m3 ;                                    \
+        movabsq $0x5812631a5cf5d3ed, %rax ;                        \
+        mulq    %rbx;                                            \
+        movq    %rax, %rbp ;                                       \
+        movq    %rdx, %rcx ;                                       \
+        movabsq $0x14def9dea2f79cd6, %rax ;                        \
+        mulq    %rbx;                                            \
+        addq    %rax, %rcx ;                                       \
+        adcq    $0x0, %rdx ;                                       \
+        subq    %rbp, m0 ;                                        \
+        sbbq    %rcx, m1 ;                                        \
+        sbbq    %rdx, m2 ;                                        \
+        sbbq    $0x0, m3 ;                                        \
+        sbbq    %rbx, %rbx ;                                       \
+        movabsq $0x5812631a5cf5d3ed, %rax ;                        \
+        andq    %rbx, %rax ;                                       \
+        movabsq $0x14def9dea2f79cd6, %rdx ;                        \
+        andq    %rbx, %rdx ;                                       \
+        movabsq $0x1000000000000000, %rbx ;                        \
+        andq    %rax, %rbx ;                                       \
+        addq    %rax, m0 ;                                        \
+        adcq    %rdx, m1 ;                                        \
+        adcq    $0x0, m2 ;                                        \
+        adcq    %rbx, m3
+
+// Special case of "reduce" with m4 = 0. As well as not using m4,
+// the quotient selection is slightly simpler, just floor(m/2^252)
+// versus min (floor(m/2^252)) (2^63-1).
+
+#define reduce0(m3,m2,m1,m0)                                    \
+        movq    m3, %rbx ;                                        \
+        shrq    $60, %rbx ;                                        \
+        shlq    $4, m3 ;                                          \
+        shrq    $4, m3 ;                                          \
+        movabsq $0x5812631a5cf5d3ed, %rax ;                        \
+        mulq    %rbx;                                            \
+        movq    %rax, %rbp ;                                       \
+        movq    %rdx, %rcx ;                                       \
+        movabsq $0x14def9dea2f79cd6, %rax ;                        \
+        mulq    %rbx;                                            \
+        addq    %rax, %rcx ;                                       \
+        adcq    $0x0, %rdx ;                                       \
+        subq    %rbp, m0 ;                                        \
+        sbbq    %rcx, m1 ;                                        \
+        sbbq    %rdx, m2 ;                                        \
+        sbbq    $0x0, m3 ;                                        \
+        sbbq    %rbx, %rbx ;                                       \
+        movabsq $0x5812631a5cf5d3ed, %rax ;                        \
+        andq    %rbx, %rax ;                                       \
+        movabsq $0x14def9dea2f79cd6, %rdx ;                        \
+        andq    %rbx, %rdx ;                                       \
+        movabsq $0x1000000000000000, %rbx ;                        \
+        andq    %rax, %rbx ;                                       \
+        addq    %rax, m0 ;                                        \
+        adcq    %rdx, m1 ;                                        \
+        adcq    $0x0, m2 ;                                        \
+        adcq    %rbx, m3
+
+S2N_BN_SYMBOL(bignum_madd_n25519_alt):
+
+#if WINDOWS_ABI
+        pushq   %rdi
+        pushq   %rsi
+        movq    %rcx, %rdi
+        movq    %rdx, %rsi
+        movq    %r8, %rdx
+        movq    %r9, %rcx
+#endif
+
+// Save some additional registers for use
+
+        pushq   %rbx
+        pushq   %rbp
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// First compute [%r15;%r14;%r13;%r12;%r11;%r10;%r9;%r8] = x * y + c. This inserts
+// some addition terms for c into a core Comba multiplier similar to
+// the start of bignum_mul_p256k1_alt.
+
+        movq    %rdx, %rbp
+        movq    (%rsi), %rax
+        mulq     (%rbp)
+        addq    (%rcx), %rax
+        adcq    $0, %rdx
+        movq    %rax, %r8
+        movq    %rdx, %r9
+        xorq    %r10, %r10
+        xorq    %r11, %r11
+        movq    (%rsi), %rax
+        mulq     0x8(%rbp)
+        addq    8(%rcx), %rax
+        adcq    $0, %rdx
+        addq    %rax, %r9
+        adcq    %rdx, %r10
+        movq    0x8(%rsi), %rax
+        mulq     (%rbp)
+        addq    %rax, %r9
+        adcq    %rdx, %r10
+        adcq    $0x0, %r11
+        xorq    %r12, %r12
+        movq    (%rsi), %rax
+        mulq     0x10(%rbp)
+        addq    16(%rcx), %rax
+        adcq    $0, %rdx
+        addq    %rax, %r10
+        adcq    %rdx, %r11
+        adcq    %r12, %r12
+        movq    0x8(%rsi), %rax
+        mulq     0x8(%rbp)
+        addq    %rax, %r10
+        adcq    %rdx, %r11
+        adcq    $0x0, %r12
+        movq    0x10(%rsi), %rax
+        mulq     (%rbp)
+        addq    %rax, %r10
+        adcq    %rdx, %r11
+        adcq    $0x0, %r12
+        xorq    %r13, %r13
+        movq    (%rsi), %rax
+        mulq     0x18(%rbp)
+        addq    24(%rcx), %rax
+        adcq    $0, %rdx
+        addq    %rax, %r11
+        adcq    %rdx, %r12
+        adcq    %r13, %r13
+        movq    0x8(%rsi), %rax
+        mulq     0x10(%rbp)
+        addq    %rax, %r11
+        adcq    %rdx, %r12
+        adcq    $0x0, %r13
+        movq    0x10(%rsi), %rax
+        mulq     0x8(%rbp)
+        addq    %rax, %r11
+        adcq    %rdx, %r12
+        adcq    $0x0, %r13
+        movq    0x18(%rsi), %rax
+        mulq     (%rbp)
+        addq    %rax, %r11
+        adcq    %rdx, %r12
+        adcq    $0x0, %r13
+        xorq    %r14, %r14
+        movq    0x8(%rsi), %rax
+        mulq     0x18(%rbp)
+        addq    %rax, %r12
+        adcq    %rdx, %r13
+        adcq    %r14, %r14
+        movq    0x10(%rsi), %rax
+        mulq     0x10(%rbp)
+        addq    %rax, %r12
+        adcq    %rdx, %r13
+        adcq    $0x0, %r14
+        movq    0x18(%rsi), %rax
+        mulq     0x8(%rbp)
+        addq    %rax, %r12
+        adcq    %rdx, %r13
+        adcq    $0x0, %r14
+        xorq    %r15, %r15
+        movq    0x10(%rsi), %rax
+        mulq     0x18(%rbp)
+        addq    %rax, %r13
+        adcq    %rdx, %r14
+        adcq    %r15, %r15
+        movq    0x18(%rsi), %rax
+        mulq     0x10(%rbp)
+        addq    %rax, %r13
+        adcq    %rdx, %r14
+        adcq    $0x0, %r15
+        movq    0x18(%rsi), %rax
+        mulq     0x18(%rbp)
+        addq    %rax, %r14
+        adcq    %rdx, %r15
+
+
+// Now do the modular reduction and write back
+
+        reduce0(%r15,%r14,%r13,%r12)
+        reduce(%r15,%r14,%r13,%r12,%r11)
+        reduce(%r14,%r13,%r12,%r11,%r10)
+        reduce(%r13,%r12,%r11,%r10,%r9)
+        reduce(%r12,%r11,%r10,%r9,%r8)
+
+        movq    %r8, (%rdi)
+        movq    %r9, 8(%rdi)
+        movq    %r10, 16(%rdi)
+        movq    %r11, 24(%rdi)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbp
+        popq    %rbx
+
+#if WINDOWS_ABI
+        popq   %rsi
+        popq   %rdi
+#endif
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/third_party/s2n-bignum/x86_att/curve25519/edwards25519_scalarmulbase.S
+++ b/third_party/s2n-bignum/x86_att/curve25519/edwards25519_scalarmulbase.S
@@ -431,7 +431,7 @@ edwards25519_scalarmulbase_standard:
 // (X,Y,Z,T), representing an affine point on the edwards25519 curve
 // (x,y) via x = X/Z, y = Y/Z and x * y = T/Z (so X * Y = T * Z).
 // In comments B means the standard basepoint (x,4/5) =
-// (0x216....f25d51a,0x0x6666..666658).
+// (0x216....f25d51a,0x6666..666658).
 //
 // Initialize accumulator "acc" to either 0 or 2^251 * B depending on
 // bit 251 of the (reduced) scalar. That leaves bits 0..250 to handle.

--- a/third_party/s2n-bignum/x86_att/curve25519/edwards25519_scalarmulbase_alt.S
+++ b/third_party/s2n-bignum/x86_att/curve25519/edwards25519_scalarmulbase_alt.S
@@ -507,7 +507,7 @@ edwards25519_scalarmulbase_alt_standard:
 // (X,Y,Z,T), representing an affine point on the edwards25519 curve
 // (x,y) via x = X/Z, y = Y/Z and x * y = T/Z (so X * Y = T * Z).
 // In comments B means the standard basepoint (x,4/5) =
-// (0x216....f25d51a,0x0x6666..666658).
+// (0x216....f25d51a,0x6666..666658).
 //
 // Initialize accumulator "acc" to either 0 or 2^251 * B depending on
 // bit 251 of the (reduced) scalar. That leaves bits 0..250 to handle.

--- a/third_party/s2n-bignum/x86_att/curve25519/edwards25519_scalarmuldouble.S
+++ b/third_party/s2n-bignum/x86_att/curve25519/edwards25519_scalarmuldouble.S
@@ -1528,7 +1528,7 @@ edwards25519_scalarmuldouble_loop:
 // form amounts to swapping the first two fields and negating the third.
 // The negation does not always fully reduce even mod 2^256-38 in the zero
 // case, instead giving -0 = 2^256-38. But that is fine since the result is
-// always fed to a multipliction inside the "pepadd" function below that
+// always fed to a multiplication inside the "pepadd" function below that
 // handles any 256-bit input.
 
         movq    cf, %rdi
@@ -2072,8 +2072,8 @@ edwards25519_scalarmuldouble_loop:
         movq    %rax, 0x78(%rsp)
         movq    $0xa,  0x90(%rsp)
         movq    $0x1,  0x98(%rsp)
-        jmp     curve25519_x25519_midloop
-curve25519_x25519_inverseloop:
+        jmp     edwards25519_scalarmuldouble_midloop
+edwards25519_scalarmuldouble_inverseloop:
         movq    %r8, %r9
         sarq    $0x3f, %r9
         xorq    %r9, %r8
@@ -2364,7 +2364,7 @@ curve25519_x25519_inverseloop:
         shlq    $0x3f, %rax
         addq    %rax, %rsi
         movq    %rsi, 0x78(%rsp)
-curve25519_x25519_midloop:
+edwards25519_scalarmuldouble_midloop:
         movq    0x98(%rsp), %rsi
         movq    (%rsp), %rdx
         movq    0x20(%rsp), %rcx
@@ -3265,7 +3265,7 @@ curve25519_x25519_midloop:
         leaq    (%rax,%rdx), %r12
         movq    %rsi, 0x98(%rsp)
         decq     0x90(%rsp)
-        jne     curve25519_x25519_inverseloop
+        jne     edwards25519_scalarmuldouble_inverseloop
         movq    (%rsp), %rax
         movq    0x20(%rsp), %rcx
         imulq   %r8, %rax

--- a/third_party/s2n-bignum/x86_att/curve25519/edwards25519_scalarmuldouble_alt.S
+++ b/third_party/s2n-bignum/x86_att/curve25519/edwards25519_scalarmuldouble_alt.S
@@ -1645,7 +1645,7 @@ edwards25519_scalarmuldouble_alt_loop:
 // form amounts to swapping the first two fields and negating the third.
 // The negation does not always fully reduce even mod 2^256-38 in the zero
 // case, instead giving -0 = 2^256-38. But that is fine since the result is
-// always fed to a multipliction inside the "pepadd" function below that
+// always fed to a multiplication inside the "pepadd" function below that
 // handles any 256-bit input.
 
         movq    cf, %rdi
@@ -2189,8 +2189,8 @@ edwards25519_scalarmuldouble_alt_loop:
         movq    %rax, 0x78(%rsp)
         movq    $0xa,  0x90(%rsp)
         movq    $0x1,  0x98(%rsp)
-        jmp     curve25519_x25519_midloop
-curve25519_x25519_inverseloop:
+        jmp     edwards25519_scalarmuldouble_alt_midloop
+edwards25519_scalarmuldouble_alt_inverseloop:
         movq    %r8, %r9
         sarq    $0x3f, %r9
         xorq    %r9, %r8
@@ -2481,7 +2481,7 @@ curve25519_x25519_inverseloop:
         shlq    $0x3f, %rax
         addq    %rax, %rsi
         movq    %rsi, 0x78(%rsp)
-curve25519_x25519_midloop:
+edwards25519_scalarmuldouble_alt_midloop:
         movq    0x98(%rsp), %rsi
         movq    (%rsp), %rdx
         movq    0x20(%rsp), %rcx
@@ -3382,7 +3382,7 @@ curve25519_x25519_midloop:
         leaq    (%rax,%rdx), %r12
         movq    %rsi, 0x98(%rsp)
         decq     0x90(%rsp)
-        jne     curve25519_x25519_inverseloop
+        jne     edwards25519_scalarmuldouble_alt_inverseloop
         movq    (%rsp), %rax
         movq    0x20(%rsp), %rcx
         imulq   %r8, %rax


### PR DESCRIPTION
### Description of changes: 

Pull in the latest changes from s2n-bignum:
* Add missing files that I missed in https://github.com/aws/aws-lc/pull/1308
* Resolve duplicate labels
* Some typo fixes

The commands in the internal Quip document was used, with PATHS_TO_KEEP defined as follows:
```
PATHS_TO_KEEP="\
./arm/p384 ./x86_att/p384 ./arm/p521 ./x86_att/p521 \
./arm/fastmul/bignum_emontredc_8n.S \
./arm/fastmul/bignum_kmul_16_32.S \
./arm/fastmul/bignum_kmul_32_64.S \
./arm/fastmul/bignum_ksqr_16_32.S \
./arm/fastmul/bignum_ksqr_32_64.S \
./arm/generic/bignum_ge.S \
./arm/generic/bignum_mul.S \
./arm/generic/bignum_optsub.S \
./arm/generic/bignum_sqr.S \
./x86_att/curve25519/curve25519_x25519.S \
./x86_att/curve25519/curve25519_x25519base.S \
./x86_att/curve25519/curve25519_x25519_alt.S \
./x86_att/curve25519/curve25519_x25519base_alt.S  \
./x86_att/curve25519/bignum_neg_p25519.S \
./x86_att/curve25519/bignum_mod_n25519.S  \
./x86_att/curve25519/bignum_madd_n25519.S \
./x86_att/curve25519/bignum_madd_n25519_alt.S \
./x86_att/curve25519/edwards25519_decode.S  \
./x86_att/curve25519/edwards25519_decode_alt.S  \
./x86_att/curve25519/edwards25519_encode.S  \
./x86_att/curve25519/edwards25519_scalarmulbase.S  \
./x86_att/curve25519/edwards25519_scalarmulbase_alt.S  \
./x86_att/curve25519/edwards25519_scalarmuldouble.S  \
./x86_att/curve25519/edwards25519_scalarmuldouble_alt.S  \
./arm/curve25519/curve25519_x25519.S \
./arm/curve25519/curve25519_x25519base.S \
./arm/curve25519/curve25519_x25519_alt.S \
./arm/curve25519/curve25519_x25519base_alt.S \
./arm/curve25519/curve25519_x25519_byte.S \
./arm/curve25519/curve25519_x25519base_byte.S \
./arm/curve25519/curve25519_x25519_byte_alt.S \
./arm/curve25519/curve25519_x25519base_byte_alt.S \
./arm/curve25519/bignum_neg_p25519.S \
./arm/curve25519/bignum_mod_n25519.S  \
./arm/curve25519/bignum_madd_n25519.S \
./arm/curve25519/bignum_madd_n25519_alt.S \
./arm/curve25519/edwards25519_decode.S  \
./arm/curve25519/edwards25519_decode_alt.S  \
./arm/curve25519/edwards25519_encode.S  \
./arm/curve25519/edwards25519_scalarmulbase.S  \
./arm/curve25519/edwards25519_scalarmulbase_alt.S  \
./arm/curve25519/edwards25519_scalarmuldouble.S  \
./arm/curve25519/edwards25519_scalarmuldouble_alt.S \
./include/_internal_s2n_bignum.h"
```

### Call-outs:

Resolved two merge conflicts in files that had the duplicated files. Just modified the merge strategy to "theirs" using "-X theirs". That is:
```
git merge -s subtree -Xsubtree="third_party/s2n-bignum" -X theirs s2n-bignum-${TODAY} --allow-unrelated-histories 
```

Info
```
TODAY=2023-11-19
branch: aws-lc-s2n-bignum-update-2023-11-19
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
