### PR TITLE
Add updated porting guide for AWS-LC

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -1,40 +1,21 @@
-# Porting from OpenSSL to BoringSSL
+# Introduction
 
-BoringSSL is an OpenSSL derivative and is mostly source-compatible, for the
-subset of OpenSSL retained. Libraries ideally need little to no changes for
-BoringSSL support, provided they do not use removed APIs. In general, see if the
-library compiles and, on failure, consult the documentation in the header files
-and see if problematic features can be removed.
+AWS-LC is a fork of BoringSSL, which is a derivative of OpenSSL. AWS-LC aims to be API compatible with the `OPENSSL_VERSION_NUMBER` defined in [`openssl/base.h`](https://github.com/aws/aws-lc/blob/main/include/openssl/base.h) (currently OpenSSL 1.1.1). Version checks against the macro should ideally work as-is with AWS-LC. AWS-LC defines the corresponding `OPENSSL_NO_*` feature macros corresponding to removed features.
 
-BoringSSL's `OPENSSL_VERSION_NUMBER` matches the OpenSSL version it targets.
-Version checks for OpenSSL should ideally work as-is in BoringSSL. BoringSSL
-also defines upstream's `OPENSSL_NO_*` feature macros corresponding to removed
-features. If the preprocessor is needed, use these version checks or feature
-macros where possible, especially when patching third-party projects. Such
-patches are more generally useful to OpenSSL consumers and thus more
-appropriate to send upstream.
+There may be missing APIs or macros and subtle behavioral differences when migrating to AWS-LC from OpenSSL. OpenSSL may have underlying behavioral conventions that aren't standardized and there's no guarantee that these will be consistent within AWS-LC. In general, see if the AWS-LC compiles and runs against the tests with your application, consult the documentation available in [the header files](https://github.com/aws/aws-lc/tree/main/include/openssl), and check if problematic features can be removed if possible. **If not, feel free to [**contact us**](https://github.com/aws/aws-lc/issues/new?assignees=&labels=&projects=&template=general-issue.md&title=) about adding new features or missing symbols, we will typically add compatibility for convenience.**
 
-In some cases, BoringSSL-specific code may be necessary. Use the
-`OPENSSL_IS_BORINGSSL` preprocessor macro in `#ifdef`s. However, first contact
-the BoringSSL maintainers about the missing APIs. We will typically add
-compatibility functions for convenience. In particular, *contact BoringSSL
-maintainers before working around missing OpenSSL 1.1.0 accessors*. BoringSSL
-was originally derived from OpenSSL 1.0.2 but now targets OpenSSL 1.1.0. Some
-newer APIs may be missing but can be added on request. (Not all projects have
-been ported to OpenSSL 1.1.0, so BoringSSL also remains largely compatible with
-OpenSSL 1.0.2.)
+In rarer instances, AWS-LC-specific code may be necessary. The `OPENSSL_IS_AWSLC` preprocessor macro can be used in `#ifdef`s and configure scripts to distinguish OpenSSL from AWS-LC. Please do not use the presence or absence of particular symbols to detect AWS-LC. AWS-LC is commited to having a stable API, but is not ABI stable. Systems cannot directly swap out OpenSSL with AWS-LC without recompiling. This makes it not suitable as a system library in a traditional Linux distribution.
 
-The `OPENSSL_IS_BORINGSSL` macro may also be used to distinguish OpenSSL from
-BoringSSL in configure scripts. Do not use the presence or absence of particular
-symbols to detect BoringSSL.
+Despite supporting certain OpenSSL APIs, AWS-LC will not behave exactly the same in regards to non-standardized lower level details. Function signatures and parameters generally remain the same across both libraries. AWS-LC attempts to make cryptography and ssl less configurable and hard to misuse. AWS-LC has diverged since the initial fork off of OpenSSL 1.0.2 and does not implement every feature OpenSSL has today. This porting guide compiles a list of known differences and fall into 4 main categories. More details on each difference and the justifications will be outlined in each section.
 
-Note: BoringSSL does *not* have a stable API or ABI. It must be updated with its
-consumers. It is not suitable for, say, a system library in a traditional Linux
-distribution. For instance, Chromium statically links the specific revision of
-BoringSSL it was built against. Likewise, Android's system-internal copy of
-BoringSSL is not exposed by the NDK and must not be used by third-party
-applications.
+1. [Preexisting BoringSSL Changes](#preexisting-boringssl-changes)
+2. [No-op Symbols and Configurations](docs/porting/functionality-differences.md) 
+3. [Differences in Configuration Defaults](docs/porting/configuration-differences.md)
+4. Functional Differences (WIP)
 
+# Preexisting BoringSSL Changes
+
+The following callouts are remnants of BoringSSL's original porting guide. 
 
 ## Major API changes
 

--- a/PORTING_TO_AWSLC.md
+++ b/PORTING_TO_AWSLC.md
@@ -1,5 +1,0 @@
-# Porting from OpenSSL/BoringSSL to AWS-LC
-
-When porting from OpenSSL to AWS-LC, most notes of BoringSSL [PORTING.md](/PORTING.md) are applicable except below:
-
-* AWS-LC has replaced `OPENSSL_IS_BORINGSSL` with `OPENSSL_IS_AWSLC` to distinguish BoringSSL from AWS-LC.

--- a/docs/porting/configuration-differences.md
+++ b/docs/porting/configuration-differences.md
@@ -53,16 +53,28 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td rowspan=5>
-  <p><span><a
-  href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html">SSL_CTX_set_mode<br>
-  <span style='color:windowtext;text-decoration:none'>SSL_set_mode</span></a><br>
-  <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html"><br>
-  SSL_CTX_clear_mode<br>
-  SSL_clear_mode</a></span></p>
+  <p>
+    <span>
+      <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html">
+        SSL_CTX_set_mode<br>
+        SSL_set_mode
+      </a>
+      <br><br>
+      <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html">
+        SSL_CTX_clear_mode<br>
+        SSL_clear_mode
+      </a>
+    </span>
+  </p>
   </td>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/ssl.h#L839-L849">SSL_MODE_NO_AUTO_CHAIN</a></span></p>
+  <p>
+    <span>
+      <a href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/ssl.h#L839-L849">
+        SSL_MODE_NO_AUTO_CHAIN
+      </a>
+    </span>
+    </p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -117,12 +129,19 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td rowspan=10>
-  <p><span><a
-  href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">SSL_CTX_set_options<br>
-  <span style='color:windowtext;text-decoration:none'>SSL_set_options</span></a><br>
-  <br>
-  <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">SSL_CTX_clear_options<br>
-  SSL_clear_options</a></span></p>
+  <p>
+    <span>
+      <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">
+        SSL_CTX_set_options<br>
+        SSL_set_options
+      </a>
+      <br><br>
+      <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">
+        SSL_CTX_clear_options<br>
+        SSL_clear_options
+      </a>
+    </span>
+    </p>
   </td>
   <td>
   <p><span>SSL_OP_ALL</span></p>
@@ -186,12 +205,10 @@ The following table contains the differences in libssl configuration options AWS
   <p><span>ON</span></p>
   </td>
   <td>
-  <p><span>NO-OP<br>
-  <br>
-  Renegotiation is enabled with </span><span style='font-size:10.0pt;
-  font-family:"Courier New"'>SSL_set_renegotiate_mode</span>
-  <span>, an AWS-LC/BoringSSL specific
-  API.</span></p>
+  <p>
+    NO-OP<br><br>
+    Renegotiation is enabled with SSL_set_renegotiate_mode, an AWS-LC/BoringSSL specific API.
+  </p>
   </td>
  </tr>
  <tr>
@@ -240,12 +257,17 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td rowspan=2>
-  <p><span><a
-  href="https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_get0_peername.html">SSL_set_hostflags<br>
-  X509_STORE_CTX_set_flags<br>
-  X509_STORE_set_flags<br>
-  X509_VERIFY_PARAM_set_flags<br>
-  X509_VERIFY_PARAM_set_hostflags</a></span></p>
+  <p>
+    <span>
+      <a href="https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_get0_peername.html">
+        SSL_set_hostflags<br>
+        X509_STORE_CTX_set_flags<br>
+        X509_STORE_set_flags<br>
+        X509_VERIFY_PARAM_set_flags<br>
+        X509_VERIFY_PARAM_set_hostflags
+      </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>X509_V_FLAG_X509_STRICT</span></p>
@@ -295,12 +317,16 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td rowspan=6>
-  <p><span><a
-  href="https://www.openssl.org/docs/manmaster/man3/X509_check_host.html">X509_check_host
-  <br>
-  X509_check_email<br>
-  X509_check_ip<br>
-  X509_check_ip_asc</a></span></p>
+  <p>
+    <span>
+      <a href="https://www.openssl.org/docs/manmaster/man3/X509_check_host.html">
+        X509_check_host<br>
+        X509_check_email<br>
+        X509_check_ip<br>
+        X509_check_ip_asc
+      </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>X509_CHECK_FLAG_NO_WILDCARDS</span></p>
@@ -369,8 +395,13 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td rowspan=8>
-  <p><span><a
-  href="https://www.openssl.org/docs/manmaster/man3/PKCS7_sign.html">PKCS7_sign</a></span></p>
+  <p>
+    <span>
+      <a href="https://www.openssl.org/docs/manmaster/man3/PKCS7_sign.html">
+        PKCS7_sign
+      </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>PKCS7_DETACHED</span></p>
@@ -387,20 +418,19 @@ The following table contains the differences in libcrypto configuration options 
   <p><span>PKCS7_BINARY</span></p>
   </td>
   <td rowspan=3>
-  <p><i><span>Partially Supported<br>
-  </span></
-  i><sp><br>
-  These flags must be used simultaneously together with </span>
-  <span style='font-family:"Courier New"'>PKCS7_DETACHED</span>
-  <span> to generate a detached RSA
-  SHA-256 signature of the data and produces a PKCS#7 SignedData structure
-  containing it.</span></p>
+  <p>
+    <i>Partially Supported</i><br><br>
+    These flags must be used simultaneously together with
+    PKCS7_DETACHED to generate a detached RSA
+    SHA-256 signature of the data and produces a PKCS#7 SignedData structure
+    containing it.
+  </p>
   </td>
   <td rowspan=3>
-  <p><b><span>Must be used along with </span></b><b>
-        <span>PKCS7_DETACHED</span></b>
-  <span>. Other combinations are not
-  supported<b>.</b></span></p>
+  <p>
+    <b>Must be used along with PKCS7_DETACHED.</b>
+    Other combinations are not supported.
+  </p>
   </td>
  </tr>
  <tr>
@@ -531,8 +561,13 @@ The following table contains configuration options AWS-LC has intentionally omit
   <p><span>BN_set_flags</span></p>
   </td>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/f61870199f1bdfe3182e493231e60ea7243edbcb/include/openssl/bn.h#L1053-L1062">BN_FLG_CONSTTIME</a></span></p>
+  <p>
+    <span>
+      <a href="https://github.com/aws/aws-lc/blob/f61870199f1bdfe3182e493231e60ea7243edbcb/include/openssl/bn.h#L1053-L1062">
+        BN_FLG_CONSTTIME
+      </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>Not Implemented</span></p>

--- a/docs/porting/configuration-differences.md
+++ b/docs/porting/configuration-differences.md
@@ -1,0 +1,857 @@
+# Differences in Configuration Defaults
+
+Cryptography and SSL should have less configurations and be hard to misuse. As mentioned earlier, AWS-LC has cut down on the available knobs in crypto/ssl and made certain optimizations the default. Most configuration flags OpenSSL historically had available have been changed to no-ops in AWS-LC. 
+No-op flags can also be differentiated into two types here:
+
+1. The configuration is already provided by default in AWS-LC.  
+2. There are certain configurations and historic workarounds in OpenSSL that we don’t support (see [`SSL_OP_ALL`](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html)).
+
+There are also a few configurations which OpenSSL has “OFF” by default, that AWS-LC has turned “ON” by default. This section outlines all known no-op configuration flags and default configuration differences.
+
+## Default Behavioral Differences and No-op Configuration Flags
+
+The following tables only contains the differences in configuration options AWS-LC and OpenSSL provides.
+
+1. **The following two tables under `libssl` and `libcrypto` only focus on the flags that exist within AWS-LC. There are other flags supported by only OpenSSL that aren’t listed here. Missing flags we are aware of are documented in [Intentionally Omitted Configuration Flags](#intentionally-omitted-configuration-flags).
+    If there is a valid use case for an undocumented flag non-existent within AWS-LC, feel free to** [**cut an issue**](https://github.com/aws/aws-lc/issues/new?assignees=&labels=&projects=&template=general-issue.md&title=) **to us.**
+2. Flags that are no-ops within both AWS-LC and OpenSSL have been omitted from the table.
+3. Flags that are listed as no-ops in the **Configurability** section, means that there is no support to configure the listed behavior within AWS-LC. The flags are merely provided for easier compatibility.
+
+### Things to be Aware
+
+**When integrating with AWS-LC, it is important to keep note if your application is dependent on any of the flags outlined in the following tables.  Your application should have tests regarding expected behavior and understand the customer impact behavioral changes will cause before migrating to AWS-LC.**
+
+* <ins>**Anything that is labeled “ON” in “AWS-LC Default” is a behavioral difference between AWS-LC and OpenSSL</ins> (with the exception of** [**`SSL_MODE_AUTO_RETRY`**](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_mode.html)**). Developers should make sure that migrating to AWS-LC, is the equivalent of turning these flags “ON” by default in OpenSSL.**
+    * **Aside from** [**`SSL_MODE_NO_AUTO_CHAIN`**](https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/ssl.h#L839-L849), <ins>**there is no way to clear any flags that are “ON” by default in AWS-LC.**</ins>
+* <ins>**Anything that is labeled “OFF” in “AWS-LC Default” is also a "NO-OP". These flags merely exist for compatibility and the state of AWS-LC does not change when attempting to configure them.</ins> If any of these flags are used, differences will be exposed at run-time with your application.** 
+
+To determine whether your consuming application is impacted, do a search for the relevant “**Context Flags Setting Function**"s in your codebase. If the function is used, be aware of any relevant flags that have been listed in “**Context Flags**”. More context on what each flag configures can be found in our documentation by clicking the corresponding link.
+
+## libssl Differences
+
+The following table contains the differences in libssl configuration options AWS-LC and OpenSSL provides. **These flags are relevant to all TLS connections, unless specified otherwise.**
+
+* **Aside from and `SSL_MODE_AUTO_RETRY` being "ON" by default in OpenSSL, everything is "OFF" by default in OpenSSL.**
+* Each “**Context Flag”** has a link that provides more details on the flag’s functionality and our decision behind it (WIP)
+
+
+<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+ style='border-collapse:collapse'>
+ <tr>
+  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Context Flags Setting Function</span></b></p>
+  </td>
+  <td width=362 style='width:271.5pt;border:solid #E6E6E6 1.0pt;border-left:
+  none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Context Flags</span></b></p>
+  </td>
+  <td width=204 style='width:153.0pt;border:solid #E6E6E6 1.0pt;border-left:
+  none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>AWS-LC Default</span></b></p>
+  </td>
+  <td width=386 style='width:289.15pt;border:solid #E6E6E6 1.0pt;border-left:
+  none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Configurability</span></b></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=5 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'><a
+  href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html">SSL_CTX_set_mode<br>
+  <span style='color:windowtext;text-decoration:none'>SSL_set_mode</span></a><br>
+  <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html"><br>
+  SSL_CTX_clear_mode<br>
+  SSL_clear_mode</a></span></p>
+  </td>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'><a
+  href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/ssl.h#L839-L849">SSL_MODE_NO_AUTO_CHAIN</a></span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Configurable</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_MODE_AUTO_RETRY</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_MODE_RELEASE_BUFFERS</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_MODE_SEND_CLIENTHELLO_TIME</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_MODE_SEND_SERVERHELLO_TIME</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=10 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:
+  .75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'><a
+  href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">SSL_CTX_set_options<br>
+  <span style='color:windowtext;text-decoration:none'>SSL_set_options</span></a><br>
+  <br>
+  <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">SSL_CTX_clear_options<br>
+  SSL_clear_options</a></span></p>
+  </td>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_ALL</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_LEGACY_SERVER_CONNECT</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_NO_COMPRESSION</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_NO_RENEGOTIATION</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP<br>
+  <br>
+  Renegotiation is enabled with </span><span style='font-size:10.0pt;
+  font-family:"Courier New"'>SSL_set_renegotiate_mode</span><span
+  style='font-family:"Times New Roman",serif'>, an AWS-LC/BoringSSL specific
+  API.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_NO_SSLv3</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_TLS_ROLLBACK_BUG</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_VERIFY_CLIENT_ONCE</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=2 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_get0_peername.html">SSL_set_hostflags<br>
+  X509_STORE_CTX_set_flags<br>
+  X509_STORE_set_flags<br>
+  X509_VERIFY_PARAM_set_flags<br>
+  X509_VERIFY_PARAM_set_hostflags</a></span></p>
+  </td>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>X509_V_FLAG_X509_STRICT</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>X509_V_FLAG_ALLOW_PROXY_CERTS</span></p>
+  </td>
+  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+</table>
+
+## libcrypto Differences
+
+The following table contains the differences in libcrypto configuration options AWS-LC and OpenSSL provides. 
+
+* **Everything is "OFF" and "Configurable" by default in OpenSSL.**
+* Each “**Context Flag”** has a link that provides more details on the flag’s functionality (WIP)
+
+<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+ style='border-collapse:collapse'>
+ <tr>
+  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Context Flags Setting Function</span></b></p>
+  </td>
+  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Context Flags</span></b></p>
+  </td>
+  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>AWS-LC Default</span></b></p>
+  </td>
+  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Configurability</span></b></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=6 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://www.openssl.org/docs/manmaster/man3/X509_check_host.html">X509_check_host
+  <br>
+  X509_check_email<br>
+  X509_check_ip<br>
+  X509_check_ip_asc</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_NO_WILDCARDS</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Configurable</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_NEVER_CHECK_SUBJECT</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Configurable</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ON</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=8 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://www.openssl.org/docs/manmaster/man3/PKCS7_sign.html">PKCS7_sign</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_DETACHED</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Configurable</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_BINARY</span></p>
+  </td>
+  <td rowspan=3 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><i><span
+  style='font-family:"Times New Roman",serif'>Partially Supported<br>
+  </span></i><span style='font-family:"Times New Roman",serif'><br>
+  These flags must be used simultaneously together with </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_DETACHED</span><span
+  style='font-family:"Times New Roman",serif'> to generate a detached RSA
+  SHA-256 signature of the data and produces a PKCS#7 SignedData structure
+  containing it.</span></p>
+  </td>
+  <td rowspan=3 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Must be used along with </span></b><b><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_DETACHED</span></b><span
+  style='font-family:"Times New Roman",serif'>. Other combinations are not
+  supported<b>.</b></span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_NOATTR</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_PARTIAL</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_TEXT</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_NOCERTS</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_STREAM</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_NOSMIMECAP</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=4 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_assign</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_DH</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Not Supported</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_X448</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Not Supported</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_ED448</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Not Supported</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_RSA2</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Not Supported</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  </td>
+ </tr>
+</table>
+
+### Intentionally Omitted Configuration Flags
+
+The following table contains configuration options AWS-LC has intentionally omitted. If your application uses a non-existent flag outlined here, it will fail to compile with AWS-LC.  
+
+* Each “**Context Flag”** has a link that provides more details on the flag’s functionality (WIP)
+* If you feel that there is a valid use case for any of these flags, feel free to [cut an issue](https://github.com/aws/aws-lc/issues/new?assignees=&labels=&projects=&template=general-issue.md&title=) to us.
+
+<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+ style='border-collapse:collapse'>
+ <tr>
+  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Context Flags Setting Function</span></b></p>
+  </td>
+  <td width=251 style='width:188.05pt;border:solid #E6E6E6 1.0pt;border-left:
+  none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Context Flags</span></b></p>
+  </td>
+  <td width=278 style='width:208.65pt;border:solid #E6E6E6 1.0pt;border-left:
+  none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>AWS-LC Default</span></b></p>
+  </td>
+ </tr>
+ <tr style='height:70.05pt'>
+  <td style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt;
+  height:70.05pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>BN_set_flags</span></p>
+  </td>
+  <td width=251 style='width:188.05pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt;height:70.05pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'><a
+  href="https://github.com/aws/aws-lc/blob/f61870199f1bdfe3182e493231e60ea7243edbcb/include/openssl/bn.h#L1053-L1062">BN_FLG_CONSTTIME</a></span></p>
+  </td>
+  <td width=278 style='width:208.65pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt;height:70.05pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Not Implemented</span></p>
+  </td>
+ </tr>
+ <tr style='height:49.35pt'>
+  <td rowspan=2 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt;
+  height:49.35pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_aux_cb</span></p>
+  </td>
+  <td width=251 style='width:188.05pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt;height:49.35pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_OP_I2D_PRE</span></p>
+  </td>
+  <td width=278 style='width:208.65pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt;height:49.35pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Not Implemented</span></p>
+  </td>
+ </tr>
+ <tr style='height:68.7pt'>
+  <td width=251 style='width:188.05pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt;height:68.7pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_OP_I2D_POST</span></p>
+  </td>
+  <td width=278 style='width:208.65pt;border-top:none;border-left:none;
+  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
+  padding:.75pt .75pt .75pt .75pt;height:68.7pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Not Implemented</span></p>
+  </td>
+ </tr>
+</table>

--- a/docs/porting/configuration-differences.md
+++ b/docs/porting/configuration-differences.md
@@ -35,401 +35,237 @@ The following table contains the differences in libssl configuration options AWS
 * Each “**Context Flag”** has a link that provides more details on the flag’s functionality and our decision behind it (WIP)
 
 
-<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+<table border=0 cellspacing=0 cellpadding=0
  style='border-collapse:collapse'>
  <tr>
-  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Context Flags Setting Function</span></b></p>
+  <td>
+  <p><b><span>Context Flags Setting Function</span></b></p>
   </td>
-  <td width=362 style='width:271.5pt;border:solid #E6E6E6 1.0pt;border-left:
-  none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Context Flags</span></b></p>
+  <td>
+  <p><b><span>Context Flags</span></b></p>
   </td>
-  <td width=204 style='width:153.0pt;border:solid #E6E6E6 1.0pt;border-left:
-  none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>AWS-LC Default</span></b></p>
+  <td>
+  <p><b><span>AWS-LC Default</span></b></p>
   </td>
-  <td width=386 style='width:289.15pt;border:solid #E6E6E6 1.0pt;border-left:
-  none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Configurability</span></b></p>
+  <td>
+  <p><b><span>Configurability</span></b></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=5 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'><a
+  <td rowspan=5>
+  <p><span><a
   href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html">SSL_CTX_set_mode<br>
   <span style='color:windowtext;text-decoration:none'>SSL_set_mode</span></a><br>
   <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html"><br>
   SSL_CTX_clear_mode<br>
   SSL_clear_mode</a></span></p>
   </td>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/ssl.h#L839-L849">SSL_MODE_NO_AUTO_CHAIN</a></span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Configurable</span></p>
+  <td>
+  <p><span>Configurable</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_MODE_AUTO_RETRY</span></p>
+  <td>
+  <p><span>SSL_MODE_AUTO_RETRY</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_MODE_RELEASE_BUFFERS</span></p>
+  <td>
+  <p><span>SSL_MODE_RELEASE_BUFFERS</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_MODE_SEND_CLIENTHELLO_TIME</span></p>
+  <td>
+  <p><span>SSL_MODE_SEND_CLIENTHELLO_TIME</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_MODE_SEND_SERVERHELLO_TIME</span></p>
+  <td>
+  <p><span>SSL_MODE_SEND_SERVERHELLO_TIME</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=10 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:
-  .75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'><a
+  <td rowspan=10>
+  <p><span><a
   href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">SSL_CTX_set_options<br>
   <span style='color:windowtext;text-decoration:none'>SSL_set_options</span></a><br>
   <br>
   <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">SSL_CTX_clear_options<br>
   SSL_clear_options</a></span></p>
   </td>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_ALL</span></p>
+  <td>
+  <p><span>SSL_OP_ALL</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION</span></p>
+  <td>
+  <p><span>SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS</span></p>
+  <td>
+  <p><span>SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_LEGACY_SERVER_CONNECT</span></p>
+  <td>
+  <p><span>SSL_OP_LEGACY_SERVER_CONNECT</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_NO_COMPRESSION</span></p>
+  <td>
+  <p><span>SSL_OP_NO_COMPRESSION</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_NO_RENEGOTIATION</span></p>
+  <td>
+  <p><span>SSL_OP_NO_RENEGOTIATION</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP<br>
+  <td>
+  <p><span>NO-OP<br>
   <br>
   Renegotiation is enabled with </span><span style='font-size:10.0pt;
-  font-family:"Courier New"'>SSL_set_renegotiate_mode</span><span
-  style='font-family:"Times New Roman",serif'>, an AWS-LC/BoringSSL specific
+  font-family:"Courier New"'>SSL_set_renegotiate_mode</span>
+  <span>, an AWS-LC/BoringSSL specific
   API.</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION</span></p>
+  <td>
+  <p><span>SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_NO_SSLv3</span></p>
+  <td>
+  <p><span>SSL_OP_NO_SSLv3</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_OP_TLS_ROLLBACK_BUG</span></p>
+  <td>
+  <p><span>SSL_OP_TLS_ROLLBACK_BUG</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_VERIFY_CLIENT_ONCE</span></p>
+  <td>
+  <p><span>SSL_VERIFY_CLIENT_ONCE</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=2 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=2>
+  <p><span><a
   href="https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_get0_peername.html">SSL_set_hostflags<br>
   X509_STORE_CTX_set_flags<br>
   X509_STORE_set_flags<br>
   X509_VERIFY_PARAM_set_flags<br>
   X509_VERIFY_PARAM_set_hostflags</a></span></p>
   </td>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>X509_V_FLAG_X509_STRICT</span></p>
+  <td>
+  <p><span>X509_V_FLAG_X509_STRICT</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td width=362 style='width:271.5pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>X509_V_FLAG_ALLOW_PROXY_CERTS</span></p>
+  <td>
+  <p><span>X509_V_FLAG_ALLOW_PROXY_CERTS</span></p>
   </td>
-  <td width=204 style='width:153.0pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td width=386 style='width:289.15pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
 </table>
@@ -441,337 +277,231 @@ The following table contains the differences in libcrypto configuration options 
 * **Everything is "OFF" and "Configurable" by default in OpenSSL.**
 * Each “**Context Flag”** has a link that provides more details on the flag’s functionality (WIP)
 
-<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+<table border=0 cellspacing=0 cellpadding=0
  style='border-collapse:collapse'>
  <tr>
-  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Context Flags Setting Function</span></b></p>
+  <td>
+  <p><b><span>Context Flags Setting Function</span></b></p>
   </td>
-  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Context Flags</span></b></p>
+  <td>
+  <p><b><span>Context Flags</span></b></p>
   </td>
-  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>AWS-LC Default</span></b></p>
+  <td>
+  <p><b><span>AWS-LC Default</span></b></p>
   </td>
-  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Configurability</span></b></p>
+  <td>
+  <p><b><span>Configurability</span></b></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=6 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=6>
+  <p><span><a
   href="https://www.openssl.org/docs/manmaster/man3/X509_check_host.html">X509_check_host
   <br>
   X509_check_email<br>
   X509_check_ip<br>
   X509_check_ip_asc</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_NO_WILDCARDS</span></p>
+  <td>
+  <p><span>X509_CHECK_FLAG_NO_WILDCARDS</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Configurable</span></p>
+  <td>
+  <p><span>Configurable</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_NEVER_CHECK_SUBJECT</span></p>
+  <td>
+  <p><span>X509_CHECK_FLAG_NEVER_CHECK_SUBJECT</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Configurable</span></p>
+  <td>
+  <p><span>Configurable</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT</span></p>
+  <td>
+  <p><span>X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS</span></p>
+  <td>
+  <p><span>X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ON</span></p>
+  <td>
+  <p><span>ON</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS</span></p>
+  <td>
+  <p><span>X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS</span></p>
+  <td>
+  <p><span>X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=8 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=8>
+  <p><span><a
   href="https://www.openssl.org/docs/manmaster/man3/PKCS7_sign.html">PKCS7_sign</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_DETACHED</span></p>
+  <td>
+  <p><span>PKCS7_DETACHED</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Configurable</span></p>
+  <td>
+  <p><span>Configurable</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_BINARY</span></p>
+  <td>
+  <p><span>PKCS7_BINARY</span></p>
   </td>
-  <td rowspan=3 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><i><span
-  style='font-family:"Times New Roman",serif'>Partially Supported<br>
-  </span></i><span style='font-family:"Times New Roman",serif'><br>
-  These flags must be used simultaneously together with </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_DETACHED</span><span
-  style='font-family:"Times New Roman",serif'> to generate a detached RSA
+  <td rowspan=3>
+  <p><i><span>Partially Supported<br>
+  </span></
+  i><sp><br>
+  These flags must be used simultaneously together with </span>
+  <span style='font-family:"Courier New"'>PKCS7_DETACHED</span>
+  <span> to generate a detached RSA
   SHA-256 signature of the data and produces a PKCS#7 SignedData structure
   containing it.</span></p>
   </td>
-  <td rowspan=3 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Must be used along with </span></b><b><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_DETACHED</span></b><span
-  style='font-family:"Times New Roman",serif'>. Other combinations are not
+  <td rowspan=3>
+  <p><b><span>Must be used along with </span></b><b>
+        <span>PKCS7_DETACHED</span></b>
+  <span>. Other combinations are not
   supported<b>.</b></span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_NOATTR</span></p>
+  <td>
+  <p><span>PKCS7_NOATTR</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_PARTIAL</span></p>
+  <td>
+  <p><span>PKCS7_PARTIAL</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_TEXT</span></p>
+  <td>
+  <p><span>PKCS7_TEXT</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_NOCERTS</span></p>
+  <td>
+  <p><span>PKCS7_NOCERTS</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_STREAM</span></p>
+  <td>
+  <p><span>PKCS7_STREAM</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>PKCS7_NOSMIMECAP</span></p>
+  <td>
+  <p><span>PKCS7_NOSMIMECAP</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>OFF</span></p>
+  <td>
+  <p><span>OFF</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=4 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_assign</span></p>
+  <td rowspan=4>
+  <p><span>EVP_PKEY_assign</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_DH</span></p>
+  <td>
+  <p><span>EVP_PKEY_DH</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Not Supported</span></p>
+  <td>
+  <p><span>Not Supported</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_X448</span></p>
+  <td>
+  <p><span>EVP_PKEY_X448</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Not Supported</span></p>
+  <td>
+  <p><span>Not Supported</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_ED448</span></p>
+  <td>
+  <p><span>EVP_PKEY_ED448</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Not Supported</span></p>
+  <td>
+  <p><span>Not Supported</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_RSA2</span></p>
+  <td>
+  <p><span>EVP_PKEY_RSA2</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Not Supported</span></p>
+  <td>
+  <p><span>Not Supported</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>NO-OP</span></p>
+  <td>
+  <p><span>NO-OP</span></p>
   </td>
  </tr>
 </table>
@@ -783,75 +513,48 @@ The following table contains configuration options AWS-LC has intentionally omit
 * Each “**Context Flag”** has a link that provides more details on the flag’s functionality (WIP)
 * If you feel that there is a valid use case for any of these flags, feel free to [cut an issue](https://github.com/aws/aws-lc/issues/new?assignees=&labels=&projects=&template=general-issue.md&title=) to us.
 
-<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+<table border=0 cellspacing=0 cellpadding=0
  style='border-collapse:collapse'>
  <tr>
-  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Context Flags Setting Function</span></b></p>
+  <td>
+  <p><b><span>Context Flags Setting Function</span></b></p>
   </td>
-  <td width=251 style='width:188.05pt;border:solid #E6E6E6 1.0pt;border-left:
-  none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Context Flags</span></b></p>
+  <td>
+  <p><b><span>Context Flags</span></b></p>
   </td>
-  <td width=278 style='width:208.65pt;border:solid #E6E6E6 1.0pt;border-left:
-  none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>AWS-LC Default</span></b></p>
+  <td>
+  <p><b><span>AWS-LC Default</span></b></p>
   </td>
  </tr>
- <tr style='height:70.05pt'>
-  <td style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt;
-  height:70.05pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>BN_set_flags</span></p>
+ <tr>
+  <td>
+  <p><span>BN_set_flags</span></p>
   </td>
-  <td width=251 style='width:188.05pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt;height:70.05pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/f61870199f1bdfe3182e493231e60ea7243edbcb/include/openssl/bn.h#L1053-L1062">BN_FLG_CONSTTIME</a></span></p>
   </td>
-  <td width=278 style='width:208.65pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt;height:70.05pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Not Implemented</span></p>
+  <td>
+  <p><span>Not Implemented</span></p>
   </td>
  </tr>
- <tr style='height:49.35pt'>
-  <td rowspan=2 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt;
-  height:49.35pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_aux_cb</span></p>
+ <tr>
+  <td rowspan=2>
+  <p><span>ASN1_aux_cb</span></p>
   </td>
-  <td width=251 style='width:188.05pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt;height:49.35pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_OP_I2D_PRE</span></p>
+  <td>
+  <p><span>ASN1_OP_I2D_PRE</span></p>
   </td>
-  <td width=278 style='width:208.65pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt;height:49.35pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Not Implemented</span></p>
+  <td>
+  <p><span>Not Implemented</span></p>
   </td>
  </tr>
- <tr style='height:68.7pt'>
-  <td width=251 style='width:188.05pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt;height:68.7pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_OP_I2D_POST</span></p>
+ <tr>
+  <td>
+  <p><span>ASN1_OP_I2D_POST</span></p>
   </td>
-  <td width=278 style='width:208.65pt;border-top:none;border-left:none;
-  border-bottom:solid #E6E6E6 1.0pt;border-right:solid #E6E6E6 1.0pt;
-  padding:.75pt .75pt .75pt .75pt;height:68.7pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Not Implemented</span></p>
+  <td>
+  <p><span>Not Implemented</span></p>
   </td>
  </tr>
 </table>

--- a/docs/porting/functionality-differences.md
+++ b/docs/porting/functionality-differences.md
@@ -38,9 +38,13 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <p><span>Security Levels</span></p>
   </td>
   <td rowspan=2>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5211-L5240">ssl.h<br>
-  Security Levels</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5211-L5240">
+            ssl.h<br>
+            Security Levels
+        </a>
+    </span></p>
   </td>
   <td>
   <p><span>SSL_CTX_get_security_level</span></p>
@@ -62,10 +66,13 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <p><span>DH ciphersuites</span></p>
   </td>
   <td rowspan=4>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5148-L5161">ssl.h
-  <br>
-  Deprecated DH functions</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5148-L5161">
+            ssl.h<br>
+            Deprecated DH functions
+        </a>
+    </span></p>
   </td>
   <td>
   <p><span>SSL_CTX_set_tmp_dh</span></p>
@@ -105,10 +112,13 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <span>COMP_METHOD</span></p>
   </td>
   <td rowspan=6>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4938-L4957">ssl.h
-  <br>
-  Deprecated COMP functions</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4938-L4957">
+            ssl.h<br>
+            Deprecated COMP functions
+        </a>
+    </span></p>
   </td>
   <td>
   <p><span>SSL_COMP_get_compression_methods</span></p>
@@ -162,31 +172,25 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <p><span>TLS Renegotiation</span></p>
   </td>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4542-L4609">ssl.h<br>
-  TLS Renegotiation</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4542-L4609">
+            ssl.h<br>
+            TLS Renegotiation
+        </a>
+    </span></p>
   </td>
   <td>
   <p><span>SSL_renegotiate</span></p>
   </td>
   <td>
-  <p><span>Returns 1 on success, 0 on
-  failure. <br>
-  <br>
-  There is no support for renegotiation for TLS as a server or DTLS. <br>
-  <br>
-  There is only minimal support for initiating renegotiation as a client. </span>
-  <span>SSL_set_renegotiate_mode</span>
-  <span> must be set to </span>
-  <span>ssl_renegotiate_once</span>
-  <span>, </span><span style=
-  'font-size:
-  10.0 font-family:"Courier New"'>ssl_renegotiate_freely</span>
-  <span>, or </span>
-  <span>ssl_renegotiate_explicit</span>
-  <span> for </span>
-  <span>SSL_renegotiate</span>
-  <span> to work.</span></p>
+  <p>
+    Returns 1 on success, 0 on failure. <br><br>
+    There is no support for renegotiation for TLS as a server or DTLS. <br><br>
+    There is only minimal support for initiating renegotiation as a client.
+    SSL_set_renegotiate_mode must be set to ssl_renegotiate_once, ssl_renegotiate_freely, 
+    or ssl_renegotiate_explicit for SSL_renegotiate to work.
+  </p>
   </td>
  </tr>
  <tr>
@@ -194,23 +198,30 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <p><span>General</span></p>
   </td>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5085-L5087">ssl.h<br>
-  SSL_get_shared_ciphers</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5085-L5087">
+            ssl.h<br>
+            SSL_get_shared_ciphers
+        </a>
+    </span></p>
   </td>
   <td>
   <p><span>SSL_get_shared_ciphers</span></p>
   </td>
   <td>
-  <p><span>Writes an empty string and
-  returns a pointer containing it or returns NULL.</span></p>
+  <p><span>Writes an empty string and returns a pointer containing it or returns NULL.</span></p>
   </td>
  </tr>
  <tr>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5089-L5092">ssl.h<br>
-  SSL_get_shared_sigalgs</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5089-L5092">
+            ssl.h<br>
+            SSL_get_shared_sigalgs
+        </a>
+    </span></p>
   </td>
   <td>
   <p><span>SSL_get_shared_sigalgs</span></p>
@@ -221,9 +232,13 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
  </tr>
  <tr>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5145-L5146C20">ssl.h<br>
-  SSL_get_server_tmp_key</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5145-L5146C20">
+            ssl.h<br>
+            SSL_get_server_tmp_key
+        </a>
+    </span></p>
   </td>
   <td>
   <p><span>SSL_get_server_tmp_key</span></p>
@@ -315,9 +330,16 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>EVP_PKEY</span></p>
   </td>
   <td rowspan=2>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L182">evp.h</a><br>
-  <a href="https://github.com/aws/aws-lc/blob/main/PORTING.md#dsa-evp_pkeys">EVP_PKEY_DSA</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L182">
+            evp.h
+        </a><br>
+        <a href="https://github.com/aws/aws-lc/blob/main/PORTING.md#dsa-evp_pkeys">
+            EVP_PKEY_DSA
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>EVP_PKEY_CTX_set_dsa_paramgen_bits</span></p>
@@ -336,8 +358,13 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
  </tr>
  <tr>
   <td rowspan=2>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L932-L934">evp.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L932-L934">
+            evp.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>EVP_PKEY_get0_DH</span></p>
@@ -356,15 +383,21 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
  </tr>
  <tr>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L948-L951">evp.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L948-L951">
+            evp.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
-  <p><span>EVP_PKEY_get0</span></p>
+  <p>EVP_PKEY_get0</p>
   </td>
   <td>
-  <p><span>Void function that does not
-  return anything (NULL).</span></p>
+  <p>
+    Void function that does not return anything (NULL).
+  </p>
   </td>
  </tr>
  <tr>
@@ -372,11 +405,16 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>EC</span></p>
   </td>
   <td rowspan=3>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec_key.h#L314-L315">ec_key.h<br>
-  </a><br>
-  <a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L413-L417">ec.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec_key.h#L314-L315">
+            ec_key.h
+        </a><br><br>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L413-L417">
+            ec.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>EC_KEY_set_asn1_flag</span></p>
@@ -398,22 +436,24 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>EC_GROUP_get_asn1_flag</span></p>
   </td>
   <td>
-  <p><span>Returns </span>
-  <span>OPENSSL_EC_NAMED_CURVE</span>
-  <span>.</span></p>
+  <p><span>Returns OPENSSL_EC_NAMED_CURVE.</span></p>
   </td>
  </tr>
  <tr>
   <td rowspan=2>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L419-L425">ec.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L419-L425">
+            ec.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>EC_GROUP_method_of</span></p>
   </td>
   <td>
-  <p><span>Returns a dummy non-NULL
-  EC_METHOD pointer.</span></p>
+  <p><span>Returns a dummy non-NULL EC_METHOD pointer.</span></p>
   </td>
  </tr>
  <tr>
@@ -421,24 +461,27 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>EC_METHOD_get_field_type</span></p>
   </td>
   <td>
-  <p><span>Returns </span>
-  <span>NID_X9_62_prime_field</span>
-  <span>.</span></p>
+  <p><span>Returns NID_X9_62_prime_field.</span></p>
   </td>
  </tr>
  <tr>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L427-L431">ec.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L427-L431">
+            ec.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>EC_GROUP_set_point_conversion_form</span></p>
   </td>
   <td>
-  <p><span>Returns nothing as a void
-  function. Aborts if a form other than</span>
-  <span style='font-family:"Courier New"'> POINT_CONVERSION_UNCOMPRESSED</span>
-  <span> is requested.</span></p>
+  <p>
+    Returns nothing as a void function. Aborts if a form other than
+    POINT_CONVERSION_UNCOMPRESSED is requested.
+  </p>
   </td>
  </tr>
  <tr>
@@ -446,8 +489,13 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>CONF modules</span></p>
   </td>
   <td rowspan=4>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/conf.h#L134-L147">conf.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/conf.h#L134-L147">
+            conf.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>CONF_modules_load_file</span></p>
@@ -485,9 +533,13 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>RAND Functions</span></p>
   </td>
   <td rowspan=13>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/crypto/fipsmodule/FIPS.md#entropy-sources">Entropy
-  Sources</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/crypto/fipsmodule/FIPS.md#entropy-sources">
+            Entropy Sources
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>RAND_load_file</span></p>
@@ -501,8 +553,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>RAND_write_file</span></p>
   </td>
   <td>
-  <p><span>Does nothing and returns negative
-  one.</span></p>
+  <p><span>Does nothing and returns negative one.</span></p>
   </td>
  </tr>
  <tr>
@@ -558,9 +609,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>RAND_SSLeay</span></p>
   </td>
   <td>
-  <p><span>Returns a dummy </span>
-  <span>RAND_METHOD</span>
-  <span> pointer.</span></p>
+  <p><span>Returns a dummy RAND_METHOD pointer.</span></p>
   </td>
  </tr>
  <tr>
@@ -568,9 +617,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>RAND_OpenSSL</span></p>
   </td>
   <td>
-  <p><span>Returns a dummy </span>
-  <span>RAND_METHOD</span>
-  <span> pointer.</span></p>
+  <p><span>Returns a dummy RAND_METHOD pointer.</span></p>
   </td>
  </tr>
  <tr>
@@ -604,8 +651,13 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>ASN1</span></p>
   </td>
   <td rowspan=4>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/asn1.h#L1894-L1904">asn1.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/asn1.h#L1894-L1904">
+            asn1.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>ASN1_STRING_set_default_mask</span></p>
@@ -627,9 +679,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>ASN1_STRING_get_default_mask</span></p>
   </td>
   <td>
-  <p><span>Returns </span>
-  <span>B_ASN1_UTF8STRING</span>
-  <span> (The default value AWS-LC uses).</span></p>
+  <p><span>Returns B_ASN1_UTF8STRING (The default value AWS-LC uses).</span></p>
   </td>
  </tr>
  <tr>
@@ -645,9 +695,13 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>Thread Safety</span></p>
   </td>
   <td rowspan=16>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/API-CONVENTIONS.md#thread-safety">Thread
-  safety</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/f31f7091ec6b13163c7764519a6d95daefacd6e5/include/openssl/thread.h#L119-L199">
+            thread.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>CRYPTO_num_locks</span></p>
@@ -686,9 +740,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   </td>
   <td>
   <p><span>Returns a fixed dummy string
-  (&quot;</span>
-  <sp>No
-  old-style OpenSSL locks anymore&quot;)</span></p>
+  (&quot;</span>No old-style OpenSSL locks anymore&quot;)</p>
   </td>
  </tr>
  <tr>
@@ -784,8 +836,13 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>Miscellaneous</span></p>
   </td>
   <td rowspan=5>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/evp.h#L961-L975">evp.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/evp.h#L961-L975">
+            evp.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>OpenSSL_add_all_algorithms</span></p>
@@ -828,21 +885,26 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
  </tr>
  <tr>
   <td rowspan=2>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L561-L566">cipher.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L561-L566">
+            cipher.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>EVP_CIPHER_CTX_set_flags</span></p>
   </td>
   <td>
-  <p><span>Does nothing.<br>
+  <p><span>Does nothing.</span><br>
   <br>
-  This functions sets flags for </span>
-  <span style='font-family:"Courier New"'>EVP_CIPHER_CTX</span><span style='font-family:
-  "Times New Roman",serif'>, so any related flags are also no-ops. Related
-  no-op flags can be found in <a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L560-L566">the
-  surrounding documentation</a>.</span></p>
+  This functions sets flags for EVP_CIPHER_CTX, so any related flags are also no-ops. Related no-op flags can be found in 
+    <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L560-L566">
+      the surrounding documentation
+    </a>
+    .
+  </p>
   </td>
  </tr>
  <tr>
@@ -855,21 +917,26 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
  </tr>
  <tr>
   <td rowspan=2>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/digest.h#L303-L310">digest.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/digest.h#L303-L310">
+            digest.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>EVP_MD_CTX_set_flags</span></p>
   </td>
   <td>
-  <p><span>Does nothing.<br>
-  <br>
-  This functions sets flags for </span>
-  <span style='font-family:"Courier New"'>EVP_MD_CTX</span>
-  <sp>,
-  so any related flags are also no-ops. Related no-op flags can be found in <a
-  href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/digest.h#L303-L310">the
-  surrounding documentation</a>.</span></p>
+  <p>
+    Does nothing.<br><br>
+    This functions sets flags for EVP_MD_CTX, so any related flags are also no-ops. Related no-op flags can be found in 
+    <a href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/digest.h#L303-L310">
+      the surrounding documentation
+    </a>
+    .
+  </p>
   </td>
  </tr>
  <tr>
@@ -882,28 +949,37 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
  </tr>
  <tr>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/dh.h#L351-L360">dh.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/dh.h#L351-L360">
+            dh.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>DH_clear_flags</span></p>
   </td>
   <td>
-  <p><span>Does nothing.<br>
-  <br>
-  <br>
-  This functions clears flags for </span>
-  <span style='font-family:"Courier New"'>DH</span>
-  <sp>,
-  so any related flags are also no-ops. Related no-op flags can be found in <a
-  href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/dh.h#L351-L360">the
-  surrounding documentation</a>.</span></p>
+  <p>
+    Does nothing.<br><br>
+    This functions clears flags for DH, so any related flags are also no-ops. Related no-op flags can be found in 
+    <a href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/dh.h#L351-L360">
+      the surrounding documentation
+    </a>
+    .
+  </p>
   </td>
  </tr>
  <tr>
   <td rowspan=2>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ex_data.h#L180-L185">ex_data.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ex_data.h#L180-L185">
+            ex_data.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>CRYPTO_cleanup_all_ex_data</span></p>
@@ -917,14 +993,18 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>CRYPTO_EX_dup</span></p>
   </td>
   <td>
-  <p><span>Legacy Callback function that's
-  ignored.</span></p>
+  <p><span>Legacy Callback function that's ignored.</span></p>
   </td>
  </tr>
  <tr>
   <td>
-  <p><span><a
-  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/bio.h#L865-L866">bio.h</a></span></p>
+  <p>
+    <span>
+        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/bio.h#L865-L866">
+            bio.h
+        </a>
+    </span>
+  </p>
   </td>
   <td>
   <p><span>BIO_set_write_buffer_size</span></p>

--- a/docs/porting/functionality-differences.md
+++ b/docs/porting/functionality-differences.md
@@ -17,305 +17,219 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
 
 ### libssl No-ops
 
-<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+<table border=0 cellspacing=0 cellpadding=0
  style='border-collapse:collapse'>
  <tr>
-  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Related Functionality</span></b></p>
+  <td>
+  <p><b><span>Related Functionality</span></b></p>
   </td>
-  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Details</span></b></p>
+  <td>
+  <p><b><span>Details</span></b></p>
   </td>
-  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>No-op function</span></b></p>
+  <td>
+  <p><b><span>No-op function</span></b></p>
   </td>
-  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Return value</span></b></p>
+  <td>
+  <p><b><span>Return value</span></b></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=2 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Security Levels</span></p>
+  <td rowspan=2>
+  <p><span>Security Levels</span></p>
   </td>
-  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=2>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5211-L5240">ssl.h<br>
   Security Levels</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_CTX_get_security_level</span></p>
+  <td>
+  <p><span>SSL_CTX_get_security_level</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  <td>
+  <p><span>Returns zero.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_CTX_set_security_level</span></p>
+  <td>
+  <p><span>SSL_CTX_set_security_level</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=4 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>DH ciphersuites</span></p>
+  <td rowspan=4>
+  <p><span>DH ciphersuites</span></p>
   </td>
-  <td rowspan=4 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=4>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5148-L5161">ssl.h
   <br>
   Deprecated DH functions</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_CTX_set_tmp_dh</span></p>
+  <td>
+  <p><span>SSL_CTX_set_tmp_dh</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_set_tmp_dh</span></p>
+  <td>
+  <p><span>SSL_set_tmp_dh</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_CTX_set_tmp_dh_callback</span></p>
+  <td>
+  <p><span>SSL_CTX_set_tmp_dh_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_set_tmp_dh_callback</span></p>
+  <td>
+  <p><span>SSL_set_tmp_dh_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=6 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP</span><span
-  style='font-family:"Times New Roman",serif'> and </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>COMP_METHOD</span></p>
+  <td rowspan=6>
+  <p><span>SSL_COMP</span>
+    <span> and </span>
+  <span>COMP_METHOD</span></p>
   </td>
-  <td rowspan=6 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=6>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4938-L4957">ssl.h
   <br>
   Deprecated COMP functions</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP_get_compression_methods</span></p>
+  <td>
+  <p><span>SSL_COMP_get_compression_methods</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP_add_compression_method</span></p>
+  <td>
+  <p><span>SSL_COMP_add_compression_method</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP_get_name</span></p>
+  <td>
+  <p><span>SSL_COMP_get_name</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP_free_compression_methods</span></p>
+  <td>
+  <p><span>SSL_COMP_free_compression_methods</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_current_compression</span></p>
+  <td>
+  <p><span>SSL_get_current_compression</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_current_expansion</span></p>
+  <td>
+  <p><span>SSL_get_current_expansion</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>TLS Renegotiation</span></p>
+  <td>
+  <p><span>TLS Renegotiation</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4542-L4609">ssl.h<br>
   TLS Renegotiation</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_renegotiate</span></p>
+  <td>
+  <p><span>SSL_renegotiate</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns 1 on success, 0 on
+  <td>
+  <p><span>Returns 1 on success, 0 on
   failure. <br>
   <br>
   There is no support for renegotiation for TLS as a server or DTLS. <br>
   <br>
-  There is only minimal support for initiating renegotiation as a client. </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_set_renegotiate_mode</span><span
-  style='font-family:"Times New Roman",serif'> must be set to </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>ssl_renegotiate_once</span><span
-  style='font-family:"Times New Roman",serif'>, </span><span style='font-size:
-  10.0pt;font-family:"Courier New"'>ssl_renegotiate_freely</span><span
-  style='font-family:"Times New Roman",serif'>, or </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>ssl_renegotiate_explicit</span><span
-  style='font-family:"Times New Roman",serif'> for </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_renegotiate</span><span
-  style='font-family:"Times New Roman",serif'> to work.</span></p>
+  There is only minimal support for initiating renegotiation as a client. </span>
+  <span>SSL_set_renegotiate_mode</span>
+  <span> must be set to </span>
+  <span>ssl_renegotiate_once</span>
+  <span>, </span><span style=
+  'font-size:
+  10.0 font-family:"Courier New"'>ssl_renegotiate_freely</span>
+  <span>, or </span>
+  <span>ssl_renegotiate_explicit</span>
+  <span> for </span>
+  <span>SSL_renegotiate</span>
+  <span> to work.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=3 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>General</span></p>
+  <td rowspan=3>
+  <p><span>General</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5085-L5087">ssl.h<br>
   SSL_get_shared_ciphers</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_shared_ciphers</span></p>
+  <td>
+  <p><span>SSL_get_shared_ciphers</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Writes an empty string and
+  <td>
+  <p><span>Writes an empty string and
   returns a pointer containing it or returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5089-L5092">ssl.h<br>
   SSL_get_shared_sigalgs</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_shared_sigalgs</span></p>
+  <td>
+  <p><span>SSL_get_shared_sigalgs</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  <td>
+  <p><span>Returns zero.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5145-L5146C20">ssl.h<br>
   SSL_get_server_tmp_key</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_server_tmp_key</span></p>
+  <td>
+  <p><span>SSL_get_server_tmp_key</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  <td>
+  <p><span>Returns zero.</span></p>
   </td>
  </tr>
 </table>
@@ -380,804 +294,551 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
 
 ### libcrypto No-ops
 
-<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+<table border=0 cellspacing=0 cellpadding=0
  style='border-collapse:collapse'>
  <tr>
-  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Related Functionality</span></b></p>
+  <td>
+  <p><b><span>Related Functionality</span></b></p>
   </td>
-  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Details</span></b></p>
+  <td>
+  <p><b><span>Details</span></b></p>
   </td>
-  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>No-op function</span></b></p>
+  <td>
+  <p><b><span>No-op function</span></b></p>
   </td>
-  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><b><span
-  style='font-family:"Times New Roman",serif'>Return value</span></b></p>
+  <td>
+  <p><b><span>Return value</span></b></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=5 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>EVP_PKEY</span></p>
+  <td rowspan=5>
+  <p><span>EVP_PKEY</span></p>
   </td>
-  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=2>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L182">evp.h</a><br>
   <a href="https://github.com/aws/aws-lc/blob/main/PORTING.md#dsa-evp_pkeys">EVP_PKEY_DSA</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_CTX_set_dsa_paramgen_bits</span></p>
+  <td>
+  <p><span>EVP_PKEY_CTX_set_dsa_paramgen_bits</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  <td>
+  <p><span>Returns zero.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_CTX_set_dsa_paramgen_q_bits</span></p>
+  <td>
+  <p><span>EVP_PKEY_CTX_set_dsa_paramgen_q_bits</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  <td>
+  <p><span>Returns zero.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=2>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L932-L934">evp.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_get0_DH</span></p>
+  <td>
+  <p><span>EVP_PKEY_get0_DH</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_get1_DH</span></p>
+  <td>
+  <p><span>EVP_PKEY_get1_DH</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L948-L951">evp.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_get0</span></p>
+  <td>
+  <p><span>EVP_PKEY_get0</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Void function that does not
+  <td>
+  <p><span>Void function that does not
   return anything (NULL).</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=6 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>EC</span></p>
+  <td rowspan=6>
+  <p><span>EC</span></p>
   </td>
-  <td rowspan=3 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=3>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec_key.h#L314-L315">ec_key.h<br>
   </a><br>
   <a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L413-L417">ec.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EC_KEY_set_asn1_flag</span></p>
+  <td>
+  <p><span>EC_KEY_set_asn1_flag</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EC_GROUP_set_asn1_flag</span></p>
+  <td>
+  <p><span>EC_GROUP_set_asn1_flag</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EC_GROUP_get_asn1_flag</span></p>
+  <td>
+  <p><span>EC_GROUP_get_asn1_flag</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>OPENSSL_EC_NAMED_CURVE</span><span
-  style='font-family:"Times New Roman",serif'>.</span></p>
+  <td>
+  <p><span>Returns </span>
+  <span>OPENSSL_EC_NAMED_CURVE</span>
+  <span>.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=2>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L419-L425">ec.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EC_GROUP_method_of</span></p>
+  <td>
+  <p><span>EC_GROUP_method_of</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns a dummy non-NULL
+  <td>
+  <p><span>Returns a dummy non-NULL
   EC_METHOD pointer.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EC_METHOD_get_field_type</span></p>
+  <td>
+  <p><span>EC_METHOD_get_field_type</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>NID_X9_62_prime_field</span><span
-  style='font-family:"Times New Roman",serif'>.</span></p>
+  <td>
+  <p><span>Returns </span>
+  <span>NID_X9_62_prime_field</span>
+  <span>.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L427-L431">ec.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EC_GROUP_set_point_conversion_form</span></p>
+  <td>
+  <p><span>EC_GROUP_set_point_conversion_form</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns nothing as a void
-  function. Aborts if a form other than</span><span style='font-size:10.0pt;
-  font-family:"Courier New"'> POINT_CONVERSION_UNCOMPRESSED</span><span
-  style='font-family:"Times New Roman",serif'> is requested.</span></p>
+  <td>
+  <p><span>Returns nothing as a void
+  function. Aborts if a form other than</span>
+  <span style='font-family:"Courier New"'> POINT_CONVERSION_UNCOMPRESSED</span>
+  <span> is requested.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=4 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>CONF modules</span></p>
+  <td rowspan=4>
+  <p><span>CONF modules</span></p>
   </td>
-  <td rowspan=4 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=4>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/conf.h#L134-L147">conf.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CONF_modules_load_file</span></p>
+  <td>
+  <p><span>CONF_modules_load_file</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CONF_modules_unload</span></p>
+  <td>
+  <p><span>CONF_modules_unload</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CONF_modules_finish</span></p>
+  <td>
+  <p><span>CONF_modules_finish</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CONF_modules_free</span></p>
+  <td>
+  <p><span>CONF_modules_free</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=13 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:
-  .75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>RAND Functions</span></p>
+  <td rowspan=13>
+  <p><span>RAND Functions</span></p>
   </td>
-  <td rowspan=13 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=13>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/crypto/fipsmodule/FIPS.md#entropy-sources">Entropy
   Sources</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_load_file</span></p>
+  <td>
+  <p><span>RAND_load_file</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns a non-negative number.</span></p>
+  <td>
+  <p><span>Returns a non-negative number.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_write_file</span></p>
+  <td>
+  <p><span>RAND_write_file</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing and returns negative
+  <td>
+  <p><span>Does nothing and returns negative
   one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_file_name</span></p>
+  <td>
+  <p><span>RAND_file_name</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_add</span></p>
+  <td>
+  <p><span>RAND_add</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_egd</span></p>
+  <td>
+  <p><span>RAND_egd</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns 255.</span></p>
+  <td>
+  <p><span>Returns 255.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_poll</span></p>
+  <td>
+  <p><span>RAND_poll</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_status</span></p>
+  <td>
+  <p><span>RAND_status</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_cleanup</span></p>
+  <td>
+  <p><span>RAND_cleanup</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_SSLeay</span></p>
+  <td>
+  <p><span>RAND_SSLeay</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns a dummy </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_METHOD</span><span
-  style='font-family:"Times New Roman",serif'> pointer.</span></p>
+  <td>
+  <p><span>Returns a dummy </span>
+  <span>RAND_METHOD</span>
+  <span> pointer.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_OpenSSL</span></p>
+  <td>
+  <p><span>RAND_OpenSSL</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns a dummy </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_METHOD</span><span
-  style='font-family:"Times New Roman",serif'> pointer.</span></p>
+  <td>
+  <p><span>Returns a dummy </span>
+  <span>RAND_METHOD</span>
+  <span> pointer.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_get_rand_method</span></p>
+  <td>
+  <p><span>RAND_get_rand_method</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns a dummy </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_METHOD</span><span
-  style='font-family:"Times New Roman",serif'> pointer.</span></p>
+  <td>
+  <p><span>Returns a dummy </span>
+  <span>RAND_METHOD</span>
+  <span> pointer.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_set_rand_method</span></p>
+  <td>
+  <p><span>RAND_set_rand_method</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>RAND_keep_random_devices_open</span></p>
+  <td>
+  <p><span>RAND_keep_random_devices_open</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=4 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>ASN1</span></p>
+  <td rowspan=4>
+  <p><span>ASN1</span></p>
   </td>
-  <td rowspan=4 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=4>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/asn1.h#L1894-L1904">asn1.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_STRING_set_default_mask</span></p>
+  <td>
+  <p><span>ASN1_STRING_set_default_mask</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_STRING_set_default_mask_asc</span></p>
+  <td>
+  <p><span>ASN1_STRING_set_default_mask_asc</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_STRING_get_default_mask</span></p>
+  <td>
+  <p><span>ASN1_STRING_get_default_mask</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns </span><span
-  style='font-size:10.0pt;font-family:"Courier New"'>B_ASN1_UTF8STRING</span><span
-  style='font-family:"Times New Roman",serif'> (The default value AWS-LC uses).</span></p>
+  <td>
+  <p><span>Returns </span>
+  <span>B_ASN1_UTF8STRING</span>
+  <span> (The default value AWS-LC uses).</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_STRING_TABLE_cleanup</span></p>
+  <td>
+  <p><span>ASN1_STRING_TABLE_cleanup</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=16 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:
-  .75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Thread Safety</span></p>
+  <td rowspan=16>
+  <p><span>Thread Safety</span></p>
   </td>
-  <td rowspan=16 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=16>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/API-CONVENTIONS.md#thread-safety">Thread
   safety</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_num_locks</span></p>
+  <td>
+  <p><span>CRYPTO_num_locks</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_locking_callback</span></p>
+  <td>
+  <p><span>CRYPTO_set_locking_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_add_lock_callback</span></p>
+  <td>
+  <p><span>CRYPTO_set_add_lock_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_locking_callback</span></p>
+  <td>
+  <p><span>CRYPTO_get_locking_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_lock_name</span></p>
+  <td>
+  <p><span>CRYPTO_get_lock_name</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns a fixed dummy string
-  (&quot;</span><span style='font-size:10.0pt;font-family:"Courier New"'>No
+  <td>
+  <p><span>Returns a fixed dummy string
+  (&quot;</span>
+  <sp>No
   old-style OpenSSL locks anymore&quot;)</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_THREADID_set_callback</span></p>
+  <td>
+  <p><span>CRYPTO_THREADID_set_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  <td>
+  <p><span>Returns one.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_THREADID_set_numeric</span></p>
+  <td>
+  <p><span>CRYPTO_THREADID_set_numeric</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_THREADID_set_pointer</span></p>
+  <td>
+  <p><span>CRYPTO_THREADID_set_pointer</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_THREADID_current</span></p>
+  <td>
+  <p><span>CRYPTO_THREADID_current</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_id_callback</span></p>
+  <td>
+  <p><span>CRYPTO_set_id_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_dynlock_create_callback</span></p>
+  <td>
+  <p><span>CRYPTO_set_dynlock_create_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_dynlock_lock_callback</span></p>
+  <td>
+  <p><span>CRYPTO_set_dynlock_lock_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_dynlock_destroy_callback</span></p>
+  <td>
+  <p><span>CRYPTO_set_dynlock_destroy_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_dynlock_create_callback</span></p>
+  <td>
+  <p><span>CRYPTO_get_dynlock_create_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_dynlock_lock_callback</span></p>
+  <td>
+  <p><span>CRYPTO_get_dynlock_lock_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_dynlock_destroy_callback</span></p>
+  <td>
+  <p><span>CRYPTO_get_dynlock_destroy_callback</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  <td>
+  <p><span>Returns NULL.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=13 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:
-  .75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Miscellaneous</span></p>
+  <td rowspan=13>
+  <p><span>Miscellaneous</span></p>
   </td>
-  <td rowspan=5 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=5>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/evp.h#L961-L975">evp.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>OpenSSL_add_all_algorithms</span></p>
+  <td>
+  <p><span>OpenSSL_add_all_algorithms</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>OPENSSL_add_all_algorithms_conf</span></p>
+  <td>
+  <p><span>OPENSSL_add_all_algorithms_conf</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>OpenSSL_add_all_ciphers</span></p>
+  <td>
+  <p><span>OpenSSL_add_all_ciphers</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>OpenSSL_add_all_digests</span></p>
+  <td>
+  <p><span>OpenSSL_add_all_digests</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_cleanup</span></p>
+  <td>
+  <p><span>EVP_cleanup</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=2>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L561-L566">cipher.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_CIPHER_CTX_set_flags</span></p>
+  <td>
+  <p><span>EVP_CIPHER_CTX_set_flags</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.<br>
+  <td>
+  <p><span>Does nothing.<br>
   <br>
-  This functions sets flags for </span><span style='font-size:10.0pt;
-  font-family:"Courier New"'>EVP_CIPHER_CTX</span><span style='font-family:
+  This functions sets flags for </span>
+  <span style='font-family:"Courier New"'>EVP_CIPHER_CTX</span><span style='font-family:
   "Times New Roman",serif'>, so any related flags are also no-ops. Related
   no-op flags can be found in <a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L560-L566">the
@@ -1185,125 +846,91 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_add_cipher_alias</span></p>
+  <td>
+  <p><span>EVP_add_cipher_alias</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing and returns one</span></p>
+  <td>
+  <p><span>Does nothing and returns one</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=2>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/digest.h#L303-L310">digest.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_MD_CTX_set_flags</span></p>
+  <td>
+  <p><span>EVP_MD_CTX_set_flags</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.<br>
+  <td>
+  <p><span>Does nothing.<br>
   <br>
-  This functions sets flags for </span><span style='font-size:10.0pt;
-  font-family:"Courier New"'>EVP_MD_CTX</span><span style='font-family:"Times New Roman",serif'>,
+  This functions sets flags for </span>
+  <span style='font-family:"Courier New"'>EVP_MD_CTX</span>
+  <sp>,
   so any related flags are also no-ops. Related no-op flags can be found in <a
   href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/digest.h#L303-L310">the
   surrounding documentation</a>.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>EVP_add_digest</span></p>
+  <td>
+  <p><span>EVP_add_digest</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing and returns one</span></p>
+  <td>
+  <p><span>Does nothing and returns one</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/dh.h#L351-L360">dh.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>DH_clear_flags</span></p>
+  <td>
+  <p><span>DH_clear_flags</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.<br>
+  <td>
+  <p><span>Does nothing.<br>
   <br>
   <br>
-  This functions clears flags for </span><span style='font-size:10.0pt;
-  font-family:"Courier New"'>DH</span><span style='font-family:"Times New Roman",serif'>,
+  This functions clears flags for </span>
+  <span style='font-family:"Courier New"'>DH</span>
+  <sp>,
   so any related flags are also no-ops. Related no-op flags can be found in <a
   href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/dh.h#L351-L360">the
   surrounding documentation</a>.</span></p>
   </td>
  </tr>
  <tr>
-  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td rowspan=2>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ex_data.h#L180-L185">ex_data.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_cleanup_all_ex_data</span></p>
+  <td>
+  <p><span>CRYPTO_cleanup_all_ex_data</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  <td>
+  <p><span>Does nothing.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_EX_dup</span></p>
+  <td>
+  <p><span>CRYPTO_EX_dup</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Legacy Callback function that's
+  <td>
+  <p><span>Legacy Callback function that's
   ignored.</span></p>
   </td>
  </tr>
  <tr>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'><a
+  <td>
+  <p><span><a
   href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/bio.h#L865-L866">bio.h</a></span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-size:10.0pt;font-family:"Courier New"'>BIO_set_write_buffer_size</span></p>
+  <td>
+  <p><span>BIO_set_write_buffer_size</span></p>
   </td>
-  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
-  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
-  <p class=MsoNormal align=center style='text-align:center'><span
-  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  <td>
+  <p><span>Returns zero.</span></p>
   </td>
  </tr>
 </table>

--- a/docs/porting/functionality-differences.md
+++ b/docs/porting/functionality-differences.md
@@ -1,0 +1,1309 @@
+# No-op Symbols and Configurations
+
+Although the `OPENSSL_IS_AWSLC` preprocessor macro is available for downstream projects to distinguish AWS-LC from OpenSSL, we wish to limit the number of `#ifdef`s needed for projects to support us. No-ops symbols are used in place for functions that are less involved in key code paths to allow for easier integration. A no-op (no operation) symbol refers to a symbol that does nothing and has no effect on the state of the program. AWS-LC uses these across various utility functions and configuration flags to provide easier compatibility with OpenSSL.
+
+No-op symbols can be differentiated into two types:
+
+1. Symbols related to certain functionalities and configurations in OpenSSL that we don’t support (i.e. Security Levels, DH ciphersuites, etc).
+2. Symbols that were historically needed to configure OpenSSL correctly, but aren’t needed to configure AWS-LC (i.e. threading, entropy configuration, etc.)
+
+## libssl No-ops & Absent Functionality
+
+libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have support for every OpenSSL libssl feature. Notable absent functionalities from libssl include SSL Security Levels, SSL Compression, and DANE TLSA. Certain SSL ciphersuites are also not supported such as ciphers using FFDH and RC4. Partially absent features include minimal[TLS renegotiation support](https://github.com/aws/aws-lc/blob/main/PORTING.md#dsa-evp_pkeys) and Stateful Session Resumption (only supported for TLS 1.2 and earlier). More details can be found in the [ssl.h header documentation](https://github.com/aws/aws-lc/blob/main/include/openssl/ssl.h).
+
+**When migrating to AWS-LC, it is important to understand the SSL features your application is reliant on from** **OpenSSL****. Many nuances with libssl can only be discovered at runtime****, so consumers should have specific test cases available****. For example, absent ciphersuite support cannot be detected unless there are specific tests expecting the ciphersuite to be available.** <ins>**Migrators to AWS-LC are expected to understand their intended use cases and have tests surrounding functionality they are dependent on.**</ins> AWS-LC provides test coverage for functional correctness and compliance with TLS standards and implemented extensions. Different cryptographic libraries may implement some behavior by convention that is not standardized and thus is not guaranteed to work the same way in AWS-LC. Customers are responsible for writing their own tests to determine whether they are affected by these kinds of differences, and AWS-LC will publish a list of known differences in the future.
+
+**If you have a valid use case for any missing functionality or if anything is not clarified in our documentation, feel free to [cut an issue](https://github.com/aws/aws-lc/issues/new?assignees=&labels=&projects=&template=general-issue.md&title=) or create a PR to let us know.**
+
+### libssl No-ops
+
+<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+ style='border-collapse:collapse'>
+ <tr>
+  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Related Functionality</span></b></p>
+  </td>
+  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Details</span></b></p>
+  </td>
+  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>No-op function</span></b></p>
+  </td>
+  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Return value</span></b></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=2 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Security Levels</span></p>
+  </td>
+  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5211-L5240">ssl.h<br>
+  Security Levels</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_CTX_get_security_level</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_CTX_set_security_level</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=4 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>DH ciphersuites</span></p>
+  </td>
+  <td rowspan=4 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5148-L5161">ssl.h
+  <br>
+  Deprecated DH functions</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_CTX_set_tmp_dh</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_set_tmp_dh</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_CTX_set_tmp_dh_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_set_tmp_dh_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=6 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP</span><span
+  style='font-family:"Times New Roman",serif'> and </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>COMP_METHOD</span></p>
+  </td>
+  <td rowspan=6 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4938-L4957">ssl.h
+  <br>
+  Deprecated COMP functions</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP_get_compression_methods</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP_add_compression_method</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP_get_name</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_COMP_free_compression_methods</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_current_compression</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_current_expansion</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>TLS Renegotiation</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4542-L4609">ssl.h<br>
+  TLS Renegotiation</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_renegotiate</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns 1 on success, 0 on
+  failure. <br>
+  <br>
+  There is no support for renegotiation for TLS as a server or DTLS. <br>
+  <br>
+  There is only minimal support for initiating renegotiation as a client. </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_set_renegotiate_mode</span><span
+  style='font-family:"Times New Roman",serif'> must be set to </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>ssl_renegotiate_once</span><span
+  style='font-family:"Times New Roman",serif'>, </span><span style='font-size:
+  10.0pt;font-family:"Courier New"'>ssl_renegotiate_freely</span><span
+  style='font-family:"Times New Roman",serif'>, or </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>ssl_renegotiate_explicit</span><span
+  style='font-family:"Times New Roman",serif'> for </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_renegotiate</span><span
+  style='font-family:"Times New Roman",serif'> to work.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=3 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>General</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5085-L5087">ssl.h<br>
+  SSL_get_shared_ciphers</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_shared_ciphers</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Writes an empty string and
+  returns a pointer containing it or returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5089-L5092">ssl.h<br>
+  SSL_get_shared_sigalgs</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_shared_sigalgs</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5145-L5146C20">ssl.h<br>
+  SSL_get_server_tmp_key</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>SSL_get_server_tmp_key</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  </td>
+ </tr>
+</table>
+
+### libssl TLS supported ciphersuites
+
+TLS 1.2 supported cipher suites between AWS-LC and OpenSSL 1.1.1u:
+
+|Ciphersuite	|OpenSSL 1.1.1	|AWS-LC	|
+|---	|---	|---	|
+|AES128-GCM-SHA256	|X	|X	|
+|AES128-SHA	|X	|X	|
+|AES128-SHA256	|X	|X	|
+|AES256-GCM-SHA384	|X	|X	|
+|AES256-SHA	|X	|X	|
+|AES256-SHA256	|X	|	|
+|DES-CBC3-SHA	|	|X	|
+|DHE-RSA-AES128-GCM-SHA256	|X	|	|
+|DHE-RSA-AES128-SHA	|X	|	|
+|DHE-RSA-AES128-SHA256	|X	|	|
+|DHE-RSA-AES256-GCM-SHA384	|X	|	|
+|DHE-RSA-AES256-SHA	|X	|	|
+|DHE-RSA-AES256-SHA256	|X	|	|
+|DHE-RSA-CHACHA20-POLY1305	|X	|	|
+|ECDHE-ECDSA-AES128-GCM-SHA256	|X	|X	|
+|ECDHE-ECDSA-AES128-SHA	|X	|X	|
+|ECDHE-ECDSA-AES128-SHA256	|X	|	|
+|ECDHE-ECDSA-AES256-GCM-SHA384	|X	|X	|
+|ECDHE-ECDSA-AES256-SHA	|X	|X	|
+|ECDHE-ECDSA-AES256-SHA384	|X	|	|
+|ECDHE-ECDSA-CHACHA20-POLY1305	|X	|X	|
+|ECDHE-PSK-AES128-CBC-SHA	|	|X	|
+|ECDHE-PSK-AES256-CBC-SHA	|	|X	|
+|ECDHE-PSK-CHACHA20-POLY1305	|	|X	|
+|ECDHE-RSA-AES128-GCM-SHA256	|X	|X	|
+|ECDHE-RSA-AES128-SHA	|X	|X	|
+|ECDHE-RSA-AES128-SHA256	|X	|X	|
+|ECDHE-RSA-AES256-GCM-SHA384	|X	|X	|
+|ECDHE-RSA-AES256-SHA	|X	|X	|
+|ECDHE-RSA-AES256-SHA384	|X	|	|
+|ECDHE-RSA-CHACHA20-POLY1305	|X	|X	|
+|PSK-AES128-CBC-SHA	|	|X	|
+|PSK-AES256-CBC-SHA	|	|X	|
+
+TLS 1.3 supported cipher suites between AWS-LC and OpenSSL 1.1.1u:
+
+|Ciphersuite	|OpenSSL 1.1.1	|AWS-LC	|
+|---	|---	|---	|
+|TLS_AES_128_GCM_SHA256	|X	|X	|
+|TLS_AES_256_GCM_SHA384	|X	|X	|
+|TLS_CHACHA20_POLY1305_SHA256	|X	|X	|
+
+## libcrypto No-ops & Absent Functionality
+
+libcrypto is the portion of OpenSSL for performing general-purpose cryptography, which can be used without libssl. Commonly used standardized formats such as `X509` and `ASN1` are also implemented in libcrypto. AWS-LC does not have support for every feature in OpenSSL’s libcrypto. Notable absent functionalities include OpenSSL’s [`CONF` modules](https://www.openssl.org/docs/manmaster/man3/CONF_modules_load_file.html). Utility functions surrounding `RAND` are no-ops, consumers should call `RAND_bytes` directly instead. Setting flags to configure `EVP_MD_CTX` and `EVP_CIPHER_CTX` is also not supported.
+
+Older and less common usages of `EVP_PKEY` have been removed. For example, signing and verifying with `EVP_PKEY_DSA`  is not supported. More details on specific features can be found in the corresponding [header documentation](https://github.com/aws/aws-lc/tree/main/include/openssl).
+
+**When migrating to AWS-LC, it is important to understand the specific libcrypto components your application is reliant on from OpenSSL. For example, there may be underlying differences when consuming** **X509 certificate verification** **from AWS-LC.** <ins>**Migrators to AWS-LC are expected to understand their intended use cases and have tests surrounding functionality they are dependent on.**</ins> AWS-LC provides test coverage for functional and cryptographic correctness, along with compliance with standards like PKCS and X509. Different cryptographic libraries may implement some behavior by convention that is not standardized and thus is not guaranteed to work the same way in AWS-LC. Customers are responsible for writing their own tests to determine whether they are affected by these kinds of differences, and AWS-LC will publish a list of known differences in the future.
+
+**If you have a valid use case for any missing functionality or if anything is not clarified in our documentation, feel free to [cut an issue](https://github.com/aws/aws-lc/issues/new?assignees=&labels=&projects=&template=general-issue.md&title=) or create a PR to let us know.**
+
+### libcrypto No-ops
+
+<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0
+ style='border-collapse:collapse'>
+ <tr>
+  <td style='border:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Related Functionality</span></b></p>
+  </td>
+  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Details</span></b></p>
+  </td>
+  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>No-op function</span></b></p>
+  </td>
+  <td style='border:solid #E6E6E6 1.0pt;border-left:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><b><span
+  style='font-family:"Times New Roman",serif'>Return value</span></b></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=5 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>EVP_PKEY</span></p>
+  </td>
+  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L182">evp.h</a><br>
+  <a href="https://github.com/aws/aws-lc/blob/main/PORTING.md#dsa-evp_pkeys">EVP_PKEY_DSA</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_CTX_set_dsa_paramgen_bits</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_CTX_set_dsa_paramgen_q_bits</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L932-L934">evp.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_get0_DH</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_get1_DH</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L948-L951">evp.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_PKEY_get0</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Void function that does not
+  return anything (NULL).</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=6 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>EC</span></p>
+  </td>
+  <td rowspan=3 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec_key.h#L314-L315">ec_key.h<br>
+  </a><br>
+  <a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L413-L417">ec.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EC_KEY_set_asn1_flag</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EC_GROUP_set_asn1_flag</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EC_GROUP_get_asn1_flag</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>OPENSSL_EC_NAMED_CURVE</span><span
+  style='font-family:"Times New Roman",serif'>.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L419-L425">ec.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EC_GROUP_method_of</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns a dummy non-NULL
+  EC_METHOD pointer.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EC_METHOD_get_field_type</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>NID_X9_62_prime_field</span><span
+  style='font-family:"Times New Roman",serif'>.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L427-L431">ec.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EC_GROUP_set_point_conversion_form</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns nothing as a void
+  function. Aborts if a form other than</span><span style='font-size:10.0pt;
+  font-family:"Courier New"'> POINT_CONVERSION_UNCOMPRESSED</span><span
+  style='font-family:"Times New Roman",serif'> is requested.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=4 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>CONF modules</span></p>
+  </td>
+  <td rowspan=4 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/conf.h#L134-L147">conf.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CONF_modules_load_file</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CONF_modules_unload</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CONF_modules_finish</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CONF_modules_free</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=13 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:
+  .75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>RAND Functions</span></p>
+  </td>
+  <td rowspan=13 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/crypto/fipsmodule/FIPS.md#entropy-sources">Entropy
+  Sources</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_load_file</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns a non-negative number.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_write_file</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing and returns negative
+  one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_file_name</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_add</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_egd</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns 255.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_poll</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_status</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_cleanup</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_SSLeay</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns a dummy </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_METHOD</span><span
+  style='font-family:"Times New Roman",serif'> pointer.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_OpenSSL</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns a dummy </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_METHOD</span><span
+  style='font-family:"Times New Roman",serif'> pointer.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_get_rand_method</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns a dummy </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_METHOD</span><span
+  style='font-family:"Times New Roman",serif'> pointer.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_set_rand_method</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>RAND_keep_random_devices_open</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=4 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>ASN1</span></p>
+  </td>
+  <td rowspan=4 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/asn1.h#L1894-L1904">asn1.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_STRING_set_default_mask</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_STRING_set_default_mask_asc</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_STRING_get_default_mask</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns </span><span
+  style='font-size:10.0pt;font-family:"Courier New"'>B_ASN1_UTF8STRING</span><span
+  style='font-family:"Times New Roman",serif'> (The default value AWS-LC uses).</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>ASN1_STRING_TABLE_cleanup</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=16 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:
+  .75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Thread Safety</span></p>
+  </td>
+  <td rowspan=16 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/API-CONVENTIONS.md#thread-safety">Thread
+  safety</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_num_locks</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_locking_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_add_lock_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_locking_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_lock_name</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns a fixed dummy string
+  (&quot;</span><span style='font-size:10.0pt;font-family:"Courier New"'>No
+  old-style OpenSSL locks anymore&quot;)</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_THREADID_set_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns one.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_THREADID_set_numeric</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_THREADID_set_pointer</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_THREADID_current</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_id_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_dynlock_create_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_dynlock_lock_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_set_dynlock_destroy_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_dynlock_create_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_dynlock_lock_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_get_dynlock_destroy_callback</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns NULL.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=13 style='border:solid #E6E6E6 1.0pt;border-top:none;padding:
+  .75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Miscellaneous</span></p>
+  </td>
+  <td rowspan=5 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/evp.h#L961-L975">evp.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>OpenSSL_add_all_algorithms</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>OPENSSL_add_all_algorithms_conf</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>OpenSSL_add_all_ciphers</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>OpenSSL_add_all_digests</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_cleanup</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L561-L566">cipher.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_CIPHER_CTX_set_flags</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.<br>
+  <br>
+  This functions sets flags for </span><span style='font-size:10.0pt;
+  font-family:"Courier New"'>EVP_CIPHER_CTX</span><span style='font-family:
+  "Times New Roman",serif'>, so any related flags are also no-ops. Related
+  no-op flags can be found in <a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L560-L566">the
+  surrounding documentation</a>.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_add_cipher_alias</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing and returns one</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/digest.h#L303-L310">digest.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_MD_CTX_set_flags</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.<br>
+  <br>
+  This functions sets flags for </span><span style='font-size:10.0pt;
+  font-family:"Courier New"'>EVP_MD_CTX</span><span style='font-family:"Times New Roman",serif'>,
+  so any related flags are also no-ops. Related no-op flags can be found in <a
+  href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/digest.h#L303-L310">the
+  surrounding documentation</a>.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>EVP_add_digest</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing and returns one</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/dh.h#L351-L360">dh.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>DH_clear_flags</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.<br>
+  <br>
+  <br>
+  This functions clears flags for </span><span style='font-size:10.0pt;
+  font-family:"Courier New"'>DH</span><span style='font-family:"Times New Roman",serif'>,
+  so any related flags are also no-ops. Related no-op flags can be found in <a
+  href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/dh.h#L351-L360">the
+  surrounding documentation</a>.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td rowspan=2 style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ex_data.h#L180-L185">ex_data.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_cleanup_all_ex_data</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>CRYPTO_EX_dup</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Legacy Callback function that's
+  ignored.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'><a
+  href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/bio.h#L865-L866">bio.h</a></span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-size:10.0pt;font-family:"Courier New"'>BIO_set_write_buffer_size</span></p>
+  </td>
+  <td style='border-top:none;border-left:none;border-bottom:solid #E6E6E6 1.0pt;
+  border-right:solid #E6E6E6 1.0pt;padding:.75pt .75pt .75pt .75pt'>
+  <p class=MsoNormal align=center style='text-align:center'><span
+  style='font-family:"Times New Roman",serif'>Returns zero.</span></p>
+  </td>
+ </tr>
+</table>


### PR DESCRIPTION
### Description of changes: 
Update porting guide for AWS-LC. This is the first phase, which just includes the text and tables. Second phase will include links to the corresponding functions/sections for the tables along with updated function documentation.

### Call-outs:
There were some issues auto-generating the Markdown files with the internal docs. Apparently Markdown doesn't support merged row/columns, so I had to use html instead.
I'll write up a runbook on how to regenerate the files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
