### PR TITLE
Add field-based accessors to SHA_CTX for compatibility

### DIFF
--- a/include/openssl/sha.h
+++ b/include/openssl/sha.h
@@ -97,7 +97,23 @@ OPENSSL_EXPORT void SHA1_Transform(SHA_CTX *sha,
                                    const uint8_t block[SHA_CBLOCK]);
 
 struct sha_state_st {
+#if defined(__cplusplus) || defined(OPENSSL_WINDOWS)
   uint32_t h[5];
+#else
+  // wpa_supplicant accesses |h0|..|h4| so we must support those names for
+  // compatibility with it until it can be updated. Anonymous unions are only
+  // standard in C11, so disable this workaround in C++.
+  union {
+    uint32_t h[5];
+    struct {
+      uint32_t h0;
+      uint32_t h1;
+      uint32_t h2;
+      uint32_t h3;
+      uint32_t h4;
+    };
+  };
+#endif
   uint32_t Nl, Nh;
   uint8_t data[SHA_CBLOCK];
   unsigned num;


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-2081

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

Upstream OpenSSL defines the h_n values as individual fields rather than
an array which BoringSSL introduced. This will improve our compatibility with
code that typically builds against OpenSSL. For example, this is breaking the
strongSwan build when compiling against AWS-LC.

Original BoringSSL source [here](https://github.com/google/boringssl/blob/master/include/openssl/sha.h#L116)

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

These fields were removed from AWS-LC early on in the project by PR #58.
Seemed more incidental rather than intentional, but I don't have the full
context here.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
