### PR TITLE
Add null-check for input args in SSL_{read|write}_ex

### DIFF
--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1026,7 +1026,10 @@ static int ssl_read_impl(SSL *ssl) {
 }
 
 int SSL_read_ex(SSL *ssl, void *buf, size_t num, size_t *read_bytes) {
-  if (num == 0 && read_bytes != nullptr) {
+  if (read_bytes == nullptr) {
+    return 0;
+  }
+  if (num == 0) {
     *read_bytes = 0;
     return 1;
   }
@@ -1123,7 +1126,10 @@ int SSL_write(SSL *ssl, const void *buf, int num) {
 }
 
 int SSL_write_ex(SSL *ssl, const void *buf, size_t num, size_t *written) {
-  if (num == 0 && written != nullptr) {
+  if (written == nullptr) {
+    return 0;
+  }
+  if (num == 0) {
     *written = 0;
     return 1;
   }

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1026,10 +1026,7 @@ static int ssl_read_impl(SSL *ssl) {
 }
 
 int SSL_read_ex(SSL *ssl, void *buf, size_t num, size_t *read_bytes) {
-  if (read_bytes == nullptr) {
-    return 0;
-  }
-  if (num == 0) {
+  if (num == 0 && read_bytes != nullptr) {
     *read_bytes = 0;
     return 1;
   }
@@ -1037,7 +1034,9 @@ int SSL_read_ex(SSL *ssl, void *buf, size_t num, size_t *read_bytes) {
   if (ret <= 0) {
     return 0;
   }
-  *read_bytes = ret;
+  if (read_bytes != nullptr) {
+    *read_bytes = ret;
+  }
   return 1;
 }
 
@@ -1126,10 +1125,7 @@ int SSL_write(SSL *ssl, const void *buf, int num) {
 }
 
 int SSL_write_ex(SSL *ssl, const void *buf, size_t num, size_t *written) {
-  if (written == nullptr) {
-    return 0;
-  }
-  if (num == 0) {
+  if (num == 0 && written != nullptr) {
     *written = 0;
     return 1;
   }
@@ -1137,7 +1133,9 @@ int SSL_write_ex(SSL *ssl, const void *buf, size_t num, size_t *written) {
   if (ret <= 0) {
     return 0;
   }
-  *written = ret;
+  if (written != nullptr) {
+    *written = ret;
+  }
   return 1;
 }
 


### PR DESCRIPTION
### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Add null-check for input args in SSL_{read|write}_ex to avoid potentially dereferencing nullptr.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
