### PR TITLE
[fips-2022-11-02] Backport: Fix Clang-6 FIPS static build issue (#1424)

### DIFF
--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -61,7 +61,7 @@ const (
 
 // represents a unique symbol for an occurrence of OPENSSL_ia32cap_P.
 type cpuCapUniqueSymbol struct {
-	registerName string
+	registerName     string
 	suffixUniqueness string
 }
 
@@ -78,8 +78,8 @@ func (uniqueSymbol cpuCapUniqueSymbol) getx86SymbolReturn() string {
 // uniqueness must be a globally unique integer value.
 func newCpuCapUniqueSymbol(uniqueness int, registerName string) *cpuCapUniqueSymbol {
 	return &cpuCapUniqueSymbol{
-	    registerName: strings.Trim(registerName, "%"), // should work with both AT&T and Intel syntax.
-	    suffixUniqueness: strconv.Itoa(uniqueness),
+		registerName:     strings.Trim(registerName, "%"), // should work with both AT&T and Intel syntax.
+		suffixUniqueness: strconv.Itoa(uniqueness),
 	}
 }
 
@@ -1713,10 +1713,6 @@ func transform(w stringWriter, inputs []inputFile) error {
 	// maxObservedFileNumber contains the largest seen file number in a
 	// .file directive. Zero is not a valid number.
 	maxObservedFileNumber := 0
-	// fileDirectivesContainMD5 is true if the compiler is outputting MD5
-	// checksums in .file directives. If it does so, then this script needs
-	// to match that behaviour otherwise warnings result.
-	fileDirectivesContainMD5 := false
 
 	// OPENSSL_ia32cap_get will be synthesized by this script.
 	symbols["OPENSSL_ia32cap_get"] = struct{}{}
@@ -1776,12 +1772,6 @@ func transform(w stringWriter, inputs []inputFile) error {
 			if fileNo > maxObservedFileNumber {
 				maxObservedFileNumber = fileNo
 			}
-
-			for _, token := range parts[2:] {
-				if token == "md5" {
-					fileDirectivesContainMD5 = true
-				}
-			}
 		}, ruleStatement, ruleLocationDirective)
 	}
 
@@ -1796,27 +1786,21 @@ func transform(w stringWriter, inputs []inputFile) error {
 	}
 
 	d := &delocation{
-		symbols:             	symbols,
-		localEntrySymbols:   	localEntrySymbols,
-		processor:           	processor,
-		commentIndicator:    	commentIndicator,
-		output:              	w,
-		cpuCapUniqueSymbols:    []*cpuCapUniqueSymbol{},
-		redirectors:         	make(map[string]string),
-		bssAccessorsNeeded:  	make(map[string]string),
-		tocLoaders:          	make(map[string]struct{}),
-		gotExternalsNeeded:  	make(map[string]struct{}),
-		gotOffsetsNeeded:    	make(map[string]struct{}),
-		gotOffOffsetsNeeded: 	make(map[string]struct{}),
+		symbols:             symbols,
+		localEntrySymbols:   localEntrySymbols,
+		processor:           processor,
+		commentIndicator:    commentIndicator,
+		output:              w,
+		cpuCapUniqueSymbols: []*cpuCapUniqueSymbol{},
+		redirectors:         make(map[string]string),
+		bssAccessorsNeeded:  make(map[string]string),
+		tocLoaders:          make(map[string]struct{}),
+		gotExternalsNeeded:  make(map[string]struct{}),
+		gotOffsetsNeeded:    make(map[string]struct{}),
+		gotOffOffsetsNeeded: make(map[string]struct{}),
 	}
 
 	w.WriteString(".text\n")
-	var fileTrailing string
-	if fileDirectivesContainMD5 {
-		fileTrailing = " md5 0x00000000000000000000000000000000"
-	}
-	w.WriteString(fmt.Sprintf(".file %d \"inserted_by_delocate.c\"%s\n", maxObservedFileNumber+1, fileTrailing))
-	w.WriteString(fmt.Sprintf(".loc %d 1 0\n", maxObservedFileNumber+1))
 	w.WriteString("BORINGSSL_bcm_text_start:\n")
 
 	for _, input := range inputs {
@@ -1826,7 +1810,6 @@ func transform(w stringWriter, inputs []inputFile) error {
 	}
 
 	w.WriteString(".text\n")
-	w.WriteString(fmt.Sprintf(".loc %d 2 0\n", maxObservedFileNumber+1))
 	w.WriteString("BORINGSSL_bcm_text_end:\n")
 
 	// Emit redirector functions. Each is a single jump instruction.

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -1432,7 +1432,7 @@ Args:
 
 				classification := classifyInstruction(instructionName, argNodes)
 				if classification != instrThreeArg && classification != instrCompare && i != 0 {
-					return nil, fmt.Errorf("GOT access must be source operand, %w", classification)
+					return nil, fmt.Errorf("GOT access must be source operand, %v", classification)
 				}
 
 				// Reduce the instruction to movq symbol@GOTPCREL, targetReg.

--- a/util/fipstools/delocate/testdata/aarch64-Basic/out.s
+++ b/util/fipstools/delocate/testdata/aarch64-Basic/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.type foo, %function
 	.globl foo
@@ -138,7 +136,6 @@ bss_symbol:
 .word 0
 .size bss_symbol, 4
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .p2align 2
 .hidden bcm_redirector_remote_function

--- a/util/fipstools/delocate/testdata/generic-FileDirectives/out.s
+++ b/util/fipstools/delocate/testdata/generic-FileDirectives/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1002 "inserted_by_delocate.c" md5 0x00000000000000000000000000000000
-.loc 1002 1 0
 BORINGSSL_bcm_text_start:
 .file 10 "some/path/file.c" "file.c"
 .file 1000 "some/path/file2.c" "file2.c"
@@ -9,7 +7,6 @@ BORINGSSL_bcm_text_start:
 # An instruction is needed to satisfy the architecture auto-detection.
         movq %rax, %rbx
 .text
-.loc 1002 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get

--- a/util/fipstools/delocate/testdata/ppc64le-GlobalEntry/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-GlobalEntry/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 .Lfoo_local_target:
@@ -21,7 +19,6 @@ foo:
 
 	bl
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .LBORINGSSL_external_toc:
 .quad .TOC.-.LBORINGSSL_external_toc

--- a/util/fipstools/delocate/testdata/ppc64le-LoadToR0/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-LoadToR0/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 .Lfoo_local_target:
@@ -25,7 +23,6 @@ foo:
 	ld 3, -8(1)
 	addi 1, 1, 288
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type bcm_loadtoc_bar, @function
 bcm_loadtoc_bar:

--- a/util/fipstools/delocate/testdata/ppc64le-Sample/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-Sample/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.file	"foo.c"
 	.abiversion 2
@@ -417,7 +415,6 @@ exported_function:
 	.ident	"GCC: (Ubuntu 4.9.2-10ubuntu13) 4.9.2"
 	.section	.note.GNU-stack,"",@progbits
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .section ".toc", "aw"
 .Lredirector_toc_fprintf:

--- a/util/fipstools/delocate/testdata/ppc64le-Sample2/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-Sample2/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.file	"foo.c"
 	.abiversion 2
@@ -536,7 +534,6 @@ bss:
 	.ident	"GCC: (Ubuntu 4.9.2-10ubuntu13) 4.9.2"
 	.section	.note.GNU-stack,"",@progbits
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .section ".toc", "aw"
 .Lredirector_toc___fprintf_chk:

--- a/util/fipstools/delocate/testdata/ppc64le-TOCWithOffset/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-TOCWithOffset/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 .Lfoo_local_target:
@@ -101,7 +99,6 @@ foo:
 	ld 3, -16(1)
 	addi 1, 1, 288
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type bcm_loadtoc__dot_Lfoo_local_target, @function
 bcm_loadtoc__dot_Lfoo_local_target:

--- a/util/fipstools/delocate/testdata/x86_64-BSS/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-BSS/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 	movq %rax, %rax
@@ -43,7 +41,6 @@ z:
 
 	.quad 0
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type aes_128_ctr_generic_storage_bss_get, @function
 aes_128_ctr_generic_storage_bss_get:

--- a/util/fipstools/delocate/testdata/x86_64-Basic/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-Basic/out.s
@@ -1,6 +1,4 @@
 .text
-.file 2 "inserted_by_delocate.c"
-.loc 2 1 0
 BORINGSSL_bcm_text_start:
 	# Most instructions and lines should pass unaltered. This is made up of
 	# copy-and-pasted bits of compiler output and likely does not actually
@@ -57,7 +55,6 @@ foo:
 .type	foo, @function
 .uleb128 .foo-1-.bar
 .text
-.loc 2 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get

--- a/util/fipstools/delocate/testdata/x86_64-GOTRewrite/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-GOTRewrite/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 .Lfoo_local_target:
@@ -258,7 +256,6 @@ LOPENSSL_ia32cap_P_rbx3_return:
 
 .comm foobar,64,32
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type foobar_bss_get, @function
 foobar_bss_get:

--- a/util/fipstools/delocate/testdata/x86_64-LabelRewrite/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-LabelRewrite/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.type foo, @function
 	.globl foo
@@ -96,7 +94,6 @@ bar:
 	.byte	(.LBB231_40_BCM_1-.LBB231_19_BCM_1)>>2, 4, .Lfoo_BCM_1, (.Lfoo_BCM_1), .Lfoo_BCM_1<<400, (   .Lfoo_BCM_1 ) <<  66
 .byte   421
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type bcm_redirector_memcpy, @function
 bcm_redirector_memcpy:

--- a/util/fipstools/delocate/testdata/x86_64-LargeMemory/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-LargeMemory/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 
@@ -39,7 +37,6 @@ BORINGSSL_bcm_text_start:
         # jmpq    *%rax
 
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get

--- a/util/fipstools/delocate/testdata/x86_64-Sections/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-Sections/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	# .text stays in .text
 	.text
@@ -45,7 +43,6 @@ foo:
 	.byte	0x1
 	.long	.L3
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get

--- a/util/fipstools/delocate/testdata/x86_64-ThreeArg/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-ThreeArg/out.s
@@ -1,6 +1,4 @@
 .text
-.file 1 "inserted_by_delocate.c"
-.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.type foo, @function
 	.globl foo
@@ -32,7 +30,6 @@ foo:
 kBoringSSLRSASqrtTwo:
 	.quad	-2404814165548301886    # 0xdea06241f7aa81c2
 .text
-.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get


### PR DESCRIPTION
Backports the previously reviewed https://github.com/aws/aws-lc/pull/1424 from main to fips-2022-11-02 branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
