### PR TITLE
Shorten cmake test names so they fit in GitHub

### DIFF
--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -1,4 +1,4 @@
-name: AWS-LC ABI Diff
+name: ABI Diff
 on:
   pull_request:
     branches: [ '*' ]

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -1,4 +1,4 @@
-name: AWS-LC CI Tests
+name: General CI Tests
 on:
   pull_request:
     branches: [ '*' ]

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,7 +13,7 @@ env:
   GOPROXY: https://proxy.golang.org,direct
 jobs:
   cmake:
-    name: CMake ${{ matrix.cmake.version}} build with ${{ matrix.generator}}
+    name: CMake ${{ matrix.cmake.version}} build with ${{ matrix.generator}} FIPS=${{ matrix.fips }}
     strategy:
       matrix:
         cmake:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,4 @@
-name: AWS-LC CMake Compatability
+name: CMake Compatability
 on:
   pull_request:
     branches: [ '*' ]
@@ -13,7 +13,7 @@ env:
   GOPROXY: https://proxy.golang.org,direct
 jobs:
   cmake:
-    name: CMake Version Build
+    name: CMake ${{ matrix.cmake.version}} build with ${{ matrix.generator}}
     strategy:
       matrix:
         cmake:

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -1,4 +1,4 @@
-name: aws-lc integration tests
+name: Integration tests
 on:
   push:
     branches: [ '*' ]


### PR DESCRIPTION
### Description of changes: 
Update GitHub Action name config:
1. The AWS-LC in the names are redundant and take up space in the table
2. Only use the CMake version name, not the entire url which gets truncated:
`AWS-LC CMake Compatability / CMake Version Build (3.28, https://cmake.org/files/v3.28/cmake-3.28.1.tar.gz, 15e94f83e647f7d620a...`
becomes:
`CMake Compatability / CMake 3.2 build with Unix Makefiles`.

### Call-outs:
None of these tests are required (yet) so it should be safe to just rename them. 

### Testing:
Waiting to see what happens in this PR. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
