### PR TITLE
Backport Perl Compat Fix and Division Fix to fips-2022-11-02, Bump Version to 2.0.3

### DIFF
--- a/crypto/fipsmodule/modes/asm/aesni-gcm-avx512.pl
+++ b/crypto/fipsmodule/modes/asm/aesni-gcm-avx512.pl
@@ -4722,8 +4722,8 @@ ___
 sub evex_byte1 {
   my ($mm, $src1, $dst) = @_;
   # set default to zero
-  $src1 //= 0;
-  $dst //= 0;
+  $src1 = 0 if (!defined($src1));
+  $dst = 0 if (!defined($dst));
 
   my $byte = 0xf0 | $mm;
 

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4051,7 +4051,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 2.0.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 2.0.3");
 }
 
 #else
@@ -4094,6 +4094,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 2.0.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 2.0.3");
 }
 #endif // AWSLC_FIPS

--- a/crypto/kyber/README.md
+++ b/crypto/kyber/README.md
@@ -23,5 +23,6 @@ The following changes were made to the source code in `pqcrystals_kyber_ref_comm
 * `kem.c`: calls to `randombytes` function is replaced with calls to `pq_custom_randombytes` and the appropriate header file is included (`crypto/rand_extra/pq_custom_randombytes.h`).
 * `symmetric-shake.c`: unnecessary include of `fips202.h` is removed.
 * `api.h`, `fips202.h`, `params.h`: modified [in this PR](https://github.com/aws/aws-lc/pull/655) to support our [prefixed symbols build](https://github.com/aws/aws-lc/blob/main/BUILDING.md#building-with-prefixed-symbols).
+* `poly.c` was modified to remove 2 lines of comment from [this commit](https://github.com/pq-crystals/kyber/commit/dda29cc63af721981ee2c831cf00822e69be3220)
 
 **Usage.** The KEM API is defined and documented in `include/openssl/evp.h`. To see examples of how to use any KEM, including Kyber, see `crypto/kem/README.md`.

--- a/crypto/kyber/pqcrystals_kyber_ref_common/poly.c
+++ b/crypto/kyber/pqcrystals_kyber_ref_common/poly.c
@@ -180,14 +180,17 @@ void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES])
 void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a)
 {
   unsigned int i,j;
-  uint16_t t;
+  uint32_t t;
 
   for(i=0;i<KYBER_N/8;i++) {
     msg[i] = 0;
     for(j=0;j<8;j++) {
       t  = a->coeffs[8*i+j];
-      t += ((int16_t)t >> 15) & KYBER_Q;
-      t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+      t <<= 1;
+      t += 1665;
+      t *= 80635;
+      t >>= 28;
+      t &= 1;
       msg[i] |= t << j;
     }
   }

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -214,7 +214,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "2.0.2"
+#define AWSLC_VERSION_NUMBER_STRING "2.0.3"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
* Backport https://github.com/aws/aws-lc/pull/960
* Backport https://github.com/aws/aws-lc/pull/1360
* Bump version to 2.0.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
