### PR TITLE
Improve backwards compatability for the TLS transfer parser

### DIFF
--- a/ssl/ssl_transfer_asn1.cc
+++ b/ssl/ssl_transfer_asn1.cc
@@ -922,7 +922,7 @@ static int SSL3_STATE_from_bytes(SSL *ssl, CBS *cbs, const SSL_CTX *ctx) {
 
 // SSL_CONFIG serialization.
 
-static const unsigned kSSLConfigVersion = 1;
+static const unsigned kSSLConfigVersion = 2;
 
 static const unsigned kSSLConfigOcspStaplingEnabledTag =
     CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0;

--- a/ssl/ssl_transfer_asn1.cc
+++ b/ssl/ssl_transfer_asn1.cc
@@ -182,91 +182,7 @@ static const unsigned kS3AeadWriteCtxTag =
 // ssl3_state_to_bytes serializes |in| to bytes stored in |cbb|.
 // It returns one on success and zero on failure.
 //
-// An SSL3_STATE is serialized as the following ASN.1 structure, a complete
-// description can be found in tls_transfer.asn:
-//
-// SSL3StateSerializationVersion ::= INTEGER {
-//                   v1 (1),
-//                   v2 (2) -- Added additional fields to support TLS 1.3
-//               }
-//
-// SSL3State ::= SEQUENCE {
-//   serializationVersion SSL3StateSerializationVersion,
-//   readSequence   OCTET STRING,
-//   writeSequence  OCTET STRING,
-//   serverRandom   OCTET STRING,
-//   clientRandom   OCTET STRING,
-//   sendAlert      OCTET STRING,
-//   rwstate        INTEGER,
-//   earlyDataReason INTEGER,
-//   previousClientFinished OCTET STRING,
-//   previousClientFinishedLen INTEGER,
-//   previousServerFinished OCTET STRING,
-//   previousServerFinishedLen INTEGER,
-//   emptyRecordCount INTEGER,
-//   warningAlertCount INTEGER,
-//   totalRenegotiations INTEGER,
-//   -- Simplified to SEQUENCE here, uses SSL_SESSION_to_bytes_full
-//   establishedSession [0] SEQUENCE {...},
-//   sessionReused  [1] BOOLEAN OPTIONAL,
-//   hostname       [2] OCTET STRING OPTIONAL,
-//   alpnSelected   [3] OCTET STRING OPTIONAL,
-//   nextProtoNegotiated [4] OCTET STRING OPTIONAL,
-//   channelIdValid [5] BOOLEAN OPTIONAL,
-//   channelId      [6] OCTET STRING OPTIONAL,
-//   sendConnectionBinding [7] BOOLEAN OPTIONAL,
-//   -- pending_app_data is a Span in the SS3_STATE that points into read_buffer
-//   pendingAppData [8] Span OPTIONAL,
-//   readBuffer     [9] SSLBuffer OPTIONAL,
-//   notResumable   [10] BOOLEAN OPTIONAL,
-//   ...,
-//   -- Extension describing v2 serialization format for TLS 1.3 support.
-//   [[ 2:
-//   earlyDataSkipped [11] INTEGER OPTIONAL,
-//   delegatedCredentialUsed [12] BOOLEAN OPTIONAL,
-//   earlyDataAccepted [13] BOOLEAN OPTIONAL,
-//   usedHelloRetryRequest [14] BOOLEAN OPTIONAL,
-//   ticketAgeSkew  [15] INTEGER OPTIONAL,
-//   writeTrafficSecret [16] OCTET STRING OPTIONAL,
-//   writeTrafficSecretLen [17] INTEGER OPTIONAL,
-//   readTrafficSecret [18] OCTET STRING OPTIONAL,
-//   readTrafficSecretLen [19] INTEGER OPTIONAL,
-//   exporterSecret [20] OCTET STRING OPTIONAL,
-//   exporterSecretLen [21] INTEGER OPTIONAL,
-//   hsBuffer       [22] OCTET STRING OPTIONAL,
-//   echStatus      [23] INTEGER OPTIONAL,
-//   pendingHsData  [24] OCTET STRING OPTIONAL,
-//   pendingFlight  [25] OCTET STRING OPTIONAL,
-//   aeadReadCtx    [26] SSLAEADContext OPTIONAL,
-//   aeadWriteCtx   [27] SSLAEADContext OPTIONAL
-//   ]],
-//   ...
-// }
-//
-// Span ::= SEQUENCE {
-//   offset         INTEGER,
-//   size           INTEGER
-// }
-//
-// SSLBufferSerializationVersion ::= INTEGER {v1 (1)}
-//
-// SSLBuffer ::= SEQUENCE {
-//   serializationVersion SSLBufferSerializationVersion,
-//   bufferAllocated BOOLEAN,
-//   offset         INTEGER,
-//   size           INTEGER,
-//   capacity       INTEGER
-// }
-//
-// SSLConfigSerializationVersion ::= INTEGER {v1 (1)}
-//
-// SSLConfig ::= SEQUENCE {
-//   serializationVersion SSLConfigSerializationVersion,
-//   confMaxVersion INTEGER,
-//   confMinVersion INTEGER,
-//   ocspStaplingEnabled [0] BOOLEAN OPTIONAL,
-//   jdk11Workaround [1] BOOLEAN OPTIONAL
-// }
+// SSL3_STATE ASN.1 structure: see ssl_transfer_asn1.cc
 static int SSL3_STATE_to_bytes(SSL3_STATE *in, uint16_t protocol_version,
                                CBB *cbb) {
   if (in == NULL || cbb == NULL) {
@@ -944,16 +860,7 @@ static const unsigned kSSLConfigConfMinVersionUseDefault =
 // SSL_CONFIG_to_bytes serializes |in| to bytes stored in |cbb|.
 // It returns one on success and zero on failure.
 //
-// An SSL_CONFIG is serialized as the following ASN.1 structure:
-//
-// SSL_CONFIG ::= SEQUENCE {
-//    version                           INTEGER (1),  -- SSL_CONFIG structure
-//    version confMaxVersion                    INTEGER, confMinVersion INTEGER,
-//    ocspStaplingEnabled               [0] BOOLEAN OPTIONAL,
-//    jdk11Workaround                   [1] BOOLEAN OPTIONAL,
-//    confMaxVersionUseDefault          [2] BOOLEAN OPTIONAL,
-//    confMinVersionUseDefault          [3] BOOLEAN OPTIONAL
-// }
+// SSL_CONFIG ASN.1 structure: see ssl_transfer_asn1.cc
 static int SSL_CONFIG_to_bytes(SSL_CONFIG *in, CBB *cbb) {
   if (in == NULL || cbb == NULL) {
     return 0;
@@ -1048,18 +955,8 @@ static const unsigned kSSLConfigTag =
 // SSL_to_bytes_full serializes |in| to bytes stored in |cbb|.
 // It returns one on success and zero on failure.
 //
-// An SSL is serialized as the following ASN.1 structure:
-//
-// SSL ::= SEQUENCE {
-//     sslSerialVer      UINT64   -- version of the SSL serialization format
-//     version           UINT64
-//     maxSendFragement  UINT64
-//     s3                SSL3State
-//     mode              UINT64
-//     options           UINT64
-//     quietShutdown     [0] BOOLEAN OPTIONAL
-//     config            [1] SEQUENCE OPTIONAL
-// }
+// SSL ASN.1 structure: see ssl_transfer_asn1.cc
+SSL3_STATE
 static int SSL_to_bytes_full(const SSL *in, CBB *cbb) {
   CBB ssl, child;
 

--- a/ssl/tls_transfer.asn
+++ b/ssl/tls_transfer.asn
@@ -119,7 +119,10 @@ SSLBuffer ::= SEQUENCE {
     capacity       INTEGER
 }
 
-SSLConfigSerializationVersion ::= INTEGER {v1 (1)}
+SSLConfigSerializationVersion ::= INTEGER {
+    v1 (1),
+    v2 (2) -- Added confMaxVersionUseDefault and confMinVersionUseDefault fields
+}
 
 SSLConfig ::= SEQUENCE {
     serializationVersion SSLConfigSerializationVersion,


### PR DESCRIPTION
### Description of changes: 

Allows the parser to deserialise TLS transfer state as long as the state version is as old or older than the parser.

https://github.com/aws/aws-lc/pull/1322 added a few more (optional) fields to the TLS transfer format. We want this to impose a version bump. But the parser currently doesn't allow inputting state serialised through an older parser. Improve backwards compatibility to allow future version bumps.

This makes deploying to a large fleet with a long delta of software versions being out-of-sync much easier. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
