### PR TITLE
Add socat integration test

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - name: Install OS Dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make autoconf pkg-config
+          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make autoconf pkg-config openssl
       - uses: actions/checkout@v3
       - name: Run integration build
         run: |

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -71,3 +71,14 @@ jobs:
       - name: Run ntp build
         run: |
           ./tests/ci/integration/run_ntp_integration.sh
+  socat:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make autoconf pkg-config
+      - uses: actions/checkout@v3
+      - name: Run integration build
+        run: |
+          ./tests/ci/integration/run_socat_integration.sh
+

--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -22,7 +22,27 @@ function build_and_test_socat() {
   autoconf
   ./configure --enable-openssl-base="$AWS_LC_INSTALL_FOLDER"
   make -j "$NUM_CPU_THREADS"
-  ./test.sh -d -v "$@"
+  # test 146 OPENSSLLISTENDSA: fails because AWS-LC doesn't support FFDH ciphersuites which are needed for DSA
+  # test 216 UDP6MULTICAST_UNIDIR: known flaky test in socat with newer kernels
+  # test 309 OPENSSLRENEG1: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
+  # but that has caveats. See PORTING.md 'TLS renegotiation'
+  # test 310 OPENSSLRENEG2: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
+  # but that has caveats. See PORTING.md 'TLS renegotiation'
+  # test 399 OPENSSL_DTLS_CLIENT: Unknown issue running openssl s_server
+  # test 467 EXEC_FDS: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
+  # test 468 EXEC_SNIFF: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
+  # test 478 SIGUSR1_STATISTICS: GHA does not support tty
+  # test 492 ACCEPT_FD: uses systemd-socket-activate which doesn't inherit the LD_LIBRARY_PATH so socat can't find libcrypto.so
+  # test 498 SHELL_SOCKETPAIR: GHA does not specify expected shell environment variables
+  # test 499 SHELL_PIPES: GHA does not specify expected shell environment variables
+  # test 500 SHELL_PTY: GHA does not specify expected shell environment variables
+  # test 501 SHELL_SOCKETPAIR_FLUSH: GHA does not specify expected shell environment variables
+  # test 502 SHELL_PIPES: GHA does not specify expected shell environment variables
+  # test 503 SYSTEM_SIGINT: GHA does not specify expected shell environment variables
+  # test 506 CHDIR_ON_SHELL: GHA does not specify expected shell environment variables
+  # test 508 UMASK_ON_SYSTEM: GHA does not specify expected shell environment variables
+  # test 528 PROCAN_CTTY: GHA does not support tty
+  ./test.sh -d -v --expect-fail 146,216,309,310,399,467,468,478,492,498,499,500,501,502,503,506,508,528
   popd
 }
 
