### PR TITLE
Adds CI job to test strongSwan integration

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -124,3 +124,16 @@ jobs:
       - name: Run bind9 build
         run: |
           ./tests/ci/integration/run_bind9_integration.sh
+  strongswan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y --no-install-recommends install \
+          cmake gcc ninja-build golang make gperf bison flex autogen autoconf \
+          pkg-config libtool gettext libgmp-dev libsystemd-dev
+      - uses: actions/checkout@v4
+      - name: Run strongswan build
+        run: |
+          ./tests/ci/integration/run_strongswan_integration.sh

--- a/tests/ci/integration/run_strongswan_integration.sh
+++ b/tests/ci/integration/run_strongswan_integration.sh
@@ -30,6 +30,9 @@ function strongswan_build() {
   --disable-dependency-tracking --enable-silent-rules --enable-test-vectors \
   --enable-monolithic=no --enable-leak-detective=no --enable-asan
   make -j ${NUM_CPU_THREADS}
+  local openssl_plugin="${STRONGSWAN_SRC_FOLDER}/src/libstrongswan/plugins/openssl/.libs/libstrongswan-openssl.so"
+  ldd ${openssl_plugin} \
+    | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
 }
 
 function strongswan_run_tests() {

--- a/tests/ci/integration/run_strongswan_integration.sh
+++ b/tests/ci/integration/run_strongswan_integration.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -exu
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# SYS_ROOT
+#  - SRC_ROOT(aws-lc)
+#    - SCRATCH_FOLDER
+#      - AWS_LC_BUILD_FOLDER
+#      - AWS_LC_INSTALL_FOLDER
+#      - STRONGSWAN_SRC_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER="${SRC_ROOT}/STRONGSWAN_BUILD_ROOT"
+STRONGSWAN_SRC_FOLDER="${SCRATCH_FOLDER}/strongswan"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+
+function strongswan_build() {
+  export CFLAGS="-I${AWS_LC_INSTALL_FOLDER}/include"
+  export LDFLAGS="-L${AWS_LC_INSTALL_FOLDER}/lib"
+  autoreconf -ivf
+  # Mirror the configuration flags set by strongSwan's CI by taking all of the
+  # flags specified within CONFIG when TEST is openssl-awslc in their test.sh.
+  # https://github.com/strongswan/strongswan/blob/44e241fccc166211ccfdd322047c1213ff3ae73c/scripts/test.sh#L468
+  ./configure --disable-defaults --enable-pki --enable-openssl --enable-pem \
+  --disable-dependency-tracking --enable-silent-rules --enable-test-vectors \
+  --enable-monolithic=no --enable-leak-detective=no --enable-asan
+  make -j ${NUM_CPU_THREADS}
+}
+
+function strongswan_run_tests() {
+  make -j ${NUM_CPU_THREADS} check
+}
+
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf ${SCRATCH_FOLDER}/*
+cd ${SCRATCH_FOLDER}
+
+git clone --depth 1 https://github.com/strongswan/strongswan.git ${STRONGSWAN_SRC_FOLDER}
+
+mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
+
+aws_lc_build ${SRC_ROOT} ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} \
+-DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DBUILD_SHARED_LIBS=1
+
+export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib"
+
+pushd ${STRONGSWAN_SRC_FOLDER}
+strongswan_build
+strongswan_run_tests
+popd


### PR DESCRIPTION
### Issues:
Resolves PQCrypto-7

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

This CI job tests AWS-LC against the tip of strongswan/master. We use
AWS-LC's shared library build and override the libcrypto used by
strongSwan by setting LD_LIBRARY_PATH. We also run through strongSwan's
unit test framework to make sure there are no correctness issues.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

`act -W .github/workflows/integrations.yml -j strongswan`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
