### PR TITLE
Speed up CodeBuild CI

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -36,7 +36,7 @@ batch:
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_crt_integration.sh"
 
-    - identifier: openssh_integration_x86_64
+    - identifier: openssh_integration_master_x86_64
       buildspec: tests/ci/codebuild/common/run_simple_target.yml
       env:
         type: LINUX_CONTAINER
@@ -45,8 +45,20 @@ batch:
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:amazonlinux-2023_clang-15x_sanitizer_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_openssh_integration.sh"
+          OPENSSH_BRANCH: "master"
 
-    - identifier: openssh_integration_aarch
+    - identifier: openssh_integration_8_9_x86_64
+      buildspec: tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_SMALL
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:amazonlinux-2023_clang-15x_sanitizer_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_openssh_integration.sh"
+          OPENSSH_BRANCH: "V_8_9"
+
+    - identifier: openssh_integration_master_aarch
       buildspec: tests/ci/codebuild/common/run_simple_target.yml
       env:
         type: ARM_CONTAINER
@@ -55,6 +67,18 @@ batch:
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2023_clang-15x_sanitizer_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_openssh_integration.sh"
+          OPENSSH_BRANCH: "master"
+
+    - identifier: openssh_integration_8_9_aarch
+      buildspec: tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2023_clang-15x_sanitizer_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_openssh_integration.sh"
+          OPENSSH_BRANCH: "V_8_9"
 
     - identifier: postgres_integration_x86_64
       buildspec: tests/ci/codebuild/common/run_nonroot_target.yml

--- a/tests/ci/integration/run_mysql_integration.sh
+++ b/tests/ci/integration/run_mysql_integration.sh
@@ -45,8 +45,8 @@ function mysql_patch_reminder() {
 }
 
 function mysql_build() {
-  cmake ${MYSQL_SRC_FOLDER} -GNinja -DWITH_BOOST=${BOOST_INSTALL_FOLDER} -DWITH_SSL=${AWS_LC_INSTALL_FOLDER} "-B${MYSQL_BUILD_FOLDER}"
-  ninja -C ${MYSQL_BUILD_FOLDER}
+  cmake ${MYSQL_SRC_FOLDER} -GNinja -DWITH_BOOST=${BOOST_INSTALL_FOLDER} -DWITH_SSL=${AWS_LC_INSTALL_FOLDER} "-B${MYSQL_BUILD_FOLDER}" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  time ninja -C ${MYSQL_BUILD_FOLDER}
   ls -R ${MYSQL_BUILD_FOLDER}
 }
 
@@ -88,7 +88,7 @@ main.client_ssl_data_print  : Bug#0002 AWS-LC does not support Stateful session 
 main.ssl_cache : Bug#0002 AWS-LC does not support Stateful session resumption (Session Caching).
 main.ssl_cache_tls13 : Bug#0002 AWS-LC does not support Stateful session resumption (Session Caching).
 "> skiplist
-  ./mtr --suite=main --force --parallel=auto --skip-test-list=${MYSQL_BUILD_FOLDER}/mysql-test/skiplist --retry-failure=3 --retry=3 --report-unstable-tests
+  ./mtr --suite=main --force --parallel=$((NUM_CPU_THREADS * 2)) --skip-test-list=${MYSQL_BUILD_FOLDER}/mysql-test/skiplist --retry-failure=3 --retry=3 --report-unstable-tests
   popd
 }
 

--- a/tests/ci/integration/run_mysql_integration.sh
+++ b/tests/ci/integration/run_mysql_integration.sh
@@ -88,7 +88,7 @@ main.client_ssl_data_print  : Bug#0002 AWS-LC does not support Stateful session 
 main.ssl_cache : Bug#0002 AWS-LC does not support Stateful session resumption (Session Caching).
 main.ssl_cache_tls13 : Bug#0002 AWS-LC does not support Stateful session resumption (Session Caching).
 "> skiplist
-  ./mtr --suite=main --force --parallel=$((NUM_CPU_THREADS * 2)) --skip-test-list=${MYSQL_BUILD_FOLDER}/mysql-test/skiplist --retry-failure=3 --retry=3 --report-unstable-tests
+  ./mtr --suite=main --force --parallel=auto --skip-test-list=${MYSQL_BUILD_FOLDER}/mysql-test/skiplist --retry-failure=3 --retry=3 --report-unstable-tests
   popd
 }
 

--- a/tests/ci/run_fuzz_tests.sh
+++ b/tests/ci/run_fuzz_tests.sh
@@ -15,8 +15,8 @@ set -u
 # 18 minutes for cleanup and merging files
 if [[ $PLATFORM == "aarch64" ]]; then
   # Arm sanitizers are very slow which causes the clean up time to take longer per
-  # fuzz test, only run for 16 minutes
-  TOTAL_FUZZ_TEST_TIME=1000
+  # fuzz test, only run for 8 minutes
+  TOTAL_FUZZ_TEST_TIME=500
 else
   TOTAL_FUZZ_TEST_TIME=1500
 fi


### PR DESCRIPTION
### Description of changes: 
1. Split OpenSSH into two jobs, one for main branch, and another for 8.9
2. Use RelWithDebInfo build for MySQL
3. Force MySQL to use double the number of jobs to run the tests
4. Update ARM fuzzer to run for a shorter period of time

### Call-outs:
The majority of the MySQL CI time is spent building (~50 minutes) and then running the tests (22 minutes). The build already uses all CPU cores, but the tests seem not take full advantage with the default `parallel=auto` which just uses 1 test per core (orange is CPU usage %, blue is memory usage %): 
![image](https://github.com/aws/aws-lc/assets/41167468/74e367b4-e650-44f9-b993-bfb85388da45)


### Testing:
Locally and in this CI. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
