### PR TITLE
Convert ERR_LIB_* from enum to macros

### DIFF
--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -305,42 +305,40 @@ OPENSSL_EXPORT int ERR_get_next_error_library(void);
 // Built-in library and reason codes.
 
 // The following values are built-in library codes.
-enum {
-  ERR_LIB_NONE = 1,
-  ERR_LIB_SYS,
-  ERR_LIB_BN,
-  ERR_LIB_RSA,
-  ERR_LIB_DH,
-  ERR_LIB_EVP,
-  ERR_LIB_BUF,
-  ERR_LIB_OBJ,
-  ERR_LIB_PEM,
-  ERR_LIB_DSA,
-  ERR_LIB_X509,
-  ERR_LIB_ASN1,
-  ERR_LIB_CONF,
-  ERR_LIB_CRYPTO,
-  ERR_LIB_EC,
-  ERR_LIB_SSL,
-  ERR_LIB_BIO,
-  ERR_LIB_PKCS7,
-  ERR_LIB_PKCS8,
-  ERR_LIB_X509V3,
-  ERR_LIB_RAND,
-  ERR_LIB_ENGINE,
-  ERR_LIB_OCSP,
-  ERR_LIB_UI,
-  ERR_LIB_COMP,
-  ERR_LIB_ECDSA,
-  ERR_LIB_ECDH,
-  ERR_LIB_HMAC,
-  ERR_LIB_DIGEST,
-  ERR_LIB_CIPHER,
-  ERR_LIB_HKDF,
-  ERR_LIB_TRUST_TOKEN,
-  ERR_LIB_USER,
-  ERR_NUM_LIBS
-};
+#define ERR_LIB_NONE            1
+#define ERR_LIB_SYS             2
+#define ERR_LIB_BN              3
+#define ERR_LIB_RSA             4
+#define ERR_LIB_DH              5
+#define ERR_LIB_EVP             6
+#define ERR_LIB_BUF             7
+#define ERR_LIB_OBJ             8
+#define ERR_LIB_PEM             9
+#define ERR_LIB_DSA             10
+#define ERR_LIB_X509            11
+#define ERR_LIB_ASN1            12
+#define ERR_LIB_CONF            13
+#define ERR_LIB_CRYPTO          14
+#define ERR_LIB_EC              15
+#define ERR_LIB_SSL             16
+#define ERR_LIB_BIO             17
+#define ERR_LIB_PKCS7           18
+#define ERR_LIB_PKCS8           19
+#define ERR_LIB_X509V3          20
+#define ERR_LIB_RAND            21
+#define ERR_LIB_ENGINE          22
+#define ERR_LIB_OCSP            23
+#define ERR_LIB_UI              24
+#define ERR_LIB_COMP            25
+#define ERR_LIB_ECDSA           26
+#define ERR_LIB_ECDH            27
+#define ERR_LIB_HMAC            28
+#define ERR_LIB_DIGEST          29
+#define ERR_LIB_CIPHER          30
+#define ERR_LIB_HKDF            31
+#define ERR_LIB_TRUST_TOKEN     32
+#define ERR_LIB_USER            33
+#define ERR_NUM_LIBS            34
 
 // The following reason codes used to denote an error occuring in another
 // library. They are sometimes used for a stack trace.


### PR DESCRIPTION
### Issues:
- n/a

### Description of changes: 
Defining our various `ERR_LIB_*` as enum values rather than macros prevents the preprocessor (or other projects' preprocessors) from seeing them, potentially cuasing subtle and unexpected behavior at pre-process itme, then made even more subtle at build/run time. The macro-based approach requires manually providing integer values for individual error codes, but this inconvenience is worth if for [increased OpenSSL compatibility][1].

This issue was found due to a failing [test][2] in CPython that relies on an [array built at pre-process time][3]. Prior to this change, that array was not populated with any entries, as the preprocessor wasn't aware of the `enum` in our `err.h`, though obviously the compiler would would be aware.

[1]: https://github.com/openssl/openssl/blob/master/include/openssl/err.h.in#L72
[2]: https://github.com/python/cpython/blob/main/Lib/test/test_ssl.py#L1653
[3]: https://github.com/python/cpython/blob/main/Modules/_ssl_data_111.h#L2

### Call-outs:
- n/a

### Testing:
- CI tests
- local testing against CPython. before this change, above mentioned test failed due to library code array being empty. after this change, that test passed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
