### PR TITLE
Always run 'apt-get update' before 'installing'

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Sanity Test Run
         run: |
+          sudo apt-get update
           sudo apt-get install ninja-build
           cmake -GNinja -Btest_build_dir
           ninja -C test_build_dir run_tests

--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -30,6 +30,7 @@ jobs:
           args: rust-script
       - name: Install OS Dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y --no-install-recommends install cmake gcc clang ninja-build golang
       - name: Remove aws-lc submodule from crate directory
         working-directory: ./aws-lc-rs/aws-lc-sys

--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install lcov
-        run: sudo apt-get -y install lcov
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install lcov
       - uses: actions/checkout@v4
       - name: Run Code Coverage Build
         run: ./util/codecov-ci.sh ${{ runner.temp }}/build

--- a/.github/workflows/cross-test.yml
+++ b/.github/workflows/cross-test.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
-        run: sudo apt-get -y install qemu-user qemu-user-binfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install qemu-user qemu-user-binfmt
       - uses: actions/checkout@v4
       - name: PPC64 Build/Test
         run: tests/ci/run_cross_tests.sh ppc64 powerpc64-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_BUILD_TYPE=Release -DFIPS=1 -DBUILD_SHARED_LIBS=1"
@@ -20,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
-        run: sudo apt-get -y install qemu-user qemu-user-binfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install qemu-user qemu-user-binfmt
       - uses: actions/checkout@v4
       - name: PPC32 Build/Test
         run: tests/ci/run_cross_tests.sh ppc powerpc-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release"
@@ -28,7 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
-        run: sudo apt-get -y install qemu-user qemu-user-binfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install qemu-user qemu-user-binfmt
       - uses: actions/checkout@v4
       - name: PPC32 Build/Test
         run: tests/ci/run_cross_tests.sh ppc powerpc-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release -DFIPS=1 -DBUILD_SHARED_LIBS=1"
@@ -36,7 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
-        run: sudo apt-get -y install qemu-user qemu-user-binfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install qemu-user qemu-user-binfmt
       - uses: actions/checkout@v4
       - name: PPC64LE Build/Test
         run: tests/ci/run_cross_tests.sh ppc64le powerpc64le-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_BUILD_TYPE=Release -DFIPS=1 -DBUILD_SHARED_LIBS=1"

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Install OS Dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
       - uses: actions/checkout@v3
       - name: Run integration build
@@ -31,7 +32,8 @@ jobs:
     steps:
       - name: Install OS Dependencies
         run: |
-          apt-get update && apt-get -y --no-install-recommends install cmake gcc g++ ninja-build golang make python3 python3-sphinx autoconf libtool pkg-config git libc++-dev
+          apt-get update
+          apt-get -y --no-install-recommends install cmake gcc g++ ninja-build golang make python3 python3-sphinx autoconf libtool pkg-config git libc++-dev
       - uses: actions/checkout@v3
       - name: Run integration build
         run: |
@@ -41,7 +43,8 @@ jobs:
     steps:
       - name: Install OS Dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make libpcap-dev binutils-dev
+          sudo apt-get update
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make libpcap-dev binutils-dev
       - uses: actions/checkout@v3
       - name: Run integration build
         run: |
@@ -51,7 +54,8 @@ jobs:
     steps:
       - name: Install OS Dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
+          sudo apt-get update
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
       - uses: actions/checkout@v3
       - name: Run trousers build
         run: |
@@ -61,7 +65,8 @@ jobs:
     steps:
       - name: Install OS Dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
+          sudo apt-get update
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
       - uses: actions/checkout@v3
       - name: Run ntp build
         run: |


### PR DESCRIPTION
### Description of changes: 
We're getting a lot of failures like https://github.com/aws/aws-lc/actions/runs/7469118239/job/20325716833?pr=1390:
```
Err:3 http://security.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu-user amd64 1:6.2+dfsg-2ubuntu6.15
  404  Not Found [IP: 52.147.219.192 80]
```
which is similar to https://github.com/actions/runner-images/issues/7452 and the recommended fix is [always running apt-get-update](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners).

### Testing:
GHA will do it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
