### PR TITLE
Dockerfile and structure change for SAW proofs on X86_64

### DIFF
--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_clang-10x_formal-verification/create_image.sh
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_clang-10x_formal-verification/create_image.sh
@@ -10,6 +10,6 @@ fi
 rm -rf aws-lc-verification
 git clone https://github.com/awslabs/aws-lc-verification.git
 cd aws-lc-verification
-docker build --pull --no-cache -f Dockerfile.saw -t ${docker_tag} .
+docker build --pull --no-cache -f Dockerfile.saw_x86 -t ${docker_tag} .
 cd ..
 rm -rf aws-lc-verification

--- a/tests/ci/run_formal_verification.sh
+++ b/tests/ci/run_formal_verification.sh
@@ -10,14 +10,12 @@ rm -rf aws-lc-verification-build
 git clone https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
 
 cd aws-lc-verification-build
-# We avoid pulling the saw-script submodule since the repo will take forever to clone.
 git submodule update --init
-pushd Coq/fiat-crypto; git submodule update --init --recursive; popd
 
 # aws-lc-verification has aws-lc as one submodule under 'src' dir.
 # Below is to copy code of **target** aws-lc to 'src' dir.
 rm -rf ./src/* && cp -r "${ROOT}/${AWS_LC_DIR}/"* ./src
 # execute the entry to saw scripts.
-./SAW/scripts/docker_entrypoint.sh
+./SAW/scripts/x86_64/docker_entrypoint.sh
 cd ..
 rm -rf aws-lc-verification-build


### PR DESCRIPTION
### Issues:
None

### Description of changes: 
One pending merge PR (https://github.com/awslabs/aws-lc-verification/pull/128) in AWS-LC-verification will change the Dockerfile name for SAW proofs on X86_64 and will change where the shell scripts are for running the proofs. This is a coordination PR to make sure that once that PR is merged, AWS-LC CI will continue to run smoothly.

### Call-outs:
None

### Testing:
Changes are tested by downloading existing docker image `aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-10x_formal-verification_latest`, and running the proofs in the AWS-LC-verification PR (https://github.com/awslabs/aws-lc-verification/pull/128) within the docker image using adjusted commands from the script `run_formal_verification.sh`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
