### PR TITLE
Fix case issue with sha-224 in speed tool

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2636,7 +2636,7 @@ bool Speed(const std::vector<std::string> &args) {
 #endif
        !SpeedHash(EVP_md5(), "MD5", selected) ||
        !SpeedHash(EVP_sha1(), "SHA-1", selected) ||
-       !SpeedHash(EVP_sha224(), "sha-224", selected) ||
+       !SpeedHash(EVP_sha224(), "SHA-224", selected) ||
        !SpeedHash(EVP_sha256(), "SHA-256", selected) ||
        !SpeedHash(EVP_sha384(), "SHA-384", selected) ||
        !SpeedHash(EVP_sha512(), "SHA-512", selected) ||


### PR DESCRIPTION
### Description of changes: 

Speed tool filtering functionality is case-sensitive.

Before
```
$ ./tool/bssl speed -filter SHA- -chunks 16                                                                                                                  
Did 13563000 SHA-1 (16 bytes) operations in 1000019us (13562742.3 ops/sec): 217.0 MB/s
Did 11213250 SHA-256 (16 bytes) operations in 1000022us (11213003.3 ops/sec): 179.4 MB/s
Did 3752750 SHA-384 (16 bytes) operations in 1000048us (3752569.9 ops/sec): 60.0 MB/s
Did 3727000 SHA-512 (16 bytes) operations in 1000029us (3726891.9 ops/sec): 59.6 MB/s
```

After
```
$ ./tool/bssl speed -filter SHA- -chunks 16
Did 13658000 SHA-1 (16 bytes) operations in 1000061us (13657166.9 ops/sec): 218.5 MB/s
Did 11268500 SHA-224 (16 bytes) operations in 1000009us (11268398.6 ops/sec): 180.3 MB/s
Did 11229000 SHA-256 (16 bytes) operations in 1000021us (11228764.2 ops/sec): 179.7 MB/s
Did 3753250 SHA-384 (16 bytes) operations in 1000036us (3753114.9 ops/sec): 60.0 MB/s
Did 3740000 SHA-512 (16 bytes) operations in 1000023us (3739914.0 ops/sec): 59.8 MB/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
