### PR TITLE
Initialize min/max use_default values in SSL_CTX

### DIFF
--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -3309,14 +3309,14 @@ struct SSL_CONFIG {
   // method. By default, |SSL_new| will set this to true and connections will use
   // the default max version. callers can change the max version used by calling
   // |SSL_set_max_proto_version| with a non-zero value.
-  bool conf_max_version_use_default;
+  bool conf_max_version_use_default : 1;
 
   // conf_min_version_use_default indicates whether the |SSL_CONFIG| is configured
   // to use the default minimum protocol version for the relevant protocol
   // method. By default, |SSL_new| will set this to true and connections will use
   // the default min version. callers can change the min version used by calling
   // |SSL_set_min_proto_version| with a non-zero value.
-  bool conf_min_version_use_default;
+  bool conf_min_version_use_default : 1;
 };
 
 // From RFC 8446, used in determining PSK modes.
@@ -3990,14 +3990,14 @@ struct ssl_ctx_st {
   // method. By default, |SSL_CTX_new| will set this to true and connections will
   // use the default max version. callers can change the max version used by calling
   // |SSL_CTX_set_max_proto_version| with a non-zero value.
-  bool conf_max_version_use_default;
+  bool conf_max_version_use_default : 1;
 
   // conf_min_version_use_default indicates whether the |SSL_CTX| is configured
   // to use the default minimum protocol version for the relevant protocol
   // method. By default, |SSL_CTX_new| will set this to true and connections will
   // use the default min version. callers can change the min version used by calling
   // |SSL_CTX_set_min_proto_version| with a non-zero value.
-  bool conf_min_version_use_default;
+  bool conf_min_version_use_default : 1;
 
  private:
   ~ssl_ctx_st();

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -541,7 +541,9 @@ ssl_ctx_st::ssl_ctx_st(const SSL_METHOD *ssl_method)
       handoff(false),
       enable_early_data(false),
       aes_hw_override(false),
-      aes_hw_override_value(false) {
+      aes_hw_override_value(false),
+      conf_max_version_use_default(true),
+      conf_min_version_use_default(true) {
   CRYPTO_MUTEX_init(&lock);
   CRYPTO_new_ex_data(&ex_data);
 }
@@ -657,8 +659,8 @@ SSL *SSL_new(SSL_CTX *ctx) {
   }
   ssl->config->conf_min_version = ctx->conf_min_version;
   ssl->config->conf_max_version = ctx->conf_max_version;
-  ssl->config->conf_min_version_use_default = ctx->conf_min_version_use_default;
   ssl->config->conf_max_version_use_default = ctx->conf_max_version_use_default;
+  ssl->config->conf_min_version_use_default = ctx->conf_min_version_use_default;
 
   ssl->config->cert = ssl_cert_dup(ctx->cert.get());
   if (ssl->config->cert == nullptr) {
@@ -720,7 +722,9 @@ SSL_CONFIG::SSL_CONFIG(SSL *ssl_arg)
       shed_handshake_config(false),
       jdk11_workaround(false),
       quic_use_legacy_codepoint(false),
-      permute_extensions(false) {
+      permute_extensions(false),
+      conf_max_version_use_default(true),
+      conf_min_version_use_default(true) {
   assert(ssl);
 }
 


### PR DESCRIPTION
### Issues:
Resolves an internal ticket.

### Description of changes: 
Coverity didn't like the lack of initialization for our new variables.

### Call-outs:
- n/a

### Testing:
- CI tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