@@ -33,33 +53,8 @@ rm -rf "${SCRATCH_FOLDER:?}"/*
 mkdir -p "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER"
 git clone --depth 1 https://repo.or.cz/socat.git "$SOCAT_SRC"
 
-aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-# test 146 OPENSSLLISTENDSA: fails because AWS-LC doesn't support FFDH ciphersuites which are needed for DSA
-# test 216 UDP6MULTICAST_UNIDIR: known flaky test in socat with newer kernels
-# test 309 OPENSSLRENEG1: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
-# but that has caveats. See PORTING.md 'TLS renegotiation'
-# test 310 OPENSSLRENEG2: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
-# but that has caveats. See PORTING.md 'TLS renegotiation'
-build_and_test_socat --expect-fail 146,216,309,310
-
-rm -rf "$AWS_LC_INSTALL_FOLDER"
-
 aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_SHARED_LIBS=1 -DBUILD_TESTING=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib/:${LD_LIBRARY_PATH:-}"
-# test 399 OPENSSL_DTLS_CLIENT: Unknown issue running openssl s_server
-# test 467 EXEC_FDS: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
-# test 468 EXEC_SNIFF: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
-# test 478 SIGUSR1_STATISTICS: GHA does not support tty
-# test 492 ACCEPT_FD: uses systemd-socket-activate which doesn't inherit the LD_LIBRARY_PATH so socat can't find libcrypto.so
-# test 498 SHELL_SOCKETPAIR: GHA does not specify expected shell environment variables
-# test 499 SHELL_PIPES: GHA does not specify expected shell environment variables
-# test 500 SHELL_PTY: GHA does not specify expected shell environment variables
-# test 501 SHELL_SOCKETPAIR_FLUSH: GHA does not specify expected shell environment variables
-# test 502 SHELL_PIPES: GHA does not specify expected shell environment variables
-# test 503 SYSTEM_SIGINT: GHA does not specify expected shell environment variables
-# test 506 CHDIR_ON_SHELL: GHA does not specify expected shell environment variables
-# test 508 UMASK_ON_SYSTEM: GHA does not specify expected shell environment variables
-# test 528 PROCAN_CTTY: GHA does not support tty
-build_and_test_socat --expect-fail 146,216,309,310,399,467,468,478,492,498,499,500,501,502,503,506,508,528
+build_and_test_socat
 
 ldd "${SOCAT_SRC}/socat" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1

--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -29,7 +29,7 @@ function build_and_test_socat() {
   # test 310 OPENSSLRENEG2: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
   # but that has caveats. See PORTING.md 'TLS renegotiation'
   # test 492 ACCEPT_FD: uses systemd-socket-activate which doesn't inherit the LD_LIBRARY_PATH so socat can't find libcrypto.so
-  ./test.sh --expect-fail 146,216,309,310,492
+  ./test.sh -d -v --expect-fail 146,216,309,310,492
   popd
 }
 

--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -28,8 +28,20 @@ function build_and_test_socat() {
   # but that has caveats. See PORTING.md 'TLS renegotiation'
   # test 310 OPENSSLRENEG2: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
   # but that has caveats. See PORTING.md 'TLS renegotiation'
+  # test 399 OPENSSL_DTLS_CLIENT: Unknown issue running openssl s_server
+  # test 467 EXEC_FDS: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
+  # test 468 EXEC_SNIFF: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
   # test 492 ACCEPT_FD: uses systemd-socket-activate which doesn't inherit the LD_LIBRARY_PATH so socat can't find libcrypto.so
-  ./test.sh -d -v --expect-fail 146,216,309,310,492
+  # test 498 SHELL_SOCKETPAIR: GHA does not specify expected shell environment variables
+  # test 499 SHELL_PIPES: GHA does not specify expected shell environment variables
+  # test 500 SHELL_PTY: GHA does not specify expected shell environment variables
+  # test 501 SHELL_SOCKETPAIR_FLUSH: GHA does not specify expected shell environment variables
+  # test 502 SHELL_PIPES: GHA does not specify expected shell environment variables
+  # test 503 SYSTEM_SIGINT: GHA does not specify expected shell environment variables
+  # test 506 CHDIR_ON_SHELL: GHA does not specify expected shell environment variables
+  # test 508 UMASK_ON_SYSTEM: GHA does not specify expected shell environment variables
+  # test 528 PROCAN_CTTY: GHA does not support tty
+  ./test.sh -d -v --expect-fail 146,216,309,310,399,467,468,492,498,499,500,501,502,503,506,508,528
   popd
 }
 

--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -22,27 +22,7 @@ function build_and_test_socat() {
   autoconf
   ./configure --enable-openssl-base="$AWS_LC_INSTALL_FOLDER"
   make -j "$NUM_CPU_THREADS"
-  # test 146 OPENSSLLISTENDSA: fails because AWS-LC doesn't support FFDH ciphersuites which are needed for DSA
-  # test 216 UDP6MULTICAST_UNIDIR: known flaky test in socat with newer kernels
-  # test 309 OPENSSLRENEG1: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
-  # but that has caveats. See PORTING.md 'TLS renegotiation'
-  # test 310 OPENSSLRENEG2: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
-  # but that has caveats. See PORTING.md 'TLS renegotiation'
-  # test 399 OPENSSL_DTLS_CLIENT: Unknown issue running openssl s_server
-  # test 467 EXEC_FDS: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
-  # test 468 EXEC_SNIFF: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
-  # test 478 SIGUSR1_STATISTICS: GHA does not support tty
-  # test 492 ACCEPT_FD: uses systemd-socket-activate which doesn't inherit the LD_LIBRARY_PATH so socat can't find libcrypto.so
-  # test 498 SHELL_SOCKETPAIR: GHA does not specify expected shell environment variables
-  # test 499 SHELL_PIPES: GHA does not specify expected shell environment variables
-  # test 500 SHELL_PTY: GHA does not specify expected shell environment variables
-  # test 501 SHELL_SOCKETPAIR_FLUSH: GHA does not specify expected shell environment variables
-  # test 502 SHELL_PIPES: GHA does not specify expected shell environment variables
-  # test 503 SYSTEM_SIGINT: GHA does not specify expected shell environment variables
-  # test 506 CHDIR_ON_SHELL: GHA does not specify expected shell environment variables
-  # test 508 UMASK_ON_SYSTEM: GHA does not specify expected shell environment variables
-  # test 528 PROCAN_CTTY: GHA does not support tty
-  ./test.sh -d -v --expect-fail 146,216,309,310,399,467,468,478,492,498,499,500,501,502,503,506,508,528
+  ./test.sh -d -v "$@"
   popd
 }
 
@@ -53,8 +33,33 @@ rm -rf "${SCRATCH_FOLDER:?}"/*
 mkdir -p "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER"
 git clone --depth 1 https://repo.or.cz/socat.git "$SOCAT_SRC"
 
+aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+# test 146 OPENSSLLISTENDSA: fails because AWS-LC doesn't support FFDH ciphersuites which are needed for DSA
+# test 216 UDP6MULTICAST_UNIDIR: known flaky test in socat with newer kernels
+# test 309 OPENSSLRENEG1: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
+# but that has caveats. See PORTING.md 'TLS renegotiation'
+# test 310 OPENSSLRENEG2: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
+# but that has caveats. See PORTING.md 'TLS renegotiation'
+build_and_test_socat --expect-fail 146,216,309,310
+
+rm -rf "$AWS_LC_INSTALL_FOLDER"
+
 aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_SHARED_LIBS=1 -DBUILD_TESTING=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib/:${LD_LIBRARY_PATH:-}"
-build_and_test_socat
+# test 399 OPENSSL_DTLS_CLIENT: Unknown issue running openssl s_server
+# test 467 EXEC_FDS: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
+# test 468 EXEC_SNIFF: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
+# test 478 SIGUSR1_STATISTICS: GHA does not support tty
+# test 492 ACCEPT_FD: uses systemd-socket-activate which doesn't inherit the LD_LIBRARY_PATH so socat can't find libcrypto.so
+# test 498 SHELL_SOCKETPAIR: GHA does not specify expected shell environment variables
+# test 499 SHELL_PIPES: GHA does not specify expected shell environment variables
+# test 500 SHELL_PTY: GHA does not specify expected shell environment variables
+# test 501 SHELL_SOCKETPAIR_FLUSH: GHA does not specify expected shell environment variables
+# test 502 SHELL_PIPES: GHA does not specify expected shell environment variables
+# test 503 SYSTEM_SIGINT: GHA does not specify expected shell environment variables
+# test 506 CHDIR_ON_SHELL: GHA does not specify expected shell environment variables
+# test 508 UMASK_ON_SYSTEM: GHA does not specify expected shell environment variables
+# test 528 PROCAN_CTTY: GHA does not support tty
+build_and_test_socat --expect-fail 146,216,309,310,399,467,468,478,492,498,499,500,501,502,503,506,508,528
 
 ldd "${SOCAT_SRC}/socat" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1

--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -31,6 +31,7 @@ function build_and_test_socat() {
   # test 399 OPENSSL_DTLS_CLIENT: Unknown issue running openssl s_server
   # test 467 EXEC_FDS: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
   # test 468 EXEC_SNIFF: Something broken with exec'ing and not inheriting LD_LIBRARY_PATH
+  # test 478 SIGUSR1_STATISTICS: GHA does not support tty
   # test 492 ACCEPT_FD: uses systemd-socket-activate which doesn't inherit the LD_LIBRARY_PATH so socat can't find libcrypto.so
   # test 498 SHELL_SOCKETPAIR: GHA does not specify expected shell environment variables
   # test 499 SHELL_PIPES: GHA does not specify expected shell environment variables
@@ -41,7 +42,7 @@ function build_and_test_socat() {
   # test 506 CHDIR_ON_SHELL: GHA does not specify expected shell environment variables
   # test 508 UMASK_ON_SYSTEM: GHA does not specify expected shell environment variables
   # test 528 PROCAN_CTTY: GHA does not support tty
-  ./test.sh -d -v --expect-fail 146,216,309,310,399,467,468,492,498,499,500,501,502,503,506,508,528
+  ./test.sh -d -v --expect-fail 146,216,309,310,399,467,468,478,492,498,499,500,501,502,503,506,508,528
   popd
 }
 

--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -exu
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+# SRC_ROOT(aws-lc)
+#  - SCRATCH_FOLDER
+#    - SOCAT_SRC
+#    - AWS_LC_BUILD_FOLDER
+#    - AWS_LC_INSTALL_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER=${SRC_ROOT}/"scratch"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+SOCAT_SRC="${SCRATCH_FOLDER}/socat"
+
+function build_and_test_socat() {
+  cd "$SOCAT_SRC"
+  autoconf
+  ./configure --enable-openssl-base="$AWS_LC_INSTALL_FOLDER"
+  make -j "$NUM_CPU_THREADS"
+  # test 146 OPENSSLLISTENDSA: fails because AWS-LC doesn't support FFDH ciphersuites which are needed for DSA
+  # test 216 UDP6MULTICAST_UNIDIR: known flaky test in socat with newer kernels
+  # test 309 OPENSSLRENEG1: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
+  # but that has caveats. See PORTING.md 'TLS renegotiation'
+  # test 310 OPENSSLRENEG2: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode
+  # but that has caveats. See PORTING.md 'TLS renegotiation'
+  # test 492 ACCEPT_FD: uses systemd-socket-activate which doesn't inherit the LD_LIBRARY_PATH so socat can't find libcrypto.so
+  ./test.sh --expect-fail 146,216,309,310,492
+}
+
+# Make script execution idempotent.
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf "${SCRATCH_FOLDER:?}"/*
+cd ${SCRATCH_FOLDER}
+
+mkdir -p "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER"
+git clone --depth 1 https://repo.or.cz/socat.git
+cd socat
+
+aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_SHARED_LIBS=1 -DBUILD_TESTING=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${AWS_LC_INSTALL_FOLDER}/lib/"
+build_and_test_socat
+
+ldd "${SOCAT_SRC}/socat" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1

--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -58,3 +58,4 @@ export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib/:${LD_LIBRARY_PATH:-}"
 build_and_test_socat
 
 ldd "${SOCAT_SRC}/socat" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
+ldd "${SOCAT_SRC}/socat" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libssl.so" || exit 1


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-2188

### Call-outs:
I decided to skip the renegotiation tests for now. If a customer needs socat + AWS-LC we can investigate adding the support to socat by calling `SSL_set_renegotiate_mode` which is an AWS-LC specific API. Or we could change the default behavior and enable renegotiation by default to match OpenSSL.

### Testing:
New GHA that runs, tested run_socat_integration.sh locally. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
