### PR TITLE
Update base ec2 test framework

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
@@ -12,7 +12,7 @@ batch:
       env:
         type: LINUX_CONTAINER
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
+        compute-type: BUILD_GENERAL1_SMALL
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
         variables:
           EC2_AMI: "ami-0a24e6e101933d294"

--- a/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
@@ -15,6 +15,6 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
         variables:
-          EC2_AMI: "ami-0c79a55dda52434da"
+          EC2_AMI: "ami-0a24e6e101933d294"
           EC2_INSTANCE_TYPE: "c7g.2xlarge"
           ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"

--- a/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
+++ b/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
@@ -41,3 +41,4 @@ mainSteps:
         - $exec_docker ./tests/ci/run_posix_sanitizers.sh
         - chmod +x ./tests/ci/run_fips_tests.sh
         - $exec_docker ./tests/ci/run_fips_tests.sh
+        - echo All ec2 test framework tests passed

--- a/tests/ci/run_ec2_test_framework.sh
+++ b/tests/ci/run_ec2_test_framework.sh
@@ -33,7 +33,7 @@ create_ec2_instances() {
   instance_id="$(aws ec2 run-instances --image-id "$1" --count 1 \
     --instance-type "$2" --security-group-ids "${sg_id}" --subnet-id "${subnet_id}" \
     --block-device-mappings 'DeviceName="/dev/sda1",Ebs={DeleteOnTermination=True,VolumeSize=200}' \
-    --tag-specifications 'ResourceType="instance",Tags=[{Key="aws-lc",Value="aws-lc-ci-ec2-test-framework-ec2-x86-instance"}]' \
+    --tag-specifications 'ResourceType="instance",Tags=[{Key="Name",Value="ec2-test-'"$CODEBUILD_WEBHOOK_TRIGGER"'"}]' \
     --iam-instance-profile Name=aws-lc-ci-ec2-test-framework-ec2-profile \
     --placement 'AvailabilityZone=us-west-2a' \
     --instance-initiated-shutdown-behavior terminate \


### PR DESCRIPTION
### Description of changes: 
1. Use latest ARM Ubuntu image
2. Tag instances with a name that links back to the requesting PR to make tracking leaks easier
3. Add a final log message to see if that shows up in CloudWatch logs

### Call-outs:
I think the older AMI just happened to have an SSM agent that couldn't handle the large output of the single "command" and crashed with `document process failed unexpectedly: document worker timed out` I haven't been able to reproduce that issue with this newer AMI.

Verified in the ec2 console the new name shows up `{Key="Name",Value="ec2-test-pr/1395"}`

### Testing:
Manually tested with SSM run command in my account, lets see what happens here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
