### PR TITLE
More test coverage for AWSLC_thread_local_clear

### DIFF
--- a/crypto/thread_test.cc
+++ b/crypto/thread_test.cc
@@ -152,6 +152,8 @@ TEST(ThreadTest, RandState) {
   thread.join();
 }
 
+#if defined(OPENSSL_PTHREADS)
+
 static void thread_task(bool *myFlag) {
   EXPECT_EQ(1, AWSLC_thread_local_clear());
   EXPECT_EQ(1, AWSLC_thread_local_clear());
@@ -179,6 +181,8 @@ TEST(ThreadTest, ClearState) {
     ASSERT_TRUE(myFlags[i]) << "Thread " << i << " failed.";
   }
 }
+
+#endif // OPENSSL_PTHREADS
 
 TEST(ThreadTest, InitThreads) {
   constexpr size_t kNumThreads = 10;

--- a/crypto/thread_test.cc
+++ b/crypto/thread_test.cc
@@ -152,6 +152,34 @@ TEST(ThreadTest, RandState) {
   thread.join();
 }
 
+static void thread_task(bool *myFlag) {
+  EXPECT_EQ(1, AWSLC_thread_local_clear());
+  EXPECT_EQ(1, AWSLC_thread_local_clear());
+  uint8_t buf[8];
+  EXPECT_EQ(1, RAND_bytes(buf, sizeof(buf)));
+  EXPECT_EQ(1, AWSLC_thread_local_clear());
+  ERR_clear_error();
+  EXPECT_EQ(1, AWSLC_thread_local_clear());
+  EXPECT_EQ(1, AWSLC_thread_local_clear());
+  *myFlag = true;
+}
+
+TEST(ThreadTest, ClearState) {
+  const int kNumThreads = 10;
+  bool myFlags[kNumThreads];
+  std::thread myThreads[kNumThreads];
+
+  for (int i = 0; i < kNumThreads; i++) {
+    bool* myFlag = &myFlags[i];
+    *myFlag = false;
+    myThreads[i] = std::thread(thread_task, myFlag);
+  }
+  for (int i = 0; i < kNumThreads; i++) {
+    myThreads[i].join();
+    ASSERT_TRUE(myFlags[i]) << "Thread " << i << " failed.";
+  }
+}
+
 TEST(ThreadTest, InitThreads) {
   constexpr size_t kNumThreads = 10;
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Adds unit test coverage for `AWSLC_thread_local_clear`

### Call-outs:
* This function also gets tested by `dynamic_loading_test.c`, but that does not run as part of the `crypto_test` target.

### Testing:
Tested in dev environment on my Mac.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
