### PR TITLE
Fixes for NTP and add an integration test. 

### DIFF
--- a/crypto/des/des.c
+++ b/crypto/des/des.c
@@ -349,6 +349,12 @@ void DES_set_key(const DES_cblock *key, DES_key_schedule *schedule) {
   }
 }
 
+int DES_key_sched(const DES_cblock *key, DES_key_schedule *schedule) {
+  DES_set_key(key, schedule);
+  return 1;
+}
+
+
 static const uint8_t kOddParity[256] = {
     1,   1,   2,   2,   4,   4,   7,   7,   8,   8,   11,  11,  13,  13,  14,
     14,  16,  16,  19,  19,  21,  21,  22,  22,  25,  25,  26,  26,  28,  28,

--- a/crypto/digest_extra/digest_test.cc
+++ b/crypto/digest_extra/digest_test.cc
@@ -25,6 +25,7 @@
 #include <openssl/bytestring.h>
 #include <openssl/crypto.h>
 #include <openssl/digest.h>
+#include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/md4.h>
 #include <openssl/md5.h>
@@ -393,6 +394,9 @@ TEST(DigestTest, Getters) {
   EXPECT_EQ(EVP_sha512(), EVP_get_digestbyname("sha512"));
 
   EXPECT_EQ(EVP_sha512(), EVP_get_digestbynid(NID_sha512));
+  EXPECT_EQ(NID_sha1WithRSAEncryption, EVP_MD_get_pkey_type(EVP_sha1()));
+  EXPECT_EQ(NID_sha512WithRSAEncryption, EVP_MD_get_pkey_type(EVP_sha512()));
+  EXPECT_EQ("SHA512", EVP_MD_get0_name(EVP_sha512()));
   EXPECT_EQ(nullptr, EVP_get_digestbynid(NID_sha512WithRSAEncryption));
   EXPECT_EQ(nullptr, EVP_get_digestbynid(NID_undef));
 

--- a/crypto/dsa/dsa_test.cc
+++ b/crypto/dsa/dsa_test.cc
@@ -416,3 +416,42 @@ s2lmkAIcLIFUDFrbC2nViaB5ATM9ARKk6F2QwnCfGCyZ6A==
   EXPECT_EQ(1, DSA_verify(0, fips_digest, sizeof(fips_digest), sig.data(),
                           sig.size(), dsa.get()));
 }
+
+TEST(DSATest, DSAPrint) {
+  bssl::UniquePtr<DSA> dsa = GetFIPSDSA();
+  ASSERT_TRUE(dsa);
+  bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
+
+  DSA_print(bio.get(), dsa.get(), 4);
+  const uint8_t *data;
+  size_t len;
+  BIO_mem_contents(bio.get(), &data, &len);
+
+  const char *expected = ""
+      "    Private-Key: (512 bit)\n"
+      "    priv:\n"
+      "        20:70:b3:22:3d:ba:37:2f:de:1c:0f:fc:7b:2e:3b:\n"
+      "        49:8b:26:06:14\n"
+      "    pub:\n"
+      "        19:13:18:71:d7:5b:16:12:a8:19:f2:9d:78:d1:b0:\n"
+      "        d7:34:6f:7a:a7:7b:b6:2a:85:9b:fd:6c:56:75:da:\n"
+      "        9d:21:2d:3a:36:ef:16:72:ef:66:0b:8c:7c:25:5c:\n"
+      "        c0:ec:74:85:8f:ba:33:f4:4c:06:69:96:30:a7:6b:\n"
+      "        03:0e:e3:33\n"
+      "    P:\n"
+      "        00:8d:f2:a4:94:49:22:76:aa:3d:25:75:9b:b0:68:\n"
+      "        69:cb:ea:c0:d8:3a:fb:8d:0c:f7:cb:b8:32:4f:0d:\n"
+      "        78:82:e5:d0:76:2f:c5:b7:21:0e:af:c2:e9:ad:ac:\n"
+      "        32:ab:7a:ac:49:69:3d:fb:f8:37:24:c2:ec:07:36:\n"
+      "        ee:31:c8:02:91\n"
+      "    Q:\n"
+      "        00:c7:73:21:8c:73:7e:c8:ee:99:3b:4f:2d:ed:30:\n"
+      "        f4:8e:da:ce:91:5f\n"
+      "    G:\n"
+      "        62:6d:02:78:39:ea:0a:13:41:31:63:a5:5b:4c:b5:\n"
+      "        00:29:9d:55:22:95:6c:ef:cb:3b:ff:10:f3:99:ce:\n"
+      "        2c:2e:71:cb:9d:e5:fa:24:ba:bf:58:e5:b7:95:21:\n"
+      "        92:5c:9c:c4:2e:9f:6f:46:4b:08:8c:c5:72:af:53:\n"
+      "        e6:d7:88:02\n";
+  ASSERT_STREQ(expected, (const char *) data);
+}

--- a/crypto/fipsmodule/evp/evp.c
+++ b/crypto/fipsmodule/evp/evp.c
@@ -210,6 +210,24 @@ int EVP_PKEY_id(const EVP_PKEY *pkey) {
   return pkey->type;
 }
 
+int EVP_MD_get_pkey_type(const EVP_MD *md) {
+  if (md) {
+    int sig_nid, result = 0;
+    result = OBJ_find_sigid_by_algs(&sig_nid, md->type, NID_rsaEncryption);
+    if (result) {
+      return sig_nid;
+    }
+  }
+  return 0;
+}
+
+const char *EVP_MD_get0_name(const EVP_MD *md) {
+  if (md) {
+    return OBJ_nid2sn(EVP_MD_nid(md));
+  }
+  return NULL;
+}
+
 extern const EVP_PKEY_ASN1_METHOD *const *AWSLC_non_fips_pkey_evp_asn1_methods(void);
 
 // evp_pkey_asn1_find returns the ASN.1 method table for the given |nid|, which

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -545,6 +545,11 @@ int RAND_bytes(uint8_t *out, size_t out_len) {
   return 1;
 }
 
+int RAND_write_file(const char *file) {
+  (void) file;
+  return 1;
+}
+
 int RAND_priv_bytes(uint8_t *out, size_t out_len) {
     return RAND_bytes(out, out_len);
 }

--- a/crypto/rsa_extra/rsa_print.c
+++ b/crypto/rsa_extra/rsa_print.c
@@ -9,6 +9,8 @@
 
 #include <openssl/rsa.h>
 
+#include <openssl/bio.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
 
 
@@ -18,5 +20,19 @@ int RSA_print(BIO *bio, const RSA *rsa, int indent) {
             EVP_PKEY_set1_RSA(pkey, (RSA *)rsa) &&
             EVP_PKEY_print_private(bio, pkey, indent, NULL);
   EVP_PKEY_free(pkey);
+  return ret;
+}
+
+int RSA_print_fp(FILE *fp, const RSA *rsa, int indent) {
+  BIO *bio;
+  int ret;
+
+  if ((bio = BIO_new(BIO_s_file())) == NULL) {
+    OPENSSL_PUT_ERROR(RSA, ERR_R_BUF_LIB);
+    return 0;
+  }
+  BIO_set_fp(bio, fp, BIO_NOCLOSE);
+    ret = RSA_print(bio, rsa, indent);
+  BIO_free(bio);
   return ret;
 }

--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -62,6 +62,7 @@
 #include <gtest/gtest.h>
 
 #include <openssl/bn.h>
+#include <openssl/bio.h>
 #include <openssl/bytestring.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
@@ -1390,6 +1391,55 @@ TEST(RSATest, OverwriteKey) {
       check_rsa_compatible(/*enc=*/key1.get(), /*dec=*/key2.get()));
   ASSERT_NO_FATAL_FAILURE(
       check_rsa_compatible(/*enc=*/key2.get(), /*dec=*/key1.get()));
+}
+
+TEST(RSATest, PrintBio) {
+  bssl::UniquePtr<RSA> rsa(
+      RSA_private_key_from_bytes(kKey1, sizeof(kKey1) - 1));
+  ASSERT_TRUE(rsa);
+  bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
+
+  RSA_print(bio.get(), rsa.get(), 4);
+  const uint8_t *data;
+  size_t len;
+  BIO_mem_contents(bio.get(), &data, &len);
+
+  const char *expected = ""
+      "    Private-Key: (512 bit)\n    modulus:\n"
+      "        00:aa:36:ab:ce:88:ac:fd:ff:55:52:3c:7f:c4:52:\n"
+      "        3f:90:ef:a0:0d:f3:77:4a:25:9f:2e:62:b4:c5:d9:\n"
+      "        9c:b5:ad:b3:00:a0:28:5e:53:01:93:0e:0c:70:fb:\n"
+      "        68:76:93:9c:e6:16:ce:62:4a:11:e0:08:6d:34:1e:\n"
+      "        bc:ac:a0:a1:f5\n"
+      "    publicExponent: 17 (0x11)\n"
+      "    privateExponent:\n"
+      "        0a:03:37:48:62:64:87:69:5f:5f:30:bc:38:b9:8b:\n"
+      "        44:c2:cd:2d:ff:43:40:98:cd:20:d8:a1:38:d0:90:\n"
+      "        bf:64:79:7c:3f:a7:a2:cd:cb:3c:d1:e0:bd:ba:26:\n"
+      "        54:b4:f9:df:8e:8a:e5:9d:73:3d:9f:33:b3:01:62:\n"
+      "        4a:fd:1d:51\n"
+      "    prime1:\n"
+      "        00:d8:40:b4:16:66:b4:2e:92:ea:0d:a3:b4:32:04:\n"
+      "        b5:cf:ce:33:52:52:4d:04:16:a5:a4:41:e7:00:af:\n"
+      "        46:12:0d\n"
+      "    prime2:\n"
+      "        00:c9:7f:b1:f0:27:f4:53:f6:34:12:33:ea:aa:d1:\n"
+      "        d9:35:3f:6c:42:d0:88:66:b1:d0:5a:0f:20:35:02:\n"
+      "        8b:9d:89\n"
+      "    exponent1:\n"
+      "        59:0b:95:72:a2:c2:a9:c4:06:05:9d:c2:ab:2f:1d:\n"
+      "        af:eb:7e:8b:4f:10:a7:54:9e:8e:ed:f5:b4:fc:e0:\n"
+      "        9e:05\n"
+      "    exponent2:\n"
+      "        00:8e:3c:05:21:fe:15:e0:ea:06:a3:6f:f0:f1:0c:\n"
+      "        99:52:c3:5b:7a:75:14:fd:32:38:b8:0a:ad:52:98:\n"
+      "        62:8d:51\n"
+      "    coefficient:\n"
+      "        36:3f:f7:18:9d:a8:e9:0b:1d:34:1f:71:d0:9b:76:\n"
+      "        a8:a9:43:e1:1d:10:b2:4d:24:9f:2d:ea:fe:f8:0c:\n"
+      "        18:26\n";
+
+  ASSERT_STREQ(expected, (const char *) data);
 }
 
 #if !defined(BORINGSSL_SHARED_LIBRARY)

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -73,6 +73,7 @@
 // setting up include paths do not accidentally pick up the system
 // opensslconf.h.
 #include <openssl/is_awslc.h>
