### PR TITLE
tcpdump CI - 'apt-get update' before install

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Install OS Dependencies
         run: |
-          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make libpcap-dev binutils-dev
+          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make libpcap-dev binutils-dev
       - uses: actions/checkout@v3
       - name: Run integration build
         run: |


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Fix repeated failures of CI for tcpdump integ test

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
