### PR TITLE
More caution with 'rm -rf'

### DIFF
--- a/tests/ci/common_fuzz.sh
+++ b/tests/ci/common_fuzz.sh
@@ -21,7 +21,7 @@ echo "$BUILD_ID"
 DATE_NOW="$(date +%Y-%m-%d)"
 SHARED_FAILURE_ROOT="${CORPUS_ROOT}/runs/${DATE_NOW}/${BUILD_ID}"
 LOCAL_RUN_ROOT="${BUILD_ROOT}/fuzz_run_root"
-rm -rf "$LOCAL_RUN_ROOT"
+rm -rf "${LOCAL_RUN_ROOT:?}"
 
 function put_metric_count {
   put_metric --unit Count "$@"

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -57,7 +57,7 @@ fi
 
 function run_build {
   local cflags=("$@")
-  rm -rf "$BUILD_ROOT"
+  rm -rf "${BUILD_ROOT:?}"
   mkdir -p "$BUILD_ROOT"
   cd "$BUILD_ROOT" || exit 1
 
@@ -207,7 +207,7 @@ function aws_lc_build() {
   ${CMAKE_COMMAND} ${AWS_LC_DIR} -GNinja "-B${BUILD_FOLDER}" "-DCMAKE_INSTALL_PREFIX=${INSTALL_FOLDER}" "${@:4}"
   ninja -C ${BUILD_FOLDER} install
   ls -R ${INSTALL_FOLDER}
-  rm -rf ${BUILD_FOLDER:?}/*
+  rm -rf "${BUILD_FOLDER:?}"/*
 }
 
 function print_executable_information {

--- a/tests/ci/docker_images/dependencies/build_cryptofuzz_modules.sh
+++ b/tests/ci/docker_images/dependencies/build_cryptofuzz_modules.sh
@@ -61,7 +61,7 @@ env CRYPTOFUZZ_SRC "$CRYPTOFUZZ_SRC"
 
 # Cryptofuzz builds its modules into $CRYPTOFUZZ_SRC/modules that includes everything it needs, deleting the module source
 # code saves a substantial amount of space in the docker image
-rm -rf "$MODULES_ROOT"
+rm -rf "${MODULES_ROOT:?}"
 
 # Prebuild the required libcpu_features to save time
 cd "$CRYPTOFUZZ_SRC"

--- a/tests/ci/integration/run_crt_integration.sh
+++ b/tests/ci/integration/run_crt_integration.sh
@@ -10,7 +10,7 @@ SCRATCH_FOLDER=${SYS_ROOT}/SCRATCH_AWSLC_CRT_TEST
 
 # Make script execution idempotent.
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 git clone --recursive https://github.com/awslabs/aws-crt-cpp.git

--- a/tests/ci/integration/run_curl_integration.sh
+++ b/tests/ci/integration/run_curl_integration.sh
@@ -25,7 +25,7 @@ AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${CURL_SRC_FOLDER}/aws-lc-install"
 
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 function curl_build() {

--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -43,7 +43,7 @@ function build_and_test_haproxy() {
 
 # Make script execution idempotent.
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
@@ -55,8 +55,8 @@ cd haproxy
 aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=0
 build_and_test_haproxy $HAPROXY_SRC
 
-rm -rf ${AWS_LC_INSTALL_FOLDER}/*
-rm -rf ${AWS_LC_BUILD_FOLDER}/*
+rm -rf "${AWS_LC_INSTALL_FOLDER:?}"/*
+rm -rf "${AWS_LC_BUILD_FOLDER:?}"/*
 
 # Test with shared AWS-LC libraries
 aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_SHARED_LIBS=1 -DBUILD_TESTING=0

--- a/tests/ci/integration/run_mariadb_integration.sh
+++ b/tests/ci/integration/run_mariadb_integration.sh
@@ -30,7 +30,7 @@ AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${MARIADB_SRC_FOLDER}/aws-lc-install"
 
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 function mariadb_build() {

--- a/tests/ci/integration/run_monit_integration.sh
+++ b/tests/ci/integration/run_monit_integration.sh
@@ -38,7 +38,7 @@ function monit_run_tests() {
 }
 
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 git clone https://bitbucket.org/tildeslash/monit.git ${MONIT_SRC_FOLDER} --depth 1

--- a/tests/ci/integration/run_mysql_integration.sh
+++ b/tests/ci/integration/run_mysql_integration.sh
@@ -32,7 +32,7 @@ AWS_LC_INSTALL_FOLDER="${MYSQL_SRC_FOLDER}/aws-lc-install"
 
 
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 function mysql_patch_reminder() {

--- a/tests/ci/integration/run_nginx_integration.sh
+++ b/tests/ci/integration/run_nginx_integration.sh
@@ -26,7 +26,7 @@ AWS_LC_INSTALL_FOLDER="${NGINX_SRC_FOLDER}/aws-lc-install"
 
 
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 function nginx_build() {

--- a/tests/ci/integration/run_openssh_integration.sh
+++ b/tests/ci/integration/run_openssh_integration.sh
@@ -30,7 +30,7 @@ if ! ${NINJA_COMMAND} --version; then
 fi
 
 # Make script execution idempotent.
-rm -rf "${SCRATCH_FOLDER}"
+rm -rf "${SCRATCH_FOLDER:?}"
 mkdir -p "${SCRATCH_FOLDER}"
 pushd "${SCRATCH_FOLDER}"
 

--- a/tests/ci/integration/run_postgres_integration.sh
+++ b/tests/ci/integration/run_postgres_integration.sh
@@ -21,7 +21,7 @@ AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${POSTGRES_SRC_FOLDER}/aws-lc-install"
 
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 function postgres_build() {

--- a/tests/ci/integration/run_s2n_integration.sh
+++ b/tests/ci/integration/run_s2n_integration.sh
@@ -25,7 +25,7 @@ S2N_TLS_BUILD_FOLDER="${SCRATCH_FOLDER}/s2n-tls-build"
 
 # Make script execution idempotent.
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 # Test helper functions.
@@ -50,7 +50,7 @@ function s2n_tls_run_tests() {
 }
 
 function s2n_tls_prepare_new_build() {
-	rm -rf ${S2N_TLS_BUILD_FOLDER}/*
+	rm -rf "${S2N_TLS_BUILD_FOLDER:?}"/*
 }
 
 # Get latest s2n-tls version.

--- a/tests/ci/integration/run_sslproxy_integration.sh
+++ b/tests/ci/integration/run_sslproxy_integration.sh
@@ -76,7 +76,7 @@ function sslproxy_run_tests() {
 sslproxy_patch_reminder
 
 mkdir -p ${SCRATCH_FOLDER}
-rm -rf ${SCRATCH_FOLDER}/*
+rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 git clone https://github.com/sonertari/SSLproxy.git ${SSLPROXY_SRC_FOLDER} --depth 1

--- a/tests/ci/run_cross_tests.sh
+++ b/tests/ci/run_cross_tests.sh
@@ -25,7 +25,7 @@ SCRATCH_FOLDER="${SYS_ROOT}/SCRATCH_${TARGET_CPU}"
 if [ -e "${SCRATCH_FOLDER}" ]; then
     # Some directories in the archive lack write permission, preventing deletion of files
     chmod +w -R "${SCRATCH_FOLDER}"
-    rm -rf "${SCRATCH_FOLDER}"
+    rm -rf "${SCRATCH_FOLDER:?}"
 fi
 mkdir -p "${SCRATCH_FOLDER}"
 

--- a/tests/ci/run_cryptofuzz.sh
+++ b/tests/ci/run_cryptofuzz.sh
@@ -9,7 +9,7 @@ source "${FUZZ_ROOT}/fuzz_env.sh"
 # After loading everything any undefined variables should fail the build
 set -u
 
-rm -rf "$BUILD_ROOT"
+rm -rf "${BUILD_ROOT:?}"
 mkdir -p "$BUILD_ROOT"
 cd "$BUILD_ROOT"
 
@@ -60,7 +60,7 @@ FUZZ_TEST_PATH="${CRYPTOFUZZ_SRC}/${FUZZ_NAME}"
 SRC_CORPUS="$CRYPTOFUZZ_SEED_CORPUS"
 
 # For cryptofuzz development only, uncomment below code to generate new corpus.
-# rm -rf "$CRYPTOFUZZ_SEED_CORPUS" && mkdir "$CRYPTOFUZZ_SEED_CORPUS"
+# rm -rf "${CRYPTOFUZZ_SEED_CORPUS:?}" && mkdir "$CRYPTOFUZZ_SEED_CORPUS"
 # ./generate_corpus "$CRYPTOFUZZ_SEED_CORPUS"
 
 # Perform the actual fuzzing. We want the total build time to be about 45 minutes:

--- a/tests/ci/run_install_shared_and_static.sh
+++ b/tests/ci/run_install_shared_and_static.sh
@@ -27,7 +27,7 @@ ROOT=$(realpath ${AWS_LC_DIR}/..)
 
 SCRATCH_DIR=${ROOT}/SCRATCH_AWSLC_INSTALL_SHARED_AND_STATIC
 mkdir -p ${SCRATCH_DIR}
-rm -rf ${SCRATCH_DIR}/*
+rm -rf "${SCRATCH_DIR:?}"/*
 
 function fail() {
     echo "test failure: $1"
@@ -39,7 +39,7 @@ function install_aws_lc() {
     local BUILD_SHARED_LIBS=$2
 
     local BUILD_DIR=${SCRATCH_DIR}/build
-    rm -rf ${BUILD_DIR}
+    rm -rf "${BUILD_DIR:?}"
     ${CMAKE_COMMAND} -H${AWS_LC_DIR} -B${BUILD_DIR} -GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF -D${BUILD_SHARED_LIBS}
     ${CMAKE_COMMAND} --build ${BUILD_DIR} --target install
 }
@@ -58,7 +58,7 @@ install_aws_lc install-both BUILD_SHARED_LIBS=ON
 # - mylib: a library that uses AWS-LC
 # - myapp: executable that uses mylib
 MYAPP_SRC_DIR=${SCRATCH_DIR}/myapp-src
-rm -rf ${MYAPP_SRC_DIR}
+rm -rf "${MYAPP_SRC_DIR:?}"
 mkdir -p ${MYAPP_SRC_DIR}
 
 cat <<EOF > ${MYAPP_SRC_DIR}/mylib.c
@@ -92,7 +92,7 @@ build_myapp() {
     local EXPECT_USE_LIB_TYPE=$3 # (".so" or ".a") which types of libssl and libcrypto are expected to be used
 
     local BUILD_DIR=${SCRATCH_DIR}/build
-    rm -rf ${BUILD_DIR}
+    rm -rf "${BUILD_DIR:?}"
 
     cmake -H${MYAPP_SRC_DIR} -B${BUILD_DIR} -GNinja -D${BUILD_SHARED_LIBS} -DCMAKE_PREFIX_PATH=${SCRATCH_DIR}/${AWS_LC_INSTALL_DIR}
     cmake --build ${BUILD_DIR}
@@ -134,7 +134,7 @@ build_myapp BUILD_SHARED_LIBS=OFF install-both .a # myapp should use libssl.a/li
 # ------------------------------------------------------- #
 #           Test for the static library constructor       #
 # ------------------------------------------------------- #
-rm -rf ${MYAPP_SRC_DIR}
+rm -rf "${MYAPP_SRC_DIR:?}"
 mkdir -p ${MYAPP_SRC_DIR}
 
 cat <<EOF > ${MYAPP_SRC_DIR}/static_constructor_test.c


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Prevent accidental deletions (via `rm -rf`) when a variable is not defined.

### Call-outs:
* See Bash documentation for [parameter expansion](https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion).

> ${parameter:?word}
>
> If parameter is null or unset, the expansion of word (or a message to that effect if 
> word is not present) is written to the standard error and the shell, if it is not 
> interactive, exits. Otherwise, the value of parameter is substituted. 

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