+#include <openssl/opensslv.h>
 #include <openssl/opensslconf.h>
 #include <openssl/target.h>  // IWYU pragma: export
 
@@ -99,30 +100,6 @@ extern "C" {
 
 #define AWSLC_VERSION_NAME "AWS-LC"
 #define OPENSSL_IS_AWSLC
-// |OPENSSL_VERSION_NUMBER| should match the version number in opensslv.h.
-#define OPENSSL_VERSION_NUMBER 0x1010107f
-#define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER
-
-// BORINGSSL_API_VERSION is replaced with AWSLC_API_VERSION to avoid users interpreting AWSLC as BoringSSL.
-// Below are BoringSSL's comments on BORINGSSL_API_VERSION.
-// BORINGSSL_API_VERSION is a positive integer that increments as BoringSSL
-// changes over time. The value itself is not meaningful. It will be incremented
-// whenever is convenient to coordinate an API change with consumers. This will
-// not denote any special point in development.
-//
-// A consumer may use this symbol in the preprocessor to temporarily build
-// against multiple revisions of BoringSSL at the same time. It is not
-// recommended to do so for longer than is necessary.
-
-#define AWSLC_API_VERSION 23
-
-// This string tracks the most current production release version on Github
-// https://github.com/aws/aws-lc/releases.
-// When bumping the encoded version number, also update the test fixture:
-// ServiceIndicatorTest.AWSLCVersionString
-// Note: there are two versions of this test. Only one test is compiled
-// depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.18.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -113,7 +113,6 @@ OPENSSL_EXPORT size_t FIPS_read_counter(enum fips_counter_t counter);
 
 // OPENSSL_VERSION_TEXT contains a string the identifies the version of
 // “OpenSSL”. node.js requires a version number in this text.
-#define OPENSSL_VERSION_TEXT "OpenSSL 1.1.1 (compatible; AWS-LC " AWSLC_VERSION_NUMBER_STRING ")"
 
 #define OPENSSL_VERSION 0
 #define OPENSSL_CFLAGS 1

--- a/include/openssl/des.h
+++ b/include/openssl/des.h
@@ -95,6 +95,9 @@ typedef struct DES_ks {
 OPENSSL_EXPORT void DES_set_key(const DES_cblock *key,
                                 DES_key_schedule *schedule);
 
+// DES_key_sched calls |DES_set_key| and returns 1.
+OPENSSL_EXPORT int DES_key_sched(const DES_cblock *key, DES_key_schedule *schedule);
+
 // DES_set_odd_parity sets the parity bits (the least-significant bits in each
 // byte) of |key| given the other bits in each byte.
 OPENSSL_EXPORT void DES_set_odd_parity(DES_cblock *key);

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -63,6 +63,7 @@
 #include <openssl/base.h>
 
 #include <openssl/ex_data.h>
+#include <stdio.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -89,6 +90,13 @@ OPENSSL_EXPORT void DSA_free(DSA *dsa);
 // DSA_up_ref increments the reference count of |dsa| and returns one.
 OPENSSL_EXPORT int DSA_up_ref(DSA *dsa);
 
+// DSA_print prints a textual representation of |dsa| to |bio|. It returns one
+// on success or zero otherwise.
+OPENSSL_EXPORT int DSA_print(BIO *bio, const DSA *dsa, int indent);
+
+// DSA_print_fp prints a textual representation of |dsa| to |fp|. It returns one
+// on success or zero otherwise.
+OPENSSL_EXPORT int DSA_print_fp(FILE *fp, const DSA *dsa, int indent);
 
 // Properties.
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -62,15 +62,14 @@
 #include <openssl/evp_errors.h>
 #include <openssl/thread.h>
 
-// OpenSSL included digest and cipher functions in this header so we include
-// them for users that still expect that.
-//
-// TODO(fork): clean up callers so that they include what they use.
+// OpenSSL included digest, cipher, and object functions in this header so we
+// include them for users that still expect that.
 #include <openssl/aead.h>
 #include <openssl/base64.h>
 #include <openssl/cipher.h>
 #include <openssl/digest.h>
 #include <openssl/nid.h>
+#include <openssl/objects.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -140,6 +139,16 @@ OPENSSL_EXPORT int EVP_PKEY_id(const EVP_PKEY *pkey);
 // EVP_PKEY_type returns |nid| if |nid| is a known key type and |NID_undef|
 // otherwise.
 OPENSSL_EXPORT int EVP_PKEY_type(int nid);
+
+// EVP_MD_get_pkey_type returns the NID of the public key signing algorithm
+// associated with |md| and RSA.
+OPENSSL_EXPORT int EVP_MD_get_pkey_type(const EVP_MD *md);
+#define EVP_MD_pkey_type EVP_MD_get_pkey_type
+
+// EVP_MD_get0_name returns the short name of |md|
+OPENSSL_EXPORT const char *EVP_MD_get0_name(const EVP_MD *md);
+#define EVP_MD_name EVP_MD_get0_name
+
 
 
 // Getting and setting concrete public key types.

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -1,27 +1,33 @@
-/* Copyright (c) 2014, Google Inc.
- *
- * Permission to use, copy, modify, and/or distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
- * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
- * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
 
-/* This header is provided in order to make compiling against code that expects
-   OpenSSL easier. */
+#ifndef OPENSSL_HEADER_OPENSSLV_H
+#define OPENSSL_HEADER_OPENSSLV_H
 
-#include "crypto.h"
+// BORINGSSL_API_VERSION is replaced with AWSLC_API_VERSION to avoid users interpreting AWSLC as BoringSSL.
+// Below are BoringSSL's comments on BORINGSSL_API_VERSION.
+// BORINGSSL_API_VERSION is a positive integer that increments as BoringSSL
+// changes over time. The value itself is not meaningful. It will be incremented
+// whenever is convenient to coordinate an API change with consumers. This will
+// not denote any special point in development.
+//
+// A consumer may use this symbol in the preprocessor to temporarily build
+// against multiple revisions of BoringSSL at the same time. It is not
+// recommended to do so for longer than is necessary.
 
-// MySQL does regex parsing on the opensslv.h file directly.
-// https://github.com/mysql/mysql-server/blob/8.0/cmake/ssl.cmake#L208-L227
-// |OPENSSL_VERSION_NUMBER| is defined here again to comply to this. MySQL
-// only parses this to define version numbers in their CMake script.
-// It does not require it to be active.
-#if 0
+#define AWSLC_API_VERSION 23
+
+// This string tracks the most current production release version on Github
+// https://github.com/aws/aws-lc/releases.
+// When bumping the encoded version number, also update the test fixture:
+// ServiceIndicatorTest.AWSLCVersionString
+// Note: there are two versions of this test. Only one test is compiled
+// depending on FIPS mode.
+#define AWSLC_VERSION_NUMBER_STRING "1.18.0"
+
+
 #define OPENSSL_VERSION_NUMBER 0x1010107f
+#define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER
+#define OPENSSL_VERSION_TEXT "OpenSSL 1.1.1 (compatible; AWS-LC " AWSLC_VERSION_NUMBER_STRING ")"
+
 #endif

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -23,7 +23,7 @@ extern "C" {
 
 
 // Random number generation.
-
+OPENSSL_EXPORT int RAND_write_file(const char *file);
 
 // RAND_bytes writes |len| bytes of random data to |buf| and returns one. In the
 // event that sufficient random data can not be obtained, |abort| is called.

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -62,7 +62,7 @@
 #include <openssl/engine.h>
 #include <openssl/ex_data.h>
 #include <openssl/thread.h>
-
+#include <stdio.h>
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -693,6 +693,10 @@ OPENSSL_EXPORT int RSA_padding_add_PKCS1_OAEP(uint8_t *to, size_t to_len,
 // RSA_print prints a textual representation of |rsa| to |bio|. It returns one
 // on success or zero otherwise.
 OPENSSL_EXPORT int RSA_print(BIO *bio, const RSA *rsa, int indent);
+
+// RSA_print prints a textual representation of |rsa| to |fp|. It returns one
+// on success or zero otherwise.
+OPENSSL_EXPORT int RSA_print_fp(FILE *fp, const RSA *rsa, int indent);
 
 // RSA_get0_pss_params returns NULL. In OpenSSL, this function retries RSA-PSS
 // parameters associated with |RSA| objects, but BoringSSL does not support

--- a/tests/ci/integration/ntp_patch/digests.patch
+++ b/tests/ci/integration/ntp_patch/digests.patch
@@ -1,0 +1,11 @@
+--- a/tests/libntp/digests.c
++++ b/tests/libntp/digests.c
+@@ -238,7 +238,7 @@
+ void test_Digest_MDC2(void);
+ void test_Digest_MDC2(void)
+ {
+-#ifdef OPENSSL
++#if defined(OPENSSL) && !defined(OPENSSL_NO_MDC2)
+ 	u_char expectedA[MAX_MAC_LEN] =
+ 		{
+ 			0, 0, 0, KEYID_A,

--- a/tests/ci/integration/run_ntp_integration.sh
+++ b/tests/ci/integration/run_ntp_integration.sh
@@ -1,0 +1,66 @@
+#!/bin/bash -exu
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# SYS_ROOT
+#  - SRC_ROOT(aws-lc)
+#    - SCRATCH_FOLDER
+#      - ntp
+#      - AWS_LC_BUILD_FOLDER
+#      - AWS_LC_INSTALL_FOLDER
+#      - NTP_BUILD_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER="${SRC_ROOT}/NTP_BUILD_ROOT"
+NTP_VERSION="ntp-4.2.8p17"
+NTP_SRC_FOLDER="${SCRATCH_FOLDER}/${NTP_VERSION}"
+NTP_BUILD_FOLDER="${SCRATCH_FOLDER}/ntp-aws-lc"
+NTP_PATCH_FOLDER="${SRC_ROOT}/tests/ci/integration/ntp_patch"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+
+# TODO: Remove this when we make an upstream contribution.
+function ntp_patch() {
+  for patchfile in $(find -L "${NTP_PATCH_FOLDER}" -type f -name '*.patch'); do
+    echo "Apply patch $patchfile..."
+    patch -p1 --quiet -i "$patchfile"
+  done
+}
+
+function ntp_build() {
+  ./configure --with-openssl-incdir="${AWS_LC_INSTALL_FOLDER}/include" --with-openssl-libdir="${AWS_LC_INSTALL_FOLDER}/lib/"
+  make -j "${NUM_CPU_THREADS}"
+}
+
+function ntp_run_tests() {
+  export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib"
+  make check
+}
+
+mkdir -p "${SCRATCH_FOLDER}"
+rm -rf "${SCRATCH_FOLDER:?}/*"
+cd "${SCRATCH_FOLDER}"
+
+wget "https://www.eecis.udel.edu/~ntp/ntp_spool//ntp4/ntp-4.2/${NTP_VERSION}.tar.gz"
+tar -xzvf "${NTP_VERSION}.tar.gz"
+cd "${NTP_VERSION}"
+
+mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${NTP_BUILD_FOLDER}
+ls
+
+aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=1
+
+# Build ntp from source.
+pushd ${NTP_SRC_FOLDER}
+
+ntp_patch
+ntp_build
+ntp_run_tests
+
+popd
+
+ldd "${NTP_SRC_FOLDER}/ntpd/ntpd" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-2187

### Description of changes: 
Fixes include:
1. Move version macros from base.h to opensslv.h
2. Update evp.h to also include objects.h
3. Implement DSA_print_fp, RSA_print_fp, and RAND_write_file

### Call outs
I still need to implement `RAND_write_file`.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
