### PR TITLE
Use OPENSSL_zalloc in more places

### DIFF
--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -188,11 +188,6 @@ ASN1_OBJECT *ASN1_OBJECT_new(void) {
   if (ret == NULL) {
     return NULL;
   }
-  assert(ret->length == 0);
-  assert(ret->data == NULL);
-  assert(ret->nid == 0);
-  assert(ret->sn == NULL);
-  assert(ret->ln == NULL);
   ret->flags = ASN1_OBJECT_FLAG_DYNAMIC;
   return ret;
 }

--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -184,15 +184,15 @@ ASN1_OBJECT *c2i_ASN1_OBJECT(ASN1_OBJECT **out, const unsigned char **inp,
 ASN1_OBJECT *ASN1_OBJECT_new(void) {
   ASN1_OBJECT *ret;
 
-  ret = (ASN1_OBJECT *)OPENSSL_malloc(sizeof(ASN1_OBJECT));
+  ret = (ASN1_OBJECT *)OPENSSL_zalloc(sizeof(ASN1_OBJECT));
   if (ret == NULL) {
     return NULL;
   }
-  ret->length = 0;
-  ret->data = NULL;
-  ret->nid = 0;
-  ret->sn = NULL;
-  ret->ln = NULL;
+  assert(ret->length == 0);
+  assert(ret->data == NULL);
+  assert(ret->nid == 0);
+  assert(ret->sn == NULL);
+  assert(ret->ln == NULL);
   ret->flags = ASN1_OBJECT_FLAG_DYNAMIC;
   return ret;
 }

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -332,10 +332,7 @@ ASN1_STRING *ASN1_STRING_type_new(int type) {
   if (ret == NULL) {
     return NULL;
   }
-  assert(ret->length == 0);
   ret->type = type;
-  assert(ret->data == NULL);
-  assert(ret->flags == 0);
   return ret;
 }
 

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -328,14 +328,14 @@ ASN1_STRING *ASN1_STRING_new(void) {
 ASN1_STRING *ASN1_STRING_type_new(int type) {
   ASN1_STRING *ret;
 
-  ret = (ASN1_STRING *)OPENSSL_malloc(sizeof(ASN1_STRING));
+  ret = (ASN1_STRING *)OPENSSL_zalloc(sizeof(ASN1_STRING));
   if (ret == NULL) {
     return NULL;
   }
-  ret->length = 0;
+  assert(ret->length == 0);
   ret->type = type;
-  ret->data = NULL;
-  ret->flags = 0;
+  assert(ret->data == NULL);
+  assert(ret->flags == 0);
   return ret;
 }
 

--- a/crypto/asn1/tasn_new.c
+++ b/crypto/asn1/tasn_new.c
@@ -297,11 +297,11 @@ static int ASN1_primitive_new(ASN1_VALUE **pval, const ASN1_ITEM *it) {
       return 1;
 
     case V_ASN1_ANY: {
-      ASN1_TYPE *typ = OPENSSL_malloc(sizeof(ASN1_TYPE));
+      ASN1_TYPE *typ = OPENSSL_zalloc(sizeof(ASN1_TYPE));
       if (!typ) {
         return 0;
       }
-      typ->value.ptr = NULL;
+      assert(typ->value.ptr == NULL);
       typ->type = -1;
       *pval = (ASN1_VALUE *)typ;
       break;

--- a/crypto/asn1/tasn_new.c
+++ b/crypto/asn1/tasn_new.c
@@ -301,7 +301,6 @@ static int ASN1_primitive_new(ASN1_VALUE **pval, const ASN1_ITEM *it) {
       if (!typ) {
         return 0;
       }
-      assert(typ->value.ptr == NULL);
       typ->type = -1;
       *pval = (ASN1_VALUE *)typ;
       break;

--- a/crypto/bn_extra/convert.c
+++ b/crypto/bn_extra/convert.c
@@ -78,7 +78,7 @@ static const char hextable[] = "0123456789abcdef";
 
 char *BN_bn2hex(const BIGNUM *bn) {
   int width = bn_minimal_width(bn);
-  char *buf = OPENSSL_malloc(1 /* leading '-' */ + 1 /* zero is non-empty */ +
+  char *buf = OPENSSL_zalloc(1 /* leading '-' */ + 1 /* zero is non-empty */ +
                              width * BN_BYTES * 2 + 1 /* trailing NUL */);
   if (buf == NULL) {
     return NULL;
@@ -105,7 +105,7 @@ char *BN_bn2hex(const BIGNUM *bn) {
       }
     }
   }
-  *p = '\0';
+  assert(*p == '\0');
 
   return buf;
 }

--- a/crypto/cipher_extra/e_chacha20poly1305.c
+++ b/crypto/cipher_extra/e_chacha20poly1305.c
@@ -669,11 +669,6 @@ static int32_t cipher_chacha20_poly1305_ctrl(EVP_CIPHER_CTX *ctx, int32_t type,
           OPENSSL_PUT_ERROR(CIPHER, CIPHER_R_INITIALIZATION_ERROR);
           return 0;
         }
-        assert(cipher_ctx->len.aad == 0);
-        assert(cipher_ctx->len.text == 0);
-        assert(cipher_ctx->pad_aad == 0);
-        assert(cipher_ctx->poly_initialized == 0);
-        assert(cipher_ctx->tag_len == 0);
       } else {
         cipher_ctx->len.aad = 0;
         cipher_ctx->len.text = 0;

--- a/crypto/cipher_extra/e_chacha20poly1305.c
+++ b/crypto/cipher_extra/e_chacha20poly1305.c
@@ -664,17 +664,24 @@ static int32_t cipher_chacha20_poly1305_ctrl(EVP_CIPHER_CTX *ctx, int32_t type,
   switch (type) {
     case EVP_CTRL_INIT:
       if (cipher_ctx == NULL) {
-        cipher_ctx = ctx->cipher_data = OPENSSL_malloc(ctx->cipher->ctx_size);
+        cipher_ctx = ctx->cipher_data = OPENSSL_zalloc(ctx->cipher->ctx_size);
+        if (cipher_ctx == NULL) {
+          OPENSSL_PUT_ERROR(CIPHER, CIPHER_R_INITIALIZATION_ERROR);
+          return 0;
+        }
+        assert(cipher_ctx->len.aad == 0);
+        assert(cipher_ctx->len.text == 0);
+        assert(cipher_ctx->pad_aad == 0);
+        assert(cipher_ctx->poly_initialized == 0);
+        assert(cipher_ctx->tag_len == 0);
+      } else {
+        cipher_ctx->len.aad = 0;
+        cipher_ctx->len.text = 0;
+        cipher_ctx->pad_aad = 0;
+        cipher_ctx->poly_initialized = 0;
+        cipher_ctx->tag_len = 0;
       }
-      if (cipher_ctx == NULL) {
-        OPENSSL_PUT_ERROR(CIPHER, CIPHER_R_INITIALIZATION_ERROR);
-        return 0;
-      }
-      cipher_ctx->len.aad = 0;
-      cipher_ctx->len.text = 0;
-      cipher_ctx->pad_aad = 0;
-      cipher_ctx->poly_initialized = 0;
-      cipher_ctx->tag_len = 0;
+
       return 1;
     case EVP_CTRL_COPY:
       if (cipher_ctx && cipher_ctx->poly_initialized) {

--- a/crypto/decrepit/bio/base64_bio.c
+++ b/crypto/decrepit/bio/base64_bio.c
@@ -91,12 +91,10 @@ typedef struct b64_struct {
 static int b64_new(BIO *bio) {
   BIO_B64_CTX *ctx;
 
-  ctx = OPENSSL_malloc(sizeof(*ctx));
+  ctx = OPENSSL_zalloc(sizeof(*ctx));
   if (ctx == NULL) {
     return 0;
   }
-
-  OPENSSL_memset(ctx, 0, sizeof(*ctx));
 
   ctx->cont = 1;
   ctx->start = 1;

--- a/crypto/evp_extra/p_kem.c
+++ b/crypto/evp_extra/p_kem.c
@@ -18,11 +18,10 @@ typedef struct {
 
 static int pkey_kem_init(EVP_PKEY_CTX *ctx) {
   KEM_PKEY_CTX *dctx;
-  dctx = OPENSSL_malloc(sizeof(KEM_PKEY_CTX));
+  dctx = OPENSSL_zalloc(sizeof(KEM_PKEY_CTX));
   if (dctx == NULL) {
     return 0;
   }
-  OPENSSL_memset(dctx, 0, sizeof(KEM_PKEY_CTX));
 
   ctx->data = dctx;
 

--- a/crypto/evp_extra/print.c
+++ b/crypto/evp_extra/print.c
@@ -126,7 +126,6 @@ static int bn_print(BIO *bp, const char *name, const BIGNUM *num, int off) {
     return 0;
   }
 
-  assert(buf[0] == 0);
   BN_bn2bin(num, buf + 1);
   int ret;
   if (len > 0 && (buf[1] & 0x80) != 0) {

--- a/crypto/evp_extra/print.c
+++ b/crypto/evp_extra/print.c
@@ -121,12 +121,12 @@ static int bn_print(BIO *bp, const char *name, const BIGNUM *num, int off) {
   // TODO(davidben): Do we need to do this? We already print "(Negative)" above
   // and negative values are never valid in keys anyway.
   size_t len = BN_num_bytes(num);
-  uint8_t *buf = OPENSSL_malloc(len + 1);
+  uint8_t *buf = OPENSSL_zalloc(len + 1);
   if (buf == NULL) {
     return 0;
   }
 
-  buf[0] = 0;
+  assert(buf[0] == 0);
   BN_bn2bin(num, buf + 1);
   int ret;
   if (len > 0 && (buf[1] & 0x80) != 0) {

--- a/crypto/fipsmodule/bn/bn.c
+++ b/crypto/fipsmodule/bn/bn.c
@@ -72,13 +72,12 @@
 #define BN_MAX_WORDS (INT_MAX / (4 * BN_BITS2))
 
 BIGNUM *BN_new(void) {
-  BIGNUM *bn = OPENSSL_malloc(sizeof(BIGNUM));
+  BIGNUM *bn = OPENSSL_zalloc(sizeof(BIGNUM));
 
   if (bn == NULL) {
     return NULL;
   }
 
-  OPENSSL_memset(bn, 0, sizeof(BIGNUM));
   bn->flags = BN_FLG_MALLOCED;
 
   return bn;

--- a/crypto/fipsmodule/bn/ctx.c
+++ b/crypto/fipsmodule/bn/ctx.c
@@ -106,17 +106,17 @@ struct bignum_ctx {
 };
 
 BN_CTX *BN_CTX_new(void) {
-  BN_CTX *ret = OPENSSL_malloc(sizeof(BN_CTX));
+  BN_CTX *ret = OPENSSL_zalloc(sizeof(BN_CTX));
   if (!ret) {
     return NULL;
   }
 
   // Initialise the structure
-  ret->bignums = NULL;
+  assert(ret->bignums == NULL);
   BN_STACK_init(&ret->stack);
-  ret->used = 0;
-  ret->error = 0;
-  ret->defer_error = 0;
+  assert(ret->used == 0);
+  assert(ret->error == 0);
+  assert(ret->defer_error == 0);
   return ret;
 }
 

--- a/crypto/fipsmodule/bn/ctx.c
+++ b/crypto/fipsmodule/bn/ctx.c
@@ -112,11 +112,7 @@ BN_CTX *BN_CTX_new(void) {
   }
 
   // Initialise the structure
-  assert(ret->bignums == NULL);
   BN_STACK_init(&ret->stack);
-  assert(ret->used == 0);
-  assert(ret->error == 0);
-  assert(ret->defer_error == 0);
   return ret;
 }
 

--- a/crypto/fipsmodule/bn/exponentiation.c
+++ b/crypto/fipsmodule/bn/exponentiation.c
@@ -1030,13 +1030,14 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
   assert(powerbuf != NULL || top * BN_BITS2 > 1024);
 #endif
   if (powerbuf == NULL) {
-    powerbuf_free = OPENSSL_malloc(powerbuf_len + MOD_EXP_CTIME_ALIGN);
+    powerbuf_free = OPENSSL_zalloc(powerbuf_len + MOD_EXP_CTIME_ALIGN);
     if (powerbuf_free == NULL) {
       goto err;
     }
     powerbuf = align_pointer(powerbuf_free, MOD_EXP_CTIME_ALIGN);
+  } else {
+    OPENSSL_memset(powerbuf, 0, powerbuf_len);
   }
-  OPENSSL_memset(powerbuf, 0, powerbuf_len);
 
   // Place |tmp| and |am| right after powers table.
   BIGNUM tmp, am;

--- a/crypto/fipsmodule/cipher/aead.c
+++ b/crypto/fipsmodule/cipher/aead.c
@@ -41,6 +41,9 @@ void EVP_AEAD_CTX_zero(EVP_AEAD_CTX *ctx) {
 EVP_AEAD_CTX *EVP_AEAD_CTX_new(const EVP_AEAD *aead, const uint8_t *key,
                                size_t key_len, size_t tag_len) {
   EVP_AEAD_CTX *ctx = OPENSSL_zalloc(sizeof(EVP_AEAD_CTX));
+  if (ctx == NULL) {
+    return NULL;
+  }
   // NO-OP: struct already zeroed
   //EVP_AEAD_CTX_zero(ctx);
 

--- a/crypto/fipsmodule/cipher/aead.c
+++ b/crypto/fipsmodule/cipher/aead.c
@@ -40,8 +40,9 @@ void EVP_AEAD_CTX_zero(EVP_AEAD_CTX *ctx) {
 
 EVP_AEAD_CTX *EVP_AEAD_CTX_new(const EVP_AEAD *aead, const uint8_t *key,
                                size_t key_len, size_t tag_len) {
-  EVP_AEAD_CTX *ctx = OPENSSL_malloc(sizeof(EVP_AEAD_CTX));
-  EVP_AEAD_CTX_zero(ctx);
+  EVP_AEAD_CTX *ctx = OPENSSL_zalloc(sizeof(EVP_AEAD_CTX));
+  // NO-OP: struct already zeroed
+  //EVP_AEAD_CTX_zero(ctx);
 
   if (EVP_AEAD_CTX_init(ctx, aead, key, key_len, tag_len, NULL)) {
     return ctx;

--- a/crypto/fipsmodule/cipher/cipher.c
+++ b/crypto/fipsmodule/cipher/cipher.c
@@ -73,9 +73,10 @@ void EVP_CIPHER_CTX_init(EVP_CIPHER_CTX *ctx) {
 }
 
 EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void) {
-  EVP_CIPHER_CTX *ctx = OPENSSL_malloc(sizeof(EVP_CIPHER_CTX));
+  EVP_CIPHER_CTX *ctx = OPENSSL_zalloc(sizeof(EVP_CIPHER_CTX));
   if (ctx) {
-    EVP_CIPHER_CTX_init(ctx);
+    // NO-OP: struct already zeroed
+    // EVP_CIPHER_CTX_init(ctx);
   }
   return ctx;
 }

--- a/crypto/fipsmodule/cmac/cmac.c
+++ b/crypto/fipsmodule/cmac/cmac.c
@@ -117,9 +117,10 @@ int AES_CMAC(uint8_t out[16], const uint8_t *key, size_t key_len,
 }
 
 CMAC_CTX *CMAC_CTX_new(void) {
-  CMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
+  CMAC_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
   if (ctx != NULL) {
-    CMAC_CTX_init(ctx);
+    // NO-OP: struct already zeroed
+    //CMAC_CTX_init(ctx);
   }
   return ctx;
 }

--- a/crypto/fipsmodule/digest/digest.c
+++ b/crypto/fipsmodule/digest/digest.c
@@ -85,10 +85,11 @@ void EVP_MD_CTX_init(EVP_MD_CTX *ctx) {
 }
 
 EVP_MD_CTX *EVP_MD_CTX_new(void) {
-  EVP_MD_CTX *ctx = OPENSSL_malloc(sizeof(EVP_MD_CTX));
+  EVP_MD_CTX *ctx = OPENSSL_zalloc(sizeof(EVP_MD_CTX));
 
   if (ctx) {
-    EVP_MD_CTX_init(ctx);
+    // NO-OP: struct already zeroed
+    //EVP_MD_CTX_init(ctx);
   }
 
   return ctx;

--- a/crypto/fipsmodule/hmac/hmac.c
+++ b/crypto/fipsmodule/hmac/hmac.c
@@ -216,9 +216,10 @@ void HMAC_CTX_init(HMAC_CTX *ctx) {
 }
 
 HMAC_CTX *HMAC_CTX_new(void) {
-  HMAC_CTX *ctx = OPENSSL_malloc(sizeof(HMAC_CTX));
+  HMAC_CTX *ctx = OPENSSL_zalloc(sizeof(HMAC_CTX));
   if (ctx != NULL) {
-    HMAC_CTX_init(ctx);
+    // NO-OP: struct already zeroed
+    //HMAC_CTX_init(ctx);
   }
   return ctx;
 }

--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -554,11 +554,12 @@ void EVP_HPKE_CTX_cleanup(EVP_HPKE_CTX *ctx) {
 }
 
 EVP_HPKE_CTX *EVP_HPKE_CTX_new(void) {
-  EVP_HPKE_CTX *ctx = OPENSSL_malloc(sizeof(EVP_HPKE_CTX));
+  EVP_HPKE_CTX *ctx = OPENSSL_zalloc(sizeof(EVP_HPKE_CTX));
   if (ctx == NULL) {
     return NULL;
   }
-  EVP_HPKE_CTX_zero(ctx);
+  // NO-OP: struct already zeroed
+  //EVP_HPKE_CTX_zero(ctx);
   return ctx;
 }
 

--- a/crypto/kem/kem.c
+++ b/crypto/kem/kem.c
@@ -74,12 +74,11 @@ const KEM *KEM_find_kem_by_nid(int nid) {
 }
 
 KEM_KEY *KEM_KEY_new(void) {
-  KEM_KEY *ret = OPENSSL_malloc(sizeof(KEM_KEY));
+  KEM_KEY *ret = OPENSSL_zalloc(sizeof(KEM_KEY));
   if (ret == NULL) {
     return NULL;
   }
 
-  OPENSSL_memset(ret, 0, sizeof(KEM_KEY));
   return ret;
 }
 

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -289,7 +289,6 @@ int OPENSSL_lh_insert(_LHASH *lh, void **old_data, void *data,
 
   item->data = data;
   item->hash = hash;
-  assert(item->next == NULL);
   *next_ptr = item;
   lh->num_items++;
   lh_maybe_resize(lh);

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -282,14 +282,14 @@ int OPENSSL_lh_insert(_LHASH *lh, void **old_data, void *data,
   }
 
   // An element equal to |data| doesn't exist in the hash table yet.
-  item = OPENSSL_malloc(sizeof(LHASH_ITEM));
+  item = OPENSSL_zalloc(sizeof(LHASH_ITEM));
   if (item == NULL) {
     return 0;
   }
 
   item->data = data;
   item->hash = hash;
-  item->next = NULL;
+  assert(item->next == NULL);
   *next_ptr = item;
   lh->num_items++;
   lh_maybe_resize(lh);

--- a/crypto/rsa_extra/rsassa_pss_asn1.c
+++ b/crypto/rsa_extra/rsassa_pss_asn1.c
@@ -310,38 +310,34 @@ static int pss_parse_nid(int nid, RSA_ALGOR_IDENTIFIER **out) {
 }
 
 RSA_INTEGER *RSA_INTEGER_new(void) {
-  RSA_INTEGER *ret = OPENSSL_malloc(sizeof(RSA_INTEGER));
+  RSA_INTEGER *ret = OPENSSL_zalloc(sizeof(RSA_INTEGER));
   if (ret == NULL) {
     return NULL;
   }
-  OPENSSL_memset(ret, 0, sizeof(RSA_INTEGER));
   return ret;
 }
 
 RSA_ALGOR_IDENTIFIER *RSA_ALGOR_IDENTIFIER_new(void) {
-  RSA_ALGOR_IDENTIFIER *ret = OPENSSL_malloc(sizeof(RSA_ALGOR_IDENTIFIER));
+  RSA_ALGOR_IDENTIFIER *ret = OPENSSL_zalloc(sizeof(RSA_ALGOR_IDENTIFIER));
   if (ret == NULL) {
     return NULL;
   }
-  OPENSSL_memset(ret, 0, sizeof(RSA_ALGOR_IDENTIFIER));
   return ret;
 }
 
 RSA_MGA_IDENTIFIER *RSA_MGA_IDENTIFIER_new(void) {
-  RSA_MGA_IDENTIFIER *ret = OPENSSL_malloc(sizeof(RSA_MGA_IDENTIFIER));
+  RSA_MGA_IDENTIFIER *ret = OPENSSL_zalloc(sizeof(RSA_MGA_IDENTIFIER));
   if (ret == NULL) {
     return NULL;
   }
-  OPENSSL_memset(ret, 0, sizeof(RSA_MGA_IDENTIFIER));
   return ret;
 }
 
 RSASSA_PSS_PARAMS *RSASSA_PSS_PARAMS_new(void) {
-  RSASSA_PSS_PARAMS *ret = OPENSSL_malloc(sizeof(RSASSA_PSS_PARAMS));
+  RSASSA_PSS_PARAMS *ret = OPENSSL_zalloc(sizeof(RSASSA_PSS_PARAMS));
   if (ret == NULL) {
     return NULL;
   }
-  OPENSSL_memset(ret, 0, sizeof(RSASSA_PSS_PARAMS));
   return ret;
 }
 

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -68,16 +68,16 @@
 X509_LOOKUP *X509_LOOKUP_new(X509_LOOKUP_METHOD *method) {
   X509_LOOKUP *ret;
 
-  ret = (X509_LOOKUP *)OPENSSL_malloc(sizeof(X509_LOOKUP));
+  ret = (X509_LOOKUP *)OPENSSL_zalloc(sizeof(X509_LOOKUP));
   if (ret == NULL) {
     return NULL;
   }
 
-  ret->init = 0;
-  ret->skip = 0;
+  assert(ret->init == 0);
+  assert(ret->skip == 0);
   ret->method = method;
-  ret->method_data = NULL;
-  ret->store_ctx = NULL;
+  assert(ret->method_data == NULL);
+  assert(ret->store_ctx == NULL);
   if ((method->new_item != NULL) && !method->new_item(ret)) {
     OPENSSL_free(ret);
     return NULL;
@@ -358,11 +358,10 @@ int X509_STORE_add_crl(X509_STORE *ctx, X509_CRL *x) {
 }
 
 X509_OBJECT *X509_OBJECT_new(void) {
-  X509_OBJECT *ret = OPENSSL_malloc(sizeof(X509_OBJECT));
+  X509_OBJECT *ret = OPENSSL_zalloc(sizeof(X509_OBJECT));
   if (ret == NULL) {
     return NULL;
   }
-  OPENSSL_memset(ret, 0, sizeof(X509_OBJECT));
   return ret;
 }
 

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -73,11 +73,7 @@ X509_LOOKUP *X509_LOOKUP_new(X509_LOOKUP_METHOD *method) {
     return NULL;
   }
 
-  assert(ret->init == 0);
-  assert(ret->skip == 0);
   ret->method = method;
-  assert(ret->method_data == NULL);
-  assert(ret->store_ctx == NULL);
   if ((method->new_item != NULL) && !method->new_item(ret)) {
     OPENSSL_free(ret);
     return NULL;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2086,11 +2086,12 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
 
 X509_STORE_CTX *X509_STORE_CTX_new(void) {
   X509_STORE_CTX *ctx;
-  ctx = (X509_STORE_CTX *)OPENSSL_malloc(sizeof(X509_STORE_CTX));
+  ctx = (X509_STORE_CTX *)OPENSSL_zalloc(sizeof(X509_STORE_CTX));
   if (!ctx) {
     return NULL;
   }
-  X509_STORE_CTX_zero(ctx);
+  // NO-OP: struct already zeroed
+  //X509_STORE_CTX_zero(ctx);
   return ctx;
 }
 

--- a/crypto/x509/x_info.c
+++ b/crypto/x509/x_info.c
@@ -60,22 +60,23 @@
 #include <openssl/err.h>
 #include <openssl/mem.h>
 #include <openssl/thread.h>
+#include <assert.h>
 
 X509_INFO *X509_INFO_new(void) {
   X509_INFO *ret = NULL;
 
-  ret = (X509_INFO *)OPENSSL_malloc(sizeof(X509_INFO));
+  ret = (X509_INFO *)OPENSSL_zalloc(sizeof(X509_INFO));
   if (ret == NULL) {
     return NULL;
   }
 
-  ret->enc_cipher.cipher = NULL;
-  ret->enc_len = 0;
-  ret->enc_data = NULL;
+  assert(ret->enc_cipher.cipher == NULL);
+  assert(ret->enc_len == 0);
+  assert(ret->enc_data == NULL);
 
-  ret->x509 = NULL;
-  ret->crl = NULL;
-  ret->x_pkey = NULL;
+  assert(ret->x509 == NULL);
+  assert(ret->crl == NULL);
+  assert(ret->x_pkey == NULL);
   return ret;
 }
 

--- a/crypto/x509/x_info.c
+++ b/crypto/x509/x_info.c
@@ -70,13 +70,6 @@ X509_INFO *X509_INFO_new(void) {
     return NULL;
   }
 
-  assert(ret->enc_cipher.cipher == NULL);
-  assert(ret->enc_len == 0);
-  assert(ret->enc_data == NULL);
-
-  assert(ret->x509 == NULL);
-  assert(ret->crl == NULL);
-  assert(ret->x_pkey == NULL);
   return ret;
 }
 


### PR DESCRIPTION
### Description of changes: 
* Use `OPENSSL_zalloc` instead of `OPENSSL_malloc` when it makes subsequent initialization unnecessary. 

### Call-outs:
* If we either define an `OPENSSL_rezalloc` or modify `OPENSSL_realloc` to call `OPENSSL_zalloc`, there's a couple more places where we might avoid subsequent initializations.

### Testing:
Debug/FIPS build succeeded on my Mac.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
