### PR TITLE
Drop python main from integration tests

### DIFF
--- a/tests/ci/integration/run_python_integration.sh
+++ b/tests/ci/integration/run_python_integration.sh
@@ -130,7 +130,7 @@ echo 0 >/proc/sys/net/ipv6/conf/all/disable_ipv6 || /bin/true
 
 # NOTE: cpython keeps a unique branch per version, add version branches here
 # NOTE: As we add more versions to support, we may want to parallelize here
-for branch in 3.10 3.11 3.12 main; do
+for branch in 3.10 3.11 3.12; do
     python_patch ${branch}
     python_build ${branch}
     python_run_tests ${branch}


### PR DESCRIPTION
### Issues:
n/a

### Description of changes: 

This change drops CPython's main branch from our integration CI, which is currently failing due to AWS-LC's lack 4 OpenSSL functions newly used in [this commit](https://github.com/python/cpython/commit/bce693111bff906ccf9281c22371331aaff766ab).

### Call-outs:
n/a

### Testing:
- CI tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
