### PR TITLE
Add option to run speed for specified milliseconds

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -224,8 +224,8 @@ static uint64_t time_now() {
 }
 #endif
 
-#define TIMEOUT_SECONDS_DEFAULT 1
-static uint64_t g_timeout_seconds = TIMEOUT_SECONDS_DEFAULT;
+#define TIMEOUT_MS_DEFAULT 1000
+static uint64_t g_timeout_ms = TIMEOUT_MS_DEFAULT;
 static std::vector<size_t> g_chunk_lengths = {16, 256, 1350, 8192, 16384};
 static std::vector<size_t> g_prime_bit_lengths = {2048, 3072};
 static std::vector<std::string> g_filters = {""};
@@ -238,7 +238,7 @@ static bool TimeFunction(TimeResults *results, std::function<bool()> func) {
   }
   // total_us is the total amount of time that we'll aim to measure a function
   // for.
-  const uint64_t total_us = g_timeout_seconds * 1000000;
+  const uint64_t total_us = g_timeout_ms * 1000;
   uint64_t start = time_now(), now, delta;
 
   if (!func()) {
@@ -2340,9 +2340,9 @@ static bool SpeedDHcheck(std::string selected) {
     return true;
   }
 
-  uint64_t maybe_reset_timeout = g_timeout_seconds;
-  if (g_timeout_seconds == TIMEOUT_SECONDS_DEFAULT) {
-    g_timeout_seconds = 10;
+  uint64_t maybe_reset_timeout = g_timeout_ms;
+  if (g_timeout_ms == TIMEOUT_MS_DEFAULT) {
+    g_timeout_ms = 10000;
   }
 
   for (size_t prime_bit_length : g_prime_bit_lengths) {
@@ -2351,7 +2351,7 @@ static bool SpeedDHcheck(std::string selected) {
     }
   }
 
-  g_timeout_seconds = maybe_reset_timeout;
+  g_timeout_ms = maybe_reset_timeout;
 
   return true;
 }
@@ -2451,6 +2451,11 @@ static const argument_t kArguments[] = {
         "The number of seconds to run each test for (default is 1)",
     },
     {
+        "-timeout_ms",
+        kOptionalArgument,
+        "The number of milliseconds to run each test for (default is 1000)",
+    },
+    {
         "-chunks",
         kOptionalArgument,
         "A comma-separated list of input sizes to run tests at (default is "
@@ -2546,8 +2551,18 @@ bool Speed(const std::vector<std::string> &args) {
     g_print_json = true;
   }
 
+  if (args_map.count("-timeout") != 0 && args_map.count("-timeout_ms") != 0) {
+    puts("'-timeout' and '-timeout_ms' are mutually exclusive");
+    PrintUsage(kArguments);
+    return false;
+  }
+
   if (args_map.count("-timeout") != 0) {
-    g_timeout_seconds = atoi(args_map["-timeout"].c_str());
+    g_timeout_ms = atoi(args_map["-timeout"].c_str()) * 1000;
+  }
+
+  if (args_map.count("-timeout_ms") != 0) {
+    g_timeout_ms = atoi(args_map["-timeout"].c_str());
   }
 
   if (args_map.count("-chunks") != 0) {


### PR DESCRIPTION
### Description of changes: 
Currently speed only supports running for a set number of integer seconds, which means the shortest time is 1 second. That's a good default but to generate a lot of data for various sizes (everything from 1 byte up to 1000) of symmetric ciphers this can end up taking hours.

### Call-outs:
I thought about changing the existing timeout option to take milliseconds but that might break other existing tools so I decided to add a new option. 

### Testing:
Tested that both can't be set:
```
./tool/bssl speed -timeout_ms 10 -timeout 10
'-timeout' and '-timeout_ms' are mutually exclusive
-filter A comma-separated list of filters on the speed tests to run. Each filter is applied in independent runs.
-timeout        The number of seconds to run each test for (default is 1)
-timeout_ms     The number of milliseconds to run each test for (default is 1000)
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
