### PR TITLE
Add more platforms to CI

### DIFF
--- a/.github/workflows/cross-test.yml
+++ b/.github/workflows/cross-test.yml
@@ -48,6 +48,46 @@ jobs:
       - uses: actions/checkout@v4
       - name: PPC64LE Build/Test
         run: tests/ci/run_cross_tests.sh ppc64le powerpc64le-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_BUILD_TYPE=Release -DFIPS=1 -DBUILD_SHARED_LIBS=1"
+  riscv64-non-fips-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install qemu
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install qemu-user qemu-user-binfmt
+      - uses: actions/checkout@v4
+      - name: RISC-V 64 Build/Test
+# The flag below is set to avoid the following error with GCC 11.4.0:
+#
+#  /home/runner/work/aws-lc/aws-lc/crypto/pem/pem_lib.c:705:11: error: 'strncmp' of strings of length 1 and 9 and bound of 9 evaluates to nonzero [-Werror=string-compare]
+#  705 |       if (strncmp(buf, "-----END ", 9) == 0) {
+#      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        env:
+          CFLAGS: "-Wno-string-compare"
+        run: tests/ci/run_cross_tests.sh riscv riscv64-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release"
+  armv6-non-fips-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install qemu
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install qemu-user qemu-user-binfmt
+      - uses: actions/checkout@v4
+      - name: armv6 Build/Test
+        run: tests/ci/run_cross_tests.sh armv6 armv6-unknown-linux-gnueabi "-DCMAKE_BUILD_TYPE=Release"
+#  TODO: enable once qemu-user-binfmt in ubuntu-latest supports loongarch64
+#        * QEMU added support for loongarch64 in 7.1: https://www.qemu.org/2022/08/30/qemu-7-1-0/
+#        * The next Ubuntu LTS should have a QEMU 8.x: https://packages.ubuntu.com/noble/qemu-user-binfmt
+#  loongarch64-non-fips-build-test:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Install qemu
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get -y install qemu-user qemu-user-binfmt
+#      - uses: actions/checkout@v4
+#      - name: armv6 Build/Test
+#        run: tests/ci/run_cross_tests.sh loongarch64 loongarch64-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release"
   s390x-non-fips-build-test:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ that improve the experience for consumers on these platforms.
 | Android   | arm32       |
 | iOS       | aarch64     |
 | Linux     | arm32       |
-| Linux     | Loongarch64 | 
+| Linux     | loongarch64 |
+| Linux     | risc-v64    |
+| Linux     | s390x       |
 | Windows   | aarch64     |
 | OpenBSD   | x86-64      |
 | FreeBSD   | x86-64      |

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -194,4 +194,3 @@ runs in AWS EFS. Cryptofuzz is built with 3 modules:
 -----------|--------------|--------------|--------------|--------|
  CodeBuild | clang 10.0.0 | x86-64       | Ubuntu 20.04 | ASAN=1 |
  CodeBuild | clang 10.0.0 | aarch64      | Ubuntu 20.04 | ASAN=1 |
-


### PR DESCRIPTION
### Description of changes: 
* Add CI coverage for riscv64, armv6 and loongarch64.
* Update "Other Platforms" section of README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
