### PR TITLE
Mark bcm_redirector functions as local

### DIFF
--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -2294,7 +2294,7 @@ func isFipsScopeMarkers(symbol string) bool {
 }
 
 func redirectorName(symbol string) string {
-	return "bcm_redirector_" + symbol
+	return ".Lbcm_redirector_" + symbol
 }
 
 // sectionType returns the type of a section. I.e. a section called “.text.foo”

--- a/util/fipstools/delocate/testdata/aarch64-Basic/out.s
+++ b/util/fipstools/delocate/testdata/aarch64-Basic/out.s
@@ -97,7 +97,7 @@ foo:
 	bl	.Llocal_function_local_target
 
 // WAS bl remote_function
-	bl	bcm_redirector_remote_function
+	bl	.Lbcm_redirector_remote_function
 
 	bl bss_symbol_bss_get
 
@@ -123,9 +123,9 @@ foo:
 	// But 'y' is not a register prefix so far, so these should be
 	// processed as symbols.
 // WAS add y0, y0
-	add	bcm_redirector_y0, bcm_redirector_y0
+	add	.Lbcm_redirector_y0, .Lbcm_redirector_y0
 // WAS add y12, y12
-	add	bcm_redirector_y12, bcm_redirector_y12
+	add	.Lbcm_redirector_y12, .Lbcm_redirector_y12
 
 	// Make sure that the magic extension constants are recognised rather
 	// than being interpreted as symbols.
@@ -176,29 +176,29 @@ bss_symbol:
 .type BORINGSSL_bcm_text_end, @function
 BORINGSSL_bcm_text_end:
 .p2align 2
-.hidden bcm_redirector_remote_function
-.type bcm_redirector_remote_function, @function
-bcm_redirector_remote_function:
+.hidden .Lbcm_redirector_remote_function
+.type .Lbcm_redirector_remote_function, @function
+.Lbcm_redirector_remote_function:
 .cfi_startproc
 	b remote_function
 .cfi_endproc
-.size bcm_redirector_remote_function, .-bcm_redirector_remote_function
+.size .Lbcm_redirector_remote_function, .-.Lbcm_redirector_remote_function
 .p2align 2
-.hidden bcm_redirector_y0
-.type bcm_redirector_y0, @function
-bcm_redirector_y0:
+.hidden .Lbcm_redirector_y0
+.type .Lbcm_redirector_y0, @function
+.Lbcm_redirector_y0:
 .cfi_startproc
 	b y0
 .cfi_endproc
-.size bcm_redirector_y0, .-bcm_redirector_y0
+.size .Lbcm_redirector_y0, .-.Lbcm_redirector_y0
 .p2align 2
-.hidden bcm_redirector_y12
-.type bcm_redirector_y12, @function
-bcm_redirector_y12:
+.hidden .Lbcm_redirector_y12
+.type .Lbcm_redirector_y12, @function
+.Lbcm_redirector_y12:
 .cfi_startproc
 	b y12
 .cfi_endproc
-.size bcm_redirector_y12, .-bcm_redirector_y12
+.size .Lbcm_redirector_y12, .-.Lbcm_redirector_y12
 .p2align 2
 .hidden bss_symbol_bss_get
 .type bss_symbol_bss_get, @function

--- a/util/fipstools/delocate/testdata/ppc64le-Sample/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-Sample/out.s
@@ -135,7 +135,7 @@ function:
 	ld 3, -16(1)
 	addi 1, 1, 288
 # WAS bl fprintf
-	bl	bcm_redirector_fprintf
+	bl	.Lbcm_redirector_fprintf
 	ld 2, 24(1)
 	nop
 # WAS addis 10,2,.LC0@toc@ha
@@ -182,7 +182,7 @@ function:
 	addi 1, 1, 288
 	ld 5, 0(5)
 # WAS bl fprintf
-	bl	bcm_redirector_fprintf
+	bl	.Lbcm_redirector_fprintf
 	ld 2, 24(1)
 	nop
 # WAS addis 10,2,.LC0@toc@ha
@@ -228,7 +228,7 @@ function:
 	ld 3, -16(1)
 	addi 1, 1, 288
 # WAS bl fprintf
-	bl	bcm_redirector_fprintf
+	bl	.Lbcm_redirector_fprintf
 	ld 2, 24(1)
 	nop
 # WAS addis 10,2,.LC0@toc@ha
@@ -275,7 +275,7 @@ function:
 	addi 1, 1, 288
 	ld 5, 0(5)
 # WAS bl fprintf
-	bl	bcm_redirector_fprintf
+	bl	.Lbcm_redirector_fprintf
 	ld 2, 24(1)
 	nop
 # WAS addis 10,2,.LC0@toc@ha
@@ -322,7 +322,7 @@ function:
 	addi 1, 1, 288
 	ld 5, 0(5)
 # WAS bl fprintf
-	bl	bcm_redirector_fprintf
+	bl	.Lbcm_redirector_fprintf
 	ld 2, 24(1)
 	nop
 # WAS addis 10,2,.LC0@toc@ha
@@ -369,7 +369,7 @@ function:
 	addi 1, 1, 288
 	ld 5, 0(5)
 # WAS bl fprintf
