### PR TITLE
Initialize ECCurveTest values to null instead of relying on uninitialized value from default constructor

### DIFF
--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1337,7 +1337,7 @@ class ECCurveTest : public testing::TestWithParam<int> {
   }
 
  private:
-  const EC_GROUP *group_;
+  const EC_GROUP *group_{};
 };
 
 TEST_P(ECCurveTest, SetAffine) {


### PR DESCRIPTION
### Issues:
Resolves V1191422372

### Description of changes: 
Before this change `group_` could be uninitialized, by adding `{}` it is always initialized to null.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
