### PR TITLE
Log symbol name for fips scope assertion error

### DIFF
--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -164,7 +164,7 @@ extern const uint8_t BORINGSSL_bcm_rodata_end[];
 // bounds of the integrity check. It checks that start <= symbol < end and
 // aborts otherwise.
 static void assert_within(const void *start, const void *symbol,
-                          const void *end) {
+                          const char *symbol_name, const void *end) {
   const uintptr_t start_val = (uintptr_t) start;
   const uintptr_t symbol_val = (uintptr_t) symbol;
   const uintptr_t end_val = (uintptr_t) end;
@@ -175,13 +175,13 @@ static void assert_within(const void *start, const void *symbol,
 
   fprintf(
       stderr,
-      "FIPS module doesn't span expected symbol. Expected %p <= %p < %p\n",
-      start, symbol, end);
+      "FIPS module doesn't span expected symbol (%s). Expected %p <= %p < %p\n",
+      symbol_name, start, symbol, end);
   BORINGSSL_FIPS_abort();
 }
 
 static void assert_not_within(const void *start, const void *symbol,
-                          const void *end) {
+                          const char *symbol_name, const void *end) {
   const uintptr_t start_val = (uintptr_t) start;
   const uintptr_t symbol_val = (uintptr_t) symbol;
   const uintptr_t end_val = (uintptr_t) end;
@@ -192,8 +192,8 @@ static void assert_not_within(const void *start, const void *symbol,
 
   fprintf(
       stderr,
-      "FIPS module spans unexpected symbol, expected %p < %p || %p > %p\n",
-      symbol, start, symbol, end);
+      "FIPS module spans unexpected symbol (%s), expected %p < %p || %p > %p\n",
+      symbol_name, symbol, start, symbol, end);
   BORINGSSL_FIPS_abort();
 }
 
@@ -265,19 +265,19 @@ int BORINGSSL_integrity_test(void) {
   const uint8_t *const start = BORINGSSL_bcm_text_start;
   const uint8_t *const end = BORINGSSL_bcm_text_end;
 
-  assert_within(start, AES_encrypt, end);
-  assert_within(start, RSA_sign, end);
-  assert_within(start, RAND_bytes, end);
-  assert_within(start, EC_GROUP_cmp, end);
-  assert_within(start, SHA256_Update, end);
-  assert_within(start, ECDSA_do_verify, end);
-  assert_within(start, EVP_AEAD_CTX_seal, end);
-  assert_not_within(start, OPENSSL_cleanse, end);
-  assert_not_within(start, CRYPTO_chacha_20, end);
+  assert_within(start, AES_encrypt, "AES_encrypt", end);
+  assert_within(start, RSA_sign, "RSA_sign", end);
+  assert_within(start, RAND_bytes, "RAND_bytes", end);
+  assert_within(start, EC_GROUP_cmp, "EC_GROUP_cmp", end);
+  assert_within(start, SHA256_Update, "SHA256_Update", end);
+  assert_within(start, ECDSA_do_verify, "ECDSA_do_verify", end);
+  assert_within(start, EVP_AEAD_CTX_seal, "EVP_AEAD_CTX_seal", end);
+  assert_not_within(start, OPENSSL_cleanse, "OPENSSL_cleanse", end);
+  assert_not_within(start, CRYPTO_chacha_20, "CRYPTO_chacha_20", end);
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
-  assert_not_within(start, OPENSSL_ia32cap_P, end);
+  assert_not_within(start, OPENSSL_ia32cap_P, "OPENSSL_ia32cap_P", end);
 #elif defined(OPENSSL_AARCH64)
-  assert_not_within(start, &OPENSSL_armcap_P, end);
+  assert_not_within(start, &OPENSSL_armcap_P, "OPENSSL_armcap_P", end);
 #endif
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
@@ -289,13 +289,13 @@ int BORINGSSL_integrity_test(void) {
   const uint8_t *const rodata_end = BORINGSSL_bcm_text_end;
 #endif
 
-  assert_within(rodata_start, kPrimes, rodata_end);
-  assert_within(rodata_start, kP256Params, rodata_end);
-  assert_within(rodata_start, kPKCS1SigPrefixes, rodata_end);
+  assert_within(rodata_start, kPrimes, "kPrimes", rodata_end);
+  assert_within(rodata_start, kP256Params, "kP256Params", rodata_end);
+  assert_within(rodata_start, kPKCS1SigPrefixes, "kPKCS1SigPrefixes", rodata_end);
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
-  assert_not_within(rodata_start, OPENSSL_ia32cap_P, rodata_end);
+  assert_not_within(rodata_start, OPENSSL_ia32cap_P, "OPENSSL_ia32cap_P", rodata_end);
 #elif defined(OPENSSL_AARCH64)
-  assert_not_within(rodata_start, &OPENSSL_armcap_P, rodata_end);
+  assert_not_within(rodata_start, &OPENSSL_armcap_P, "OPENSSL_armcap_P", rodata_end);
 #endif
 
   // Per FIPS 140-3 we have to perform the CAST of the HMAC used for integrity


### PR DESCRIPTION
### Description of changes: 

Improve logging for FIPS scope assertions. Avoid having to manually instrument the build to reverse engineer which symbol failed the assertion.

### Call-outs:

Originally, I refactored everything, generalised function and created a table of symbols that can then be asserted in a loop. But I forgot that this creates data sections in the module and I would have needed to use the delocater macro's to initialise everything lazily. Tooo much hazzle, so I reverted to just expanding the current functions.

AFAIK it's not really possible to compute the symbol/function name from just a symbol/function pointer. So, we have to add the extra string name argument to functions. At least, not without digging into non-portable methods. 

### Testing:

Manually imposed an error, yielding:
```
$ ./tool/bssl version
FIPS module doesn't span expected symbol (ECDSA_do_verify). Expected 0x4ec000 <= 0x526230 < (nil)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
