### PR TITLE
Reduce compiler ability to optimise to statisfy gcc 9.5

### DIFF
--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -4475,6 +4475,9 @@ TEST_P(SSLVersionTest, SessionTimeout) {
 }
 
 TEST_P(SSLVersionTest, DefaultTicketKeyInitialization) {
+  // Do not make static and const. See t/P118709392.
+  // It can trigger https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189 leading
+  // to transient errors.
   uint8_t kZeroKey[kTicketKeyLen] = {0};
   uint8_t ticket_key[kTicketKeyLen];
   ASSERT_EQ(1, SSL_CTX_get_tlsext_ticket_keys(server_ctx_.get(), ticket_key,

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -4475,7 +4475,7 @@ TEST_P(SSLVersionTest, SessionTimeout) {
 }
 
 TEST_P(SSLVersionTest, DefaultTicketKeyInitialization) {
-  static const uint8_t kZeroKey[kTicketKeyLen] = {};
+  uint8_t kZeroKey[kTicketKeyLen] = {0};
   uint8_t ticket_key[kTicketKeyLen];
   ASSERT_EQ(1, SSL_CTX_get_tlsext_ticket_keys(server_ctx_.get(), ticket_key,
                                               kTicketKeyLen));


### PR DESCRIPTION
### Issues:

P118709392

### Description of changes: 

This PR is an attempt to fix a transient issue with gcc 9.5 compilation. This is a test workflow, so no hot-path performance regression concerns from me.

gcc 9.5 has a bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189 that has not been backported. Essentially, the compiler will falsely reason that it's comparing a string and optimise out everything behind a null-character.

In the test fixture `SSLVersionTest.DefaultTicketKeyInitialization` it appears the gcc 9.5 compiler only compares the first byte and short-circuits there. What was observed:

```
4a6274:	394243e0 	ldrb	w0, [sp, #144] <-- first byte of ticket_key
  4a6278:	b90043ff 	str	wzr, [sp, #64] <-- zeroise stack (kzerokey presumably)
  4a627c:	b90053e0 	str	w0, [sp, #80] <-- Put w0 back on the stack(?)
  4a6280:	34000240 	cbz	w0, 4a62c8 <-- zero-test register w0, branch to failure path (adr 4a62c8) if true <_ZN4bssl12_GLOBAL__N_150SSLVersionTest_DefaultTicketKeyInitialization_Test8TestBodyEv+0x128>
```

Dropping `static const` removes optimisation options for the compiler. In my tests, gcc 9.5 now emits a direct `memcmp` instead of attempting any optimisations:
```
  4a89a4:	aa1603e0 	mov	x0, x22
  4a89a8:	d2800602 	mov	x2, #0x30                  	// #48
  4a89ac:	b90043ff 	str	wzr, [sp, #64]
  4a89b0:	910243e1 	add	x1, sp, #0x90
  4a89b4:	97fd915f 	bl	40cf30 <memcmp@plt>
```

### Testing:

Tested on machines with gcc 9.5 runtime. Before failed, after this patch, no failure (even when forcing first byte to 0).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
