### PR TITLE
Add assertions and unify tmpfile uniqueptr

### DIFF
--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -160,14 +160,6 @@ TEST(BIOTest, CloseFlags) {
   GTEST_SKIP();
 #endif
 
-  // unique_ptr will automatically call fclose on the file descriptior when the
-  // variable goes out of scope, so we need to specify BIO_NOCLOSE close flags
-  // to avoid a double-free condition.
-  struct fclose_deleter {
-    void operator()(FILE *f) const { fclose(f); }
-  };
-  using TempFILE = std::unique_ptr<FILE, fclose_deleter>;
-
   const char *test_str = "test\ntest\ntest\n";
 
   // Assert that CRLF line endings get inserted on write and translated back out
@@ -536,12 +528,7 @@ TEST(BIOTest, Gets) {
       check_bio_gets(bio.get());
     }
 
-    struct fclose_deleter {
-      void operator()(FILE *f) const { fclose(f); }
-    };
-
-    using ScopedFILE = std::unique_ptr<FILE, fclose_deleter>;
-    ScopedFILE file(tmpfile());
+    TempFILE file(tmpfile());
 #if defined(OPENSSL_ANDROID)
     // On Android, when running from an APK, |tmpfile| does not work. See
     // b/36991167#comment8.

--- a/crypto/pem/pem_test.cc
+++ b/crypto/pem/pem_test.cc
@@ -18,10 +18,13 @@
 
 #include <openssl/asn1.h>
 #include <openssl/bio.h>
-#include <openssl/err.h>
-#include <openssl/rsa.h>
-#include <openssl/evp.h>
 #include <openssl/cipher.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+
+
+#include "../test/test_util.h"
 
 const char* SECRET = "test";
 
@@ -56,12 +59,6 @@ TEST(PEMTest, NoRC4) {
   EXPECT_EQ(PEM_R_UNSUPPORTED_ENCRYPTION, ERR_GET_REASON(err));
 }
 
-struct TmpFileDeleter {
-  void operator()(FILE *f) const { fclose(f); }
-};
-
-using TmpFilePtr = std::unique_ptr<FILE, TmpFileDeleter>;
-
 static void* d2i_ASN1_INTEGER_void(void ** out, const unsigned char **inp, long len) {
   return d2i_ASN1_INTEGER((ASN1_INTEGER **)out, inp, len);
 }
@@ -91,7 +88,7 @@ TEST(PEMTest, WriteReadASN1IntegerPem) {
     ASSERT_TRUE(ASN1_INTEGER_set(asn1_int.get(), original_value));
 
     // Create buffer for writing
-    TmpFilePtr pem_file(tmpfile());
+    TempFILE pem_file(tmpfile());
     ASSERT_TRUE(pem_file);
 
     // Write the ASN1_INTEGER to a PEM-formatted string

--- a/crypto/test/test_util.h
+++ b/crypto/test/test_util.h
@@ -73,4 +73,13 @@ std::string EncodeHex(bssl::Span<const uint8_t> in);
 // |X509*|.
 bssl::UniquePtr<X509> CertFromPEM(const char *pem);
 
+// unique_ptr will automatically call fclose on the file descriptior when the
+// variable goes out of scope, so we need to specify BIO_NOCLOSE close flags
+// to avoid a double-free condition.
+struct fclose_deleter {
+  void operator()(FILE *f) const { fclose(f); }
+};
+
+using TempFILE = std::unique_ptr<FILE, fclose_deleter>;
+
 #endif  // OPENSSL_HEADER_CRYPTO_TEST_TEST_UTIL_H


### PR DESCRIPTION
### Issues:
Resolves `V1159778876`

### Description of changes: 
Static Analysis was complaining about our lack of assertions. I also unified our usage of `tmpfile` deleters while I was at it.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