-	bl	bcm_redirector_fprintf
+	bl	.Lbcm_redirector_fprintf
 	ld 2, 24(1)
 	nop
 # WAS bl exported_function
@@ -423,8 +423,8 @@ BORINGSSL_bcm_text_end:
 .Lredirector_toc_fprintf:
 .quad fprintf
 .text
-.type bcm_redirector_fprintf, @function
-bcm_redirector_fprintf:
+.type .Lbcm_redirector_fprintf, @function
+.Lbcm_redirector_fprintf:
 	std 2, 24(1)
 	addis 12, 2, .Lredirector_toc_fprintf@toc@ha
 	ld 12, .Lredirector_toc_fprintf@toc@l(12)

--- a/util/fipstools/delocate/testdata/ppc64le-Sample2/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-Sample2/out.s
@@ -207,7 +207,7 @@ exported_function:
 	mr 6,29
 	li 4,1
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 	ld 3,0(31)
@@ -215,7 +215,7 @@ exported_function:
 	mr 6,19
 	li 4,1
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 	ld 3,0(31)
@@ -223,7 +223,7 @@ exported_function:
 	mr 6,24
 	li 4,1
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 	ld 3,0(31)
@@ -231,7 +231,7 @@ exported_function:
 	mr 6,20
 	li 4,1
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 	ld 3,0(31)
@@ -239,7 +239,7 @@ exported_function:
 	mr 6,27
 	li 4,1
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 	ld 3,0(31)
@@ -247,7 +247,7 @@ exported_function:
 	mr 5,28
 	mr 6,30
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 	b .L2
@@ -323,7 +323,7 @@ function:
 	stdu 1,-112(1)
 	ld 3,0(31)
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 # WAS addis 6,2,.LC12@toc@ha		# gpr load fusion, type long
@@ -356,7 +356,7 @@ function:
 	ld 3, -16(1)
 	addi 1, 1, 288
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 	ld 3,0(31)
@@ -388,7 +388,7 @@ function:
 	addi 1, 1, 288
 	li 4,1
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 # WAS addis 6,2,.LC13@toc@ha		# gpr load fusion, type long
@@ -421,7 +421,7 @@ function:
 	ld 3, -16(1)
 	addi 1, 1, 288
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 	ld 3,0(31)
@@ -441,7 +441,7 @@ function:
 	addi 1, 1, 288
 	li 4,1
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 	ld 3,0(31)
@@ -462,7 +462,7 @@ function:
 	addi 1, 1, 288
 	addi 6,6,-29404
 # WAS bl __fprintf_chk
-	bl	bcm_redirector___fprintf_chk
+	bl	.Lbcm_redirector___fprintf_chk
 	ld 2, 24(1)
 	nop
 # WAS bl exported_function
@@ -542,8 +542,8 @@ BORINGSSL_bcm_text_end:
 .Lredirector_toc___fprintf_chk:
 .quad __fprintf_chk
 .text
-.type bcm_redirector___fprintf_chk, @function
-bcm_redirector___fprintf_chk:
+.type .Lbcm_redirector___fprintf_chk, @function
+.Lbcm_redirector___fprintf_chk:
 	std 2, 24(1)
 	addis 12, 2, .Lredirector_toc___fprintf_chk@toc@ha
 	ld 12, .Lredirector_toc___fprintf_chk@toc@l(12)

--- a/util/fipstools/delocate/testdata/x86_64-LabelRewrite/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-LabelRewrite/out.s
@@ -23,11 +23,11 @@ bar:
 
 	# Jumps to PLT symbols are rewritten through redirectors.
 # WAS call memcpy@PLT
-	call	bcm_redirector_memcpy
+	call	.Lbcm_redirector_memcpy
 # WAS jmp memcpy@PLT
-	jmp	bcm_redirector_memcpy
+	jmp	.Lbcm_redirector_memcpy
 # WAS jbe memcpy@PLT
-	jbe	bcm_redirector_memcpy
+	jbe	.Lbcm_redirector_memcpy
 
 	# Jumps to local PLT symbols use their local targets.
 # WAS call foo@PLT
@@ -98,8 +98,8 @@ bar:
 .text
 .loc 1 2 0
 BORINGSSL_bcm_text_end:
-.type bcm_redirector_memcpy, @function
-bcm_redirector_memcpy:
+.type .Lbcm_redirector_memcpy, @function
+.Lbcm_redirector_memcpy:
 	jmp	memcpy@PLT
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get


### PR DESCRIPTION
### Description of changes: 
Today the `bcm_redirector_*` functions are symbols that are present in the bcm.o file, and are subject to potential collisions if they are not correctly "prefixed". Today since we have the odd behavior of prefixing symbols prior to running delocate this hasn't cause an issue as we would get redirect symbols like `bcm_redirector_myprefix_OPENSSL_malloc` etc. While working on https://github.com/aws/aws-lc/pull/1342 I realized a side-effect to prefixing after running the delocator would cause the `bcm_redirector_` functions to more then likely collide since they would no longer contain the prefix e.g. `bcm_redirector_OPENSSL_malloc`. Since these symbols are only referenced within the bcm.o file this PR marks these symbols as local so that they don't appear in the object file.

### Testing:
With the FIPS static build enabled I have validated that `go run ./util/all_tests.go` passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
