### PR TITLE
Add support and CI for building with librelp

### DIFF
--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -354,6 +354,8 @@ void BIO_clear_retry_flags(BIO *bio) {
 
 int BIO_method_type(const BIO *bio) { return bio->method->type; }
 
+const char *BIO_method_name(const BIO *bio) { return bio->method->name; }
+
 void BIO_copy_next_retry(BIO *bio) {
   BIO_clear_retry_flags(bio);
   BIO_set_flags(bio, BIO_get_retry_flags(bio->next_bio));

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -132,6 +132,7 @@ TEST(BIOTest, Printf) {
 
   bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
   ASSERT_TRUE(bio);
+  ASSERT_EQ(strcmp(BIO_method_name(bio.get()), "memory buffer"), 0);
 
   for (size_t length : kLengths) {
     SCOPED_TRACE(length);

--- a/crypto/engine/engine.c
+++ b/crypto/engine/engine.c
@@ -97,3 +97,5 @@ void METHOD_unref(void *method_in) {
 }
 
 OPENSSL_DECLARE_ERROR_REASON(ENGINE, OPERATION_NOT_SUPPORTED)
+
+void ENGINE_cleanup(void) {}

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -232,6 +232,9 @@ OPENSSL_EXPORT void BIO_clear_retry_flags(BIO *bio);
 // values.
 OPENSSL_EXPORT int BIO_method_type(const BIO *bio);
 
+// BIO_method_name returns the name of |bio|.
+OPENSSL_EXPORT const char *BIO_method_name(const BIO *b);
+
 // These are passed to the BIO callback
 #define BIO_CB_FREE 0x01
 #define BIO_CB_READ 0x02

--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -79,6 +79,13 @@ void METHOD_ref(void *method);
 void METHOD_unref(void *method);
 
 
+// Deprecated functions.
+
+// ENGINE_cleanup does nothing. This has been deprecated since OpenSSL 1.1.0 and
+// applications should not rely on it.
+OPENSSL_EXPORT void ENGINE_cleanup(void);
+
+
 // Private functions.
 
 // openssl_method_common_st contains the common part of all method structures.

--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -186,3 +186,13 @@ batch:
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_monit_integration.sh"
+
+    - identifier: librelp_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_SMALL
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_librelp_integration.sh"

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
@@ -35,6 +35,7 @@ RUN set -ex && \
     libunwind-dev \
     pkg-config \
     git \
+    gnutls-dev \
     ca-certificates \
     wget \
     lld \

--- a/tests/ci/integration/librelp_patch/aws-lc-librelp.patch
+++ b/tests/ci/integration/librelp_patch/aws-lc-librelp.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tcp.c b/src/tcp.c
-index 18cffda..3d8aa05 100644
+index 18cffda..110fcd0 100644
 --- a/src/tcp.c
 +++ b/src/tcp.c
 @@ -276,7 +276,7 @@ int opensslh_THREAD_cleanup(void)
@@ -11,7 +11,7 @@ index 18cffda..3d8aa05 100644
  long BIO_debug_callback_ex(BIO *bio, int cmd, const char LIBRELP_ATTR_UNUSED *argp,
  			   size_t LIBRELP_ATTR_UNUSED len, int argi, long LIBRELP_ATTR_UNUSED argl,
  			   int ret, size_t LIBRELP_ATTR_UNUSED *processed)
-@@ -1230,10 +1230,17 @@ relpTcpTLSSetPrio_ossl(relpTcp_t *const pThis)
+@@ -1230,10 +1230,18 @@ relpTcpTLSSetPrio_ossl(relpTcp_t *const pThis)
  {
  	char pristringBuf[4096];
  	char *pristring;
@@ -24,12 +24,13 @@ index 18cffda..3d8aa05 100644
 +			snprintf(errmsg, sizeof(errmsg),
 +				"Warning: AWS-LC does not support anonymous ciphersuites.");
 +			callOnErr(pThis, errmsg, RELP_RET_ERR_TLS);
++			ABORT_FINALIZE(RELP_RET_ERR_TLS_SETUP);
 +			#endif
 +
  			#if OPENSSL_VERSION_NUMBER >= 0x10100000L \
  				&& !defined(LIBRESSL_VERSION_NUMBER)
  			 /* NOTE: do never use: +eNULL, it DISABLES encryption! */
-@@ -1362,7 +1369,7 @@ relpTcpInitTLS(relpTcp_t *const pThis)
+@@ -1362,7 +1370,7 @@ relpTcpInitTLS(relpTcp_t *const pThis)
  
  	/* Load readable error strings */
  	SSL_load_error_strings();
@@ -38,7 +39,7 @@ index 18cffda..3d8aa05 100644
  	/*
  	* ERR_load_*(), ERR_func_error_string(), ERR_get_error_line(), ERR_get_error_line_data(), ERR_get_state()
  	* OpenSSL now loads error strings automatically so these functions are not needed.
-@@ -1660,7 +1667,7 @@ relpTcpSetSslConfCmd_ossl(relpTcp_t *const pThis, char *tlsConfigCmd)
+@@ -1660,7 +1668,7 @@ relpTcpSetSslConfCmd_ossl(relpTcp_t *const pThis, char *tlsConfigCmd)
  	} else {
  		pThis->pEngine->dbgprint((char*)"relpTcpSetSslConfCmd_ossl: set to '%s'\n", tlsConfigCmd);
  		char errmsg[1424];
@@ -47,7 +48,7 @@ index 18cffda..3d8aa05 100644
  		char *pCurrentPos;
  		char *pNextPos;
  		char *pszCmd;
-@@ -1803,7 +1810,7 @@ relpTcpAcceptConnReqInitTLS_ossl(relpTcp_t *const pThis, relpSrv_t *const pSrv)
+@@ -1803,7 +1811,7 @@ relpTcpAcceptConnReqInitTLS_ossl(relpTcp_t *const pThis, relpSrv_t *const pSrv)
  	pThis->pEngine->dbgprint((char*)"relpTcpAcceptConnReqInitTLS_ossl: Init client BIO[%p] done\n", (void *)client);
  
  	/* Set debug Callback for client BIO as well! */
@@ -56,7 +57,7 @@ index 18cffda..3d8aa05 100644
  	BIO_set_callback_ex(client, BIO_debug_callback_ex);
  #else
  	BIO_set_callback(client, BIO_debug_callback);
-@@ -1909,7 +1916,7 @@ relpTcpConnectTLSInit_ossl(relpTcp_t *const pThis)
+@@ -1909,7 +1917,7 @@ relpTcpConnectTLSInit_ossl(relpTcp_t *const pThis)
  	pThis->pEngine->dbgprint((char*)"relpTcpConnectTLSInit: Init conn BIO[%p] done\n", (void *)conn);
  
  	/* Set debug Callback for client BIO as well! */

--- a/tests/ci/integration/librelp_patch/aws-lc-librelp.patch
+++ b/tests/ci/integration/librelp_patch/aws-lc-librelp.patch
@@ -1,0 +1,96 @@
+diff --git a/src/tcp.c b/src/tcp.c
+index 18cffda..3d8aa05 100644
+--- a/src/tcp.c
++++ b/src/tcp.c
+@@ -276,7 +276,7 @@ int opensslh_THREAD_cleanup(void)
+  * alorbach, 2018-06-11
+  */
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ long BIO_debug_callback_ex(BIO *bio, int cmd, const char LIBRELP_ATTR_UNUSED *argp,
+ 			   size_t LIBRELP_ATTR_UNUSED len, int argi, long LIBRELP_ATTR_UNUSED argl,
+ 			   int ret, size_t LIBRELP_ATTR_UNUSED *processed)
+@@ -1230,10 +1230,17 @@ relpTcpTLSSetPrio_ossl(relpTcp_t *const pThis)
+ {
+ 	char pristringBuf[4096];
+ 	char *pristring;
++	char errmsg[1024];
+ 	ENTER_RELPFUNC;
+ 	/* Compute priority string (in simple cases where the user does not care...) */
+ 	if(pThis->pristring == NULL) {
+ 		if (pThis->authmode == eRelpAuthMode_None) {
++			#if defined(OPENSSL_IS_AWSLC)
++			snprintf(errmsg, sizeof(errmsg),
++				"Warning: AWS-LC does not support anonymous ciphersuites.");
++			callOnErr(pThis, errmsg, RELP_RET_ERR_TLS);
++			#endif
++
+ 			#if OPENSSL_VERSION_NUMBER >= 0x10100000L \
+ 				&& !defined(LIBRESSL_VERSION_NUMBER)
+ 			 /* NOTE: do never use: +eNULL, it DISABLES encryption! */
+@@ -1362,7 +1369,7 @@ relpTcpInitTLS(relpTcp_t *const pThis)
+ 
+ 	/* Load readable error strings */
+ 	SSL_load_error_strings();
+-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 	/*
+ 	* ERR_load_*(), ERR_func_error_string(), ERR_get_error_line(), ERR_get_error_line_data(), ERR_get_state()
+ 	* OpenSSL now loads error strings automatically so these functions are not needed.
+@@ -1660,7 +1667,7 @@ relpTcpSetSslConfCmd_ossl(relpTcp_t *const pThis, char *tlsConfigCmd)
+ 	} else {
+ 		pThis->pEngine->dbgprint((char*)"relpTcpSetSslConfCmd_ossl: set to '%s'\n", tlsConfigCmd);
+ 		char errmsg[1424];
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_AWSLC)
+ 		char *pCurrentPos;
+ 		char *pNextPos;
+ 		char *pszCmd;
+@@ -1803,7 +1810,7 @@ relpTcpAcceptConnReqInitTLS_ossl(relpTcp_t *const pThis, relpSrv_t *const pSrv)
+ 	pThis->pEngine->dbgprint((char*)"relpTcpAcceptConnReqInitTLS_ossl: Init client BIO[%p] done\n", (void *)client);
+ 
+ 	/* Set debug Callback for client BIO as well! */
+-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 	BIO_set_callback_ex(client, BIO_debug_callback_ex);
+ #else
+ 	BIO_set_callback(client, BIO_debug_callback);
+@@ -1909,7 +1916,7 @@ relpTcpConnectTLSInit_ossl(relpTcp_t *const pThis)
+ 	pThis->pEngine->dbgprint((char*)"relpTcpConnectTLSInit: Init conn BIO[%p] done\n", (void *)conn);
+ 
+ 	/* Set debug Callback for client BIO as well! */
+-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 	BIO_set_callback_ex(conn, BIO_debug_callback_ex);
+ #else
+ 	BIO_set_callback(conn, BIO_debug_callback);
+diff --git a/tests/tls-basic-anon.sh b/tests/tls-basic-anon.sh
+index 32b6682..fa1f327 100755
+--- a/tests/tls-basic-anon.sh
++++ b/tests/tls-basic-anon.sh
+@@ -14,6 +14,13 @@ function actual_test() {
+ 		printf "\nDEBUG: content of ${OUTFILE}\n"
+ 		cat $FILE_TO_CHECK
+ 
++		terminate
++		exit 77;
++	elif check_output_only "AWS-LC does not support anonymous ciphersuites"; then
++		printf "\nSKIP: AWS-LC does not support anonymous ciphersuites.\n"
++		printf "\nDEBUG: content of ${OUTFILE}\n"
++		cat $FILE_TO_CHECK
++
+ 		terminate
+ 		exit 77; 
+ 	fi
+diff --git a/tests/tls-wrong-signedcert.sh b/tests/tls-wrong-signedcert.sh
+index 81b5390..3dd8d69 100755
+--- a/tests/tls-wrong-signedcert.sh
++++ b/tests/tls-wrong-signedcert.sh
+@@ -9,5 +9,5 @@ echo 'Send Message...'
+ 
+ stop_receiver
+ # Perform multiline GREP with -z
+-check_output "authentication error.*signed certificate in certificate chain" $TESTDIR/$errorlog -z
++check_output "authentication error.*signed certificate in certificate chain\|authentication error.*unable to get local issuer certificate" $TESTDIR/$errorlog -z
+ terminate

--- a/tests/ci/integration/run_librelp_integration.sh
+++ b/tests/ci/integration/run_librelp_integration.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -exu
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# SYS_ROOT
+#  - SRC_ROOT(aws-lc)
+#    - SCRATCH_FOLDER
+#      - librelp
+#      - AWS_LC_BUILD_FOLDER
+#      - AWS_LC_INSTALL_FOLDER
+#      - LIBRELP_BUILD_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER="${SRC_ROOT}/LIBRELP_BUILD_ROOT"
+LIBRELP_SRC_FOLDER="${SCRATCH_FOLDER}/librelp"
+LIBRELP_BUILD_FOLDER="${SCRATCH_FOLDER}/librelp-aws-lc"
+LIBRELP_PATCH_BUILD_FOLDER="${SRC_ROOT}/tests/ci/integration/librelp_patch"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+
+function librelp_build() {
+  autoreconf -fi  
+  PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig" ./configure --enable-tls-openssl --enable-debug
+  make -j ${NUM_CPU_THREADS}
+}
+
+function librelp_run_tests() {
+  make check
+}
+
+# TODO: Remove this when we make an upstream contribution.
+function librelp_patch_build() {
+  for patchfile in $(find -L "${LIBRELP_PATCH_BUILD_FOLDER}" -type f -name '*.patch'); do
+    echo "Apply patch $patchfile..."
+    patch -p1 --quiet -i "$patchfile"
+  done
+}
+
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf ${SCRATCH_FOLDER}/*
+cd ${SCRATCH_FOLDER}
+
+git clone https://github.com/rsyslog/librelp.git ${LIBRELP_SRC_FOLDER} --depth 1
+mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${LIBRELP_BUILD_FOLDER}
+ls
+
+aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_TESTING=OFF
+
+# Build librelp from source.
+pushd ${LIBRELP_SRC_FOLDER}
+
+librelp_patch_build
+librelp_build
+librelp_run_tests
+
+popd
+

--- a/tests/ci/integration/run_librelp_integration.sh
+++ b/tests/ci/integration/run_librelp_integration.sh
@@ -24,11 +24,12 @@ AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
 
 function librelp_build() {
   autoreconf -fi  
-  PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig" ./configure --enable-tls-openssl --enable-debug
+  PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig" ./configure --enable-tls-openssl
   make -j ${NUM_CPU_THREADS}
 }
 
 function librelp_run_tests() {
+  export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib"
   make check
 }
 
@@ -48,7 +49,7 @@ git clone https://github.com/rsyslog/librelp.git ${LIBRELP_SRC_FOLDER} --depth 1
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${LIBRELP_BUILD_FOLDER}
 ls
 
-aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_TESTING=OFF
+aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=1
 
 # Build librelp from source.
 pushd ${LIBRELP_SRC_FOLDER}
@@ -59,3 +60,5 @@ librelp_run_tests
 
 popd
 
+ldd "${LIBRELP_SRC_FOLDER}/src/.libs/librelp.so" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
+ldd "${LIBRELP_SRC_FOLDER}/src/.libs/librelp.so" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libssl.so" || exit 1


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2165`

### Description of changes: 
librelp relies on some ancient symbols that we can easily expose as no-ops. For certain symbols like `SSL_CONF` and `BIO_set_callback` we can leverage the existing ifdefs from LibreSSL.
There are two test failures that occur when enabling AWS-LC with librelp.
1. `tls-basic-anon`: Uses anonymous ciphersuites (DH or ECDH) that don't need certificates for authentication. AWS-LC does not support this behavior, so I've added an error message in the patch to indicate so.
2. `tls-wrong-signedcert.sh `: expects a specifc error message from OpenSSL. I've added AWS-LC's error message as a pattern.


### Call-outs:
N/A

### Testing:
New CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
