### PR TITLE
Disable failing MariaDB tests

### DIFF
--- a/tests/ci/integration/run_mariadb_integration.sh
+++ b/tests/ci/integration/run_mariadb_integration.sh
@@ -60,7 +60,10 @@ main.flush_logs_not_windows : query 'flush logs' succeeded - should have failed 
 main.mysql_upgrade_noengine : upgrade output order does not match the expected
 main.plugin_load : This test generates a warning in Codebuild. Skip over since this isn't relevant to AWS-LC.
 main.ssl_crl : This test is flaky in CodeBuild CI P112867839
-main.desc_index_min_max : This test is flaky in CodeBuild CI P112867839"> skiplist
+main.desc_index_min_max : This test is flaky in CodeBuild CI P112867839
+main.ssl_autoverify : Failing with - TLS/SSL error: unable to get local issuer certificate
+main.mysql : Failing with - TLS/SSL error: unable to get local issuer certificate
+main.ssl_fp : Failing with - TLS/SSL error: unable to get local issuer certificate"> skiplist
   ./mtr --suite=main --force --parallel=auto --skip-test-list=${MARIADB_BUILD_FOLDER}/mysql-test/skiplist --retry-failure=2
   popd
 }


### PR DESCRIPTION
### Issues:
P112867839

### Description of changes: 
* Several MariaDB tests are failing, blocking our CI approval process.

### Call-outs:
* The 3 failing tests are reporting the error: `TLS/SSL error: unable to get local issuer certificate`
https://github.com/aws/aws-lc/blob/56def5a253d27280f3b7bd6564cfa5a11211aee8/crypto/x509/x509_vfy.c#L413
```
...
  // If not explicitly trusted then indicate error unless it's a single
  // self signed certificate in which case we've indicated an error already
  // and set bad_chain == 1
  if (trust != X509_TRUST_TRUSTED && !bad_chain) {
    if ((chain_ss == NULL) || !ctx->check_issued(ctx, x, chain_ss)) {
      if (ctx->last_untrusted >= num) {
        ctx->error = X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY;  //  <<-- FROM THIS LINE 
      } else {
        ctx->error = X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT;
      }
      ctx->current_cert = x;
...
```

### Testing:
MariaDB tests passing in personal account.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
