### PR TITLE
FIPS 2.0.4 release version number update

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4051,7 +4051,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 2.0.3");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 2.0.4");
 }
 
 #else
@@ -4094,6 +4094,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 2.0.3");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 2.0.4");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -214,7 +214,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "2.0.3"
+#define AWSLC_VERSION_NUMBER_STRING "2.0.4"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
New version number FIPS release with Kyber and AVX fixes. https://github.com/aws/aws-lc/releases/edit/untagged-6e40ce6d2c92d9afe58c

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
