### PR TITLE
Bump AWSLC_API_VERSION for EVP_chacha20_poly1305

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -114,7 +114,7 @@ extern "C" {
 // against multiple revisions of BoringSSL at the same time. It is not
 // recommended to do so for longer than is necessary.
 
-#define AWSLC_API_VERSION 23
+#define AWSLC_API_VERSION 24
 
 // This string tracks the most current production release version on Github
 // https://github.com/aws/aws-lc/releases.

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -7,9 +7,11 @@ source tests/ci/common_posix_setup.sh
 scratch_folder=${SYS_ROOT}/"benchmark-scratch"
 install_dir="${scratch_folder}/libcrypto_install_dir"
 openssl_url='https://github.com/openssl/openssl.git'
-openssl_1_1_branch='OpenSSL_1_1_1-stable'
-openssl_1_0_branch='OpenSSL_1_0_2-stable'
-openssl_3_0_branch='openssl-3.1'
+openssl_1_1_1_branch='OpenSSL_1_1_1-stable'
+openssl_1_0_2_branch='OpenSSL_1_0_2-stable'
+openssl_3_1_branch='openssl-3.1'
+openssl_3_2_branch='openssl-3.2'
+openssl_master_branch='master'
 
 mkdir -p "${scratch_folder}"
 rm -rf "${scratch_folder:?}"/*
@@ -42,74 +44,61 @@ function build_aws_lc_fips_2022 {
     rm -rf "${scratch_folder}/aws-lc-fips-2022-11-02"
 }
 
-function build_openssl_1_0 {
-    echo "building OpenSSL 1.0"
-    git clone --depth 1 --branch "${openssl_1_0_branch}" "${openssl_url}" "${scratch_folder}/openssl-1.0"
-    pushd "${scratch_folder}/openssl-1.0"
-    mkdir -p "${install_dir}/openssl-1.0"
-    ./config --prefix="${install_dir}/openssl-1.0" --openssldir="${install_dir}/openssl-1.0" -d
+function build_openssl {
+    branch=$1
+    echo "building OpenSSL ${branch}"
+    git clone --depth 1 --branch "${branch}" "${openssl_url}" "${scratch_folder}/openssl-${branch}"
+    pushd "${scratch_folder}/openssl-${branch}"
+    mkdir -p "${install_dir}/openssl-${branch}"
+    ./config --prefix="${install_dir}/openssl-${branch}" --openssldir="${install_dir}/openssl-${branch}" -d
     make "-j${NUM_CPU_THREADS}" > /dev/null
     make install_sw
     popd
-    rm -rf "${scratch_folder}/openssl-1.0"
+    rm -rf "${scratch_folder}/openssl-${branch}"
 }
 
-function build_openssl_1_1 {
-    echo "building OpenSSL 1.1"
-    git clone --depth 1 --branch "${openssl_1_1_branch}" "${openssl_url}" "${scratch_folder}/openssl-1.1"
-    pushd "${scratch_folder}/openssl-1.1"
-    mkdir -p "${install_dir}/openssl-1.1"
-    ./config --prefix="${install_dir}/openssl-1.1" --openssldir="${install_dir}/openssl-1.1" -d
-    make "-j${NUM_CPU_THREADS}" > /dev/null
-    make install_sw
-    popd
-    rm -rf "${scratch_folder}/openssl-1.1"
-}
-
-function build_openssl_3_0 {
-    echo "building OpenSSL 3.0"
-    git clone --depth 1 --branch "${openssl_3_0_branch}" "${openssl_url}" "${scratch_folder}/openssl-3.0"
-    pushd "${scratch_folder}/openssl-3.0"
-    mkdir -p "${install_dir}/openssl-3.0"
-    ./Configure --prefix="${install_dir}/openssl-3.0" --openssldir="${install_dir}/openssl-3.0" -d
-    make "-j${NUM_CPU_THREADS}" > /dev/null
-    make install_sw
-    popd
-    rm -rf "${scratch_folder}/openssl-3.0"
-}
-
-# We build each tool individually so we can have more insight into what is failing
+#function build_openssl_3_0 {
+#    echo "building OpenSSL 3.0"
+#    git clone --depth 1 --branch "${openssl_3_0_branch}" "${openssl_url}" "${scratch_folder}/openssl-3.0"
+#    pushd "${scratch_folder}/openssl-3.0"
+#    mkdir -p "${install_dir}/openssl-3.0"
+#    ./Configure --prefix="${install_dir}/openssl-3.0" --openssldir="${install_dir}/openssl-3.0" -d
+#    make "-j${NUM_CPU_THREADS}" > /dev/null
+#    make install_sw
+#    popd
+#    rm -rf "${scratch_folder}/openssl-3.0"
+#}
 
 # Building AWS-LC always builds bssl (which includes the speed tool) with the "local" libcrypto. We
 # also support building speed.cc with an "external" aws-lc libcrypto (and openssl). This is useful
 # when we want to compare the performance of a particular FIPS release against mainline if mainline
 # has changes in speed.cc that could affect the comparison of the FIPS to non-FIPS, or if new
 # algorithms have been added to speed.cc
-build_aws_lc_fips_2022
-echo "Testing the latest version of awslc_bm with the FIPS build of fips-2022-11-02"
-run_build -DAWSLC_INSTALL_DIR="${install_dir}/aws-lc-fips-2022-11-02" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-"${BUILD_ROOT}/tool/awslc_bm"
-
 build_aws_lc_fips
-echo "Testing awslc_bm with AWS-LC FIPS build of main"
-run_build -DAWSLC_INSTALL_DIR="${install_dir}/aws-lc-fips" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-"${BUILD_ROOT}/tool/awslc_bm"
+"${BUILD_ROOT}/tool/bssl" speed -filter RNG
 
-# Run the "local" benchmark that was built with the AWS-LC FIPS benchmark, only do this once because this tool
-# is always the same regardless of what additional external libcrypto is built
-"${BUILD_ROOT}/tool/bssl" speed
+build_aws_lc_fips_2022
+build_openssl openssl_1_0_2_branch
+build_openssl openssl_1_1_1_branch
+build_openssl openssl_3_1_branch
+build_openssl openssl_3_2_branch
+build_openssl openssl_master_branch
+
+run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBENCHMARK_LIBS="\
+    aws-lc-fips:${install_dir}/aws-lc-fips-2022-11-02;\
+    open102:${install_dir}/openssl-${openssl_1_0_2_branch};\
+    open111:${install_dir}/openssl-${openssl_1_1_1_branch};\
+    open31:${install_dir}/openssl-${openssl_3_1_branch};\
+    open32:${install_dir}/openssl-${openssl_3_2_branch};\
+    openmaster:${install_dir}/openssl-${openssl_master_branch};"
+"${BUILD_ROOT}/tool/aws-lc-fips" -filter RNG
+"${BUILD_ROOT}/tool/open102" -filter RNG
+"${BUILD_ROOT}/tool/open111" -filter RNG
+"${BUILD_ROOT}/tool/open31" -filter RNG
+"${BUILD_ROOT}/tool/open32" -filter RNG
+"${BUILD_ROOT}/tool/openmaster" -filter RNG
 
 build_openssl_1_0
-echo "Testing ossl_bm with OpenSSL 1.0"
+echo "Testing ossl_bm with OpenSSL 1.0 with the legacy build option"
 run_build -DOPENSSL_1_0_INSTALL_DIR="${install_dir}/openssl-1.0" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 "${BUILD_ROOT}/tool/ossl_1_0_bm"
-
-build_openssl_1_1
-echo "Testing ossl_bm with OpenSSL 1.1"
-run_build -DOPENSSL_1_1_INSTALL_DIR="${install_dir}/openssl-1.1" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-"${BUILD_ROOT}/tool/ossl_1_1_bm"
-
-build_openssl_3_0
-echo "Testing ossl_bm with OpenSSL 3.0"
-run_build -DOPENSSL_3_0_INSTALL_DIR="${install_dir}/openssl-3.0" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-"${BUILD_ROOT}/tool/ossl_3_0_bm"

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -4,14 +4,15 @@
 
 source tests/ci/common_posix_setup.sh
 
-install_dir="$(pwd)/../libcrypto_install_dir"
+scratch_folder=${SYS_ROOT}/"benchmark-scratch"
+install_dir="${scratch_folder}/libcrypto_install_dir"
 openssl_url='https://github.com/openssl/openssl.git'
 openssl_1_1_branch='OpenSSL_1_1_1-stable'
 openssl_1_0_branch='OpenSSL_1_0_2-stable'
-# OpenSSL 3.0 branch still isn't stable yet, so we lock down
-# a tag to prevent build failures that they introduced from
-# failing our CI.
-openssl_3_0_branch='openssl-3.0.5'
+openssl_3_0_branch='openssl-3.1'
+
+mkdir -p "${scratch_folder}"
+rm -rf "${scratch_folder:?}"/*
 
 function build_aws_lc_fips {
   echo "building aws-lc in FIPS mode"
@@ -19,46 +20,62 @@ function build_aws_lc_fips {
       -DCMAKE_INSTALL_PREFIX="${install_dir}/aws-lc-fips" \
       -DFIPS=1 \
       -DENABLE_DILITHIUM=ON \
-      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DBUILD_TESTING=OFF
   pushd "$BUILD_ROOT"
   ninja install
   popd
 }
 
+function build_aws_lc_fips_2022 {
+    echo "building the fips-2022-11-02 branch of aws-lc in FIPS mode"
+    git clone --depth 1 --branch fips-2022-11-02 https://github.com/aws/aws-lc.git "${scratch_folder}/aws-lc-fips-2022-11-02"
+    pushd "${scratch_folder}/aws-lc-fips-2022-11-02"
+    cmake -GNinja \
+        -DCMAKE_INSTALL_PREFIX="${install_dir}/aws-lc-fips-2022-11-02" \
+        -DFIPS=1 \
+        -DENABLE_DILITHIUM=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DBUILD_TESTING=OFF
+    ninja install
+    popd
+    rm -rf "${scratch_folder}/aws-lc-fips-2022-11-02"
+}
+
 function build_openssl_1_0 {
     echo "building OpenSSL 1.0"
-    git clone --depth 1 --branch "${openssl_1_0_branch}" "${openssl_url}" "../openssl-1.0"
-    pushd "../openssl-1.0"
+    git clone --depth 1 --branch "${openssl_1_0_branch}" "${openssl_url}" "${scratch_folder}/openssl-1.0"
+    pushd "${scratch_folder}/openssl-1.0"
     mkdir -p "${install_dir}/openssl-1.0"
     ./config --prefix="${install_dir}/openssl-1.0" --openssldir="${install_dir}/openssl-1.0" -d
     make "-j${NUM_CPU_THREADS}" > /dev/null
     make install_sw
     popd
-    rm -rf "../openssl-1.0"
+    rm -rf "${scratch_folder}/openssl-1.0"
 }
 
 function build_openssl_1_1 {
     echo "building OpenSSL 1.1"
-    git clone --depth 1 --branch "${openssl_1_1_branch}" "${openssl_url}" "../openssl-1.1"
-    pushd "../openssl-1.1"
+    git clone --depth 1 --branch "${openssl_1_1_branch}" "${openssl_url}" "${scratch_folder}/openssl-1.1"
+    pushd "${scratch_folder}/openssl-1.1"
     mkdir -p "${install_dir}/openssl-1.1"
     ./config --prefix="${install_dir}/openssl-1.1" --openssldir="${install_dir}/openssl-1.1" -d
     make "-j${NUM_CPU_THREADS}" > /dev/null
     make install_sw
     popd
-    rm -rf "../openssl-1.1"
+    rm -rf "${scratch_folder}/openssl-1.1"
 }
 
 function build_openssl_3_0 {
     echo "building OpenSSL 3.0"
-    git clone --depth 1 --branch "${openssl_3_0_branch}" "${openssl_url}" "../openssl-3.0"
-    pushd "../openssl-3.0"
+    git clone --depth 1 --branch "${openssl_3_0_branch}" "${openssl_url}" "${scratch_folder}/openssl-3.0"
+    pushd "${scratch_folder}/openssl-3.0"
     mkdir -p "${install_dir}/openssl-3.0"
     ./Configure --prefix="${install_dir}/openssl-3.0" --openssldir="${install_dir}/openssl-3.0" -d
     make "-j${NUM_CPU_THREADS}" > /dev/null
     make install_sw
     popd
-    rm -rf "../openssl-3.0"
+    rm -rf "${scratch_folder}/openssl-3.0"
 }
 
 # We build each tool individually so we can have more insight into what is failing
@@ -68,8 +85,13 @@ function build_openssl_3_0 {
 # when we want to compare the performance of a particular FIPS release against mainline if mainline
 # has changes in speed.cc that could affect the comparison of the FIPS to non-FIPS, or if new
 # algorithms have been added to speed.cc
+build_aws_lc_fips_2022
+echo "Testing the latest version of awslc_bm with the FIPS build of fips-2022-11-02"
+run_build -DAWSLC_INSTALL_DIR="${install_dir}/aws-lc-fips-2022-11-02" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+"${BUILD_ROOT}/tool/awslc_bm"
+
 build_aws_lc_fips
-echo "Testing awslc_bm with AWS-LC FIPS"
+echo "Testing awslc_bm with AWS-LC FIPS build of main"
 run_build -DAWSLC_INSTALL_DIR="${install_dir}/aws-lc-fips" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 "${BUILD_ROOT}/tool/awslc_bm"
 

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -57,18 +57,6 @@ function build_openssl {
     rm -rf "${scratch_folder}/openssl-${branch}"
 }
 
-#function build_openssl_3_0 {
-#    echo "building OpenSSL 3.0"
-#    git clone --depth 1 --branch "${openssl_3_0_branch}" "${openssl_url}" "${scratch_folder}/openssl-3.0"
-#    pushd "${scratch_folder}/openssl-3.0"
-#    mkdir -p "${install_dir}/openssl-3.0"
-#    ./Configure --prefix="${install_dir}/openssl-3.0" --openssldir="${install_dir}/openssl-3.0" -d
-#    make "-j${NUM_CPU_THREADS}" > /dev/null
-#    make install_sw
-#    popd
-#    rm -rf "${scratch_folder}/openssl-3.0"
-#}
-
 # Building AWS-LC always builds bssl (which includes the speed tool) with the "local" libcrypto. We
 # also support building speed.cc with an "external" aws-lc libcrypto (and openssl). This is useful
 # when we want to compare the performance of a particular FIPS release against mainline if mainline

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -78,19 +78,19 @@ build_aws_lc_fips
 "${BUILD_ROOT}/tool/bssl" speed -filter RNG
 
 build_aws_lc_fips_2022
-build_openssl openssl_1_0_2_branch
-build_openssl openssl_1_1_1_branch
-build_openssl openssl_3_1_branch
-build_openssl openssl_3_2_branch
-build_openssl openssl_master_branch
+build_openssl $openssl_1_0_2_branch
+build_openssl $openssl_1_1_1_branch
+build_openssl $openssl_3_1_branch
+build_openssl $openssl_3_2_branch
+build_openssl $openssl_master_branch
 
 run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBENCHMARK_LIBS="\
-    aws-lc-fips:${install_dir}/aws-lc-fips-2022-11-02;\
-    open102:${install_dir}/openssl-${openssl_1_0_2_branch};\
-    open111:${install_dir}/openssl-${openssl_1_1_1_branch};\
-    open31:${install_dir}/openssl-${openssl_3_1_branch};\
-    open32:${install_dir}/openssl-${openssl_3_2_branch};\
-    openmaster:${install_dir}/openssl-${openssl_master_branch};"
+aws-lc-fips:${install_dir}/aws-lc-fips-2022-11-02;\
+open102:${install_dir}/openssl-${openssl_1_0_2_branch};\
+open111:${install_dir}/openssl-${openssl_1_1_1_branch};\
+open31:${install_dir}/openssl-${openssl_3_1_branch};\
+open32:${install_dir}/openssl-${openssl_3_2_branch};\
+openmaster:${install_dir}/openssl-${openssl_master_branch};"
 "${BUILD_ROOT}/tool/aws-lc-fips" -filter RNG
 "${BUILD_ROOT}/tool/open102" -filter RNG
 "${BUILD_ROOT}/tool/open111" -filter RNG
@@ -98,7 +98,6 @@ run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBENCHMARK_LIBS="\
 "${BUILD_ROOT}/tool/open32" -filter RNG
 "${BUILD_ROOT}/tool/openmaster" -filter RNG
 
-build_openssl_1_0
 echo "Testing ossl_bm with OpenSSL 1.0 with the legacy build option"
-run_build -DOPENSSL_1_0_INSTALL_DIR="${install_dir}/openssl-1.0" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+run_build -DOPENSSL_1_0_INSTALL_DIR="${install_dir}/openssl-${openssl_1_0_2_branch}" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 "${BUILD_ROOT}/tool/ossl_1_0_bm"

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -71,7 +71,38 @@ function(build_benchmark target_name install_path)
 
 endfunction()
 
+
+
+if(BENCHMARK_LIBS)
+  set(MY_LIST "item1" "item2" "item3")
+  message(STATUS "MY_LIST ${MY_LIST}")
+  message(STATUS "BENCHMARK_LIBS ${BENCHMARK_LIBS}")
+
+  set(BENCHMARK_LIBS_STR ${BENCHMARK_LIBS} CACHE STRING "Libraries and paths")
+  message(STATUS "BENCHMARK_LIBS_STR ${BENCHMARK_LIBS_STR}")
+
+#  string(REPLACE ";" ";" LIBS_LIST ${BENCHMARK_LIBS_STR})
+#  message(STATUS "LIB_LIST ${LIBS_LIST}")
+  foreach(PAIR IN LISTS BENCHMARK_LIBS_STR)
+    message(STATUS "PAIR ${PAIR}")
+
+    string(REPLACE ":" ";" PAIR_LIST ${PAIR})
+    message(STATUS "PAIR_LIST ${PAIR_LIST}")
+
+    list(LENGTH PAIR_LIST PAIR_LENGTH)
+    if(PAIR_LENGTH EQUAL 2)
+      list(GET PAIR_LIST 0 NAME)
+      list(GET PAIR_LIST 1 INSTALL_PATH)
+      build_benchmark(${NAME} ${INSTALL_PATH})
+    else()
+      message(WARNING "Invalid benchmark pair: ${PAIR}, expected format: 'exectuable_name,/path/to/install/dir")
+    endif()
+  endforeach()
+endif()
+
+## Legacy options to build speed with a particular library. Use -DBENCHMARK_LIBS="name1,/path1;name2,/path2"
 if(AWSLC_INSTALL_DIR)
+  mesage(WARNING "Use of AWSLC_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(awslc_bm ${AWSLC_INSTALL_DIR})
 endif()
 
@@ -79,18 +110,21 @@ endif()
 # Currently this is the default OpenSSL build we target so the "OPENSSL_1_1_BENCHMARK" flag isn't used,
 # but we include this to maintain uniformity across OpenSSL versions
 if(OPENSSL_1_1_INSTALL_DIR)
+  mesage(WARNING "Use of OPENSSL_1_1_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(ossl_1_1_bm ${OPENSSL_1_1_INSTALL_DIR})
   target_compile_options(ossl_1_1_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_1_1_BENCHMARK)
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/
 if(OPENSSL_1_0_INSTALL_DIR)
+  mesage(WARNING "Use of OPENSSL_1_0_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(ossl_1_0_bm ${OPENSSL_1_0_INSTALL_DIR})
   target_compile_options(ossl_1_0_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_1_0_BENCHMARK)
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/ or lib64/
 if(OPENSSL_3_0_INSTALL_DIR)
+  mesage(WARNING "Use of OPENSSL_3_0_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(ossl_3_0_bm ${OPENSSL_3_0_INSTALL_DIR})
   target_compile_options(ossl_3_0_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_3_0_BENCHMARK)
   if(NOT MSVC)
@@ -102,6 +136,7 @@ if(OPENSSL_3_0_INSTALL_DIR)
 endif()
 
 if(BORINGSSL_INSTALL_DIR)
+  mesage(WARNING "Use of BORINGSSL_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(bssl_bm ${BORINGSSL_INSTALL_DIR})
   target_compile_options(bssl_bm PUBLIC -DBORINGSSL_BENCHMARK)
 endif()

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -68,28 +68,19 @@ function(build_benchmark target_name install_path)
   if(NOT MSVC AND NOT ANDROID)
     target_link_libraries(${target_name} pthread dl)
   endif()
+  target_compile_options(${target_name} PUBLIC -Wno-deprecated-declarations)
 
 endfunction()
 
 
 
 if(BENCHMARK_LIBS)
-  set(MY_LIST "item1" "item2" "item3")
-  message(STATUS "MY_LIST ${MY_LIST}")
-  message(STATUS "BENCHMARK_LIBS ${BENCHMARK_LIBS}")
-
   set(BENCHMARK_LIBS_STR ${BENCHMARK_LIBS} CACHE STRING "Libraries and paths")
-  message(STATUS "BENCHMARK_LIBS_STR ${BENCHMARK_LIBS_STR}")
 
-#  string(REPLACE ";" ";" LIBS_LIST ${BENCHMARK_LIBS_STR})
-#  message(STATUS "LIB_LIST ${LIBS_LIST}")
   foreach(PAIR IN LISTS BENCHMARK_LIBS_STR)
-    message(STATUS "PAIR ${PAIR}")
-
     string(REPLACE ":" ";" PAIR_LIST ${PAIR})
-    message(STATUS "PAIR_LIST ${PAIR_LIST}")
-
     list(LENGTH PAIR_LIST PAIR_LENGTH)
+
     if(PAIR_LENGTH EQUAL 2)
       list(GET PAIR_LIST 0 NAME)
       list(GET PAIR_LIST 1 INSTALL_PATH)
@@ -102,7 +93,7 @@ endif()
 
 ## Legacy options to build speed with a particular library. Use -DBENCHMARK_LIBS="name1,/path1;name2,/path2"
 if(AWSLC_INSTALL_DIR)
-  mesage(WARNING "Use of AWSLC_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
+  message(WARNING "Use of AWSLC_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(awslc_bm ${AWSLC_INSTALL_DIR})
 endif()
 
@@ -110,23 +101,20 @@ endif()
 # Currently this is the default OpenSSL build we target so the "OPENSSL_1_1_BENCHMARK" flag isn't used,
 # but we include this to maintain uniformity across OpenSSL versions
 if(OPENSSL_1_1_INSTALL_DIR)
-  mesage(WARNING "Use of OPENSSL_1_1_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
+  message(WARNING "Use of OPENSSL_1_1_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(ossl_1_1_bm ${OPENSSL_1_1_INSTALL_DIR})
-  target_compile_options(ossl_1_1_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_1_1_BENCHMARK)
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/
 if(OPENSSL_1_0_INSTALL_DIR)
-  mesage(WARNING "Use of OPENSSL_1_0_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
+  message(WARNING "Use of OPENSSL_1_0_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(ossl_1_0_bm ${OPENSSL_1_0_INSTALL_DIR})
-  target_compile_options(ossl_1_0_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_1_0_BENCHMARK)
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/ or lib64/
 if(OPENSSL_3_0_INSTALL_DIR)
-  mesage(WARNING "Use of OPENSSL_3_0_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
+  message(WARNING "Use of OPENSSL_3_0_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(ossl_3_0_bm ${OPENSSL_3_0_INSTALL_DIR})
-  target_compile_options(ossl_3_0_bm PUBLIC -DOPENSSL_BENCHMARK -DOPENSSL_3_0_BENCHMARK)
   if(NOT MSVC)
     # The low-level function calls are deprecated for OpenSSL 3.0. We should revisit using these in the future,
     # but disabling the warnings works for now
@@ -136,7 +124,6 @@ if(OPENSSL_3_0_INSTALL_DIR)
 endif()
 
 if(BORINGSSL_INSTALL_DIR)
-  mesage(WARNING "Use of BORINGSSL_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
+  message(WARNING "Use of BORINGSSL_INSTALL_DIR is deprecated, the list option '-DBENCHMARK_LIBS=awslc_bm:/install/path' is recommended")
   build_benchmark(bssl_bm ${BORINGSSL_INSTALL_DIR})
-  target_compile_options(bssl_bm PUBLIC -DBORINGSSL_BENCHMARK)
 endif()

--- a/tool/internal.h
+++ b/tool/internal.h
@@ -15,7 +15,9 @@
 #ifndef OPENSSL_HEADER_TOOL_INTERNAL_H
 #define OPENSSL_HEADER_TOOL_INTERNAL_H
 
-#if !defined(OPENSSL_BENCHMARK)
+#include <openssl/crypto.h>
+
+#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
 #include <openssl/base.h>
 #include <openssl/span.h>
 #include <openssl/bytestring.h>

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2644,7 +2644,9 @@ bool Speed(const std::vector<std::string> &args) {
        !SpeedScrypt(selected) ||
 #endif
 #if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >= 24
-        // BoringSSL doesn't support ChaCha, OpenSSL 1.0 doesn't support ChaCha, only AWS-LC after API verison 24
+        // BoringSSL doesn't support ChaCha through the EVP_CIPHER API,
+        // OpenSSL 1.0 doesn't support ChaCha at all,
+        // AWS-LC only after API version 24
        !SpeedEvpCipherGeneric(EVP_chacha20_poly1305(), "EVP-ChaCha20-Poly1305", kTLSADLen, selected) ||
 #endif
 #if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >= 22

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2628,6 +2628,9 @@ bool Speed(const std::vector<std::string> &args) {
        !SpeedECMUL(selected) ||
        // OpenSSL 1.0 doesn't support Scrypt
        !SpeedScrypt(selected) ||
+#endif
+#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >= 24
+        // BoringSSL doesn't support ChaCha, OpenSSL 1.0 doesn't support ChaCha, only AWS-LC after API verison 24
        !SpeedEvpCipherGeneric(EVP_chacha20_poly1305(), "EVP-ChaCha20-Poly1305", kTLSADLen, selected) ||
 #endif
 #if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >= 22

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -37,7 +37,7 @@
 #if defined(OPENSSL_IS_AWSLC)
 #include "bssl_bm.h"
 #elif defined(OPENSSL_IS_BORINGSSL)
-#define ORINGSSL_BENCHMARK
+#define BORINGSSL_BENCHMARK
 #include "bssl_bm.h"
 #else
 #define OPENSSL_BENCHMARK

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -41,6 +41,15 @@
 #include "bssl_bm.h"
 #else
 #define OPENSSL_BENCHMARK
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define OPENSSL_3_0_BENCHMARK
+#elif OPENSSL_VERSION_NUMBER >= 0x10100000L
+#define OPENSSL_1_1_BENCHMARK
+#elif OPENSSL_VERSION_NUMBER >= 0x10000000L
+#define OPENSSL_1_0_BENCHMARK
+#else
+#error unknown OpenSSL version
+#endif
 #include "ossl_bm.h"
 #endif
 

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -33,9 +33,14 @@
 
 #include "internal.h"
 
-#if !defined(OPENSSL_BENCHMARK)
+#include <openssl/crypto.h>
+#if defined(OPENSSL_IS_AWSLC)
+#include "bssl_bm.h"
+#elif defined(OPENSSL_IS_BORINGSSL)
+#define ORINGSSL_BENCHMARK
 #include "bssl_bm.h"
 #else
+#define OPENSSL_BENCHMARK
 #include "ossl_bm.h"
 #endif
 


### PR DESCRIPTION
### Description of changes: 
Bump API version for our new EVP_CIPHER version of ChaCha. Also add a test of speed.cc with the 2022 branch of AWS-LC. 

### Testing:
This adds a new build to make sure it continues to work. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
