### PR TITLE
Test BORINGSSL_FIPS_abort in CI

### DIFF
--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -370,12 +370,7 @@ int BORINGSSL_integrity_test(void) {
 }
 #endif  // OPENSSL_ASAN
 
-void BORINGSSL_FIPS_abort(void) {
-  for (;;) {
-    abort();
-    exit(1);
-  }
-}
+void BORINGSSL_FIPS_abort(void) { abort(); }
 
 #endif  // BORINGSSL_FIPS
 


### PR DESCRIPTION
Hey Andrew set this up to see your CI results, cases where these functions have been hooked or altered in some way. Can you give any more context as to why it's written like this?