### PR TITLE
Allow 0 byte read/write in SSL_{read,write}_ex

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -375,7 +375,7 @@ OPENSSL_EXPORT int SSL_read(SSL *ssl, void *buf, int num);
 // SSL_read_ex reads up to |num| bytes from |ssl| into |buf|. It is similar to
 // |SSL_read|, but instead of returning the number of bytes read, it returns
 // 1 on success or 0 for failure. The number of bytes actually read is stored in
-// |read_bytes|. SSL_read_ex() can be called with num=0, but will not read
+// |read_bytes|. |SSL_read_ex| can be called with |num| set as 0, but will not read
 // application data from the peer.
 
 //

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -375,7 +375,9 @@ OPENSSL_EXPORT int SSL_read(SSL *ssl, void *buf, int num);
 // SSL_read_ex reads up to |num| bytes from |ssl| into |buf|. It is similar to
 // |SSL_read|, but instead of returning the number of bytes read, it returns
 // 1 on success or 0 for failure. The number of bytes actually read is stored in
-// |read_bytes|.
+// |read_bytes|. SSL_read_ex() can be called with num=0, but will not read
+// application data from the peer.
+
 //
 // This is only maintained for OpenSSL compatibility. Use |SSL_read| instead.
 OPENSSL_EXPORT int SSL_read_ex(SSL *ssl, void *buf, size_t num,
@@ -449,7 +451,9 @@ OPENSSL_EXPORT int SSL_write(SSL *ssl, const void *buf, int num);
 // SSL_write_ex writes up to |num| bytes from |buf| into |ssl|. It is similar to
 // |SSL_write|, but instead of returning the number of bytes written, it returns
 // 1 on success or 0 for failure. The number bytes actually written is stored in
-// |written|.
+// |written|. SSL_write_ex() can be called with num=0, but will not send
+// application data to the peer.
+
 //
 // This is only maintained for OpenSSL compatibility. Use |SSL_write| instead.
 OPENSSL_EXPORT int SSL_write_ex(SSL *s, const void *buf, size_t num,

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -451,7 +451,7 @@ OPENSSL_EXPORT int SSL_write(SSL *ssl, const void *buf, int num);
 // SSL_write_ex writes up to |num| bytes from |buf| into |ssl|. It is similar to
 // |SSL_write|, but instead of returning the number of bytes written, it returns
 // 1 on success or 0 for failure. The number bytes actually written is stored in
-// |written|. SSL_write_ex() can be called with num=0, but will not send
+// |written|. |SSL_write_ex| can be called with |num| set as 0, but will not send
 // application data to the peer.
 
 //

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1026,7 +1026,7 @@ static int ssl_read_impl(SSL *ssl) {
 }
 
 int SSL_read_ex(SSL *ssl, void *buf, size_t num, size_t *read_bytes) {
-  if (num == 0) {
+  if (num == 0 && read_bytes != nullptr) {
     *read_bytes = 0;
     return 1;
   }
@@ -1123,7 +1123,7 @@ int SSL_write(SSL *ssl, const void *buf, int num) {
 }
 
 int SSL_write_ex(SSL *ssl, const void *buf, size_t num, size_t *written) {
-  if (num == 0) {
+  if (num == 0 && written != nullptr) {
     *written = 0;
     return 1;
   }

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1026,6 +1026,10 @@ static int ssl_read_impl(SSL *ssl) {
 }
 
 int SSL_read_ex(SSL *ssl, void *buf, size_t num, size_t *read_bytes) {
+  if (num == 0) {
+    *read_bytes = 0;
+    return 1;
+  }
   int ret = SSL_read(ssl, buf, (int)num);
   if (ret <= 0) {
     return 0;
@@ -1119,6 +1123,10 @@ int SSL_write(SSL *ssl, const void *buf, int num) {
 }
 
 int SSL_write_ex(SSL *ssl, const void *buf, size_t num, size_t *written) {
+  if (num == 0) {
+    *written = 0;
+    return 1;
+  }
   int ret = SSL_write(ssl, buf, (int)num);
   if (ret <= 0) {
     return 0;

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -6510,6 +6510,15 @@ TEST_P(SSLVersionTest, SSLPendingEx) {
   ASSERT_EQ(buf_len, (size_t)2);
   EXPECT_EQ(3, SSL_pending(client_.get()));
   EXPECT_EQ(1, SSL_has_pending(client_.get()));
+
+  // 0-sized IO should succeed but not read/write nor effect buffer state
+  const int client_pending = SSL_pending(client_.get());
+  ASSERT_EQ(1, SSL_read_ex(client_.get(), (void *)"", 0, &buf_len));
+  ASSERT_EQ(0UL, buf_len);
+  ASSERT_EQ(client_pending, SSL_pending(client_.get()));
+  ASSERT_EQ(1, SSL_write_ex(client_.get(), (void *)"", 0, &buf_len));
+  ASSERT_EQ(0UL, buf_len);
+  ASSERT_EQ(client_pending, SSL_pending(client_.get()));
 }
 
 // Test that post-handshake tickets consumed by |SSL_shutdown| are ignored.

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -6511,8 +6511,8 @@ TEST_P(SSLVersionTest, SSLPendingEx) {
   EXPECT_EQ(3, SSL_pending(client_.get()));
   EXPECT_EQ(1, SSL_has_pending(client_.get()));
 
-  // 0-sized IO with valied inputs should succeed but not read/write nor effect
-  // buffer state. However, NULL outlen pointer should fail.
+  // 0-sized IO with valid inputs should succeed but not read/write nor effect
+  // buffer state. However, NULL |read_bytes|/|written| pointer should fail.
   const int client_pending = SSL_pending(client_.get());
   ASSERT_EQ(1, SSL_read_ex(client_.get(), (void *)"", 0, &buf_len));
   ASSERT_EQ(0UL, buf_len);

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -6511,7 +6511,8 @@ TEST_P(SSLVersionTest, SSLPendingEx) {
   EXPECT_EQ(3, SSL_pending(client_.get()));
   EXPECT_EQ(1, SSL_has_pending(client_.get()));
 
-  // 0-sized IO should succeed but not read/write nor effect buffer state
+  // 0-sized IO with valied inputs should succeed but not read/write nor effect
+  // buffer state. However, NULL outlen pointer should fail.
   const int client_pending = SSL_pending(client_.get());
   ASSERT_EQ(1, SSL_read_ex(client_.get(), (void *)"", 0, &buf_len));
   ASSERT_EQ(0UL, buf_len);
@@ -6519,6 +6520,8 @@ TEST_P(SSLVersionTest, SSLPendingEx) {
   ASSERT_EQ(1, SSL_write_ex(client_.get(), (void *)"", 0, &buf_len));
   ASSERT_EQ(0UL, buf_len);
   ASSERT_EQ(client_pending, SSL_pending(client_.get()));
+  ASSERT_EQ(0, SSL_read_ex(client_.get(), (void *)"", 0, nullptr));
+  ASSERT_EQ(0, SSL_write_ex(client_.get(), (void *)"", 0, nullptr));
 }
 
 // Test that post-handshake tickets consumed by |SSL_shutdown| are ignored.


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-2136

### Description of changes: 

The primary motivation of this change is to match OpenSSL's behavior for these functions. Relevant links:

- [SSL_read_ex docs][1]
- [SSL_write_ex docs][2]
- [CPython update accounting for this behavior][3]

[1]: https://www.openssl.org/docs/man1.1.1/man3/SSL_read_ex.html
[2]: https://www.openssl.org/docs/man1.1.1/man3/SSL_write_ex.html
[3]: https://github.com/python/cpython/issues/75892#issuecomment-1093761352

### Call-outs:
- n/a

### Testing:
- CI checks
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
