### PR TITLE
Change sk_*_find signature to 2-arg for OpenSSL comapat

### DIFF
--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -297,7 +297,7 @@ static int get_cert_by_subject(X509_LOOKUP *xl, int type, X509_NAME *name,
       if (type == X509_LU_CRL && ent->hashes) {
         htmp.hash = h;
         CRYPTO_STATIC_MUTEX_lock_read(&g_ent_hashes_lock);
-        if (sk_BY_DIR_HASH_find(ent->hashes, &idx, &htmp)) {
+        if (sk_BY_DIR_HASH_find_awslc(ent->hashes, &idx, &htmp)) {
           hent = sk_BY_DIR_HASH_value(ent->hashes, idx);
           k = hent->suffix;
         } else {
@@ -340,7 +340,7 @@ static int get_cert_by_subject(X509_LOOKUP *xl, int type, X509_NAME *name,
       CRYPTO_MUTEX_lock_write(&xl->store_ctx->objs_lock);
       tmp = NULL;
       sk_X509_OBJECT_sort(xl->store_ctx->objs);
-      if (sk_X509_OBJECT_find(xl->store_ctx->objs, &idx, &stmp)) {
+      if (sk_X509_OBJECT_find_awslc(xl->store_ctx->objs, &idx, &stmp)) {
         tmp = sk_X509_OBJECT_value(xl->store_ctx->objs, idx);
       }
       CRYPTO_MUTEX_unlock_write(&xl->store_ctx->objs_lock);
@@ -354,7 +354,7 @@ static int get_cert_by_subject(X509_LOOKUP *xl, int type, X509_NAME *name,
         if (!hent) {
           htmp.hash = h;
           sk_BY_DIR_HASH_sort(ent->hashes);
-          if (sk_BY_DIR_HASH_find(ent->hashes, &idx, &htmp)) {
+          if (sk_BY_DIR_HASH_find_awslc(ent->hashes, &idx, &htmp)) {
             hent = sk_BY_DIR_HASH_value(ent->hashes, idx);
           }
         }

--- a/crypto/x509/policy.c
+++ b/crypto/x509/policy.c
@@ -167,7 +167,7 @@ static X509_POLICY_NODE *x509_policy_level_find(X509_POLICY_LEVEL *level,
   X509_POLICY_NODE node;
   node.policy = (ASN1_OBJECT *)policy;
   size_t idx;
-  if (!sk_X509_POLICY_NODE_find(level->nodes, &idx, &node)) {
+  if (!sk_X509_POLICY_NODE_find_awslc(level->nodes, &idx, &node)) {
     return NULL;
   }
   return sk_X509_POLICY_NODE_value(level->nodes, idx);
@@ -211,7 +211,7 @@ static int delete_if_not_in_policies(X509_POLICY_NODE *node, void *data) {
   assert(sk_POLICYINFO_is_sorted(policies));
   POLICYINFO info;
   info.policyid = node->policy;
-  if (sk_POLICYINFO_find(policies, NULL, &info)) {
+  if (sk_POLICYINFO_find_awslc(policies, NULL, &info)) {
     return 0;
   }
   x509_policy_node_free(node);
@@ -329,7 +329,7 @@ static int delete_if_mapped(X509_POLICY_NODE *node, void *data) {
   assert(sk_POLICY_MAPPING_is_sorted(mappings));
   POLICY_MAPPING mapping;
   mapping.issuerDomainPolicy = node->policy;
-  if (!sk_POLICY_MAPPING_find(mappings, /*out_index=*/NULL, &mapping)) {
+  if (!sk_POLICY_MAPPING_find(mappings, &mapping)) {
     return 0;
   }
   x509_policy_node_free(node);
@@ -630,8 +630,7 @@ static int has_explicit_policy(STACK_OF(X509_POLICY_LEVEL) *levels,
         // |node|'s parent is anyPolicy and is part of "valid_policy_node_set".
         // If it exists in |user_policies|, the intersection is non-empty and we
         // can return immediately.
-        if (sk_ASN1_OBJECT_find(user_policies, /*out_index=*/NULL,
-                                node->policy)) {
+        if (sk_ASN1_OBJECT_find(user_policies, node->policy)) {
           return 1;
         }
       } else if (i > 0) {

--- a/crypto/x509/policy.c
+++ b/crypto/x509/policy.c
@@ -329,7 +329,7 @@ static int delete_if_mapped(X509_POLICY_NODE *node, void *data) {
   assert(sk_POLICY_MAPPING_is_sorted(mappings));
   POLICY_MAPPING mapping;
   mapping.issuerDomainPolicy = node->policy;
-  if (!sk_POLICY_MAPPING_find(mappings, &mapping)) {
+  if (!sk_POLICY_MAPPING_find_awslc(mappings, NULL, &mapping)) {
     return 0;
   }
   x509_policy_node_free(node);
@@ -630,7 +630,7 @@ static int has_explicit_policy(STACK_OF(X509_POLICY_LEVEL) *levels,
         // |node|'s parent is anyPolicy and is part of "valid_policy_node_set".
         // If it exists in |user_policies|, the intersection is non-empty and we
         // can return immediately.
-        if (sk_ASN1_OBJECT_find(user_policies, node->policy)) {
+        if (sk_ASN1_OBJECT_find_awslc(user_policies, NULL, node->policy)) {
           return 1;
         }
       } else if (i > 0) {

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -438,7 +438,7 @@ static int x509_object_idx_cnt(STACK_OF(X509_OBJECT) *h, int type,
 
   size_t idx;
   sk_X509_OBJECT_sort(h);
-  if (!sk_X509_OBJECT_find(h, &idx, &stmp)) {
+  if (!sk_X509_OBJECT_find_awslc(h, &idx, &stmp)) {
     return -1;
   }
 
@@ -561,7 +561,7 @@ X509_OBJECT *X509_OBJECT_retrieve_match(STACK_OF(X509_OBJECT) *h,
                                         X509_OBJECT *x) {
   sk_X509_OBJECT_sort(h);
   size_t idx;
-  if (!sk_X509_OBJECT_find(h, &idx, x)) {
+  if (!sk_X509_OBJECT_find_awslc(h, &idx, x)) {
     return NULL;
   }
   if ((x->type != X509_LU_X509) && (x->type != X509_LU_CRL)) {

--- a/crypto/x509/x509_trs.c
+++ b/crypto/x509/x509_trs.c
@@ -152,7 +152,7 @@ int X509_TRUST_get_by_id(int id) {
   if (!trtable) {
     return -1;
   }
-  if (!sk_X509_TRUST_find(trtable, &idx, &tmp)) {
+  if (!sk_X509_TRUST_find_awslc(trtable, &idx, &tmp)) {
     return -1;
   }
   return idx + X509_TRUST_COUNT;

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -455,7 +455,7 @@ static int crl_lookup(X509_CRL *crl, X509_REVOKED **ret, ASN1_INTEGER *serial,
     CRYPTO_STATIC_MUTEX_unlock_write(&g_crl_sort_lock);
   }
 
-  if (!sk_X509_REVOKED_find(crl->crl->revoked, &idx, &rtmp)) {
+  if (!sk_X509_REVOKED_find_awslc(crl->crl->revoked, &idx, &rtmp)) {
     return 0;
   }
   // Need to look for matching name

--- a/crypto/x509v3/v3_lib.c
+++ b/crypto/x509v3/v3_lib.c
@@ -115,7 +115,7 @@ const X509V3_EXT_METHOD *X509V3_EXT_get_nid(int nid) {
     return NULL;
   }
 
-  if (!sk_X509V3_EXT_METHOD_find(ext_list, &idx, &tmp)) {
+  if (!sk_X509V3_EXT_METHOD_find_awslc(ext_list, &idx, &tmp)) {
     return NULL;
   }
   return sk_X509V3_EXT_METHOD_value(ext_list, idx);

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -200,7 +200,7 @@ int X509_PURPOSE_get_by_id(int purpose) {
     return -1;
   }
 
-  if (!sk_X509_PURPOSE_find(xptable, &idx, &tmp)) {
+  if (!sk_X509_PURPOSE_find_awslc(xptable, &idx, &tmp)) {
     return -1;
   }
   return idx + X509_PURPOSE_COUNT;

--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -659,7 +659,7 @@ static int append_ia5(STACK_OF(OPENSSL_STRING) **sk,
 
   // Don't add duplicates
   sk_OPENSSL_STRING_sort(*sk);
-  if (sk_OPENSSL_STRING_find(*sk, emtmp)) {
+  if (sk_OPENSSL_STRING_find_awslc(*sk, NULL, emtmp)) {
     OPENSSL_free(emtmp);
     return 1;
   }

--- a/crypto/x509v3/v3_utl.c
+++ b/crypto/x509v3/v3_utl.c
@@ -659,7 +659,7 @@ static int append_ia5(STACK_OF(OPENSSL_STRING) **sk,
 
   // Don't add duplicates
   sk_OPENSSL_STRING_sort(*sk);
-  if (sk_OPENSSL_STRING_find(*sk, NULL, emtmp)) {
+  if (sk_OPENSSL_STRING_find(*sk, emtmp)) {
     OPENSSL_free(emtmp);
     return 1;
   }

--- a/include/openssl/stack.h
+++ b/include/openssl/stack.h
@@ -506,7 +506,7 @@ BSSL_NAMESPACE_END
   OPENSSL_INLINE int sk_##name##_find(const STACK_OF(name) *sk,                \
                                       constptrtype p) {                        \
     const size_t mask = 0xffffffffffffffffUL << (sizeof(int) * 8);             \
-    size_t out_index;                                                          \
+    size_t out_index = 0;                                                      \
     int ok = OPENSSL_sk_find((const OPENSSL_STACK *)sk, &out_index,            \
                              (const void *)p, sk_##name##_call_cmp_func);      \
     /* return -1 if element not found or stack is larger than INT_MAX */       \

--- a/include/openssl/stack.h
+++ b/include/openssl/stack.h
@@ -492,9 +492,17 @@ BSSL_NAMESPACE_END
                          (OPENSSL_sk_delete_if_func)func, data);               \
   }                                                                            \
                                                                                \
-  OPENSSL_INLINE int sk_##name##_find(const STACK_OF(name) *sk,                \
+  /* use 3-arg sk_*_find_awslc when |out_index| needed */                      \
+  OPENSSL_INLINE int sk_##name##_find_awslc(const STACK_OF(name) *sk,          \
                                       size_t *out_index, constptrtype p) {     \
     return OPENSSL_sk_find((const OPENSSL_STACK *)sk, out_index,               \
+                           (const void *)p, sk_##name##_call_cmp_func);        \
+  }                                                                            \
+                                                                               \
+  /* use 2-arg sk_*_find for OpenSSL compatibility */                          \
+  OPENSSL_INLINE int sk_##name##_find(const STACK_OF(name) *sk,                \
+                                      constptrtype p) {                        \
+    return OPENSSL_sk_find((const OPENSSL_STACK *)sk, NULL,                    \
                            (const void *)p, sk_##name##_call_cmp_func);        \
   }                                                                            \
                                                                                \

--- a/include/openssl/stack.h
+++ b/include/openssl/stack.h
@@ -505,7 +505,9 @@ BSSL_NAMESPACE_END
   /* use 2-arg sk_*_find for OpenSSL compatibility */                          \
   OPENSSL_INLINE int sk_##name##_find(const STACK_OF(name) *sk,                \
                                       constptrtype p) {                        \
-    const size_t mask = 0xffffffffffffffffUL << (sizeof(int) * 8);             \
+    const size_t mask = sizeof(size_t) > sizeof(int)                           \
+        ? (~((size_t) 0)) << (sizeof(int) * 8)                                 \
+        : 0;                                                                   \
     size_t out_index = 0;                                                      \
     int ok = OPENSSL_sk_find((const OPENSSL_STACK *)sk, &out_index,            \
                              (const void *)p, sk_##name##_call_cmp_func);      \

--- a/include/openssl/stack.h
+++ b/include/openssl/stack.h
@@ -202,10 +202,10 @@ void sk_SAMPLE_delete_if(STACK_OF(SAMPLE) *sk, sk_SAMPLE_delete_if_func func,
 // sort |sk| if it has a comparison function defined.
 int sk_SAMPLE_find(const STACK_OF(SAMPLE) *sk, const SAMPLE *p);
 
-// sk_SAMPLE_find_awslc is like sk_SAMPLE_find, but if it finds a matching
+// sk_SAMPLE_find_awslc is like |sk_SAMPLE_find|, but if it finds a matching
 // element, it writes the index to |*out_index| (if |out_index| is not NULL)
 // and returns one. Otherwise, it returns zero.
-int sk_SAMPLE_find(const STACK_OF(SAMPLE) *sk, size_t *out_index,
+int sk_SAMPLE_find_awslc(const STACK_OF(SAMPLE) *sk, size_t *out_index,
         const SAMPLE *p);
 
 // sk_SAMPLE_shift removes and returns the first element in |sk|, or NULL if

--- a/ssl/handoff.cc
+++ b/ssl/handoff.cc
@@ -147,7 +147,7 @@ static bool apply_remote_features(SSL *ssl, CBS *in) {
     return false;
   }
   for (const SSL_CIPHER *configured_cipher : configured) {
-    if (sk_SSL_CIPHER_find(supported.get(), configured_cipher)) {
+    if (sk_SSL_CIPHER_find_awslc(supported.get(), nullptr, configured_cipher)) {
       continue;
     }
     if (!sk_SSL_CIPHER_push(unsupported.get(), configured_cipher)) {

--- a/ssl/handoff.cc
+++ b/ssl/handoff.cc
@@ -147,7 +147,7 @@ static bool apply_remote_features(SSL *ssl, CBS *in) {
     return false;
   }
   for (const SSL_CIPHER *configured_cipher : configured) {
-    if (sk_SSL_CIPHER_find(supported.get(), nullptr, configured_cipher)) {
+    if (sk_SSL_CIPHER_find(supported.get(), configured_cipher)) {
       continue;
     }
     if (!sk_SSL_CIPHER_push(unsupported.get(), configured_cipher)) {

--- a/ssl/handshake_client.cc
+++ b/ssl/handshake_client.cc
@@ -812,7 +812,7 @@ static enum ssl_hs_wait_t do_read_server_hello(SSL_HANDSHAKE *hs) {
       (cipher->algorithm_auth & mask_a) ||
       SSL_CIPHER_get_min_version(cipher) > ssl_protocol_version(ssl) ||
       SSL_CIPHER_get_max_version(cipher) < ssl_protocol_version(ssl) ||
-      !sk_SSL_CIPHER_find(SSL_get_ciphers(ssl), nullptr, cipher)) {
+      !sk_SSL_CIPHER_find(SSL_get_ciphers(ssl), cipher)) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_WRONG_CIPHER_RETURNED);
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_ILLEGAL_PARAMETER);
     return ssl_hs_error;

--- a/ssl/handshake_client.cc
+++ b/ssl/handshake_client.cc
@@ -812,7 +812,7 @@ static enum ssl_hs_wait_t do_read_server_hello(SSL_HANDSHAKE *hs) {
       (cipher->algorithm_auth & mask_a) ||
       SSL_CIPHER_get_min_version(cipher) > ssl_protocol_version(ssl) ||
       SSL_CIPHER_get_max_version(cipher) < ssl_protocol_version(ssl) ||
-      !sk_SSL_CIPHER_find(SSL_get_ciphers(ssl), cipher)) {
+      !sk_SSL_CIPHER_find_awslc(SSL_get_ciphers(ssl), nullptr, cipher)) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_WRONG_CIPHER_RETURNED);
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_ILLEGAL_PARAMETER);
     return ssl_hs_error;

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -386,7 +386,7 @@ static const SSL_CIPHER *choose_cipher(SSL_HANDSHAKE *hs,
         (c->algorithm_mkey & mask_k) &&
         (c->algorithm_auth & mask_a) &&
         // Check the cipher is in the |allow| list.
-        sk_SSL_CIPHER_find(allow, &cipher_index, c)) {
+        sk_SSL_CIPHER_find_awslc(allow, &cipher_index, c)) {
       if (in_group_flags != NULL && in_group_flags[i]) {
         // This element of |prio| is in a group. Update the minimum index found
         // so far and continue looking.

--- a/ssl/ssl_cipher.cc
+++ b/ssl/ssl_cipher.cc
@@ -825,7 +825,7 @@ bool SSLCipherPreferenceList::Init(const SSLCipherPreferenceList& other) {
 
 void SSLCipherPreferenceList::Remove(const SSL_CIPHER *cipher) {
   size_t index;
-  if (!sk_SSL_CIPHER_find(ciphers.get(), &index, cipher)) {
+  if (!sk_SSL_CIPHER_find_awslc(ciphers.get(), &index, cipher)) {
     return;
   }
   if (!in_group_flags[index] /* last element of group */ && index > 0) {

--- a/ssl/ssl_file.cc
+++ b/ssl/ssl_file.cc
@@ -166,7 +166,7 @@ static int add_bio_cert_subjects_to_stack(STACK_OF(X509_NAME) *out, BIO *bio,
     X509_NAME *subject = X509_get_subject_name(x509.get());
     // Skip if already present in |out|. Duplicates in |to_append| will be
     // handled separately.
-    if (sk_X509_NAME_find(out, /*out_index=*/NULL, subject)) {
+    if (sk_X509_NAME_find(out, subject)) {
       continue;
     }
 

--- a/ssl/ssl_file.cc
+++ b/ssl/ssl_file.cc
@@ -166,7 +166,7 @@ static int add_bio_cert_subjects_to_stack(STACK_OF(X509_NAME) *out, BIO *bio,
     X509_NAME *subject = X509_get_subject_name(x509.get());
     // Skip if already present in |out|. Duplicates in |to_append| will be
     // handled separately.
-    if (sk_X509_NAME_find(out, subject)) {
+    if (sk_X509_NAME_find_awslc(out, nullptr, subject)) {
       continue;
     }
 

--- a/tests/ci/integration/python_patch/3.10/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/3.10/aws-lc-cpython.patch
@@ -454,19 +454,6 @@ index 7a28f2d37f..07740af98b 100644
      if (ret < 1)
          return PySSL_SetError(self, ret, __FILE__, __LINE__);
      if (PySSL_ChainExceptions(self) < 0)
-@@ -2042,7 +2049,12 @@ _ssl__SSLSocket_shared_ciphers_impl(PySSLSocket *self)
-     len = 0;
-     for (i = 0; i < sk_SSL_CIPHER_num(server_ciphers); i++) {
-         cipher = sk_SSL_CIPHER_value(server_ciphers, i);
-+#if defined(OPENSSL_IS_AWSLC)
-+        size_t unused_idx;
-+        if (sk_SSL_CIPHER_find(client_ciphers, &unused_idx, cipher) == 0)
-+#else
-         if (sk_SSL_CIPHER_find(client_ciphers, cipher) < 0)
-+#endif
-             continue;
- 
-         PyObject *tup = cipher_to_tuple(cipher);
 @@ -2771,7 +2783,7 @@ static PyObject *
  _ssl__SSLSocket_verify_client_post_handshake_impl(PySSLSocket *self)
  /*[clinic end generated code: output=532147f3b1341425 input=6bfa874810a3d889]*/

--- a/tests/ci/integration/python_patch/3.11/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/3.11/aws-lc-cpython.patch
@@ -448,19 +448,6 @@ index 67ce6e97af..1132d82dd9 100644
      if (ret < 1)
          return PySSL_SetError(self, ret, __FILE__, __LINE__);
      if (PySSL_ChainExceptions(self) < 0)
-@@ -2041,7 +2048,12 @@ _ssl__SSLSocket_shared_ciphers_impl(PySSLSocket *self)
-     len = 0;
-     for (i = 0; i < sk_SSL_CIPHER_num(server_ciphers); i++) {
-         cipher = sk_SSL_CIPHER_value(server_ciphers, i);
-+#if defined(OPENSSL_IS_AWSLC)
-+        size_t unused_idx;
-+        if (sk_SSL_CIPHER_find(client_ciphers, &unused_idx, cipher) == 0)
-+#else
-         if (sk_SSL_CIPHER_find(client_ciphers, cipher) < 0)
-+#endif
-             continue;
- 
-         PyObject *tup = cipher_to_tuple(cipher);
 @@ -2775,7 +2787,7 @@ static PyObject *
  _ssl__SSLSocket_verify_client_post_handshake_impl(PySSLSocket *self)
  /*[clinic end generated code: output=532147f3b1341425 input=6bfa874810a3d889]*/

--- a/tests/ci/integration/python_patch/3.12/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/3.12/aws-lc-cpython.patch
@@ -449,19 +449,6 @@ index e939f95048..8c99e2d8a1 100644
      if (ret < 1)
          return PySSL_SetError(self, ret, __FILE__, __LINE__);
      if (PySSL_ChainExceptions(self) < 0)
-@@ -2028,7 +2035,12 @@ _ssl__SSLSocket_shared_ciphers_impl(PySSLSocket *self)
-     len = 0;
-     for (i = 0; i < sk_SSL_CIPHER_num(server_ciphers); i++) {
-         cipher = sk_SSL_CIPHER_value(server_ciphers, i);
-+#if defined(OPENSSL_IS_AWSLC)
-+        size_t unused_idx;
-+        if (sk_SSL_CIPHER_find(client_ciphers, &unused_idx, cipher) == 0)
-+#else
-         if (sk_SSL_CIPHER_find(client_ciphers, cipher) < 0)
-+#endif
-             continue;
- 
-         PyObject *tup = cipher_to_tuple(cipher);
 @@ -2754,7 +2766,7 @@ static PyObject *
  _ssl__SSLSocket_verify_client_post_handshake_impl(PySSLSocket *self)
  /*[clinic end generated code: output=532147f3b1341425 input=6bfa874810a3d889]*/

--- a/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
@@ -449,19 +449,6 @@ index bc30290942..e0e59b97e5 100644
      if (ret < 1)
          return PySSL_SetError(self, ret, __FILE__, __LINE__);
      if (PySSL_ChainExceptions(self) < 0)
-@@ -2060,7 +2068,12 @@ _ssl__SSLSocket_shared_ciphers_impl(PySSLSocket *self)
-     len = 0;
-     for (i = 0; i < sk_SSL_CIPHER_num(server_ciphers); i++) {
-         cipher = sk_SSL_CIPHER_value(server_ciphers, i);
-+#if defined(OPENSSL_IS_AWSLC)
-+        size_t unused_idx;
-+        if (sk_SSL_CIPHER_find(client_ciphers, &unused_idx, cipher) == 0)
-+#else
-         if (sk_SSL_CIPHER_find(client_ciphers, cipher) < 0)
-+#endif
-             continue;
- 
-         PyObject *tup = cipher_to_tuple(cipher);
 @@ -2787,7 +2800,7 @@ static PyObject *
  _ssl__SSLSocket_verify_client_post_handshake_impl(PySSLSocket *self)
  /*[clinic end generated code: output=532147f3b1341425 input=6bfa874810a3d889]*/


### PR DESCRIPTION
### Description of changes: 

OpenSSL [omits][1] the `|out_index|` parameter from `|sk_*_find|`. This (breaking) change conforms with that interface and exposes our old, 3-arg interface with `|out_index|` as `|sk_*_find_awslc|`.

[1]: https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_find.html

### Call-outs:
- This is a **breaking change** for consumers using the `|sk_*_find|` function. Consuming code will need to be updated to either use the new `|sk_*_find|` function or to drop the second positional `|out_index| `parameter from their function call(s).

### Testing:
- CI checks

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
