### PR TITLE
Backport: Fix issue with iOS FIPS builds. Requires -DCMAKE_SYSTEM_NAME=iOS

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -418,7 +418,11 @@ elseif(FIPS_SHARED)
     # and all the read-only data in the __const section are between the
     # respective start and end markers.
     if (CMAKE_OSX_DEPLOYMENT_TARGET)
-      set(OSX_VERSION_MIN_FLAG "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+      if(IOS)
+        set(OSX_VERSION_MIN_FLAG "-miphoneos-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+      else()
+        set(OSX_VERSION_MIN_FLAG "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+      endif()
     endif()
     add_custom_command(
       OUTPUT fips_apple_start.o

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -46,7 +46,9 @@ endif()
 target_include_directories(bssl BEFORE PRIVATE ${PROJECT_BINARY_DIR}/symbol_prefix_include)
 
 install(TARGETS bssl
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 
 if(MSVC AND CMAKE_BUILD_TYPE_LOWER MATCHES "relwithdebinfo" AND FIPS)
   install (FILES $<TARGET_FILE_DIR:bssl>/bssl.pdb DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -77,7 +79,7 @@ if(AWSLC_INSTALL_DIR)
 endif()
 
 # This expects a directory which contains the includes in include/openssl/ and the OpenSSL artifacts in lib/
-# Currently this is the default OpenSSL build we target so the "OPENSSL_1_1_BENCHMARK" flag isn't used, 
+# Currently this is the default OpenSSL build we target so the "OPENSSL_1_1_BENCHMARK" flag isn't used,
 # but we include this to maintain uniformity across OpenSSL versions
 if(OPENSSL_1_1_INSTALL_DIR)
   build_benchmark(ossl_1_1_bm ${OPENSSL_1_1_INSTALL_DIR})


### PR DESCRIPTION
### Description of changes: 
Backports https://github.com/aws/aws-lc/pull/1416 to fips-2022-11-02.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
