### PR TITLE
Add integ test for tcpdump

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -20,3 +20,13 @@ jobs:
       - name: Run integration build
         run: |
           ./tests/ci/integration/run_haproxy_integration.sh
+  tcpdump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make libpcap-dev binutils-dev
+      - uses: actions/checkout@v3
+      - name: Run integration build
+        run: |
+          ./tests/ci/integration/run_tcpdump_integration.sh

--- a/tests/ci/integration/run_tcpdump_integration.sh
+++ b/tests/ci/integration/run_tcpdump_integration.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -exu
+#
+# Copyright Amazon.com Inc. or its affiliates.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+#
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# SYS_ROOT
+#  |
+#  - SRC_ROOT(aws-lc)
+#  |
+#  - SCRATCH_FOLDER
+#    |
+#    - tcpdump
+#    - tcpdump-install
+#    - AWS_LC_BUILD_FOLDER
+#    - AWS_LC_INSTALL_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER=${SYS_ROOT}/"TCPDUMP_SCRATCH"
+TCPDUMP_SRC_FOLDER="${SCRATCH_FOLDER}/tcpdump"
+TCPDUMP_INSTALL_FOLDER="${SCRATCH_FOLDER}/tcpdump-install"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+
+mkdir -p "${SCRATCH_FOLDER}"
+rm -rf "${SCRATCH_FOLDER:?}"/*
+
+pushd "${SCRATCH_FOLDER}"
+
+function tcpdump_build() {
+  autoreconf -fi
+  ./configure --prefix="${TCPDUMP_INSTALL_FOLDER}" --with-openssl="${AWS_LC_INSTALL_FOLDER}"
+  make -j "${NUM_CPU_THREADS}"
+}
+
+function tcpdump_run_tests() {
+  make check
+  make releasecheck
+}
+
+# Get latest tcpdump version.
+git clone https://github.com/the-tcpdump-group/tcpdump.git "${TCPDUMP_SRC_FOLDER}"
+mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${TCPDUMP_INSTALL_FOLDER}"
+ls
+
+aws_lc_build "${SRC_ROOT}" "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}"
+
+pushd "${TCPDUMP_SRC_FOLDER}"
+tcpdump_build
+tcpdump_run_tests
+popd
+
+popd


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Add integration tests for tcpdump.

### Call-outs:
N/A

### Testing:
* Ran build/tests locally.
* Ran CI [on fork](https://github.com/justsmth/aws-lc/actions/runs/7120169963/job/19386862548#step:4:2305).
```
 ------------------------------------------------
   0 tests failed
 667 tests passed
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
