### PR TITLE
Add an additional test that HAProxy is built with AWS-LC

### DIFF
--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -52,12 +52,15 @@ cd haproxy
 ./scripts/build-vtest.sh
 
 # Test with static AWS-LC libraries
-aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=0
-build_and_test_haproxy $HAPROXY_SRC
+aws_lc_build "${SRC_ROOT}" "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+build_and_test_haproxy
 
 rm -rf "${AWS_LC_INSTALL_FOLDER:?}"/*
 rm -rf "${AWS_LC_BUILD_FOLDER:?}"/*
 
 # Test with shared AWS-LC libraries
-aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} -DBUILD_SHARED_LIBS=1 -DBUILD_TESTING=0
-build_and_test_haproxy $HAPROXY_SRC
+aws_lc_build "${SRC_ROOT}" "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${AWS_LC_INSTALL_FOLDER}/lib/"
+build_and_test_haproxy
+
+ldd "${HAPROXY_SRC}/haproxy" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1


### PR DESCRIPTION
### Description of changes: 
This updates the HAProxy test to follow our recent integration test best practice and adds a check that the shared library build of HAProxy is indeed loading AWS-LC. Quote variables to fix minor shellcheck warnings, and stop passing in the unused `HAPROXY_SRC` folder, the `build_and_test_haproxy` function already knows where the code is. 

### Testing:
Tested locally and in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
