### PR TITLE
Fix issue with older CMake when building FIPS static using Ninja buid system

### DIFF
--- a/cmake/go.cmake
+++ b/cmake/go.cmake
@@ -47,15 +47,23 @@ function(go_executable dest package)
       cmake_policy(SET CMP0116 OLD)
     endif()
 
-    set(depfile "${CMAKE_CURRENT_BINARY_DIR}/${dest}.d")
-    add_custom_command(OUTPUT ${dest}
-                       COMMAND ${GO_EXECUTABLE} build
-                               -o ${CMAKE_CURRENT_BINARY_DIR}/${dest} ${package}
-                       COMMAND ${GO_EXECUTABLE} run ${godeps} -format depfile
-                               -target ${target} -pkg ${package} -out ${depfile}
-                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                       DEPENDS ${godeps} ${CMAKE_SOURCE_DIR}/go.mod
-                       DEPFILE ${depfile})
+    if(CMAKE_VERSION VERSION_LESS "3.7")
+      add_custom_command(OUTPUT ${dest}
+                         COMMAND ${GO_EXECUTABLE} build
+                         -o ${CMAKE_CURRENT_BINARY_DIR}/${dest} ${package}
+                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                         DEPENDS ${CMAKE_SOURCE_DIR}/go.mod)
+    else()
+      set(depfile "${CMAKE_CURRENT_BINARY_DIR}/${dest}.d")
+      add_custom_command(OUTPUT ${dest}
+                         COMMAND ${GO_EXECUTABLE} build
+                         -o ${CMAKE_CURRENT_BINARY_DIR}/${dest} ${package}
+                         COMMAND ${GO_EXECUTABLE} run ${godeps} -format depfile
+                         -target ${target} -pkg ${package} -out ${depfile}
+                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                         DEPENDS ${godeps} ${CMAKE_SOURCE_DIR}/go.mod
+                         DEPFILE ${depfile})
+    endif()
   endif()
 endfunction()
 


### PR DESCRIPTION
### Description of changes: 
Support for `DEPFILE` argument for `add_custom_command` was not added till 3.7, gate the usage behind a version check.

### Testing:
```
ec2-user@devbox ~/aws-lc/build (cmake-compat) $ cmake --version
cmake version 3.2.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
ec2-user@devbox ~/aws-lc/build (cmake-compat) $ cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DFIPS=1 ..
-- The C compiler identification is GNU 11.4.1
-- Check for working C compiler using: Ninja
-- Check for working C compiler using: Ninja -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- FIPS build mode configured
-- FIPS entropy source method configured: Passive
-- The CXX compiler identification is GNU 11.4.1
-- Check for working CXX compiler using: Ninja
-- Check for working CXX compiler using: Ninja -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Perl: /usr/bin/perl (found version "5.32.1")
pkgconfig not found. Disabling unwind tests.
-- Run check_run file_to_test 'memcmp_invalid_stripped_check.c', flag_to_set 'MEMCMP_INVALID_STRIPPED', and compile_flags '-O3 -DNDEBUG'.
-- stdalign_check.c probe is positive, enabling AWS_LC_STDALIGN_AVAILABLE
-- builtin_swap_check.c probe is positive, enabling AWS_LC_BUILTIN_SWAP_SUPPORTED
-- linux_u32.c probe is positive, enabling AWS_LC_URANDOM_U32
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Using unsigned short
-- Check if the system is big endian - little endian
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Looking for include file pthread.h
-- Looking for include file pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE
-- Generating test executable mem_test.
-- Generating test executable mem_set_test.
-- Generating test executable dynamic_loading_test.
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ec2-user/aws-lc/build
ec2-user@devbox ~/aws-lc/build (cmake-compat) $ cmake --build .
[510/510] Linking CXX executable ssl/ssl_test
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
