### PR TITLE
Fix accidental deletion in f3e49b01

### DIFF
--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -1039,6 +1039,10 @@ static int ssl_read_impl(SSL *ssl) {
 }
 
 int SSL_read_ex(SSL *ssl, void *buf, size_t num, size_t *read_bytes) {
+  if (num == 0 && read_bytes != nullptr) {
+    *read_bytes = 0;
+    return 1;
+  }
   int ret = SSL_read(ssl, buf, (int)num);
   if (ret <= 0) {
     return 0;
@@ -1134,6 +1138,10 @@ int SSL_write(SSL *ssl, const void *buf, int num) {
 }
 
 int SSL_write_ex(SSL *ssl, const void *buf, size_t num, size_t *written) {
+  if (num == 0 && written != nullptr) {
+    *written = 0;
+    return 1;
+  }
   int ret = SSL_write(ssl, buf, (int)num);
   if (ret <= 0) {
     return 0;

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -6541,6 +6541,18 @@ TEST_P(SSLVersionTest, SSLPendingEx) {
   ASSERT_EQ(buf_len, (size_t)2);
   EXPECT_EQ(3, SSL_pending(client_.get()));
   EXPECT_EQ(1, SSL_has_pending(client_.get()));
+
+  // 0-sized IO with valid inputs should succeed but not read/write nor effect
+  // buffer state. However, NULL |read_bytes|/|written| pointer should fail.
+  const int client_pending = SSL_pending(client_.get());
+  ASSERT_EQ(1, SSL_read_ex(client_.get(), (void *)"", 0, &buf_len));
+  ASSERT_EQ(0UL, buf_len);
+  ASSERT_EQ(client_pending, SSL_pending(client_.get()));
+  ASSERT_EQ(1, SSL_write_ex(client_.get(), (void *)"", 0, &buf_len));
+  ASSERT_EQ(0UL, buf_len);
+  ASSERT_EQ(client_pending, SSL_pending(client_.get()));
+  ASSERT_EQ(0, SSL_read_ex(client_.get(), (void *)"", 0, nullptr));
+  ASSERT_EQ(0, SSL_write_ex(client_.get(), (void *)"", 0, nullptr));
 }
 
 // Test that post-handshake tickets consumed by |SSL_shutdown| are ignored.


### PR DESCRIPTION


### Issues:
- n/a

### Description of changes: 
Behavior added in commit [`89e1fd0d`][1] was accidentally removed in [`f3e49b01`][2]. This commit replaces that code.

[1]: https://github.com/aws/aws-lc/commit/89e1fd0d93360fee0b0ed54cd534ca44f6965367
[2]: https://github.com/aws/aws-lc/commit/f3e49b01fb9a58bddd5bac218d9369e36d5bfbd0

### Call-outs:
- n/a

### Testing:
- CI tests
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
