### PR TITLE
temporarily turn off 32-bit Windows SDE CI

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -9,8 +9,8 @@ concurrency:
 
 env:
   GOPROXY: https://proxy.golang.org,direct
-  SDE_MIRROR_URL: "https://downloadmirror.intel.com/777395/sde-external-9.21.1-2023-04-24-win.tar.xz"
-  SDE_VERSION_TAG: sde-external-9.21.1-2023-04-24-win
+  SDE_MIRROR_URL: "https://downloadmirror.intel.com/788820/sde-external-9.27.0-2023-09-13-win.tar.xz"
+  SDE_VERSION_TAG: sde-external-9.27.0-2023-09-13-win
   PACKAGE_NAME: aws-lc
   # Used to enable ASAN test dimension.
   AWSLC_NO_ASM_FIPS: 1

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -9,8 +9,8 @@ concurrency:
 
 env:
   GOPROXY: https://proxy.golang.org,direct
-  SDE_MIRROR_URL: "https://downloadmirror.intel.com/788820/sde-external-9.27.0-2023-09-13-win.tar.xz"
-  SDE_VERSION_TAG: sde-external-9.27.0-2023-09-13-win
+  SDE_MIRROR_URL: "https://downloadmirror.intel.com/813591/sde-external-9.33.0-2024-01-07-win.tar.xz"
+  SDE_VERSION_TAG: sde-external-9.33.0-2024-01-07-win
   PACKAGE_NAME: aws-lc
   # Used to enable ASAN test dimension.
   AWSLC_NO_ASM_FIPS: 1

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -129,30 +129,31 @@ jobs:
           echo ${env:SDEROOT}
           .\tests\ci\run_windows_tests.bat "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 true
 
-  MSVC-SDE-32-bit:
-    needs: [sanity-test-run]
-    runs-on: aws-lc_windows-2019_64-core
-    steps:
-      - name: Git clone the repository
-        uses: actions/checkout@v3
-
-      - name: Build Windows Dependencies
-        run: |
-          choco install ninja --version 1.9.0.20190208 -y &&
-          choco install nasm --version 2.14.02 -y
-
-      - name: Install SDE simulator
-        run: |
-          curl -SL --output temp.tar.xz ${{ env.SDE_MIRROR_URL }}
-          7z x temp.tar.xz
-          7z x temp.tar
-          ren ${{ env.SDE_VERSION_TAG }} windows-sde
-          del temp.tar.xz
-          del temp.tar
-
-      - name: Run Windows SDE Tests for 32 bit
-        run: |
-          $env:SDEROOT = "${PWD}\windows-sde"
-          echo ${env:SDEROOT}
-          .\tests\ci\run_windows_tests.bat "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 true
-
+    # TODO: Investigate sudden hanging tests and failures in GHA runners (P114059413)
+#  MSVC-SDE-32-bit:
+#    needs: [sanity-test-run]
+#    runs-on: aws-lc_windows-2019_64-core
+#    steps:
+#      - name: Git clone the repository
+#        uses: actions/checkout@v3
+#
+#      - name: Build Windows Dependencies
+#        run: |
+#          choco install ninja --version 1.9.0.20190208 -y &&
+#          choco install nasm --version 2.14.02 -y
+#
+#      - name: Install SDE simulator
+#        run: |
+#          curl -SL --output temp.tar.xz ${{ env.SDE_MIRROR_URL }}
+#          7z x temp.tar.xz
+#          7z x temp.tar
+#          ren ${{ env.SDE_VERSION_TAG }} windows-sde
+#          del temp.tar.xz
+#          del temp.tar
+#
+#      - name: Run Windows SDE Tests for 32 bit
+#        run: |
+#          $env:SDEROOT = "${PWD}\windows-sde"
+#          echo ${env:SDEROOT}
+#          .\tests\ci\run_windows_tests.bat "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 true
+#

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -152,12 +152,9 @@ func sdeOf(cpu, path string, args ...string) (*exec.Cmd, context.CancelFunc) {
 
 	// TODO(CryptoAlg-2154):SDE+ASAN tests will hang without exiting if tests pass for an unknown reason.
 	// Current workaround is to manually cancel the run after 20 minutes and check the output.
-	if runtime.GOOS == "linux" {
-		ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Second)
-		return exec.CommandContext(ctx, *sdePath, sdeArgs...), cancel
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Second)
 
-	return exec.Command(*sdePath, sdeArgs...), nil
+	return exec.CommandContext(ctx, *sdePath, sdeArgs...), cancel
 }
 
 var (
@@ -185,12 +182,11 @@ func runTestOnce(test test, mallocNumToFail int64) (passed bool, err error) {
 		cmd = gdbOf(prog, args...)
 	} else if *useSDE {
 		cmd, cancel = sdeOf(test.cpu, prog, args...)
-		if cancel != nil {
-			defer cancel()
-			cmd.Cancel = func() error {
-				cancelled = true
-				return cmd.Process.Kill()
-			}
+		defer cancel()
+
+		cmd.Cancel = func() error {
+			cancelled = true
+			return cmd.Process.Kill()
 		}
 	} else {
 		cmd = exec.Command(prog, args...)

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -155,11 +155,6 @@ func sdeOf(cpu, path string, args ...string) (*exec.Cmd, context.CancelFunc) {
 	if runtime.GOOS == "linux" {
 		ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Second)
 		return exec.CommandContext(ctx, *sdePath, sdeArgs...), cancel
-	} else if runtime.GOOS == "windows" {
-		// Windows SDE 32 bit also runs into the same issue. The simulation is slower, so we set a timeout
-		// of 30 minutes.
-		ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
-		return exec.CommandContext(ctx, *sdePath, sdeArgs...), cancel
 	}
 
 	return exec.Command(*sdePath, sdeArgs...), nil


### PR DESCRIPTION
Windows SDE CI dimension seems to be failing since the original version was deprecated. This updates the version to the latest one.
From an initial triage, the jobs seem to "hang" and don't finish. This is similar to what was happening with [SDE+ASAN on Linux](https://github.com/aws/aws-lc/commit/a8b2a0c87b3a9e0913f18a5cb935f7b69b224850), so the same workaround has been helping us kill some of these hanging test runs. The workaround doesn't resolve all issues for Windows SDE 32-bit however, some of the test runs fail to print `"[ PASSED ]`" at the end of the test. There are some instances where the test seems to run out of memory?
It seems like this hadn't been an issue prior to last week. The Windows SDE 32-bit CI didn't have any hanging tests at well nor did any of these issues exist.
The issues above can be seen in this run: https://github.com/aws/aws-lc/actions/runs/7575006419/job/20630784885

I've cut a ticket to investigate (`P114059413`). Current hypothesis is something with the GHA runner has changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
