### PR TITLE
Make the clang-6 bcm-delocated.S directive behavior for start/end symbols dynamic

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -159,8 +159,8 @@ endif()
 # clang-6 (and older) knows how to compile AVX512 assembly instructions,
 # but only if it's given the right flags (e.g. -mavx512*).
 # The flags are not required for any other compiler we are running in the CI.
-if ((CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
-    (CMAKE_ASM_COMPILER_VERSION VERSION_LESS "7.0.0") AND (ARCH STREQUAL "x86_64"))
+if (CLANG AND (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
+    (CMAKE_C_COMPILER_VERSION VERSION_LESS "7.0.0") AND (ARCH STREQUAL "x86_64"))
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/aesni-gcm-avx512.${ASM_EXT} PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl")
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/aesni-xts-avx512.${ASM_EXT} PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl")
 endif()
@@ -339,8 +339,8 @@ if(FIPS_DELOCATE)
   set(DELOCATE_EXTRA_ARGS "")
   # clang-6 (and older) do not appreciate the file number starting at a higher value, and incorrectly
   # assume that all file numbers less than that value are defined upon later use.
-  if ((CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
-      (CMAKE_ASM_COMPILER_VERSION VERSION_LESS "7.0.0"))
+  if (CLANG AND (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
+      (CMAKE_C_COMPILER_VERSION VERSION_LESS "7.0.0"))
     set(DELOCATE_EXTRA_ARGS "-no-se-debug-directives")
   endif()
 
@@ -371,8 +371,8 @@ if(FIPS_DELOCATE)
   # clang-6 (and older) knows how to compile AVX512 assembly instructions,
   # but only if it's given the right flags (e.g. -mavx512*).
   # The flags are not required for any other compiler we are running in the CI.
-  if ((CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
-      (CMAKE_ASM_COMPILER_VERSION VERSION_LESS "7.0.0") AND (ARCH STREQUAL "x86_64"))
+  if (CLANG AND (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
+      (CMAKE_C_COMPILER_VERSION VERSION_LESS "7.0.0") AND (ARCH STREQUAL "x86_64"))
     set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/bcm-delocated.S PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl")
   endif()
 

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -336,6 +336,14 @@ if(FIPS_DELOCATE)
     set(TARGET "--target=${CMAKE_ASM_COMPILER_TARGET}")
   endif()
 
+  set(DELOCATE_EXTRA_ARGS "")
+  # clang-6 (and older) do not appreciate the file number starting at a higher value, and incorrectly
+  # assume that all file numbers less than that value are defined upon later use.
+  if ((CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
+      (CMAKE_ASM_COMPILER_VERSION VERSION_LESS "7.0.0"))
+    set(DELOCATE_EXTRA_ARGS "-no-se-debug-directives")
+  endif()
+
   go_executable(delocate boringssl.googlesource.com/boringssl/util/fipstools/delocate)
   add_custom_command(
     OUTPUT bcm-delocated.S
@@ -345,6 +353,7 @@ if(FIPS_DELOCATE)
     -o bcm-delocated.S
     -cc ${CMAKE_ASM_COMPILER}
     -cc-flags "${TARGET} ${CMAKE_ASM_FLAGS}"
+    ${DELOCATE_EXTRA_ARGS}
     ${PROJECT_SOURCE_DIR}/include/openssl/arm_arch.h
     ${PROJECT_SOURCE_DIR}/include/openssl/asm_base.h
     ${PROJECT_SOURCE_DIR}/include/openssl/target.h

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -1776,6 +1776,10 @@ func transform(w stringWriter, includes []string, inputs []inputFile) error {
 	// maxObservedFileNumber contains the largest seen file number in a
 	// .file directive. Zero is not a valid number.
 	maxObservedFileNumber := 0
+	// fileDirectivesContainMD5 is true if the compiler is outputting MD5
+	// checksums in .file directives. If it does so, then this script needs
+	// to match that behaviour otherwise warnings result.
+	fileDirectivesContainMD5 := false
 
 	// OPENSSL_ia32cap_get will be synthesized by this script.
 	symbols["OPENSSL_ia32cap_get"] = struct{}{}
@@ -1843,6 +1847,12 @@ func transform(w stringWriter, includes []string, inputs []inputFile) error {
 			if fileNo > maxObservedFileNumber {
 				maxObservedFileNumber = fileNo
 			}
+
+			for _, token := range parts[2:] {
+				if token == "md5" {
+					fileDirectivesContainMD5 = true
+				}
+			}
 		}, ruleStatement, ruleLocationDirective)
 	}
 
@@ -1872,6 +1882,12 @@ func transform(w stringWriter, includes []string, inputs []inputFile) error {
 	}
 
 	w.WriteString(".text\n")
+	var fileTrailing string
+	if fileDirectivesContainMD5 {
+		fileTrailing = " md5 0x00000000000000000000000000000000"
+	}
+	w.WriteString(fmt.Sprintf(".file %d \"inserted_by_delocate.c\"%s\n", maxObservedFileNumber+1, fileTrailing))
+	w.WriteString(fmt.Sprintf(".loc %d 1 0\n", maxObservedFileNumber+1))
 	if d.processor == aarch64 {
 		// Grab the address of BORINGSSL_bcm_test_[start,end] via a relocation
 		// from a redirector function. For this to work, need to add the markers
@@ -1888,6 +1904,7 @@ func transform(w stringWriter, includes []string, inputs []inputFile) error {
 	}
 
 	w.WriteString(".text\n")
+	w.WriteString(fmt.Sprintf(".loc %d 2 0\n", maxObservedFileNumber+1))
 	if d.processor == aarch64 {
 		w.WriteString(fmt.Sprintf(".global BORINGSSL_bcm_text_end\n"))
 		w.WriteString(fmt.Sprintf(".type BORINGSSL_bcm_text_end, @function\n"))

--- a/util/fipstools/delocate/delocate_test.go
+++ b/util/fipstools/delocate/delocate_test.go
@@ -28,10 +28,11 @@ var (
 )
 
 type delocateTest struct {
-	name     string
-	includes []string
-	inputs   []string
-	out      string
+	name                    string
+	includes                []string
+	inputs                  []string
+	out                     string
+	startEndDebugDirectives bool
 }
 
 func (test *delocateTest) Path(file string) string {
@@ -39,21 +40,22 @@ func (test *delocateTest) Path(file string) string {
 }
 
 var delocateTests = []delocateTest{
-	{"generic-FileDirectives", nil, []string{"in.s"}, "out.s"},
-	{"generic-Includes", []string{"/some/include/path/openssl/foo.h", "/some/include/path/openssl/bar.h"}, []string{"in.s"}, "out.s"},
-	{"ppc64le-GlobalEntry", nil, []string{"in.s"}, "out.s"},
-	{"ppc64le-LoadToR0", nil, []string{"in.s"}, "out.s"},
-	{"ppc64le-Sample2", nil, []string{"in.s"}, "out.s"},
-	{"ppc64le-Sample", nil, []string{"in.s"}, "out.s"},
-	{"ppc64le-TOCWithOffset", nil, []string{"in.s"}, "out.s"},
-	{"x86_64-Basic", nil, []string{"in.s"}, "out.s"},
-	{"x86_64-BSS", nil, []string{"in.s"}, "out.s"},
-	{"x86_64-GOTRewrite", nil, []string{"in.s"}, "out.s"},
-	{"x86_64-LargeMemory", nil, []string{"in.s"}, "out.s"},
-	{"x86_64-LabelRewrite", nil, []string{"in1.s", "in2.s"}, "out.s"},
-	{"x86_64-Sections", nil, []string{"in.s"}, "out.s"},
-	{"x86_64-ThreeArg", nil, []string{"in.s"}, "out.s"},
-	{"aarch64-Basic", nil, []string{"in.s"}, "out.s"},
+	{"generic-FileDirectives", nil, []string{"in.s"}, "out.s", true},
+	{"generic-FileDirectives-no-start-end", nil, []string{"in.s"}, "out.s", false},
+	{"generic-Includes", []string{"/some/include/path/openssl/foo.h", "/some/include/path/openssl/bar.h"}, []string{"in.s"}, "out.s", true},
+	{"ppc64le-GlobalEntry", nil, []string{"in.s"}, "out.s", true},
+	{"ppc64le-LoadToR0", nil, []string{"in.s"}, "out.s", true},
+	{"ppc64le-Sample2", nil, []string{"in.s"}, "out.s", true},
+	{"ppc64le-Sample", nil, []string{"in.s"}, "out.s", true},
+	{"ppc64le-TOCWithOffset", nil, []string{"in.s"}, "out.s", true},
+	{"x86_64-Basic", nil, []string{"in.s"}, "out.s", true},
+	{"x86_64-BSS", nil, []string{"in.s"}, "out.s", true},
+	{"x86_64-GOTRewrite", nil, []string{"in.s"}, "out.s", true},
+	{"x86_64-LargeMemory", nil, []string{"in.s"}, "out.s", true},
+	{"x86_64-LabelRewrite", nil, []string{"in1.s", "in2.s"}, "out.s", true},
+	{"x86_64-Sections", nil, []string{"in.s"}, "out.s", true},
+	{"x86_64-ThreeArg", nil, []string{"in.s"}, "out.s", true},
+	{"aarch64-Basic", nil, []string{"in.s"}, "out.s", true},
 }
 
 func TestDelocate(t *testing.T) {
@@ -72,7 +74,7 @@ func TestDelocate(t *testing.T) {
 			}
 
 			var buf bytes.Buffer
-			if err := transform(&buf, test.includes, inputs); err != nil {
+			if err := transform(&buf, test.includes, inputs, test.startEndDebugDirectives); err != nil {
 				t.Fatalf("transform failed: %s", err)
 			}
 

--- a/util/fipstools/delocate/testdata/aarch64-Basic/out.s
+++ b/util/fipstools/delocate/testdata/aarch64-Basic/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 .global BORINGSSL_bcm_text_start
 .type BORINGSSL_bcm_text_start, @function
 BORINGSSL_bcm_text_start:
@@ -169,6 +171,7 @@ bss_symbol:
 .word 0
 .size bss_symbol, 4
 .text
+.loc 1 2 0
 .global BORINGSSL_bcm_text_end
 .type BORINGSSL_bcm_text_end, @function
 BORINGSSL_bcm_text_end:

--- a/util/fipstools/delocate/testdata/generic-FileDirectives-no-start-end/in.s
+++ b/util/fipstools/delocate/testdata/generic-FileDirectives-no-start-end/in.s
@@ -1,0 +1,6 @@
+.file 10 "some/path/file.c" "file.c"
+.file 1000 "some/path/file2.c" "file2.c"
+.file 1001 "some/path/file_with_md5.c" "other_name.c" md5 0x5eba7844df6449a7f2fff1556fe7ba8d239f8e2f
+
+# An instruction is needed to satisfy the architecture auto-detection.
+        movq %rax, %rbx

--- a/util/fipstools/delocate/testdata/generic-FileDirectives-no-start-end/out.s
+++ b/util/fipstools/delocate/testdata/generic-FileDirectives-no-start-end/out.s
@@ -1,0 +1,51 @@
+.text
+BORINGSSL_bcm_text_start:
+.file 10 "some/path/file.c" "file.c"
+.file 1000 "some/path/file2.c" "file2.c"
+.file 1001 "some/path/file_with_md5.c" "other_name.c" md5 0x5eba7844df6449a7f2fff1556fe7ba8d239f8e2f
+
+# An instruction is needed to satisfy the architecture auto-detection.
+        movq %rax, %rbx
+.text
+BORINGSSL_bcm_text_end:
+.type OPENSSL_ia32cap_get, @function
+.globl OPENSSL_ia32cap_get
+.LOPENSSL_ia32cap_get_local_target:
+OPENSSL_ia32cap_get:
+	leaq OPENSSL_ia32cap_P(%rip), %rax
+	ret
+.type BORINGSSL_bcm_text_hash, @object
+.size BORINGSSL_bcm_text_hash, 32
+BORINGSSL_bcm_text_hash:
+.byte 0xae
+.byte 0x2c
+.byte 0xea
+.byte 0x2a
+.byte 0xbd
+.byte 0xa6
+.byte 0xf3
+.byte 0xec
+.byte 0x97
+.byte 0x7f
+.byte 0x9b
+.byte 0xf6
+.byte 0x94
+.byte 0x9a
+.byte 0xfc
+.byte 0x83
+.byte 0x68
+.byte 0x27
+.byte 0xcb
+.byte 0xa0
+.byte 0xa0
+.byte 0x9f
+.byte 0x6b
+.byte 0x6f
+.byte 0xde
+.byte 0x52
+.byte 0xcd
+.byte 0xe2
+.byte 0xcd
+.byte 0xff
+.byte 0x31
+.byte 0x80

--- a/util/fipstools/delocate/testdata/generic-FileDirectives/out.s
+++ b/util/fipstools/delocate/testdata/generic-FileDirectives/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1002 "inserted_by_delocate.c" md5 0x00000000000000000000000000000000
+.loc 1002 1 0
 BORINGSSL_bcm_text_start:
 .file 10 "some/path/file.c" "file.c"
 .file 1000 "some/path/file2.c" "file2.c"
@@ -7,6 +9,7 @@ BORINGSSL_bcm_text_start:
 # An instruction is needed to satisfy the architecture auto-detection.
         movq %rax, %rbx
 .text
+.loc 1002 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get

--- a/util/fipstools/delocate/testdata/generic-Includes/out.s
+++ b/util/fipstools/delocate/testdata/generic-Includes/out.s
@@ -1,6 +1,8 @@
 #include <openssl/foo.h>
 #include <openssl/bar.h>
 .text
+.file 1002 "inserted_by_delocate.c" md5 0x00000000000000000000000000000000
+.loc 1002 1 0
 BORINGSSL_bcm_text_start:
 .file 10 "some/path/file.c" "file.c"
 .file 1000 "some/path/file2.c" "file2.c"
@@ -9,6 +11,7 @@ BORINGSSL_bcm_text_start:
 # An instruction is needed to satisfy the architecture auto-detection.
         movq %rax, %rbx
 .text
+.loc 1002 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get

--- a/util/fipstools/delocate/testdata/ppc64le-GlobalEntry/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-GlobalEntry/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 .Lfoo_local_target:
@@ -19,6 +21,7 @@ foo:
 
 	bl
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .LBORINGSSL_external_toc:
 .quad .TOC.-.LBORINGSSL_external_toc

--- a/util/fipstools/delocate/testdata/ppc64le-LoadToR0/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-LoadToR0/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 .Lfoo_local_target:
@@ -23,6 +25,7 @@ foo:
 	ld 3, -8(1)
 	addi 1, 1, 288
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type bcm_loadtoc_bar, @function
 bcm_loadtoc_bar:

--- a/util/fipstools/delocate/testdata/ppc64le-Sample/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-Sample/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.file	"foo.c"
 	.abiversion 2
@@ -415,6 +417,7 @@ exported_function:
 	.ident	"GCC: (Ubuntu 4.9.2-10ubuntu13) 4.9.2"
 	.section	.note.GNU-stack,"",@progbits
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .section ".toc", "aw"
 .Lredirector_toc_fprintf:

--- a/util/fipstools/delocate/testdata/ppc64le-Sample2/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-Sample2/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.file	"foo.c"
 	.abiversion 2
@@ -534,6 +536,7 @@ bss:
 	.ident	"GCC: (Ubuntu 4.9.2-10ubuntu13) 4.9.2"
 	.section	.note.GNU-stack,"",@progbits
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .section ".toc", "aw"
 .Lredirector_toc___fprintf_chk:

--- a/util/fipstools/delocate/testdata/ppc64le-TOCWithOffset/out.s
+++ b/util/fipstools/delocate/testdata/ppc64le-TOCWithOffset/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 .Lfoo_local_target:
@@ -99,6 +101,7 @@ foo:
 	ld 3, -16(1)
 	addi 1, 1, 288
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type bcm_loadtoc__dot_Lfoo_local_target, @function
 bcm_loadtoc__dot_Lfoo_local_target:

--- a/util/fipstools/delocate/testdata/x86_64-BSS/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-BSS/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 	movq %rax, %rax
@@ -41,6 +43,7 @@ z:
 
 	.quad 0
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type aes_128_ctr_generic_storage_bss_get, @function
 aes_128_ctr_generic_storage_bss_get:

--- a/util/fipstools/delocate/testdata/x86_64-Basic/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-Basic/out.s
@@ -1,4 +1,6 @@
 .text
+.file 2 "inserted_by_delocate.c"
+.loc 2 1 0
 BORINGSSL_bcm_text_start:
 	# Most instructions and lines should pass unaltered. This is made up of
 	# copy-and-pasted bits of compiler output and likely does not actually
@@ -57,6 +59,7 @@ foo:
 .type	foo, @function
 .uleb128 .foo-1-.bar
 .text
+.loc 2 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get

--- a/util/fipstools/delocate/testdata/x86_64-GOTRewrite/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-GOTRewrite/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 .Lfoo_local_target:
@@ -256,6 +258,7 @@ LOPENSSL_ia32cap_P_rbx3_return:
 
 .comm foobar,64,32
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type foobar_bss_get, @function
 foobar_bss_get:

--- a/util/fipstools/delocate/testdata/x86_64-LabelRewrite/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-LabelRewrite/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.type foo, @function
 	.globl foo
@@ -94,6 +96,7 @@ bar:
 	.byte	(.LBB231_40_BCM_1-.LBB231_19_BCM_1)>>2, 4, .Lfoo_BCM_1, (.Lfoo_BCM_1), .Lfoo_BCM_1<<400, (.Lfoo_BCM_1)<<66
 .byte   421
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type .Lbcm_redirector_memcpy, @function
 .Lbcm_redirector_memcpy:

--- a/util/fipstools/delocate/testdata/x86_64-LargeMemory/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-LargeMemory/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.text
 
@@ -37,6 +39,7 @@ BORINGSSL_bcm_text_start:
         # jmpq    *%rax
 
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get

--- a/util/fipstools/delocate/testdata/x86_64-Sections/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-Sections/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	# .text stays in .text
 	.text
@@ -43,6 +45,7 @@ foo:
 	.byte	0x1
 	.long	.L3
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get

--- a/util/fipstools/delocate/testdata/x86_64-ThreeArg/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-ThreeArg/out.s
@@ -1,4 +1,6 @@
 .text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
 BORINGSSL_bcm_text_start:
 	.type foo, @function
 	.globl foo
@@ -30,6 +32,7 @@ foo:
 kBoringSSLRSASqrtTwo:
 	.quad	-2404814165548301886    # 0xdea06241f7aa81c2
 .text
+.loc 1 2 0
 BORINGSSL_bcm_text_end:
 .type OPENSSL_ia32cap_get, @function
 .globl OPENSSL_ia32cap_get


### PR DESCRIPTION
### Description of changes: 
CRT team was seeing failures on Clang-8 with [this](https://github.com/aws/aws-lc/commit/f61870199f1bdfe3182e493231e60ea7243edbcb) change, even though we didn't have failures for clang-8 in our CI. Opting to gate this fix on detecting the clang compiler version being used. CRT reported clang-6 fix did address their issue.

### Testing
I verified that on clang-6 it continues to not emit the directive. Then verified on clang-8 that it correctly defaults to the original behavior of emitting the `.file` directive for these symbols.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
