### PR TITLE
Fixing typo in comment in md32_common.h

### DIFF
--- a/crypto/fipsmodule/digest/md32_common.h
+++ b/crypto/fipsmodule/digest/md32_common.h
@@ -76,7 +76,7 @@ extern "C" {
 //     } <NAME>_CTX;
 //
 // <chaining length> is the output length of the hash in bytes, before
-// any truncation (e.g. 64 for SHA-224 and SHA-256, 128 for SHA-384 and
+// any truncation (e.g. 32 for SHA-224 and SHA-256, 64 for SHA-384 and
 // SHA-512).
 //
 // |h| is the hash state and is updated by a function of type


### PR DESCRIPTION
### Description of changes: 

Fixing a typo in the comment in md32_common.h

The <chaining length> is 32 bytes (= 256 bits) for SHA-224 and SHA-256, and 64 bytes (= 512 bits) for SHA-384 and SHA-512. See also https://github.com/aws/aws-lc/blob/0a470e450c6f5492478319abefc6daa0e9999954/include/openssl/sha.h#L174-L179 .

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
