### PR TITLE
Add print helper functions for RSA and DSA

### DIFF
--- a/crypto/dsa/dsa.c
+++ b/crypto/dsa/dsa.c
@@ -138,8 +138,8 @@ int DSA_print(BIO *bio, const DSA *dsa, int indent) {
 
 
 int DSA_print_fp(FILE *fp, const DSA *dsa, int indent) {
-  BIO *bio;
-  if ((bio = BIO_new(BIO_s_file())) == NULL) {
+  BIO *bio = BIO_new(BIO_s_file());
+  if (bio == NULL) {
     OPENSSL_PUT_ERROR(RSA, ERR_R_BUF_LIB);
     return 0;
   }

--- a/crypto/dsa/dsa.c
+++ b/crypto/dsa/dsa.c
@@ -61,11 +61,13 @@
 
 #include <string.h>
 
+#include <openssl/bio.h>
 #include <openssl/bn.h>
 #include <openssl/dh.h>
 #include <openssl/digest.h>
 #include <openssl/engine.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 #include <openssl/ex_data.h>
 #include <openssl/mem.h>
 #include <openssl/rand.h>
@@ -123,6 +125,31 @@ void DSA_free(DSA *dsa) {
   BN_MONT_CTX_free(dsa->method_mont_q);
   CRYPTO_MUTEX_cleanup(&dsa->method_mont_lock);
   OPENSSL_free(dsa);
+}
+
+int DSA_print(BIO *bio, const DSA *dsa, int indent) {
+  EVP_PKEY *pkey = EVP_PKEY_new();
+  int ret = pkey != NULL &&
+            EVP_PKEY_set1_DSA(pkey, (DSA *)dsa) &&
+            EVP_PKEY_print_private(bio, pkey, indent, NULL);
+  EVP_PKEY_free(pkey);
+  return ret;
+}
+
+
+int DSA_print_fp(FILE *fp, const DSA *dsa, int indent) {
+  BIO *bio;
+  int ret;
+
+  if ((bio = BIO_new(BIO_s_file())) == NULL) {
+    OPENSSL_PUT_ERROR(RSA, ERR_R_BUF_LIB);
+    return 0;
+  }
+  BIO_set_fp(bio, fp, BIO_NOCLOSE);
+  ret = DSA_print(bio, dsa, indent);
+  BIO_free(bio);
+  return ret;
+
 }
 
 int DSA_up_ref(DSA *dsa) {

--- a/crypto/dsa/dsa.c
+++ b/crypto/dsa/dsa.c
@@ -139,17 +139,14 @@ int DSA_print(BIO *bio, const DSA *dsa, int indent) {
 
 int DSA_print_fp(FILE *fp, const DSA *dsa, int indent) {
   BIO *bio;
-  int ret;
-
   if ((bio = BIO_new(BIO_s_file())) == NULL) {
     OPENSSL_PUT_ERROR(RSA, ERR_R_BUF_LIB);
     return 0;
   }
   BIO_set_fp(bio, fp, BIO_NOCLOSE);
-  ret = DSA_print(bio, dsa, indent);
+  int ret = DSA_print(bio, dsa, indent);
   BIO_free(bio);
   return ret;
-
 }
 
 int DSA_up_ref(DSA *dsa) {

--- a/crypto/rsa_extra/rsa_print.c
+++ b/crypto/rsa_extra/rsa_print.c
@@ -24,8 +24,8 @@ int RSA_print(BIO *bio, const RSA *rsa, int indent) {
 }
 
 int RSA_print_fp(FILE *fp, const RSA *rsa, int indent) {
-  BIO *bio;
-  if ((bio = BIO_new(BIO_s_file())) == NULL) {
+  BIO *bio = BIO_new(BIO_s_file());
+  if (bio == NULL) {
     OPENSSL_PUT_ERROR(RSA, ERR_R_BUF_LIB);
     return 0;
   }

--- a/crypto/rsa_extra/rsa_print.c
+++ b/crypto/rsa_extra/rsa_print.c
@@ -9,6 +9,8 @@
 
 #include <openssl/rsa.h>
 
+#include <openssl/bio.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
 
 
@@ -18,5 +20,19 @@ int RSA_print(BIO *bio, const RSA *rsa, int indent) {
             EVP_PKEY_set1_RSA(pkey, (RSA *)rsa) &&
             EVP_PKEY_print_private(bio, pkey, indent, NULL);
   EVP_PKEY_free(pkey);
+  return ret;
+}
+
+int RSA_print_fp(FILE *fp, const RSA *rsa, int indent) {
+  BIO *bio;
+  int ret;
+
+  if ((bio = BIO_new(BIO_s_file())) == NULL) {
+    OPENSSL_PUT_ERROR(RSA, ERR_R_BUF_LIB);
+    return 0;
+  }
+  BIO_set_fp(bio, fp, BIO_NOCLOSE);
+  ret = RSA_print(bio, rsa, indent);
+  BIO_free(bio);
   return ret;
 }

--- a/crypto/rsa_extra/rsa_print.c
+++ b/crypto/rsa_extra/rsa_print.c
@@ -25,14 +25,12 @@ int RSA_print(BIO *bio, const RSA *rsa, int indent) {
 
 int RSA_print_fp(FILE *fp, const RSA *rsa, int indent) {
   BIO *bio;
-  int ret;
-
   if ((bio = BIO_new(BIO_s_file())) == NULL) {
     OPENSSL_PUT_ERROR(RSA, ERR_R_BUF_LIB);
     return 0;
   }
   BIO_set_fp(bio, fp, BIO_NOCLOSE);
-  ret = RSA_print(bio, rsa, indent);
+  int ret = RSA_print(bio, rsa, indent);
   BIO_free(bio);
   return ret;
 }

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -61,8 +61,10 @@
 #define OPENSSL_HEADER_DSA_H
 
 #include <openssl/base.h>
+#include <openssl/crypto.h>
 
 #include <openssl/ex_data.h>
+#include <stdio.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -89,6 +91,13 @@ OPENSSL_EXPORT void DSA_free(DSA *dsa);
 // DSA_up_ref increments the reference count of |dsa| and returns one.
 OPENSSL_EXPORT int DSA_up_ref(DSA *dsa);
 
+// DSA_print prints a textual representation of |dsa| to |bio|. It returns one
+// on success or zero otherwise.
+OPENSSL_EXPORT int DSA_print(BIO *bio, const DSA *dsa, int indent);
+
+// DSA_print_fp prints a textual representation of |dsa| to |fp|. It returns one
+// on success or zero otherwise.
+OPENSSL_EXPORT int DSA_print_fp(FILE *fp, const DSA *dsa, int indent);
 
 // Properties.
 

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -60,11 +60,11 @@
 #include <openssl/base.h>
 #include <openssl/crypto.h>
 
-
 #include <openssl/engine.h>
 #include <openssl/ex_data.h>
 #include <openssl/thread.h>
 #include <stdio.h>
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -696,7 +696,7 @@ OPENSSL_EXPORT int RSA_padding_add_PKCS1_OAEP(uint8_t *to, size_t to_len,
 // on success or zero otherwise.
 OPENSSL_EXPORT int RSA_print(BIO *bio, const RSA *rsa, int indent);
 
-// RSA_print prints a textual representation of |rsa| to |fp|. It returns one
+// RSA_print_fp prints a textual representation of |rsa| to |fp|. It returns one
 // on success or zero otherwise.
 OPENSSL_EXPORT int RSA_print_fp(FILE *fp, const RSA *rsa, int indent);
 

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -58,11 +58,13 @@
 #define OPENSSL_HEADER_RSA_H
 
 #include <openssl/base.h>
+#include <openssl/crypto.h>
+
 
 #include <openssl/engine.h>
 #include <openssl/ex_data.h>
 #include <openssl/thread.h>
-
+#include <stdio.h>
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -693,6 +695,10 @@ OPENSSL_EXPORT int RSA_padding_add_PKCS1_OAEP(uint8_t *to, size_t to_len,
 // RSA_print prints a textual representation of |rsa| to |bio|. It returns one
 // on success or zero otherwise.
 OPENSSL_EXPORT int RSA_print(BIO *bio, const RSA *rsa, int indent);
+
+// RSA_print prints a textual representation of |rsa| to |fp|. It returns one
+// on success or zero otherwise.
+OPENSSL_EXPORT int RSA_print_fp(FILE *fp, const RSA *rsa, int indent);
 
 // RSA_get0_pss_params returns NULL. In OpenSSL, this function retries RSA-PSS
 // parameters associated with |RSA| objects, but BoringSSL does not support


### PR DESCRIPTION
### Issues:

Addresses CryptoAlg-2187

### Description of changes: 
Add the following 3 print functions.
* DSA_print
* DSA_print_fp
* RSA_print_fp

### Call-outs:
We already had an implementation of RSA_print. I tried to think of ways to share more code between DSA and RSA but I don't think it's worth the complexity to make the function work for both types.

OpenSSL has OPENSSL_NO_STDIO macro that AWS-LC has in some spots, but we already include stdio.h in other spots not guarded by this macro so I decided to always include it. 

### Testing:
Included new tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
