### PR TITLE
Fix memory leaks in speed.cc

### DIFF
--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -63,7 +63,7 @@ function build_openssl {
 # has changes in speed.cc that could affect the comparison of the FIPS to non-FIPS, or if new
 # algorithms have been added to speed.cc
 build_aws_lc_fips
-"${BUILD_ROOT}/tool/bssl" speed -filter RNG
+"${BUILD_ROOT}/tool/bssl" speed -timeout_ms 10
 
 build_aws_lc_fips_2022
 build_openssl $openssl_1_0_2_branch
@@ -79,13 +79,13 @@ open111:${install_dir}/openssl-${openssl_1_1_1_branch};\
 open31:${install_dir}/openssl-${openssl_3_1_branch};\
 open32:${install_dir}/openssl-${openssl_3_2_branch};\
 openmaster:${install_dir}/openssl-${openssl_master_branch};"
-"${BUILD_ROOT}/tool/aws-lc-fips" -filter RNG
-"${BUILD_ROOT}/tool/open102" -filter RNG
-"${BUILD_ROOT}/tool/open111" -filter RNG
-"${BUILD_ROOT}/tool/open31" -filter RNG
-"${BUILD_ROOT}/tool/open32" -filter RNG
-"${BUILD_ROOT}/tool/openmaster" -filter RNG
+"${BUILD_ROOT}/tool/aws-lc-fips" -timeout_ms 10
+"${BUILD_ROOT}/tool/open102" -timeout_ms 10
+"${BUILD_ROOT}/tool/open111" -timeout_ms 10
+"${BUILD_ROOT}/tool/open31" -timeout_ms 10
+"${BUILD_ROOT}/tool/open32" -timeout_ms 10
+"${BUILD_ROOT}/tool/openmaster" -timeout_ms 10
 
 echo "Testing ossl_bm with OpenSSL 1.0 with the legacy build option"
 run_build -DOPENSSL_1_0_INSTALL_DIR="${install_dir}/openssl-${openssl_1_0_2_branch}" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-"${BUILD_ROOT}/tool/ossl_1_0_bm"
+"${BUILD_ROOT}/tool/ossl_1_0_bm" -timeout_ms 10

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -734,8 +734,8 @@ static bool SpeedAEAD(const EVP_AEAD *aead, const std::string &name,
   const size_t key_len = EVP_AEAD_key_length(aead);
   std::unique_ptr<uint8_t[]> key(new uint8_t[key_len]);
 
-  BM_NAMESPACE::ScopedEVP_AEAD_CTX ctx;
   if (!TimeFunction(&results, [&]() -> bool {
+        BM_NAMESPACE::ScopedEVP_AEAD_CTX ctx;
         return EVP_AEAD_CTX_init_with_direction(
             ctx.get(), aead, key.get(), key_len, EVP_AEAD_DEFAULT_TAG_LENGTH,
             evp_aead_seal);

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2392,13 +2392,12 @@ static bool SpeedPKCS8(const std::string &selected) {
   }
 
   CBB out;
-  if (!CBB_init(&out, 1024)) {
-    return false;
-  }
+  uint8_t buffer[1024];
 
   TimeResults results;
-  if (!TimeFunction(&results, [&out, &key]() -> bool {
-        if (!EVP_marshal_private_key(&out, key.get())) {
+  if (!TimeFunction(&results, [&out, &key, &buffer]() -> bool {
+        if (!CBB_init_fixed(&out, buffer, 1024) ||
+            !EVP_marshal_private_key(&out, key.get())) {
           return false;
         }
         return true;
@@ -2409,10 +2408,8 @@ static bool SpeedPKCS8(const std::string &selected) {
 
   CBS in;
 
-  CBS_init(&in, CBB_data(&out), CBB_len(&out));
-
-
-  if (!TimeFunction(&results, [&in]() -> bool {
+  if (!TimeFunction(&results, [&in, &out]() -> bool {
+        CBS_init(&in, CBB_data(&out), CBB_len(&out));
         EVP_PKEY *parsed = EVP_parse_private_key(&in);
         bool result = parsed != NULL;
         EVP_PKEY_free(parsed);
@@ -2424,12 +2421,10 @@ static bool SpeedPKCS8(const std::string &selected) {
 
   CBB_cleanup(&out);
 
-  if (!CBB_init(&out, 1024)) {
-    return false;
-  }
 
-  if (!TimeFunction(&results, [&out, &key]() -> bool {
-        if (!EVP_marshal_private_key_v2(&out, key.get())) {
+  if (!TimeFunction(&results, [&out, &key, &buffer]() -> bool {
+        if (!CBB_init_fixed(&out, buffer, 1024) ||
+            !EVP_marshal_private_key_v2(&out, key.get())) {
           return false;
         }
         return true;
@@ -2439,9 +2434,8 @@ static bool SpeedPKCS8(const std::string &selected) {
   }
   results.Print("Ed25519 PKCS#8 v2 encode");
 
-  CBS_init(&in, CBB_data(&out), CBB_len(&out));
-
-  if (!TimeFunction(&results, [&in]() -> bool {
+  if (!TimeFunction(&results, [&in, &out]() -> bool {
+        CBS_init(&in, CBB_data(&out), CBB_len(&out));
         EVP_PKEY *parsed = EVP_parse_private_key(&in);
         bool result = parsed != NULL;
         EVP_PKEY_free(parsed);


### PR DESCRIPTION
### Issues:
Addresses V1169792905

### Description of changes: 
Run all benchmarks with all libcryptos as a part of the build but only run them for a few milliseconds so the CI finishes faster. This helps find any library specific memory issue with address sanitizer.

Fix a small memory leak in the AEAD init benchmark. The TLS specific AEAD_init function allocate a `AEAD_TLS_CTX`  and you need to call cleanup on each one. This get handled in the rest of the benchmark thanks to the use of `ScopedEVP_AEAD_CTX` 

Fix the race condition between the encode/decode PKCS8 benchmark. Currently the CBB/CBS grow based on the number of benchmark iterations and end up at 10s of thousands of bytes long. This causes two issues:
1. The benchmark includes the time to reallocate the buffers to be bigger and bigger
2. If the decode benchmark runs for more iterations than the encode benchmark they run out of data and fail

This change uses a fixed sized input buffer and reinitialize it each run to the same buffer. `CBB_init_fixed` can't grow, and the operation is fairly cheap: it just sets the field in the item and then always returns 1.

### Call-outs:
This change invalidates any comparison of the benchmark results with old code.

### Testing:
Ran locally and tweaked the benchmark to run decode longer than encode:
```
./tool/bssl speed -filter pkcs8 -timeout_ms 1
Did 250 Ed25519 PKCS#8 v1 encode operations in 72us (3472222.2 ops/sec)
Did 1000 Ed25519 PKCS#8 v1 decode operations in 12305us (81267.8 ops/sec)
Did 250 Ed25519 PKCS#8 v2 encode operations in 64us (3906250.0 ops/sec)
Did 1000 Ed25519 PKCS#8 v2 decode operations in 11469us (87191.6 ops/sec)
```

Before:
```
./tool/bssl speed -filter pkcs8
Did 8375000 Ed25519 PKCS#8 v1 encode operations in 1000051us (8374572.9 ops/sec)
Did 170000 Ed25519 PKCS#8 v1 decode operations in 1004771us (169192.8 ops/sec)
Did 6468500 Ed25519 PKCS#8 v2 encode operations in 1015469us (6369963.0 ops/sec)
Did 171000 Ed25519 PKCS#8 v2 decode operations in 1003729us (170364.7 ops/sec)
```

After encode appears to be ~25% faster for encode because it avoids the memory allocations:
```
./tool/bssl speed -filter pkcs8
Did 9655500 Ed25519 PKCS#8 v1 encode operations in 1000004us (9655461.4 ops/sec)
Did 172000 Ed25519 PKCS#8 v1 decode operations in 1002199us (171622.6 ops/sec)
Did 8196000 Ed25519 PKCS#8 v2 encode operations in 1000097us (8195205.1 ops/sec)
Did 172000 Ed25519 PKCS#8 v2 decode operations in 1001976us (171660.8 ops/sec)
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
