### PR TITLE
Include FIPS mode in OpenSSL_version return value

### DIFF
--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -115,11 +115,10 @@ void CRYPTO_pre_sandbox_init(void) {
 
 const char *SSLeay_version(int which) { return OpenSSL_version(which); }
 
-#define AWS_LC_VERSION_TEXT AWSLC_VERSION_NAME " " AWSLC_VERSION_NUMBER_STRING
 const char *OpenSSL_version(int which) {
   switch (which) {
     case OPENSSL_VERSION:
-      return AWS_LC_VERSION_TEXT;
+      return AWSLC_VERSION_STRING;
     case OPENSSL_CFLAGS:
       return "compiler: n/a";
     case OPENSSL_BUILT_ON:

--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -22,6 +22,7 @@
 #include <openssl/crypto.h>
 #include <openssl/cipher.h>
 #include <openssl/mem.h>
+#include <openssl/service_indicator.h>
 
 #include <gtest/gtest.h>
 
@@ -41,8 +42,7 @@ TEST(CryptoTest, Version) {
   full_expected += ")";
   EXPECT_EQ(OPENSSL_VERSION_TEXT, full_expected);
 
-  full_expected = "AWS-LC ";
-  full_expected += AWSLC_VERSION_NUMBER_STRING;
+  full_expected = AWSLC_VERSION_STRING;
   std::string actual = std::string(OpenSSL_version(OPENSSL_VERSION));
   EXPECT_EQ(actual, full_expected);
 }


### PR DESCRIPTION
### Issues:
- n/a

### Description of changes: 

This change includes FIPS mode information in the return value of `OpenSSL_version(OPENSSL_VERSION)`. This will allow consumers of CPython (and likely other tools or language runtimes) to detect FIPS mode without calling to an AWS-LC-specific API, which would require either patching or forking the language or tool in question.

### Call-outs:

* we don't modify `OPENSSL_VERSION_TEXT` in `crypto.h` as it's deprecated

### Testing:
* CI testing
* built cpython 3.10 against this before/after:

```
# before change, built against AWS-LC w/ -DFIPS=1
$ ./python -c 'import ssl; print(ssl.OPENSSL_VERSION)'
AWS-LC 1.20.0

# after change, built against AWS-LC w/ -DFIPS=1
$ ./python -c 'import ssl; print(ssl.OPENSSL_VERSION)'
AWS-LC FIPS 1.20.0

# after change, built against AWS-LC w/ -DFIPS=0
$ ./python -c 'import ssl; print(ssl.OPENSSL_VERSION)'
AWS-LC 1.20.0
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
