### PR TITLE
[Backport] Use x30 instead of lr which otherwise trip some versions of gcc

### DIFF
--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -10,7 +10,7 @@
 // SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 // WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
-// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 // delocate performs several transformations of textual assembly code. See
 // crypto/fipsmodule/FIPS.md for an overview.
@@ -444,17 +444,17 @@ func (d *delocation) loadAarch64Address(statement *node32, targetReg string, sym
 	// Save x0 (which will be stomped by the return value) and the link register
 	// to the stack. Then save the program counter into the link register and
 	// jump to the helper function.
-	d.output.WriteString("\tstp x0, lr, [sp, #-16]!\n")
+	d.output.WriteString("\tstp x0, x30, [sp, #-16]!\n")
 	d.output.WriteString("\tbl " + helperFunc + "\n")
 
 	if targetReg == "x0" {
 		// If the target happens to be x0 then restore the link register from the
 		// stack and send the saved value of x0 to the zero register.
-		d.output.WriteString("\tldp xzr, lr, [sp], #16\n")
+		d.output.WriteString("\tldp xzr, x30, [sp], #16\n")
 	} else {
 		// Otherwise move the result into place and restore registers.
 		d.output.WriteString("\tmov " + targetReg + ", x0\n")
-		d.output.WriteString("\tldp x0, lr, [sp], #16\n")
+		d.output.WriteString("\tldp x0, x30, [sp], #16\n")
 	}
 
 	// Revert the red-zone adjustment.

--- a/util/fipstools/delocate/testdata/aarch64-Basic/out.s
+++ b/util/fipstools/delocate/testdata/aarch64-Basic/out.s
@@ -9,10 +9,10 @@ foo:
 	// GOT load
 // WAS adrp x1, :got:stderr
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .Lboringssl_loadgot_stderr
 	mov x1, x0
-	ldp x0, lr, [sp], #16
+	ldp x0, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr x0, [x1, :got_lo12:stderr]
 	mov x0, x1
@@ -20,9 +20,9 @@ foo:
 	// GOT load to x0
 // WAS adrp x0, :got:stderr
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .Lboringssl_loadgot_stderr
-	ldp xzr, lr, [sp], #16
+	ldp xzr, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr x1, [x0, :got_lo12:stderr]
 	mov x1, x0
@@ -30,9 +30,9 @@ foo:
 	// GOT load with no register move
 // WAS adrp x0, :got:stderr
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .Lboringssl_loadgot_stderr
-	ldp xzr, lr, [sp], #16
+	ldp xzr, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr x0, [x0, :got_lo12:stderr]
 
@@ -56,10 +56,10 @@ foo:
 	// armcap
 // WAS adrp x1, OPENSSL_armcap_P
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .LOPENSSL_armcap_P_addr
 	mov x1, x0
-	ldp x0, lr, [sp], #16
+	ldp x0, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr w2, [x1, :lo12:OPENSSL_armcap_P]
 	ldr	w2, [x1]
@@ -67,9 +67,9 @@ foo:
 	// armcap to w0
 // WAS adrp x0, OPENSSL_armcap_P
 	sub sp, sp, 128
-	stp x0, lr, [sp, #-16]!
+	stp x0, x30, [sp, #-16]!
 	bl .LOPENSSL_armcap_P_addr
-	ldp xzr, lr, [sp], #16
+	ldp xzr, x30, [sp], #16
 	add sp, sp, 128
 // WAS ldr w1, [x1, :lo12:OPENSSL_armcap_P]
 	ldr	w1, [x1]


### PR DESCRIPTION

### Description of changes:
Backport to fips-2022-11-02:
* #1464 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
