### PR TITLE
Add helper functions needed for NTP

### DIFF
--- a/crypto/des/des.c
+++ b/crypto/des/des.c
@@ -349,6 +349,11 @@ void DES_set_key(const DES_cblock *key, DES_key_schedule *schedule) {
   }
 }
 
+int DES_key_sched(const DES_cblock *key, DES_key_schedule *schedule) {
+  DES_set_key(key, schedule);
+  return 1;
+}
+
 static const uint8_t kOddParity[256] = {
     1,   1,   2,   2,   4,   4,   7,   7,   8,   8,   11,  11,  13,  13,  14,
     14,  16,  16,  19,  19,  21,  21,  22,  22,  25,  25,  26,  26,  28,  28,

--- a/crypto/digest_extra/digest_test.cc
+++ b/crypto/digest_extra/digest_test.cc
@@ -26,6 +26,7 @@
 #include <openssl/crypto.h>
 #include <openssl/digest.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 #include <openssl/md4.h>
 #include <openssl/md5.h>
 #include <openssl/nid.h>
@@ -395,6 +396,10 @@ TEST(DigestTest, Getters) {
   EXPECT_EQ(EVP_sha512(), EVP_get_digestbynid(NID_sha512));
   EXPECT_EQ(nullptr, EVP_get_digestbynid(NID_sha512WithRSAEncryption));
   EXPECT_EQ(nullptr, EVP_get_digestbynid(NID_undef));
+
+  EXPECT_EQ(NID_sha1WithRSAEncryption, EVP_MD_get_pkey_type(EVP_sha1()));
+  EXPECT_EQ(NID_sha512WithRSAEncryption, EVP_MD_get_pkey_type(EVP_sha512()));
+  EXPECT_STREQ("SHA512", EVP_MD_get0_name(EVP_sha512()));
 
   bssl::UniquePtr<ASN1_OBJECT> obj(OBJ_txt2obj("1.3.14.3.2.26", 0));
   ASSERT_TRUE(obj);

--- a/crypto/fipsmodule/evp/evp.c
+++ b/crypto/fipsmodule/evp/evp.c
@@ -221,7 +221,7 @@ int EVP_MD_get_pkey_type(const EVP_MD *md) {
 }
 
 const char *EVP_MD_get0_name(const EVP_MD *md) {
-  if (md) {
+  if (md != NULL) {
     return OBJ_nid2sn(EVP_MD_nid(md));
   }
   return NULL;

--- a/crypto/fipsmodule/evp/evp.c
+++ b/crypto/fipsmodule/evp/evp.c
@@ -210,6 +210,24 @@ int EVP_PKEY_id(const EVP_PKEY *pkey) {
   return pkey->type;
 }
 
+int EVP_MD_get_pkey_type(const EVP_MD *md) {
+  if (md) {
+    int sig_nid, result = 0;
+    result = OBJ_find_sigid_by_algs(&sig_nid, md->type, NID_rsaEncryption);
+    if (result) {
+      return sig_nid;
+    }
+  }
+  return 0;
+}
+
+const char *EVP_MD_get0_name(const EVP_MD *md) {
+  if (md) {
+    return OBJ_nid2sn(EVP_MD_nid(md));
+  }
+  return NULL;
+}
+
 extern const EVP_PKEY_ASN1_METHOD *const *AWSLC_non_fips_pkey_evp_asn1_methods(void);
 
 // evp_pkey_asn1_find returns the ASN.1 method table for the given |nid|, which

--- a/crypto/fipsmodule/evp/evp.c
+++ b/crypto/fipsmodule/evp/evp.c
@@ -220,11 +220,19 @@ int EVP_MD_get_pkey_type(const EVP_MD *md) {
   return 0;
 }
 
+int EVP_MD_pkey_type(const EVP_MD *md){
+  return EVP_MD_get_pkey_type(md);
+}
+
 const char *EVP_MD_get0_name(const EVP_MD *md) {
   if (md != NULL) {
     return OBJ_nid2sn(EVP_MD_nid(md));
   }
   return NULL;
+}
+
+const char *EVP_MD_name(const EVP_MD *md) {
+  return EVP_MD_get0_name(md);
 }
 
 extern const EVP_PKEY_ASN1_METHOD *const *AWSLC_non_fips_pkey_evp_asn1_methods(void);

--- a/crypto/fipsmodule/evp/evp.c
+++ b/crypto/fipsmodule/evp/evp.c
@@ -212,9 +212,8 @@ int EVP_PKEY_id(const EVP_PKEY *pkey) {
 
 int EVP_MD_get_pkey_type(const EVP_MD *md) {
   if (md) {
-    int sig_nid, result = 0;
-    result = OBJ_find_sigid_by_algs(&sig_nid, md->type, NID_rsaEncryption);
-    if (result) {
+    int sig_nid = 0;
+    if (OBJ_find_sigid_by_algs(&sig_nid, md->type, NID_rsaEncryption)) {
       return sig_nid;
     }
   }

--- a/crypto/rand_extra/rand_extra.c
+++ b/crypto/rand_extra/rand_extra.c
@@ -34,6 +34,10 @@ int RAND_load_file(const char *path, long num) {
   }
 }
 
+int RAND_write_file(const char *file) {
+  return -1;
+}
+
 const char *RAND_file_name(char *buf, size_t num) { return NULL; }
 
 void RAND_add(const void *buf, int num, double entropy) {}

--- a/include/openssl/des.h
+++ b/include/openssl/des.h
@@ -95,6 +95,9 @@ typedef struct DES_ks {
 OPENSSL_EXPORT void DES_set_key(const DES_cblock *key,
                                 DES_key_schedule *schedule);
 
+// DES_key_sched calls |DES_set_key| and returns 1.
+OPENSSL_EXPORT int DES_key_sched(const DES_cblock *key, DES_key_schedule *schedule);
+
 // DES_set_odd_parity sets the parity bits (the least-significant bits in each
 // byte) of |key| given the other bits in each byte.
 OPENSSL_EXPORT void DES_set_odd_parity(DES_cblock *key);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -140,11 +140,6 @@ OPENSSL_EXPORT int EVP_PKEY_id(const EVP_PKEY *pkey);
 // otherwise.
 OPENSSL_EXPORT int EVP_PKEY_type(int nid);
 
-// EVP_MD_get_pkey_type returns the NID of the public key signing algorithm
-// associated with |md| and RSA.
-OPENSSL_EXPORT int EVP_MD_get_pkey_type(const EVP_MD *md);
-#define EVP_MD_pkey_type EVP_MD_get_pkey_type
-
 // EVP_MD_get0_name returns the short name of |md|
 OPENSSL_EXPORT const char *EVP_MD_get0_name(const EVP_MD *md);
 #define EVP_MD_name EVP_MD_get0_name
@@ -953,6 +948,13 @@ OPENSSL_EXPORT int EVP_PKEY_kem_check_key(EVP_PKEY *key);
 // OpenSSL but does not return anything. Use the typed |EVP_PKEY_get0_*|
 // functions instead.
 OPENSSL_EXPORT void *EVP_PKEY_get0(const EVP_PKEY *pkey);
+
+// EVP_MD_get_pkey_type returns the NID of the public key signing algorithm
+// associated with |md| and RSA. This does not return all potential signing
+// algorithms that could work with |md| and should not be used.
+OPENSSL_EXPORT int EVP_MD_get_pkey_type(const EVP_MD *md);
+#define EVP_MD_pkey_type EVP_MD_get_pkey_type
+
 
 // OpenSSL_add_all_algorithms does nothing.
 OPENSSL_EXPORT void OpenSSL_add_all_algorithms(void);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -142,8 +142,9 @@ OPENSSL_EXPORT int EVP_PKEY_type(int nid);
 
 // EVP_MD_get0_name returns the short name of |md|
 OPENSSL_EXPORT const char *EVP_MD_get0_name(const EVP_MD *md);
-#define EVP_MD_name EVP_MD_get0_name
 
+// EVP_MD_name calls |EVP_MD_get0_name|
+OPENSSL_EXPORT const char *EVP_MD_name(const EVP_MD *md);
 
 // Getting and setting concrete public key types.
 //
@@ -952,7 +953,9 @@ OPENSSL_EXPORT void *EVP_PKEY_get0(const EVP_PKEY *pkey);
 // associated with |md| and RSA. This does not return all potential signing
 // algorithms that could work with |md| and should not be used.
 OPENSSL_EXPORT int EVP_MD_get_pkey_type(const EVP_MD *md);
-#define EVP_MD_pkey_type EVP_MD_get_pkey_type
+
+// EVP_MD_pkey_type calls |EVP_MD_get_pkey_type|.
+OPENSSL_EXPORT int EVP_MD_pkey_type(const EVP_MD *md);
 
 
 // OpenSSL_add_all_algorithms does nothing.

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -145,7 +145,6 @@ OPENSSL_EXPORT const char *EVP_MD_get0_name(const EVP_MD *md);
 #define EVP_MD_name EVP_MD_get0_name
 
 
-
 // Getting and setting concrete public key types.
 //
 // The following functions get and set the underlying public key in an

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -62,15 +62,14 @@
 #include <openssl/evp_errors.h>
 #include <openssl/thread.h>
 
-// OpenSSL included digest and cipher functions in this header so we include
-// them for users that still expect that.
-//
-// TODO(fork): clean up callers so that they include what they use.
+// OpenSSL included digest, cipher, and object functions in this header so we
+// include them for users that still expect that.
 #include <openssl/aead.h>
 #include <openssl/base64.h>
 #include <openssl/cipher.h>
 #include <openssl/digest.h>
 #include <openssl/nid.h>
+#include <openssl/objects.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -140,6 +139,16 @@ OPENSSL_EXPORT int EVP_PKEY_id(const EVP_PKEY *pkey);
 // EVP_PKEY_type returns |nid| if |nid| is a known key type and |NID_undef|
 // otherwise.
 OPENSSL_EXPORT int EVP_PKEY_type(int nid);
+
+// EVP_MD_get_pkey_type returns the NID of the public key signing algorithm
+// associated with |md| and RSA.
+OPENSSL_EXPORT int EVP_MD_get_pkey_type(const EVP_MD *md);
+#define EVP_MD_pkey_type EVP_MD_get_pkey_type
+
+// EVP_MD_get0_name returns the short name of |md|
+OPENSSL_EXPORT const char *EVP_MD_get0_name(const EVP_MD *md);
+#define EVP_MD_name EVP_MD_get0_name
+
 
 
 // Getting and setting concrete public key types.

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -145,7 +145,6 @@ OPENSSL_EXPORT const char *EVP_MD_get0_name(const EVP_MD *md);
 
 // EVP_MD_name calls |EVP_MD_get0_name|
 OPENSSL_EXPORT const char *EVP_MD_name(const EVP_MD *md);
-#define EVP_MD_name EVP_MD_name
 
 // Getting and setting concrete public key types.
 //
@@ -957,7 +956,6 @@ OPENSSL_EXPORT int EVP_MD_get_pkey_type(const EVP_MD *md);
 
 // EVP_MD_pkey_type calls |EVP_MD_get_pkey_type|.
 OPENSSL_EXPORT int EVP_MD_pkey_type(const EVP_MD *md);
-#define EVP_MD_pkey_type EVP_MD_pkey_type
 
 // OpenSSL_add_all_algorithms does nothing.
 OPENSSL_EXPORT void OpenSSL_add_all_algorithms(void);
@@ -1180,6 +1178,8 @@ OPENSSL_EXPORT int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key);
 #if !defined(BORINGSSL_PREFIX)
 #define EVP_PKEY_CTX_set_rsa_oaep_md EVP_PKEY_CTX_set_rsa_oaep_md
 #define EVP_PKEY_CTX_set0_rsa_oaep_label EVP_PKEY_CTX_set0_rsa_oaep_label
+#define EVP_MD_name EVP_MD_name
+#define EVP_MD_pkey_type EVP_MD_pkey_type
 #endif
 
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -145,6 +145,7 @@ OPENSSL_EXPORT const char *EVP_MD_get0_name(const EVP_MD *md);
 
 // EVP_MD_name calls |EVP_MD_get0_name|
 OPENSSL_EXPORT const char *EVP_MD_name(const EVP_MD *md);
+#define EVP_MD_name EVP_MD_name
 
 // Getting and setting concrete public key types.
 //
@@ -956,7 +957,7 @@ OPENSSL_EXPORT int EVP_MD_get_pkey_type(const EVP_MD *md);
 
 // EVP_MD_pkey_type calls |EVP_MD_get_pkey_type|.
 OPENSSL_EXPORT int EVP_MD_pkey_type(const EVP_MD *md);
-
+#define EVP_MD_pkey_type EVP_MD_pkey_type
 
 // OpenSSL_add_all_algorithms does nothing.
 OPENSSL_EXPORT void OpenSSL_add_all_algorithms(void);

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -82,6 +82,9 @@ OPENSSL_EXPORT void RAND_seed(const void *buf, int num);
 // RAND_load_file returns a nonnegative number.
 OPENSSL_EXPORT int RAND_load_file(const char *path, long num);
 
+// RAND_write_file does nothing and returns negative 1
+OPENSSL_EXPORT int RAND_write_file(const char *file);
+
 // RAND_file_name returns NULL.
 OPENSSL_EXPORT const char *RAND_file_name(char *buf, size_t num);
 

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -82,7 +82,7 @@ OPENSSL_EXPORT void RAND_seed(const void *buf, int num);
 // RAND_load_file returns a nonnegative number.
 OPENSSL_EXPORT int RAND_load_file(const char *path, long num);
 
-// RAND_write_file does nothing and returns negative 1
+// RAND_write_file does nothing and returns negative 1.
 OPENSSL_EXPORT int RAND_write_file(const char *file);
 
 // RAND_file_name returns NULL.


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-2187

### Description of changes: 
Add:
* EVP_MD_get_pkey_type
* EVP_MD_get0_name
* RAND_write_file
* DES_key_sched

### Call-outs:
AWS-LC doesn't support reading in entropy from a file with `RAND_load_file` so it seemed appropriate to not implement `RAND_write_file`. However, customers could try and use that with another library so we might want to implement it. For now it just returns an error and does nothing. At least for NTP they only use RAND load/write in the case that `RAND_status` returns 0, and for AWS-LC it always returns 1. 

EVP_MD_get_pkey_type is really weird, based on the [OpenSSL documentation](https://www.openssl.org/docs/manmaster/man3/EVP_MD_get_pkey_type.html) and reading [their code all current digests](https://github.com/openssl/openssl/blob/986c48c4eb26861f25bc68ea252d8f2aad592735/crypto/evp/legacy_sha.c#L124) are "associated" with RSA and they expect to return that PKEY type even though you could use ECDSA. 

### Testing:
Tested with NTP and locally with new tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
