### PR TITLE
Enable 25519 s2n-bignum backend for FIPS build

### DIFF
--- a/crypto/curve25519/curve25519.c
+++ b/crypto/curve25519/curve25519.c
@@ -60,15 +60,6 @@ OPENSSL_INLINE int curve25519_s2n_bignum_capable(void) {
 #endif
 }
 
-// Temporarily use separate function for Ed25519. See CryptoAlg-2198.
-OPENSSL_INLINE int ed25519_s2n_bignum_capable(void) {
-#if defined(CURVE25519_S2N_BIGNUM_CAPABLE) && !defined(AWSLC_FIPS)
-  return 1;
-#else
-  return 0;
-#endif
-}
-
 void ed25519_sha512(uint8_t out[SHA512_DIGEST_LENGTH],
   const void *input1, size_t len1, const void *input2, size_t len2,
   const void *input3, size_t len3) {
@@ -101,7 +92,7 @@ void ED25519_keypair_from_seed(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
 
   // Step: rfc8032 5.1.5.[3,4]
   // Compute [az]B and encode public key to a 32 byte octet.
-  if (ed25519_s2n_bignum_capable() == 1) {
+  if (curve25519_s2n_bignum_capable() == 1) {
     ed25519_public_key_from_hashed_seed_s2n_bignum(out_public_key, az);
   } else {
     ed25519_public_key_from_hashed_seed_nohw(out_public_key, az);
@@ -159,7 +150,7 @@ int ED25519_sign(uint8_t out_sig[ED25519_SIGNATURE_LEN],
     ED25519_PRIVATE_KEY_SEED_LEN, message, message_len, NULL, 0);
 
   // Step: rfc8032 5.1.6.[3,5,6,7]
-  if (ed25519_s2n_bignum_capable() == 1) {
+  if (curve25519_s2n_bignum_capable() == 1) {
     ed25519_sign_s2n_bignum(out_sig, r, az,
       private_key + ED25519_PRIVATE_KEY_SEED_LEN, message, message_len);
   } else {
@@ -215,7 +206,7 @@ int ED25519_verify(const uint8_t *message, size_t message_len,
   // Verification works by computing [S]B - [k]A' and comparing against R_expected.
   int res = 0;
   uint8_t R_computed_encoded[32];
-  if (ed25519_s2n_bignum_capable() == 1) {
+  if (curve25519_s2n_bignum_capable() == 1) {
     res = ed25519_verify_s2n_bignum(R_computed_encoded, public_key, R_expected, S,
       message, message_len);
   } else {

--- a/crypto/curve25519/curve25519_s2n_bignum_asm.c
+++ b/crypto/curve25519/curve25519_s2n_bignum_asm.c
@@ -11,7 +11,7 @@
 // Stub functions if s2n-bignum implementations are not compiled.
 // These functions have to abort, otherwise we risk applications assuming they
 // did work without actually doing anything.
-#if !defined(CURVE25519_S2N_BIGNUM_CAPABLE) || defined(BORINGSSL_FIPS)
+#if !defined(CURVE25519_S2N_BIGNUM_CAPABLE)
 
 #define S2N_BIGNUM_STUB_FUNC(return_type, symbol, ...) \
   return_type symbol(__VA_ARGS__); \
@@ -28,14 +28,11 @@ S2N_BIGNUM_STUB_FUNC(void, edwards25519_scalarmulbase, uint64_t res[8],uint64_t 
 S2N_BIGNUM_STUB_FUNC(void, edwards25519_scalarmulbase_alt, uint64_t res[8],uint64_t scalar[4])
 S2N_BIGNUM_STUB_FUNC(void, edwards25519_scalarmuldouble, uint64_t res[8], uint64_t scalar[4], uint64_t point[8], uint64_t bscalar[4])
 S2N_BIGNUM_STUB_FUNC(void, edwards25519_scalarmuldouble_alt, uint64_t res[8], uint64_t scalar[4], uint64_t point[8], uint64_t bscalar[4])
-
-#if !defined(CURVE25519_S2N_BIGNUM_CAPABLE)
 S2N_BIGNUM_STUB_FUNC(void, curve25519_x25519_byte, uint8_t res[32], const uint8_t scalar[32], const uint8_t point[32])
 S2N_BIGNUM_STUB_FUNC(void, curve25519_x25519_byte_alt, uint8_t res[32], const uint8_t scalar[32], const uint8_t point[32])
 S2N_BIGNUM_STUB_FUNC(void, curve25519_x25519base_byte, uint8_t res[32], const uint8_t scalar[32])
 S2N_BIGNUM_STUB_FUNC(void, curve25519_x25519base_byte_alt, uint8_t res[32], const uint8_t scalar[32])
 #endif // !defined(CURVE25519_S2N_BIGNUM_CAPABLE)
-#endif // !defined(CURVE25519_S2N_BIGNUM_CAPABLE) || defined(BORINGSSL_FIPS)
 
 // curve25519_s2n_bignum_use_no_alt_implementation returns 1 if the no_alt
 // s2n-bignum implementation should be used and 0 otherwise.

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -206,6 +206,18 @@ if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) OR
     p521/bignum_sqr_p521_alt.S
     p521/bignum_tolebytes_p521.S
     p521/bignum_fromlebytes_p521.S
+
+    curve25519/bignum_mod_n25519.S
+    curve25519/bignum_neg_p25519.S
+    curve25519/bignum_madd_n25519.S
+    curve25519/bignum_madd_n25519_alt.S
+    curve25519/edwards25519_decode.S
+    curve25519/edwards25519_decode_alt.S
+    curve25519/edwards25519_encode.S
+    curve25519/edwards25519_scalarmulbase.S
+    curve25519/edwards25519_scalarmulbase_alt.S
+    curve25519/edwards25519_scalarmuldouble.S
+    curve25519/edwards25519_scalarmuldouble_alt.S
   )
 
   if(ARCH STREQUAL "x86_64")
@@ -219,24 +231,8 @@ if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) OR
                 curve25519/curve25519_x25519.S
                 curve25519/curve25519_x25519_alt.S
                 curve25519/curve25519_x25519base.S
-                curve25519/curve25519_x25519base_alt.S)
-
-    # Delocater FIPS issue: CryptoAlg-2198
-    if(NOT FIPS)
-      list(APPEND S2N_BIGNUM_ASM_SOURCES
-                  curve25519/bignum_mod_n25519.S
-                  curve25519/bignum_neg_p25519.S
-                  curve25519/bignum_madd_n25519.S
-                  curve25519/bignum_madd_n25519_alt.S
-                  curve25519/edwards25519_decode.S
-                  curve25519/edwards25519_decode_alt.S
-                  curve25519/edwards25519_encode.S
-                  curve25519/edwards25519_scalarmulbase.S
-                  curve25519/edwards25519_scalarmulbase_alt.S
-                  curve25519/edwards25519_scalarmuldouble.S
-                  curve25519/edwards25519_scalarmuldouble_alt.S
-                  )
-    endif()
+                curve25519/curve25519_x25519base_alt.S
+    )
   elseif(ARCH STREQUAL "aarch64")
     # byte-level interface for aarch64 s2n-bignum x25519 are in
     # files with "byte" tags, but ed25519 is not, neither are they byte-level...
@@ -245,25 +241,7 @@ if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) OR
                 curve25519/curve25519_x25519_byte_alt.S
                 curve25519/curve25519_x25519base_byte.S
                 curve25519/curve25519_x25519base_byte_alt.S
-                )
-
-    # Delocater FIPS issue: CryptoAlg-2198
-    if(NOT FIPS)
-      list(APPEND S2N_BIGNUM_ASM_SOURCES
-                  curve25519/bignum_mod_n25519.S
-                  curve25519/bignum_neg_p25519.S
-                  curve25519/bignum_madd_n25519.S
-                  curve25519/bignum_madd_n25519_alt.S
-                  curve25519/edwards25519_decode.S
-                  curve25519/edwards25519_decode_alt.S
-                  curve25519/edwards25519_encode.S
-                  curve25519/edwards25519_scalarmulbase.S
-                  curve25519/edwards25519_scalarmulbase_alt.S
-                  curve25519/edwards25519_scalarmuldouble.S
-                  curve25519/edwards25519_scalarmuldouble_alt.S
-                  )
-    endif()
-
+    )
 
     # Big integer arithmetics using s2n-bignum
     list(APPEND S2N_BIGNUM_ASM_SOURCES
@@ -288,7 +266,7 @@ if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) OR
                 generic/bignum_copy_row_from_table_8n_neon.S
                 generic/bignum_copy_row_from_table_16_neon.S
                 generic/bignum_copy_row_from_table_32_neon.S
-                )
+    )
   endif()
 endif()
 

--- a/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
+++ b/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
@@ -247,7 +247,6 @@ extern void bignum_copy_row_from_table_16_neon (uint64_t *z, const uint64_t *tab
 extern void bignum_copy_row_from_table_32_neon (uint64_t *z, const uint64_t *table,
         uint64_t height, uint64_t idx);
 
-#if !defined(BORINGSSL_FIPS)
 // Reduction is modulo the order of the curve25519/edwards25519 basepoint,
 // which is n_25519 = 2^252 + 27742317777372353535851937790883648493.
 // Reduce modulo basepoint order, z := x mod n_25519
@@ -323,4 +322,3 @@ extern void edwards25519_scalarmuldouble(uint64_t res[static 8], uint64_t scalar
         uint64_t point[static 8], uint64_t bscalar[static 4]);
 extern void edwards25519_scalarmuldouble_alt(uint64_t res[static 8], uint64_t scalar[static 4],
         uint64_t point[static 8], uint64_t bscalar[static 4]);
-#endif


### PR DESCRIPTION
### Description of changes: 

https://github.com/aws/aws-lc/commit/43164b7dc311aee3540fbbcb7dfe496ceb2efd5f fixed an issue with the delocater. Can now enable 25519 s2n-bignum algorithms for FIPS build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
