### PR TITLE
Integration with tpm2-tss

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -21,6 +21,16 @@ jobs:
       - name: Run integration build
         run: |
           ./tests/ci/integration/run_haproxy_integration.sh
+  tpm2-tss:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
+      - uses: actions/checkout@v3
+      - name: Run integration build
+        run: |
+          ./tests/ci/integration/run_tpm2_tss_integration.sh
   grpc:
     env:
       DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Install OS Dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
+          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang autoconf-archive libcmocka0 libcmocka-dev procps iproute2 build-essential git pkg-config gcc libtool automake libssl-dev uthash-dev autoconf doxygen libjson-c-dev libini-config-dev libcurl4-openssl-dev uuid-dev libltdl-dev libusb-1.0-0-dev libftdi-dev
       - uses: actions/checkout@v3
       - name: Run integration build
         run: |

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -59,6 +59,8 @@
 
 #include <openssl/base.h>
 #include <openssl/crypto.h>
+// OpenSSL includes BN in this header: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/include/openssl/rsa.h#L21
+#include <openssl/bn.h>
 
 #include <openssl/engine.h>
 #include <openssl/ex_data.h>

--- a/tests/ci/integration/run_tpm2_tss_integration.sh
+++ b/tests/ci/integration/run_tpm2_tss_integration.sh
@@ -39,6 +39,7 @@ function curl_build() {
   cmake -DCMAKE_DEBUG_POSTFIX='' -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="${AWS_LC_INSTALL_FOLDER}" -DCMAKE_INSTALL_PREFIX="${CURL_INSTALL_FOLDER}" -B "${CURL_BUILD_FOLDER}" -S "${CURL_SRC_FOLDER}"
   cmake --build "${CURL_BUILD_FOLDER}" --target install -j "${NUM_CPU_THREADS}"
   ldd "${CURL_INSTALL_FOLDER}/lib/libcurl.so" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
+  ldd "${CURL_INSTALL_FOLDER}/lib/libcurl.so" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libssl.so" || exit 1
 }
 
 function tpm2_tss_build() {

--- a/tests/ci/integration/run_tpm2_tss_integration.sh
+++ b/tests/ci/integration/run_tpm2_tss_integration.sh
@@ -1,0 +1,73 @@
+#!/bin/bash -exu
+#
+# Copyright Amazon.com Inc. or its affiliates.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+#
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# SYS_ROOT
+#  |
+#  - SRC_ROOT(aws-lc)
+#  |
+#  - SCRATCH_FOLDER
+#    |
+#    - tpm2_tss_patch
+#    - AWS_LC_BUILD_FOLDER
+#    - AWS_LC_INSTALL_FOLDER
+#    - CURL_BUILD_FOLDER
+#    - CURL_INSTALL_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRATCH_FOLDER=${SYS_ROOT}/"TPM2_TSS_SCRATCH"
+TPM2_TSS_SRC_FOLDER="${SCRATCH_FOLDER}/tpm2-tss"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+CURL_SRC_FOLDER="${SCRATCH_FOLDER}/curl"
+CURL_BUILD_FOLDER="${SCRATCH_FOLDER}/curl-build"
+CURL_INSTALL_FOLDER="${SCRATCH_FOLDER}/curl-install"
+
+mkdir -p "${SCRATCH_FOLDER}"
+rm -rf "${SCRATCH_FOLDER:?}"/*
+
+pushd "${SCRATCH_FOLDER}"
+
+function curl_build() {
+  cmake -DCMAKE_DEBUG_POSTFIX='' -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="${AWS_LC_INSTALL_FOLDER}" -DCMAKE_INSTALL_PREFIX="${CURL_INSTALL_FOLDER}" -B "${CURL_BUILD_FOLDER}" -S "${CURL_SRC_FOLDER}"
+  cmake --build "${CURL_BUILD_FOLDER}" --target install -j "${NUM_CPU_THREADS}"
+  ldd "${CURL_INSTALL_FOLDER}/lib/libcurl.so" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
+}
+
+function tpm2_tss_build() {
+  git apply "${SCRIPT_DIR}/tpm2_tss_patch/aws-lc-tpm2-tss.patch"
+  export PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig:${CURL_INSTALL_FOLDER}/lib/pkgconfig"
+  /bin/sh ./bootstrap
+  ./configure --enable-unit --with-crypto=ossl CFLAGS="-g -ggdb -O0 -I\"${AWS_LC_INSTALL_FOLDER}\"/include -I\"${CURL_INSTALL_FOLDER}\"/include -L\"${AWS_LC_INSTALL_FOLDER}\"/lib -L\"${CURL_INSTALL_FOLDER}\"/lib" LT_SYS_LIBRARY_PATH="${LD_LIBRARY_PATH}"
+  make -j "${NUM_CPU_THREADS}" all VERBOSE=1
+  make -j "${NUM_CPU_THREADS}" check VERBOSE=1
+  ldd "${TPM2_TSS_SRC_FOLDER}/test/unit/.libs/fapi-get-web-cert" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
+}
+
+# Get latest curl and tpm2-tss
+git clone https://github.com/curl/curl.git "${CURL_SRC_FOLDER}"
+git clone https://github.com/tpm2-software/tpm2-tss.git "${TPM2_TSS_SRC_FOLDER}"
+mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${CURL_BUILD_FOLDER}" "${CURL_INSTALL_FOLDER}"
+ls
+
+aws_lc_build "${SRC_ROOT}" "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${AWS_LC_INSTALL_FOLDER}/lib/"
+
+curl_build
+
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${CURL_INSTALL_FOLDER}/lib/"
+
+pushd "${TPM2_TSS_SRC_FOLDER}"
+tpm2_tss_build
+popd
+
+popd
+
+

--- a/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
+++ b/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
@@ -1,15 +1,15 @@
-From e87c1a633b4dafd1ca226593d86aff0b910f3109 Mon Sep 17 00:00:00 2001
+From 28016c8ca9b2c0c19b06995b99b1cefc1c7359b1 Mon Sep 17 00:00:00 2001
 From: Justin W Smith <103147162+justsmth@users.noreply.github.com>
-Date: Fri, 15 Dec 2023 15:27:22 -0500
+Date: Mon, 22 Jan 2024 10:20:12 -0500
 Subject: [PATCH] Minor fixes for AWS-LC
 
 ---
  configure.ac                       | 6 ------
- src/tss2-esys/esys_crypto_ossl.c   | 4 +++-
+ src/tss2-esys/esys_crypto_ossl.c   | 2 +-
  src/tss2-fapi/ifapi_curl.c         | 6 +++---
  src/tss2-fapi/ifapi_get_web_cert.c | 1 +
  test/unit/fapi-eventlog.c          | 8 +++++---
- 5 files changed, 12 insertions(+), 13 deletions(-)
+ 5 files changed, 10 insertions(+), 13 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
 index 4250802e..f1e0cd8d 100644
@@ -29,19 +29,10 @@ index 4250802e..f1e0cd8d 100644
             TSS2_ESYS_LDFLAGS_CRYPTO="$CRYPTO_LIBS"
         ], [test "x$with_crypto" = xmbed], [
 diff --git a/src/tss2-esys/esys_crypto_ossl.c b/src/tss2-esys/esys_crypto_ossl.c
-index 1620788c..2924638a 100644
+index 1620788c..503feefc 100644
 --- a/src/tss2-esys/esys_crypto_ossl.c
 +++ b/src/tss2-esys/esys_crypto_ossl.c
-@@ -8,6 +8,8 @@
- #include <config.h>
- #endif
- 
-+#include <openssl/mem.h>
-+#include <openssl/bn.h>
- #include <openssl/rand.h>
- #include <openssl/evp.h>
- #include <openssl/rsa.h>
-@@ -751,7 +753,7 @@ iesys_cryptossl_pk_encrypt(TPM2B_PUBLIC * pub_tpm_key,
+@@ -751,7 +751,7 @@ iesys_cryptossl_pk_encrypt(TPM2B_PUBLIC * pub_tpm_key,
                     "Could not duplicate OAEP label", cleanup);
      }
  

--- a/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
+++ b/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
@@ -1,0 +1,122 @@
+From 582d4fe349c89fd2cfbd66957c472b7c687eb429 Mon Sep 17 00:00:00 2001
+From: Justin W Smith <103147162+justsmth@users.noreply.github.com>
+Date: Fri, 15 Dec 2023 15:27:22 -0500
+Subject: [PATCH] Minor fixes for AWS-LC
+
+---
+ src/tss2-esys/esys_crypto_ossl.c   | 4 +++-
+ src/tss2-fapi/ifapi_curl.c         | 6 +++---
+ src/tss2-fapi/ifapi_get_web_cert.c | 1 +
+ test/unit/fapi-eventlog.c          | 8 +++++---
+ 4 files changed, 12 insertions(+), 7 deletions(-)
+
+diff --git a/src/tss2-esys/esys_crypto_ossl.c b/src/tss2-esys/esys_crypto_ossl.c
+index 1620788c..2924638a 100644
+--- a/src/tss2-esys/esys_crypto_ossl.c
++++ b/src/tss2-esys/esys_crypto_ossl.c
+@@ -8,6 +8,8 @@
+ #include <config.h>
+ #endif
+ 
++#include <openssl/mem.h>
++#include <openssl/bn.h>
+ #include <openssl/rand.h>
+ #include <openssl/evp.h>
+ #include <openssl/rsa.h>
+@@ -751,7 +753,7 @@ iesys_cryptossl_pk_encrypt(TPM2B_PUBLIC * pub_tpm_key,
+                    "Could not duplicate OAEP label", cleanup);
+     }
+ 
+-    if (1 != EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label_copy, strlen(label_copy)+1)) {
++    if (1 != EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, (uint8_t*)label_copy, strlen(label_copy)+1)) {
+         OPENSSL_free(label_copy);
+         goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE,
+                    "Could not set RSA label.", cleanup);
+diff --git a/src/tss2-fapi/ifapi_curl.c b/src/tss2-fapi/ifapi_curl.c
+index ca4c95e7..b9ee5523 100644
+--- a/src/tss2-fapi/ifapi_curl.c
++++ b/src/tss2-fapi/ifapi_curl.c
+@@ -77,13 +77,13 @@ get_crl_from_cert(X509 *cert, X509_CRL **crl)
+     int curl_rc;
+ 
+     *crl = NULL;
+-    for (int i = 0; i < sk_DIST_POINT_num(dist_points); i++)
++    for (size_t i = 0; i < sk_DIST_POINT_num(dist_points); i++)
+     {
+         DIST_POINT *dp = sk_DIST_POINT_value(dist_points, i);
+         DIST_POINT_NAME    *distpoint = dp->distpoint;
+         if (distpoint->type==0)
+         {
+-            for (int j = 0; j < sk_GENERAL_NAME_num(distpoint->name.fullname); j++)
++            for (size_t j = 0; j < sk_GENERAL_NAME_num(distpoint->name.fullname); j++)
+             {
+                 GENERAL_NAME *gen_name = sk_GENERAL_NAME_value(distpoint->name.fullname, j);
+                 ASN1_IA5STRING *asn1_str = gen_name->d.uniformResourceIdentifier;
+@@ -147,7 +147,7 @@ ifapi_curl_verify_ek_cert(
+     X509_STORE_CTX *ctx = NULL;
+     X509_CRL *crl_intermed = NULL;
+     X509_CRL *crl_ek = NULL;
+-    int i;
++    size_t i;
+     size_t ui;
+     AUTHORITY_INFO_ACCESS *info = NULL;
+     ASN1_IA5STRING *uri = NULL;
+diff --git a/src/tss2-fapi/ifapi_get_web_cert.c b/src/tss2-fapi/ifapi_get_web_cert.c
+index d06e8d81..b03dbf6e 100644
+--- a/src/tss2-fapi/ifapi_get_web_cert.c
++++ b/src/tss2-fapi/ifapi_get_web_cert.c
+@@ -10,6 +10,7 @@
+ #include <string.h>
+ 
+ #include <curl/curl.h>
++#include <openssl/bio.h>
+ #include <openssl/buffer.h>
+ #include <openssl/evp.h>
+ #include <openssl/sha.h>
+diff --git a/test/unit/fapi-eventlog.c b/test/unit/fapi-eventlog.c
+index 1063eecd..7ce7db40 100644
+--- a/test/unit/fapi-eventlog.c
++++ b/test/unit/fapi-eventlog.c
+@@ -138,6 +138,7 @@ check_eventlog_pcr0(const char *file, uint32_t *pcr_list, size_t pcr_list_size,
+     uint8_t *eventlog;
+     size_t size;
+     json_object *json_event_list = NULL;
++#if HAVE_EVP_SM3
+     size_t n_pcrs;
+     IFAPI_PCR_REG pcrs[TPM2_MAX_PCRS];
+ 
+@@ -158,19 +159,20 @@ check_eventlog_pcr0(const char *file, uint32_t *pcr_list, size_t pcr_list_size,
+          .buffer = { 0x15, 0xf4, 0xe6, 0xca, 0x45, 0x7d, 0x1a, 0xf6, 0xbc, 0x49,
+                      0x51, 0x1a, 0x93, 0xba, 0x35, 0x00, 0xad, 0x69, 0xac, 0xc5 },
+         };
+-
++#endif
+     /* Read file to get file size for comparison. */
+     eventlog = file_to_buffer(file, &size);
+     assert_non_null(eventlog);
+ 
+     r = ifapi_get_tcg_firmware_event_list(file, pcr_list, pcr_list_size, &json_event_list);
+     assert_int_equal (r, TSS2_RC_SUCCESS);
+-
++#if HAVE_EVP_SM3
+     r = ifapi_calculate_pcrs(json_event_list, &pcr_selection, &pcrs[0], &n_pcrs);
+     assert_int_equal (r, TSS2_RC_SUCCESS);
+ 
+     /* Compare with the pcr0 value got from system with HCRTM events */
+     assert_true(!memcmp(&expected_pcr0.buffer[0], &pcrs[0].value.buffer[0], 20));
++#endif
+ 
+     json_object_put(json_event_list);
+     SAFE_FREE(eventlog);
+@@ -180,7 +182,7 @@ static void
+ check_bios_hcrtm(void **state)
+ {
+ 
+-#ifdef __FreeBSD__
++#ifndef HAVE_EVP_SM3
+     /* Free BSD does not support SM3 hashalg */
+     skip();
+ #endif
+-- 
+2.39.2 (Apple Git-143)
+

--- a/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
+++ b/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
@@ -1,15 +1,33 @@
-From 582d4fe349c89fd2cfbd66957c472b7c687eb429 Mon Sep 17 00:00:00 2001
+From e87c1a633b4dafd1ca226593d86aff0b910f3109 Mon Sep 17 00:00:00 2001
 From: Justin W Smith <103147162+justsmth@users.noreply.github.com>
 Date: Fri, 15 Dec 2023 15:27:22 -0500
 Subject: [PATCH] Minor fixes for AWS-LC
 
 ---
+ configure.ac                       | 6 ------
  src/tss2-esys/esys_crypto_ossl.c   | 4 +++-
  src/tss2-fapi/ifapi_curl.c         | 6 +++---
  src/tss2-fapi/ifapi_get_web_cert.c | 1 +
  test/unit/fapi-eventlog.c          | 8 +++++---
- 4 files changed, 12 insertions(+), 7 deletions(-)
+ 5 files changed, 12 insertions(+), 13 deletions(-)
 
+diff --git a/configure.ac b/configure.ac
+index 4250802e..f1e0cd8d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -189,12 +189,6 @@ AS_IF([test "x$enable_esys" = xyes],
+                              [libcrypto >= ossl_min_version],,
+                              [AC_MSG_ERROR([ossl_err])])
+            AC_DEFINE([OSSL], [1], [OpenSSL cryptographic backend])
+-           AC_CHECK_LIB(crypto,[EVP_sm3], [
+-               AC_DEFINE([HAVE_EVP_SM3], [1], [Support EVP_sm3 in openssl])],
+-                [])
+-           AC_CHECK_LIB(crypto, [EVP_sm4_cfb128], [
+-               AC_DEFINE([HAVE_EVP_SM4_CFB], [1], [Support EVP_sm4_cfb in openssl])],
+-                [])
+            TSS2_ESYS_CFLAGS_CRYPTO="$CRYPTO_CFLAGS"
+            TSS2_ESYS_LDFLAGS_CRYPTO="$CRYPTO_LIBS"
+        ], [test "x$with_crypto" = xmbed], [
 diff --git a/src/tss2-esys/esys_crypto_ossl.c b/src/tss2-esys/esys_crypto_ossl.c
 index 1620788c..2924638a 100644
 --- a/src/tss2-esys/esys_crypto_ossl.c
@@ -33,7 +51,7 @@ index 1620788c..2924638a 100644
          goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE,
                     "Could not set RSA label.", cleanup);
 diff --git a/src/tss2-fapi/ifapi_curl.c b/src/tss2-fapi/ifapi_curl.c
-index ca4c95e7..b9ee5523 100644
+index 976f36d0..ab39e5aa 100644
 --- a/src/tss2-fapi/ifapi_curl.c
 +++ b/src/tss2-fapi/ifapi_curl.c
 @@ -77,13 +77,13 @@ get_crl_from_cert(X509 *cert, X509_CRL **crl)
@@ -52,7 +70,7 @@ index ca4c95e7..b9ee5523 100644
              {
                  GENERAL_NAME *gen_name = sk_GENERAL_NAME_value(distpoint->name.fullname, j);
                  ASN1_IA5STRING *asn1_str = gen_name->d.uniformResourceIdentifier;
-@@ -147,7 +147,7 @@ ifapi_curl_verify_ek_cert(
+@@ -160,7 +160,7 @@ ifapi_curl_verify_ek_cert(
      X509_STORE_CTX *ctx = NULL;
      X509_CRL *crl_intermed = NULL;
      X509_CRL *crl_ek = NULL;
@@ -118,5 +136,5 @@ index 1063eecd..7ce7db40 100644
      skip();
  #endif
 -- 
-2.39.2 (Apple Git-143)
+2.39.3 (Apple Git-145)
 


### PR DESCRIPTION
DRAFT: Integration tests will not pass until #1338 has been merged.

### Issues:
N/A

### Description of changes: 
* Add integration test for [tpm2-tss](https://github.com/tpm2-software/tpm2-tss).

### Call-outs:
N/A

### Testing:
* Ran tests on ubuntu host (rebased on #1338)
```
============================================================================
Testsuite summary for tpm2-tss 4.0.1-96-g166a5538-dirty
============================================================================
# TOTAL: 57
# PASS:  57
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
