### PR TITLE
Prepare release 1.18.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4276,7 +4276,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.17.4");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.18.0");
 }
 
 #else
@@ -4319,6 +4319,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.17.4");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.18.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.17.4"
+#define AWSLC_VERSION_NUMBER_STRING "1.18.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION

### Description of changes: 
* Prepare release 1.18.0.

#### Changes for release
* Upstream merge 2023-11-20 by @torben-hansen in https://github.com/aws/aws-lc/pull/1315
* Wire up s2n-bignum Ed25519 backend by @torben-hansen in https://github.com/aws/aws-lc/pull/1309
* Allow 0 byte read/write in SSL_{read,write}_ex by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1316
* Increment session hit counter for ticket resumptions by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1320
* Add back SSL_use_certificate_chain_file by @samuel40791765 in https://github.com/aws/aws-lc/pull/1312
* Log symbol name for fips scope assertion error by @torben-hansen in https://github.com/aws/aws-lc/pull/1321
* Add support for building with pkgconfig by @samuel40791765 in https://github.com/aws/aws-lc/pull/1310
* Docker images for loongarch64, ppc64, ppc64le, and riscv64 by @justsmth in https://github.com/aws/aws-lc/pull/1168
* Use mkstemp instead of tmpname when available by @samuel40791765 in https://github.com/aws/aws-lc/pull/1325
* CI for Build/Testing on PPC64BE by @justsmth in https://github.com/aws/aws-lc/pull/1318
* Improve decision logic for s2n-bignum implementation by @torben-hansen in https://github.com/aws/aws-lc/pull/1323
* Add null-check for input args in SSL_{read|write}_ex by @dkostic in https://github.com/aws/aws-lc/pull/1326
* CI for PPC32 Cross build/test by @justsmth in https://github.com/aws/aws-lc/pull/1329
* Give BIO an ex_data by @samuel40791765 in https://github.com/aws/aws-lc/pull/1328
* Return 0 if using default proto min/max by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1322


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
