### PR TITLE
Use x30 instead of lr which otherwise trip some versions of gcc

### DIFF
--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -473,13 +473,13 @@ func (d *delocation) loadAarch64Address(statement *node32, targetReg string, sym
 	// Save x0 (which will be stomped by the return value) and the link register
 	// to the stack. Then save the program counter into the link register and
 	// jump to the helper function.
-	d.output.WriteString("\tstp x0, lr, [sp, #-16]!\n")
+	d.output.WriteString("\tstp x0, x30, [sp, #-16]!\n")
 	d.output.WriteString("\tbl " + helperFunc + "\n")
 
 	if targetReg == "x0" {
 		// If the target happens to be x0 then restore the link register from the
 		// stack and send the saved value of x0 to the zero register.
-		d.output.WriteString("\tldp xzr, lr, [sp], #16\n")
+		d.output.WriteString("\tldp xzr, x30, [sp], #16\n")
 	} else if targetReg == "x30" {
 		// If the target is x30, restore x0 only because the lr (just an alias
 		// name for x30) register is used as a general-purpose register.
@@ -492,7 +492,7 @@ func (d *delocation) loadAarch64Address(statement *node32, targetReg string, sym
 	} else {
 		// Otherwise move the result into place and restore registers.
 		d.output.WriteString("\tmov " + targetReg + ", x0\n")
-		d.output.WriteString("\tldp x0, lr, [sp], #16\n")
+		d.output.WriteString("\tldp x0, x30, [sp], #16\n")
 	}
 
 	// Revert the red-zone adjustment.

--- a/util/fipstools/delocate/testdata/aarch64-Basic/out.s
+++ b/util/fipstools/delocate/testdata/aarch64-Basic/out.s
@@ -11,10 +11,10 @@ foo:
 	// GOT load
 // WAS adrp x1, :got:stderr
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .Lboringssl_loadgot_stderr
 	mov x1, x0
-	ldp x0, lr, [sp], #16
+	ldp x0, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr x0, [x1, :got_lo12:stderr]
 	mov x0, x1
@@ -22,9 +22,9 @@ foo:
 	// GOT load to x0
 // WAS adrp x0, :got:stderr
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .Lboringssl_loadgot_stderr
-	ldp xzr, lr, [sp], #16
+	ldp xzr, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr x1, [x0, :got_lo12:stderr]
 	mov x1, x0
@@ -32,9 +32,9 @@ foo:
 	// GOT load with no register move
 // WAS adrp x0, :got:stderr
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .Lboringssl_loadgot_stderr
-	ldp xzr, lr, [sp], #16
+	ldp xzr, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr x0, [x0, :got_lo12:stderr]
 
@@ -58,10 +58,10 @@ foo:
 	// armcap
 // WAS adrp x1, OPENSSL_armcap_P
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .LOPENSSL_armcap_P_addr
 	mov x1, x0
-	ldp x0, lr, [sp], #16
+	ldp x0, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr w2, [x1, :lo12:OPENSSL_armcap_P]
 	ldr	w2, [x1]
@@ -69,7 +69,7 @@ foo:
 	// armcap to x30
 // WAS adrp x30, OPENSSL_armcap_P
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .LOPENSSL_armcap_P_addr
 	mov x30, x0
 	ldp x0, xzr, [sp], #16
@@ -80,9 +80,9 @@ foo:
 	// armcap to w0
 // WAS adrp x0, OPENSSL_armcap_P
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .LOPENSSL_armcap_P_addr
-	ldp xzr, lr, [sp], #16
+	ldp xzr, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr w1, [x1, :lo12:OPENSSL_armcap_P]
 	ldr	w1, [x1]
@@ -146,17 +146,17 @@ foo:
 	// Ensure BORINGSSL_bcm_text_[end,start] are loaded through GOT
 // WAS adrp x4, :got:BORINGSSL_bcm_text_start
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .Lboringssl_loadgot_BORINGSSL_bcm_text_start
 	mov x4, x0
-	ldp x0, lr, [sp], #16
+	ldp x0, x30, [sp], #16
 	add sp, sp, 128
 // WAS adrp x5, :got:BORINGSSL_bcm_text_end
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .Lboringssl_loadgot_BORINGSSL_bcm_text_end
 	mov x5, x0
-	ldp x0, lr, [sp], #16
+	ldp x0, x30, [sp], #16
 	add sp, sp, 128
 
 .Llocal_function_local_target:


### PR DESCRIPTION
### Description of changes: 

Cross-compiling with:
```
-- The C compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/xcc/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-gcc
```

Resulted in:
```
Scanning dependencies of target bcm_hashunset
[  6%] Building ASM object crt/aws-lc/crypto/fipsmodule/CMakeFiles/bcm_hashunset.dir/bcm-delocated.S.o
bcm.c: Assembler messages:
bcm.c:15025: Error: operand 2 must be an integer register -- `stp x0,lr,[sp,#-16]!'
bcm.c:15028: Error: operand 2 must be an integer register -- `ldp x0,lr,[sp],#16'
bcm.c:15084: Error: operand 2 must be an integer register -- `stp x0,lr,[sp,#-16]!'
bcm.c:15087: Error: operand 2 must be an integer register -- `ldp x0,lr,[sp],#16'
bcm.c:18003: Error: operand 2 must be an integer register -- `stp x0,lr,[sp,#-16]!'
bcm.c:18006: Error: operand 2 must be an integer register -- `ldp x0,lr,[sp],#16'
```

Looks like a case of some versions of GCC not liking the link register notation `lr` being used instead of `x30` where an integer register is expected for the instruction.

To recover, use `x30` instead of `lr` in the delocator. Doesn't change behaviour.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.