### PR TITLE
Document no-op functions and flags in AWS-LC

### DIFF
--- a/crypto/rand_extra/rand_extra.c
+++ b/crypto/rand_extra/rand_extra.c
@@ -54,6 +54,7 @@ int RAND_status(void) {
   return 1;
 }
 
+OPENSSL_BEGIN_ALLOW_DEPRECATED
 static const struct rand_meth_st kSSLeayMethod = {
   RAND_seed,
   RAND_bytes,
@@ -72,6 +73,7 @@ RAND_METHOD *RAND_OpenSSL(void) {
 }
 
 const RAND_METHOD *RAND_get_rand_method(void) { return RAND_SSLeay(); }
+OPENSSL_END_ALLOW_DEPRECATED
 
 int RAND_set_rand_method(const RAND_METHOD *method) { return 1; }
 

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -1438,8 +1438,8 @@ OPENSSL_EXPORT int ASN1_TIME_set_string(ASN1_TIME *s, const char *str);
 // ASN1_TIME conversion functions.
 //
 // |struct| |tm| represents a calendar date: year, month, day... it is not
-// necessarily a valid day, e.g. month 13. |time_t| is a typedef for the system's
-// type that represents the seconds since the UNIX epoch. Posix time is
+// necessarily a valid day, e.g. month 13. |time_t| is a typedef for the
+// system's type that represents the seconds since the UNIX epoch. Posix time is
 // a signed 64-bit integer which also represents the seconds since the UNIX
 // epoch.
 
@@ -2043,19 +2043,22 @@ OPENSSL_EXPORT long ASN1_ENUMERATED_get(const ASN1_ENUMERATED *a);
 
 
 // General No-op Functions [Deprecated].
-  
+
 // ASN1_STRING_set_default_mask does nothing.
-OPENSSL_EXPORT void ASN1_STRING_set_default_mask(unsigned long mask);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void ASN1_STRING_set_default_mask(
+    unsigned long mask);
 
 // ASN1_STRING_set_default_mask_asc returns one.
-OPENSSL_EXPORT int ASN1_STRING_set_default_mask_asc(const char *p);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int ASN1_STRING_set_default_mask_asc(
+    const char *p);
 
 // ASN1_STRING_get_default_mask returns |B_ASN1_UTF8STRING|. This is
 // the value AWS-LC uses by default and is not configurable.
-OPENSSL_EXPORT unsigned long ASN1_STRING_get_default_mask(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED unsigned long ASN1_STRING_get_default_mask(
+    void);
 
 // ASN1_STRING_TABLE_cleanup does nothing.
-OPENSSL_EXPORT void ASN1_STRING_TABLE_cleanup(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void ASN1_STRING_TABLE_cleanup(void);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -1923,18 +1923,6 @@ OPENSSL_EXPORT int ASN1_object_size(int constructed, int length, int tag);
 
 // Deprecated functions.
 
-// ASN1_STRING_set_default_mask does nothing.
-OPENSSL_EXPORT void ASN1_STRING_set_default_mask(unsigned long mask);
-
-// ASN1_STRING_set_default_mask_asc returns one.
-OPENSSL_EXPORT int ASN1_STRING_set_default_mask_asc(const char *p);
-
-// ASN1_STRING_get_default_mask returns |B_ASN1_UTF8STRING|.
-OPENSSL_EXPORT unsigned long ASN1_STRING_get_default_mask(void);
-
-// ASN1_STRING_TABLE_cleanup does nothing.
-OPENSSL_EXPORT void ASN1_STRING_TABLE_cleanup(void);
-
 // M_ASN1_* are legacy aliases for various |ASN1_STRING| functions. Use the
 // functions themselves.
 #define M_ASN1_STRING_length(x) ASN1_STRING_length(x)
@@ -2052,6 +2040,22 @@ OPENSSL_EXPORT long ASN1_INTEGER_get(const ASN1_INTEGER *a);
 // WARNING: This function's return value cannot distinguish errors from -1.
 // Use |ASN1_ENUMERATED_get_uint64| and |ASN1_ENUMERATED_get_int64| instead.
 OPENSSL_EXPORT long ASN1_ENUMERATED_get(const ASN1_ENUMERATED *a);
+
+
+// General No-op Functions [Deprecated].
+  
+// ASN1_STRING_set_default_mask does nothing.
+OPENSSL_EXPORT void ASN1_STRING_set_default_mask(unsigned long mask);
+
+// ASN1_STRING_set_default_mask_asc returns one.
+OPENSSL_EXPORT int ASN1_STRING_set_default_mask_asc(const char *p);
+
+// ASN1_STRING_get_default_mask returns |B_ASN1_UTF8STRING|. This is
+// the value AWS-LC uses by default and is not configurable.
+OPENSSL_EXPORT unsigned long ASN1_STRING_get_default_mask(void);
+
+// ASN1_STRING_TABLE_cleanup does nothing.
+OPENSSL_EXPORT void ASN1_STRING_TABLE_cleanup(void);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -880,7 +880,10 @@ OPENSSL_EXPORT int (*BIO_meth_get_puts(const BIO_METHOD *method)) (BIO *, const 
 // General No-op Functions [Deprecated].
 
 // BIO_set_write_buffer_size returns zero.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int BIO_set_write_buffer_size(
+//
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
+//       and depends on this.
+OPENSSL_EXPORT int BIO_set_write_buffer_size(
     BIO *bio, int buffer_size);
 
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -881,10 +881,8 @@ OPENSSL_EXPORT int (*BIO_meth_get_puts(const BIO_METHOD *method)) (BIO *, const 
 
 // BIO_set_write_buffer_size returns zero.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
-//       and depends on this.
-OPENSSL_EXPORT int BIO_set_write_buffer_size(
-    BIO *bio, int buffer_size);
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
+OPENSSL_EXPORT int BIO_set_write_buffer_size(BIO *bio, int buffer_size);
 
 
 // Private functions

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -880,7 +880,8 @@ OPENSSL_EXPORT int (*BIO_meth_get_puts(const BIO_METHOD *method)) (BIO *, const 
 // General No-op Functions [Deprecated].
 
 // BIO_set_write_buffer_size returns zero.
-OPENSSL_EXPORT int BIO_set_write_buffer_size(BIO *bio, int buffer_size);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int BIO_set_write_buffer_size(
+    BIO *bio, int buffer_size);
 
 
 // Private functions

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -862,9 +862,6 @@ OPENSSL_EXPORT const BIO_METHOD *BIO_f_base64(void);
 
 OPENSSL_EXPORT void BIO_set_retry_special(BIO *bio);
 
-// BIO_set_write_buffer_size returns zero.
-OPENSSL_EXPORT int BIO_set_write_buffer_size(BIO *bio, int buffer_size);
-
 // BIO_set_shutdown sets a method-specific "shutdown" bit on |bio|.
 OPENSSL_EXPORT void BIO_set_shutdown(BIO *bio, int shutdown);
 
@@ -878,6 +875,13 @@ OPENSSL_EXPORT int BIO_meth_set_puts(BIO_METHOD *method,
 
 // BIO_meth_get_puts returns |puts| function of |method|.
 OPENSSL_EXPORT int (*BIO_meth_get_puts(const BIO_METHOD *method)) (BIO *, const char *);
+
+
+// General No-op Functions [Deprecated].
+
+// BIO_set_write_buffer_size returns zero.
+OPENSSL_EXPORT int BIO_set_write_buffer_size(BIO *bio, int buffer_size);
+
 
 // Private functions
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -881,7 +881,8 @@ OPENSSL_EXPORT int (*BIO_meth_get_puts(const BIO_METHOD *method)) (BIO *, const 
 
 // BIO_set_write_buffer_size returns zero.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
+// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. nginx defines -Werror and
+// depends on this.
 OPENSSL_EXPORT int BIO_set_write_buffer_size(BIO *bio, int buffer_size);
 
 

--- a/include/openssl/cipher.h
+++ b/include/openssl/cipher.h
@@ -355,7 +355,7 @@ OPENSSL_EXPORT int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
 #define EVP_CIPH_XTS_MODE 0x7
 #define EVP_CIPH_CCM_MODE 0x8
 
-// Buffer length in bits not bytes: CFB1 mode only.
+// EVP_CIPH_FLAG_LENGTH_BITS buffers length in bits not bytes: CFB1 mode only.
 #define EVP_CIPH_FLAG_LENGTH_BITS 0x2000
 // The following values are never returned from |EVP_CIPHER_mode| and are
 // included only to make it easier to compile code with BoringSSL.

--- a/include/openssl/cipher.h
+++ b/include/openssl/cipher.h
@@ -470,9 +470,6 @@ OPENSSL_EXPORT int EVP_DecryptFinal(EVP_CIPHER_CTX *ctx, uint8_t *out,
 OPENSSL_EXPORT int EVP_Cipher(EVP_CIPHER_CTX *ctx, uint8_t *out,
                               const uint8_t *in, size_t in_len);
 
-// EVP_add_cipher_alias does nothing and returns one.
-OPENSSL_EXPORT int EVP_add_cipher_alias(const char *a, const char *b);
-
 // EVP_get_cipherbyname returns an |EVP_CIPHER| given a human readable name in
 // |name|, or NULL if the name is unknown. Note using this function links almost
 // every cipher implemented by BoringSSL into the binary, not just the ones the
@@ -557,13 +554,21 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED const EVP_CIPHER *EVP_cast5_ecb(void);
 // EVP_cast5_cbc is CAST5 in CBC mode and is deprecated.
 OPENSSL_EXPORT OPENSSL_DEPRECATED const EVP_CIPHER *EVP_cast5_cbc(void);
 
-// The following flags do nothing and are included only to make it easier to
-// compile code with AWS-LC.
-#define EVP_CIPHER_CTX_FLAG_WRAP_ALLOW 0
 
-// EVP_CIPHER_CTX_set_flags does nothing.
+// General No-op Functions [Deprecated].
+
+// EVP_CIPHER_CTX_set_flags does nothing. We strongly discourage doing
+// any additional configurations when consuming |EVP_CIPHER_CTX|.
 OPENSSL_EXPORT void EVP_CIPHER_CTX_set_flags(const EVP_CIPHER_CTX *ctx,
                                              uint32_t flags);
+
+// The following flags are related to |EVP_CIPHER_CTX_set_flags|. They 
+// do nothing and are included only to make it easier to compile code
+// with AWS-LC.
+#define EVP_CIPHER_CTX_FLAG_WRAP_ALLOW 0
+
+// EVP_add_cipher_alias does nothing and returns one.
+OPENSSL_EXPORT int EVP_add_cipher_alias(const char *a, const char *b);
 
 
 // Private functions.

--- a/include/openssl/cipher.h
+++ b/include/openssl/cipher.h
@@ -356,7 +356,7 @@ OPENSSL_EXPORT int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
 #define EVP_CIPH_CCM_MODE 0x8
 
 // Buffer length in bits not bytes: CFB1 mode only.
-# define EVP_CIPH_FLAG_LENGTH_BITS 0x2000
+#define EVP_CIPH_FLAG_LENGTH_BITS 0x2000
 // The following values are never returned from |EVP_CIPHER_mode| and are
 // included only to make it easier to compile code with BoringSSL.
 #define EVP_CIPH_OCB_MODE 0x9
@@ -409,7 +409,8 @@ OPENSSL_EXPORT int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
 // the named cipher algorithm. They are imported from OpenSSL to provide AES CBC
 // HMAC SHA stitch implementation. These methods are TLS specific.
 //
-// WARNING: these APIs usage can get wrong easily. Below functions include details.
+// WARNING: these APIs usage can get wrong easily. Below functions include
+// details.
 //     |aesni_cbc_hmac_sha1_cipher| and |aesni_cbc_hmac_sha256_cipher|.
 
 
@@ -559,16 +560,17 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED const EVP_CIPHER *EVP_cast5_cbc(void);
 
 // EVP_CIPHER_CTX_set_flags does nothing. We strongly discourage doing
 // any additional configurations when consuming |EVP_CIPHER_CTX|.
-OPENSSL_EXPORT void EVP_CIPHER_CTX_set_flags(const EVP_CIPHER_CTX *ctx,
-                                             uint32_t flags);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_CIPHER_CTX_set_flags(
+    const EVP_CIPHER_CTX *ctx, uint32_t flags);
 
-// The following flags are related to |EVP_CIPHER_CTX_set_flags|. They 
+// The following flags are related to |EVP_CIPHER_CTX_set_flags|. They
 // do nothing and are included only to make it easier to compile code
 // with AWS-LC.
 #define EVP_CIPHER_CTX_FLAG_WRAP_ALLOW 0
 
 // EVP_add_cipher_alias does nothing and returns one.
-OPENSSL_EXPORT int EVP_add_cipher_alias(const char *a, const char *b);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_add_cipher_alias(const char *a,
+                                                           const char *b);
 
 
 // Private functions.
@@ -617,7 +619,7 @@ struct evp_cipher_ctx_st {
   const EVP_CIPHER *cipher;
 
   // app_data is a pointer to opaque, user data.
-  void *app_data;      // application stuff
+  void *app_data;  // application stuff
 
   // cipher_data points to the |cipher| specific state.
   void *cipher_data;

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -150,7 +150,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_finish(void);
 
 // OPENSSL_config does nothing. This has been deprecated since OpenSSL 1.1.0.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
+// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. nginx defines -Werror and
+// depends on this.
 OPENSSL_EXPORT void OPENSSL_config(const char *config_name);
 
 // OPENSSL_no_config does nothing. This has been deprecated since OpenSSL

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -59,8 +59,8 @@
 
 #include <openssl/base.h>
 
-#include <openssl/stack.h>
 #include <openssl/lhash.h>
+#include <openssl/stack.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -136,25 +136,24 @@ OPENSSL_EXPORT const char *NCONF_get_string(const CONF *conf,
 
 // CONF_modules_load_file returns one. AWS-LC is defined to have no config
 // file options, thus loading from |filename| always succeeds by doing nothing.
-OPENSSL_EXPORT int CONF_modules_load_file(const char *filename,
-                                          const char *appname,
-                                          unsigned long flags);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int CONF_modules_load_file(
+    const char *filename, const char *appname, unsigned long flags);
 
 // CONF_modules_free does nothing.
-OPENSSL_EXPORT void CONF_modules_free(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_free(void);
 
 // CONF_modules_unload does nothing.
-OPENSSL_EXPORT void CONF_modules_unload(int all);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_unload(int all);
 
 // CONF_modules_finish does nothing.
-OPENSSL_EXPORT void CONF_modules_finish(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_finish(void);
 
 // OPENSSL_config does nothing. This has been deprecated since OpenSSL 1.1.0.
-OPENSSL_EXPORT void OPENSSL_config(const char *config_name);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void OPENSSL_config(const char *config_name);
 
 // OPENSSL_no_config does nothing. This has been deprecated since OpenSSL
 // 1.1.0.
-OPENSSL_EXPORT void OPENSSL_no_config(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void OPENSSL_no_config(void);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -150,8 +150,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_finish(void);
 
 // OPENSSL_config does nothing. This has been deprecated since OpenSSL 1.1.0.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
-//       and depends on this.
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
 OPENSSL_EXPORT void OPENSSL_config(const char *config_name);
 
 // OPENSSL_no_config does nothing. This has been deprecated since OpenSSL

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -124,14 +124,17 @@ OPENSSL_EXPORT const char *NCONF_get_string(const CONF *conf,
                                             const char *name);
 
 
-// Deprecated functions
+// General No-op Functions [Deprecated].
+//
+// AWS-LC has no support for loading config files to configure AWS-LC, so
+// the following functions have been deprecated as no-ops.
 
 // These defines do nothing but are provided to make old code easier to
 // compile.
 #define CONF_MFLAGS_DEFAULT_SECTION 0
 #define CONF_MFLAGS_IGNORE_MISSING_FILE 0
 
-// CONF_modules_load_file returns one. BoringSSL is defined to have no config
+// CONF_modules_load_file returns one. AWS-LC is defined to have no config
 // file options, thus loading from |filename| always succeeds by doing nothing.
 OPENSSL_EXPORT int CONF_modules_load_file(const char *filename,
                                           const char *appname,
@@ -146,10 +149,11 @@ OPENSSL_EXPORT void CONF_modules_unload(int all);
 // CONF_modules_finish does nothing.
 OPENSSL_EXPORT void CONF_modules_finish(void);
 
-// OPENSSL_config does nothing.
+// OPENSSL_config does nothing. This has been deprecated since OpenSSL 1.1.0.
 OPENSSL_EXPORT void OPENSSL_config(const char *config_name);
 
-// OPENSSL_no_config does nothing.
+// OPENSSL_no_config does nothing. This has been deprecated since OpenSSL
+// 1.1.0.
 OPENSSL_EXPORT void OPENSSL_no_config(void);
 
 

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -149,7 +149,10 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_unload(int all);
 OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_finish(void);
 
 // OPENSSL_config does nothing. This has been deprecated since OpenSSL 1.1.0.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void OPENSSL_config(const char *config_name);
+//
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
+//       and depends on this.
+OPENSSL_EXPORT void OPENSSL_config(const char *config_name);
 
 // OPENSSL_no_config does nothing. This has been deprecated since OpenSSL
 // 1.1.0.

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -353,7 +353,7 @@ OPENSSL_EXPORT DH *DH_get_2048_256(void);
 
 // DH_clear_flags does nothing and is included to simplify compiling code that
 // expects it.
-OPENSSL_EXPORT void DH_clear_flags(DH *dh, int flags);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void DH_clear_flags(DH *dh, int flags);
 
 // DH_FLAG_CACHE_MONT_P is not supported by AWS-LC and is included to simplify
 // compiling code that expects it. This flag controls if the DH APIs should

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -348,6 +348,9 @@ OPENSSL_EXPORT int DH_compute_key(uint8_t *out, const BIGNUM *peers_key,
 // This function has been deprecated with no replacement.
 OPENSSL_EXPORT DH *DH_get_2048_256(void);
 
+
+// General No-op Functions [Deprecated].
+
 // DH_clear_flags does nothing and is included to simplify compiling code that
 // expects it.
 OPENSSL_EXPORT void DH_clear_flags(DH *dh, int flags);
@@ -357,6 +360,8 @@ OPENSSL_EXPORT void DH_clear_flags(DH *dh, int flags);
 // cache the montgomery form of the prime to speed up multiplication at the cost
 // of increasing memory storage. AWS-LC always does this and does not support
 // turning this option off.
+// 
+// NOTE: This is also on by default in OpenSSL.
 #define DH_FLAG_CACHE_MONT_P 0
 
 

--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -271,7 +271,8 @@ OPENSSL_EXPORT int EVP_marshal_digest_algorithm(CBB *cbb, const EVP_MD *md);
 // EVP_MD_unstable_sha3_enable is a no-op as SHA3 is always enabled.
 OPENSSL_EXPORT void EVP_MD_unstable_sha3_enable(bool enable);
 
-// EVP_MD_unstable_sha3_is_enabled always returns true as SHA3 is always enabled.
+// EVP_MD_unstable_sha3_is_enabled always returns true as SHA3 is always
+// enabled.
 OPENSSL_EXPORT bool EVP_MD_unstable_sha3_is_enabled(void);
 
 // EVP_MD_CTX_copy sets |out|, which must /not/ be initialised, to be a copy of
@@ -312,9 +313,10 @@ OPENSSL_EXPORT int EVP_MD_nid(const EVP_MD *md);
 // associated.
 //
 // |EVP_MD_CTX_set_pkey_ctx| will overwrite any |EVP_PKEY_CTX| object associated
-// to |ctx|. If it was not associated through a previous |EVP_MD_CTX_set_pkey_ctx|
-// call, it will be freed first.
-OPENSSL_EXPORT void EVP_MD_CTX_set_pkey_ctx(EVP_MD_CTX *ctx, EVP_PKEY_CTX *pctx);
+// to |ctx|. If it was not associated through a previous
+// |EVP_MD_CTX_set_pkey_ctx| call, it will be freed first.
+OPENSSL_EXPORT void EVP_MD_CTX_set_pkey_ctx(EVP_MD_CTX *ctx,
+                                            EVP_PKEY_CTX *pctx);
 
 struct evp_md_pctx_ops;
 
@@ -352,8 +354,8 @@ struct env_md_ctx_st {
 
 // General No-op Functions [Deprecated].
 
-// EVP_MD_CTX_set_flags does nothing. We strongly discourage doing any additional
-// configurations when consuming |EVP_MD_CTX|.
+// EVP_MD_CTX_set_flags does nothing. We strongly discourage doing any
+// additional configurations when consuming |EVP_MD_CTX|.
 OPENSSL_EXPORT void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx, int flags);
 
 // EVP_MD_CTX_FLAG_NON_FIPS_ALLOW is meaningless. In OpenSSL it permits non-FIPS
@@ -365,7 +367,7 @@ OPENSSL_EXPORT void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx, int flags);
 // EVP_add_digest does nothing and returns one. It exists only for
 // compatibility with OpenSSL, which requires manually loading supported digests
 // when certain options are turned on.
-OPENSSL_EXPORT int EVP_add_digest(const EVP_MD *digest);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_add_digest(const EVP_MD *digest);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -267,14 +267,6 @@ OPENSSL_EXPORT int EVP_marshal_digest_algorithm(CBB *cbb, const EVP_MD *md);
 
 // Deprecated functions.
 
-
-// EVP_MD_unstable_sha3_enable is a no-op as SHA3 is always enabled.
-OPENSSL_EXPORT void EVP_MD_unstable_sha3_enable(bool enable);
-
-// EVP_MD_unstable_sha3_is_enabled always returns true as SHA3 is always
-// enabled.
-OPENSSL_EXPORT bool EVP_MD_unstable_sha3_is_enabled(void);
-
 // EVP_MD_CTX_copy sets |out|, which must /not/ be initialised, to be a copy of
 // |in|. It returns one on success and zero on error.
 OPENSSL_EXPORT int EVP_MD_CTX_copy(EVP_MD_CTX *out, const EVP_MD_CTX *in);
@@ -354,9 +346,17 @@ struct env_md_ctx_st {
 
 // General No-op Functions [Deprecated].
 
+// EVP_MD_unstable_sha3_enable is a no-op as SHA3 is always enabled.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_MD_unstable_sha3_enable(bool enable);
+
+// EVP_MD_unstable_sha3_is_enabled always returns true as SHA3 is always
+// enabled.
+OPENSSL_EXPORT OPENSSL_DEPRECATED bool EVP_MD_unstable_sha3_is_enabled(void);
+
 // EVP_MD_CTX_set_flags does nothing. We strongly discourage doing any
 // additional configurations when consuming |EVP_MD_CTX|.
-OPENSSL_EXPORT void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx, int flags);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx,
+                                                            int flags);
 
 // EVP_MD_CTX_FLAG_NON_FIPS_ALLOW is meaningless. In OpenSSL it permits non-FIPS
 // algorithms in FIPS mode. But BoringSSL FIPS mode doesn't prohibit algorithms

--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -278,10 +278,6 @@ OPENSSL_EXPORT bool EVP_MD_unstable_sha3_is_enabled(void);
 // |in|. It returns one on success and zero on error.
 OPENSSL_EXPORT int EVP_MD_CTX_copy(EVP_MD_CTX *out, const EVP_MD_CTX *in);
 
-// EVP_add_digest does nothing and returns one. It exists only for
-// compatibility with OpenSSL.
-OPENSSL_EXPORT int EVP_add_digest(const EVP_MD *digest);
-
 // EVP_get_digestbyname returns an |EVP_MD| given a human readable name in
 // |name|, or NULL if the name is unknown.
 OPENSSL_EXPORT const EVP_MD *EVP_get_digestbyname(const char *);
@@ -299,15 +295,6 @@ OPENSSL_EXPORT int EVP_DigestFinalXOF(EVP_MD_CTX *ctx, uint8_t *out,
 
 // EVP_MD_meth_get_flags calls |EVP_MD_flags|.
 OPENSSL_EXPORT uint32_t EVP_MD_meth_get_flags(const EVP_MD *md);
-
-// EVP_MD_CTX_set_flags does nothing.
-OPENSSL_EXPORT void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx, int flags);
-
-// EVP_MD_CTX_FLAG_NON_FIPS_ALLOW is meaningless. In OpenSSL it permits non-FIPS
-// algorithms in FIPS mode. But BoringSSL FIPS mode doesn't prohibit algorithms
-// (it's up the the caller to use the FIPS module in a fashion compliant with
-// their needs). Thus this exists only to allow code to compile.
-#define EVP_MD_CTX_FLAG_NON_FIPS_ALLOW 0
 
 // EVP_MD_nid calls |EVP_MD_type|.
 OPENSSL_EXPORT int EVP_MD_nid(const EVP_MD *md);
@@ -361,6 +348,24 @@ struct env_md_ctx_st {
   // 2. Set flag |EVP_MD_CTX_HMAC| for |EVP_PKEY_HMAC|.
   unsigned long flags;
 } /* EVP_MD_CTX */;
+
+
+// General No-op Functions [Deprecated].
+
+// EVP_MD_CTX_set_flags does nothing. We strongly discourage doing any additional
+// configurations when consuming |EVP_MD_CTX|.
+OPENSSL_EXPORT void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx, int flags);
+
+// EVP_MD_CTX_FLAG_NON_FIPS_ALLOW is meaningless. In OpenSSL it permits non-FIPS
+// algorithms in FIPS mode. But BoringSSL FIPS mode doesn't prohibit algorithms
+// (it's up the the caller to use the FIPS module in a fashion compliant with
+// their needs). Thus this exists only to allow code to compile.
+#define EVP_MD_CTX_FLAG_NON_FIPS_ALLOW 0
+
+// EVP_add_digest does nothing and returns one. It exists only for
+// compatibility with OpenSSL, which requires manually loading supported digests
+// when certain options are turned on.
+OPENSSL_EXPORT int EVP_add_digest(const EVP_MD *digest);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -410,26 +410,6 @@ OPENSSL_EXPORT int EC_GROUP_get_order(const EC_GROUP *group, BIGNUM *order,
 #define OPENSSL_EC_EXPLICIT_CURVE 0
 #define OPENSSL_EC_NAMED_CURVE 1
 
-// EC_GROUP_set_asn1_flag does nothing.
-OPENSSL_EXPORT void EC_GROUP_set_asn1_flag(EC_GROUP *group, int flag);
-
-// EC_GROUP_get_asn1_flag returns |OPENSSL_EC_NAMED_CURVE|.
-OPENSSL_EXPORT int EC_GROUP_get_asn1_flag(const EC_GROUP *group);
-
-typedef struct ec_method_st EC_METHOD;
-
-// EC_GROUP_method_of returns a dummy non-NULL pointer.
-OPENSSL_EXPORT const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *group);
-
-// EC_METHOD_get_field_type returns NID_X9_62_prime_field.
-OPENSSL_EXPORT int EC_METHOD_get_field_type(const EC_METHOD *meth);
-
-// EC_GROUP_set_point_conversion_form aborts the process if |form| is not
-// |POINT_CONVERSION_UNCOMPRESSED| or |POINT_CONVERSION_COMPRESSED|, and
-// otherwise does nothing.
-OPENSSL_EXPORT void EC_GROUP_set_point_conversion_form(
-    EC_GROUP *group, point_conversion_form_t form);
-
 // EC_builtin_curve describes a supported elliptic curve.
 typedef struct {
   int nid;
@@ -446,6 +426,42 @@ OPENSSL_EXPORT size_t EC_get_builtin_curves(EC_builtin_curve *out_curves,
 
 // EC_POINT_clear_free calls |EC_POINT_free|.
 OPENSSL_EXPORT void EC_POINT_clear_free(EC_POINT *point);
+
+
+// General No-op Functions [Deprecated].
+
+// EC_GROUP_set_asn1_flag does nothing. AWS-LC only supports
+// |OPENSSL_EC_NAMED_CURVE|.
+OPENSSL_EXPORT void EC_GROUP_set_asn1_flag(EC_GROUP *group, int flag);
+
+// EC_GROUP_get_asn1_flag returns |OPENSSL_EC_NAMED_CURVE|. This is the only
+// type AWS-LC supports.
+OPENSSL_EXPORT int EC_GROUP_get_asn1_flag(const EC_GROUP *group);
+
+// EC_GROUP_set_point_conversion_form aborts the process if |form| is not
+// |POINT_CONVERSION_UNCOMPRESSED| or |POINT_CONVERSION_COMPRESSED|, and
+// otherwise does nothing.
+// AWS-LC always uses |POINT_CONVERSION_UNCOMPRESSED|. 
+OPENSSL_EXPORT void EC_GROUP_set_point_conversion_form(
+    EC_GROUP *group, point_conversion_form_t form);
+
+
+// EC_METHOD No-ops [Deprecated].
+//
+// |EC_METHOD| is a low level implementation detail of the EC module, but
+// it’s exposed in traditionally public API. This should be an internal only
+// concept. Users should switch to a different suitable constructor like
+// |EC_GROUP_new_curve_GFp|, |EC_GROUP_new_curve_GF2m|, or
+// |EC_GROUP_new_by_curve_name|. The |EC_METHOD| APIs have also been
+// deprecated in OpenSSL 3.0.
+
+typedef struct ec_method_st EC_METHOD;
+
+// EC_GROUP_method_of returns a dummy non-NULL pointer.
+OPENSSL_EXPORT const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *group);
+
+// EC_METHOD_get_field_type returns NID_X9_62_prime_field.
+OPENSSL_EXPORT int EC_METHOD_get_field_type(const EC_METHOD *meth);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -432,17 +432,19 @@ OPENSSL_EXPORT void EC_POINT_clear_free(EC_POINT *point);
 
 // EC_GROUP_set_asn1_flag does nothing. AWS-LC only supports
 // |OPENSSL_EC_NAMED_CURVE|.
-OPENSSL_EXPORT void EC_GROUP_set_asn1_flag(EC_GROUP *group, int flag);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_asn1_flag(EC_GROUP *group,
+                                                              int flag);
 
 // EC_GROUP_get_asn1_flag returns |OPENSSL_EC_NAMED_CURVE|. This is the only
 // type AWS-LC supports.
-OPENSSL_EXPORT int EC_GROUP_get_asn1_flag(const EC_GROUP *group);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int EC_GROUP_get_asn1_flag(
+    const EC_GROUP *group);
 
 // EC_GROUP_set_point_conversion_form aborts the process if |form| is not
 // |POINT_CONVERSION_UNCOMPRESSED| or |POINT_CONVERSION_COMPRESSED|, and
 // otherwise does nothing.
-// AWS-LC always uses |POINT_CONVERSION_UNCOMPRESSED|. 
-OPENSSL_EXPORT void EC_GROUP_set_point_conversion_form(
+// AWS-LC always uses |POINT_CONVERSION_UNCOMPRESSED|.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_point_conversion_form(
     EC_GROUP *group, point_conversion_form_t form);
 
 
@@ -458,10 +460,12 @@ OPENSSL_EXPORT void EC_GROUP_set_point_conversion_form(
 typedef struct ec_method_st EC_METHOD;
 
 // EC_GROUP_method_of returns a dummy non-NULL pointer.
-OPENSSL_EXPORT const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *group);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const EC_METHOD *EC_GROUP_method_of(
+    const EC_GROUP *group);
 
 // EC_METHOD_get_field_type returns NID_X9_62_prime_field.
-OPENSSL_EXPORT int EC_METHOD_get_field_type(const EC_METHOD *meth);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int EC_METHOD_get_field_type(
+    const EC_METHOD *meth);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/ec_key.h
+++ b/include/openssl/ec_key.h
@@ -359,7 +359,8 @@ OPENSSL_EXPORT int i2o_ECPublicKey(const EC_KEY *key, unsigned char **outp);
 
 // EC_KEY_set_asn1_flag does nothing. AWS-LC only supports
 // |OPENSSL_EC_NAMED_CURVE|.
-OPENSSL_EXPORT void EC_KEY_set_asn1_flag(EC_KEY *key, int flag);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_KEY_set_asn1_flag(EC_KEY *key,
+                                                            int flag);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/ec_key.h
+++ b/include/openssl/ec_key.h
@@ -311,9 +311,6 @@ struct ecdsa_method_st {
 
 // Deprecated functions.
 
-// EC_KEY_set_asn1_flag does nothing.
-OPENSSL_EXPORT void EC_KEY_set_asn1_flag(EC_KEY *key, int flag);
-
 // d2i_ECPrivateKey parses a DER-encoded ECPrivateKey structure (RFC 5915) from
 // |len| bytes at |*inp|, as described in |d2i_SAMPLE|. On input, if |*out_key|
 // is non-NULL and has a group configured, the parameters field may be omitted
@@ -356,6 +353,13 @@ OPENSSL_EXPORT EC_KEY *o2i_ECPublicKey(EC_KEY **out_key, const uint8_t **inp,
 //
 // Use |EC_POINT_point2cbb| instead.
 OPENSSL_EXPORT int i2o_ECPublicKey(const EC_KEY *key, unsigned char **outp);
+
+
+// General No-op Functions [Deprecated].
+
+// EC_KEY_set_asn1_flag does nothing. AWS-LC only supports
+// |OPENSSL_EC_NAMED_CURVE|.
+OPENSSL_EXPORT void EC_KEY_set_asn1_flag(EC_KEY *key, int flag);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1149,42 +1149,43 @@ OPENSSL_EXPORT EVP_PKEY *EVP_PKEY_new_mac_key(int type, ENGINE *engine,
 // Note: In OpenSSL, the returned type will be different depending on the type
 //       of |EVP_PKEY| consumed. This leads to misuage very easily and has been
 //       deprecated as a no-op to avoid so.
-OPENSSL_EXPORT void *EVP_PKEY_get0(const EVP_PKEY *pkey);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void *EVP_PKEY_get0(const EVP_PKEY *pkey);
 
-// OpenSSL_add_all_algorithms does nothing. This has been deprecated since OpenSSL
-// 1.1.0.
-OPENSSL_EXPORT void OpenSSL_add_all_algorithms(void);
+// OpenSSL_add_all_algorithms does nothing. This has been deprecated since
+// OpenSSL 1.1.0.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void OpenSSL_add_all_algorithms(void);
 
 // OPENSSL_add_all_algorithms_conf does nothing. This has been deprecated since
 // OpenSSL 1.1.0.
-OPENSSL_EXPORT void OPENSSL_add_all_algorithms_conf(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void OPENSSL_add_all_algorithms_conf(void);
 
 // OpenSSL_add_all_ciphers does nothing. This has been deprecated since OpenSSL
 // 1.1.0.
-OPENSSL_EXPORT void OpenSSL_add_all_ciphers(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void OpenSSL_add_all_ciphers(void);
 
 // OpenSSL_add_all_digests does nothing. This has been deprecated since OpenSSL
 // 1.1.0.
-OPENSSL_EXPORT void OpenSSL_add_all_digests(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void OpenSSL_add_all_digests(void);
 
 // EVP_cleanup does nothing. This has been deprecated since OpenSSL 1.1.0.
-OPENSSL_EXPORT void EVP_cleanup(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_cleanup(void);
 
 
 // EVP_PKEY_DSA No-ops [Deprecated].
 //
-// |EVP_PKEY_DSA| is deprecated. It is currently still possible to parse DER into a
-// DSA |EVP_PKEY|, but signing or verifying with those objects will not work.
+// |EVP_PKEY_DSA| is deprecated. It is currently still possible to parse DER
+// into a DSA |EVP_PKEY|, but signing or verifying with those objects will not
+// work.
 
 #define EVP_PKEY_DSA NID_dsa
 
 // EVP_PKEY_CTX_set_dsa_paramgen_bits returns zero.
-OPENSSL_EXPORT int EVP_PKEY_CTX_set_dsa_paramgen_bits(EVP_PKEY_CTX *ctx,
-                                                      int nbits);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_PKEY_CTX_set_dsa_paramgen_bits(
+    EVP_PKEY_CTX *ctx, int nbits);
 
 // EVP_PKEY_CTX_set_dsa_paramgen_q_bits returns zero.
-OPENSSL_EXPORT int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(EVP_PKEY_CTX *ctx,
-                                                        int qbits);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
+    EVP_PKEY_CTX *ctx, int qbits);
 
 
 // EVP_PKEY_DH No-ops [Deprecated].
@@ -1197,10 +1198,10 @@ OPENSSL_EXPORT int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(EVP_PKEY_CTX *ctx,
 #define EVP_PKEY_DH NID_dhKeyAgreement
 
 // EVP_PKEY_get0_DH returns NULL.
-OPENSSL_EXPORT DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
+OPENSSL_EXPORT OPENSSL_DEPRECATED DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
 
 // EVP_PKEY_get1_DH returns NULL.
-OPENSSL_EXPORT DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
+OPENSSL_EXPORT OPENSSL_DEPRECATED DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
 
 
 // Preprocessor compatibility section (hidden).

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1154,8 +1154,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void *EVP_PKEY_get0(const EVP_PKEY *pkey);
 // OpenSSL_add_all_algorithms does nothing. This has been deprecated since
 // OpenSSL 1.1.0.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
-//       and depends on this.
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
 OPENSSL_EXPORT void OpenSSL_add_all_algorithms(void);
 
 // OPENSSL_add_all_algorithms_conf does nothing. This has been deprecated since

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -179,7 +179,6 @@ OPENSSL_EXPORT EC_KEY *EVP_PKEY_get1_EC_KEY(const EVP_PKEY *pkey);
 #define EVP_PKEY_NONE NID_undef
 #define EVP_PKEY_RSA NID_rsaEncryption
 #define EVP_PKEY_RSA_PSS NID_rsassaPss
-#define EVP_PKEY_DSA NID_dsa
 #define EVP_PKEY_EC NID_X9_62_id_ecPublicKey
 #define EVP_PKEY_ED25519 NID_ED25519
 #define EVP_PKEY_X25519 NID_X25519
@@ -929,10 +928,6 @@ OPENSSL_EXPORT int EVP_PKEY_kem_check_key(EVP_PKEY *key);
 
 // Deprecated functions.
 
-// EVP_PKEY_DH is defined for compatibility, but it is impossible to create an
-// |EVP_PKEY| of that type.
-#define EVP_PKEY_DH NID_dhKeyAgreement
-
 // EVP_PKEY_RSA2 was historically an alternate form for RSA public keys (OID
 // 2.5.8.1.1), but is no longer accepted.
 #define EVP_PKEY_RSA2 NID_rsa
@@ -945,11 +940,6 @@ OPENSSL_EXPORT int EVP_PKEY_kem_check_key(EVP_PKEY *key);
 // Ed448 and attempts to create keys will fail.
 #define EVP_PKEY_ED448 NID_ED448
 
-// EVP_PKEY_get0 returns NULL. This function is provided for compatibility with
-// OpenSSL but does not return anything. Use the typed |EVP_PKEY_get0_*|
-// functions instead.
-OPENSSL_EXPORT void *EVP_PKEY_get0(const EVP_PKEY *pkey);
-
 // EVP_MD_get_pkey_type returns the NID of the public key signing algorithm
 // associated with |md| and RSA. This does not return all potential signing
 // algorithms that could work with |md| and should not be used.
@@ -957,21 +947,6 @@ OPENSSL_EXPORT int EVP_MD_get_pkey_type(const EVP_MD *md);
 
 // EVP_MD_pkey_type calls |EVP_MD_get_pkey_type|.
 OPENSSL_EXPORT int EVP_MD_pkey_type(const EVP_MD *md);
-
-// OpenSSL_add_all_algorithms does nothing.
-OPENSSL_EXPORT void OpenSSL_add_all_algorithms(void);
-
-// OPENSSL_add_all_algorithms_conf does nothing.
-OPENSSL_EXPORT void OPENSSL_add_all_algorithms_conf(void);
-
-// OpenSSL_add_all_ciphers does nothing.
-OPENSSL_EXPORT void OpenSSL_add_all_ciphers(void);
-
-// OpenSSL_add_all_digests does nothing.
-OPENSSL_EXPORT void OpenSSL_add_all_digests(void);
-
-// EVP_cleanup does nothing.
-OPENSSL_EXPORT void EVP_cleanup(void);
 
 OPENSSL_EXPORT void EVP_CIPHER_do_all_sorted(
     void (*callback)(const EVP_CIPHER *cipher, const char *name,
@@ -1040,12 +1015,6 @@ OPENSSL_EXPORT EVP_PKEY *d2i_AutoPrivateKey(EVP_PKEY **out, const uint8_t **inp,
 // Use |RSA_parse_public_key| instead.
 OPENSSL_EXPORT EVP_PKEY *d2i_PublicKey(int type, EVP_PKEY **out,
                                        const uint8_t **inp, long len);
-
-// EVP_PKEY_get0_DH returns NULL.
-OPENSSL_EXPORT DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
-
-// EVP_PKEY_get1_DH returns NULL.
-OPENSSL_EXPORT DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
 
 // EVP_PKEY_CTX_set_ec_param_enc returns one if |encoding| is
 // |OPENSSL_EC_NAMED_CURVE| or zero with an error otherwise.
@@ -1151,14 +1120,6 @@ OPENSSL_EXPORT int i2d_EC_PUBKEY(const EC_KEY *ec_key, uint8_t **outp);
 OPENSSL_EXPORT EC_KEY *d2i_EC_PUBKEY(EC_KEY **out, const uint8_t **inp,
                                      long len);
 
-// EVP_PKEY_CTX_set_dsa_paramgen_bits returns zero.
-OPENSSL_EXPORT int EVP_PKEY_CTX_set_dsa_paramgen_bits(EVP_PKEY_CTX *ctx,
-                                                      int nbits);
-
-// EVP_PKEY_CTX_set_dsa_paramgen_q_bits returns zero.
-OPENSSL_EXPORT int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(EVP_PKEY_CTX *ctx,
-                                                        int qbits);
-
 // EVP_PKEY_assign sets the underlying key of |pkey| to |key|, which must be of
 // the given type. If successful, it returns one. If the |type| argument
 // is one of |EVP_PKEY_RSA|, |EVP_PKEY_DSA|, or |EVP_PKEY_EC| values it calls
@@ -1177,6 +1138,70 @@ OPENSSL_EXPORT int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key);
 OPENSSL_EXPORT EVP_PKEY *EVP_PKEY_new_mac_key(int type, ENGINE *engine,
                                               const uint8_t *mac_key,
                                               size_t mac_key_len);
+
+
+// General No-op Functions [Deprecated].
+
+// EVP_PKEY_get0 returns NULL. This function is provided for compatibility with
+// OpenSSL but does not return anything. Use the typed |EVP_PKEY_get0_*|
+// functions instead.
+//
+// Note: In OpenSSL, the returned type will be different depending on the type
+//       of |EVP_PKEY| consumed. This leads to misuage very easily and has been
+//       deprecated as a no-op to avoid so.
+OPENSSL_EXPORT void *EVP_PKEY_get0(const EVP_PKEY *pkey);
+
+// OpenSSL_add_all_algorithms does nothing. This has been deprecated since OpenSSL
+// 1.1.0.
+OPENSSL_EXPORT void OpenSSL_add_all_algorithms(void);
+
+// OPENSSL_add_all_algorithms_conf does nothing. This has been deprecated since
+// OpenSSL 1.1.0.
+OPENSSL_EXPORT void OPENSSL_add_all_algorithms_conf(void);
+
+// OpenSSL_add_all_ciphers does nothing. This has been deprecated since OpenSSL
+// 1.1.0.
+OPENSSL_EXPORT void OpenSSL_add_all_ciphers(void);
+
+// OpenSSL_add_all_digests does nothing. This has been deprecated since OpenSSL
+// 1.1.0.
+OPENSSL_EXPORT void OpenSSL_add_all_digests(void);
+
+// EVP_cleanup does nothing. This has been deprecated since OpenSSL 1.1.0.
+OPENSSL_EXPORT void EVP_cleanup(void);
+
+
+// EVP_PKEY_DSA No-ops [Deprecated].
+//
+// |EVP_PKEY_DSA| is deprecated. It is currently still possible to parse DER into a
+// DSA |EVP_PKEY|, but signing or verifying with those objects will not work.
+
+#define EVP_PKEY_DSA NID_dsa
+
+// EVP_PKEY_CTX_set_dsa_paramgen_bits returns zero.
+OPENSSL_EXPORT int EVP_PKEY_CTX_set_dsa_paramgen_bits(EVP_PKEY_CTX *ctx,
+                                                      int nbits);
+
+// EVP_PKEY_CTX_set_dsa_paramgen_q_bits returns zero.
+OPENSSL_EXPORT int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(EVP_PKEY_CTX *ctx,
+                                                        int qbits);
+
+
+// EVP_PKEY_DH No-ops [Deprecated].
+//
+// |EVP_PKEY_DH| is deprecated. It is not possible to create a DH |EVP_PKEY| in
+// AWS-LC. The following symbols are also no-ops due to the deprecation.
+
+// EVP_PKEY_DH is defined for compatibility, but it is impossible to create an
+// |EVP_PKEY| of that type.
+#define EVP_PKEY_DH NID_dhKeyAgreement
+
+// EVP_PKEY_get0_DH returns NULL.
+OPENSSL_EXPORT DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
+
+// EVP_PKEY_get1_DH returns NULL.
+OPENSSL_EXPORT DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
+
 
 // Preprocessor compatibility section (hidden).
 //

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1154,7 +1154,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void *EVP_PKEY_get0(const EVP_PKEY *pkey);
 // OpenSSL_add_all_algorithms does nothing. This has been deprecated since
 // OpenSSL 1.1.0.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
+// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. nginx defines -Werror and
+// depends on this.
 OPENSSL_EXPORT void OpenSSL_add_all_algorithms(void);
 
 // OPENSSL_add_all_algorithms_conf does nothing. This has been deprecated since
@@ -1168,8 +1169,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void OpenSSL_add_all_ciphers(void);
 // OpenSSL_add_all_digests does nothing. This has been deprecated since OpenSSL
 // 1.1.0.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. tpm2-tss defines -Wno-deprecated-declarations
-//       and depends on this.
+// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. tpm2-tss defines -Werror and
+// depends on this.
 OPENSSL_EXPORT void OpenSSL_add_all_digests(void);
 
 // EVP_cleanup does nothing. This has been deprecated since OpenSSL 1.1.0.
@@ -1204,8 +1205,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
 
 // EVP_PKEY_get0_DH returns NULL.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. curl defines -Wno-deprecated-declarations and
-//       depends on this.
+// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. curl defines -Werror and
+// depends on this.
 OPENSSL_EXPORT DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
 
 // EVP_PKEY_get1_DH returns NULL.

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1153,7 +1153,10 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void *EVP_PKEY_get0(const EVP_PKEY *pkey);
 
 // OpenSSL_add_all_algorithms does nothing. This has been deprecated since
 // OpenSSL 1.1.0.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void OpenSSL_add_all_algorithms(void);
+//
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
+//       and depends on this.
+OPENSSL_EXPORT void OpenSSL_add_all_algorithms(void);
 
 // OPENSSL_add_all_algorithms_conf does nothing. This has been deprecated since
 // OpenSSL 1.1.0.
@@ -1165,7 +1168,10 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void OpenSSL_add_all_ciphers(void);
 
 // OpenSSL_add_all_digests does nothing. This has been deprecated since OpenSSL
 // 1.1.0.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void OpenSSL_add_all_digests(void);
+//
+// TODO: Add |OPENSSL_DEPRECATED|. tpm2-tss defines -Wno-deprecated-declarations
+//       and depends on this.
+OPENSSL_EXPORT void OpenSSL_add_all_digests(void);
 
 // EVP_cleanup does nothing. This has been deprecated since OpenSSL 1.1.0.
 OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_cleanup(void);
@@ -1198,7 +1204,10 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
 #define EVP_PKEY_DH NID_dhKeyAgreement
 
 // EVP_PKEY_get0_DH returns NULL.
-OPENSSL_EXPORT OPENSSL_DEPRECATED DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
+//
+// TODO: Add |OPENSSL_DEPRECATED|. curl defines -Wno-deprecated-declarations and
+//       depends on this.
+OPENSSL_EXPORT DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
 
 // EVP_PKEY_get1_DH returns NULL.
 OPENSSL_EXPORT OPENSSL_DEPRECATED DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);

--- a/include/openssl/ex_data.h
+++ b/include/openssl/ex_data.h
@@ -178,7 +178,7 @@ typedef void CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
 // General No-op Functions [Deprecated].
 
 // CRYPTO_cleanup_all_ex_data does nothing.
-OPENSSL_EXPORT void CRYPTO_cleanup_all_ex_data(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_cleanup_all_ex_data(void);
 
 // CRYPTO_EX_dup is a legacy callback function type which is ignored.
 typedef int CRYPTO_EX_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,

--- a/include/openssl/ex_data.h
+++ b/include/openssl/ex_data.h
@@ -175,7 +175,7 @@ typedef void CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
                             int index, long argl, void *argp);
 
 
-// Deprecated functions.
+// General No-op Functions [Deprecated].
 
 // CRYPTO_cleanup_all_ex_data does nothing.
 OPENSSL_EXPORT void CRYPTO_cleanup_all_ex_data(void);

--- a/include/openssl/pkcs7.h
+++ b/include/openssl/pkcs7.h
@@ -183,21 +183,51 @@ OPENSSL_EXPORT int PKCS7_type_is_signed(const PKCS7 *p7);
 // PKCS7_type_is_signedAndEnveloped returns zero.
 OPENSSL_EXPORT int PKCS7_type_is_signedAndEnveloped(const PKCS7 *p7);
 
+
+// PKCS7_sign [Deprecated]
+//
+// Only |PKCS7_DETACHED| and a combination of
+// "PKCS7_DETACHED|PKCS7_BINARY|PKCS7_NOATTR|PKCS7_PARTIAL" is supported.
+// See |PKCS7_sign| for more details.
+
 // PKCS7_DETACHED indicates that the PKCS#7 file specifies its data externally.
 #define PKCS7_DETACHED 0x40
 
-// The following flags cause |PKCS7_sign| to fail.
+// PKCS7_BINARY disables the default translation to MIME canonical format (as
+// required by the S/MIME specifications).
+// Must be used as "PKCS7_DETACHED|PKCS7_BINARY|PKCS7_NOATTR|PKCS7_PARTIAL".
+#define PKCS7_BINARY 0x80
+
+// PKCS7_NOATTR disables usage of authenticatedAttributes.
+// Must be used as "PKCS7_DETACHED|PKCS7_BINARY|PKCS7_NOATTR|PKCS7_PARTIAL".
+#define PKCS7_NOATTR 0x100
+
+// PKCS7_PARTIAL outputs a partial PKCS7 structure which additional signers and
+// capabilities can be added before finalization.
+// Must be used as "PKCS7_DETACHED|PKCS7_BINARY|PKCS7_NOATTR|PKCS7_PARTIAL".
+#define PKCS7_PARTIAL 0x4000
+
+// PKCS7_TEXT prepends MIME headers for type text/plain to the data. Using this
+// will fail |PKCS7_sign|.
 #define PKCS7_TEXT 0x1
+
+// PKCS7_NOCERTS excludes the signer's certificate and the extra certs defined
+// from the PKCS7 structure. Using this will fail |PKCS7_sign|.
 #define PKCS7_NOCERTS 0x2
+
+// PKCS7_NOSMIMECAP omits SMIMECapabilities. Using this will fail |PKCS7_sign|.
+#define PKCS7_NOSMIMECAP 0x200
+
+// PKCS7_STREAM returns a PKCS7 structure just initialized to perform the
+// signing operation. Signing is not performed yet. Using this will fail
+// |PKCS7_sign|.
+#define PKCS7_STREAM 0x1000
+
+// The following flags are used with |PKCS7_verify| (not implemented).
 #define PKCS7_NOSIGS 0x4
 #define PKCS7_NOCHAIN 0x8
 #define PKCS7_NOINTERN 0x10
 #define PKCS7_NOVERIFY 0x20
-#define PKCS7_BINARY 0x80
-#define PKCS7_NOATTR 0x100
-#define PKCS7_NOSMIMECAP 0x200
-#define PKCS7_STREAM 0x1000
-#define PKCS7_PARTIAL 0x4000
 
 // PKCS7_sign can operate in two modes to provide some backwards compatibility:
 //

--- a/include/openssl/pkcs7.h
+++ b/include/openssl/pkcs7.h
@@ -58,8 +58,8 @@ OPENSSL_EXPORT int PKCS7_bundle_raw_certificates(
 
 // PKCS7_bundle_certificates behaves like |PKCS7_bundle_raw_certificates| but
 // takes |X509| objects as input.
-OPENSSL_EXPORT int PKCS7_bundle_certificates(
-    CBB *out, const STACK_OF(X509) *certs);
+OPENSSL_EXPORT int PKCS7_bundle_certificates(CBB *out,
+                                             const STACK_OF(X509) *certs);
 
 // PKCS7_get_CRLs parses a PKCS#7, SignedData structure from |cbs| and appends
 // the included CRLs to |out_crls|. It returns one on success and zero on error.
@@ -143,8 +143,7 @@ typedef struct {
 
 // d2i_PKCS7 parses a BER-encoded, PKCS#7 signed data ContentInfo structure from
 // |len| bytes at |*inp|, as described in |d2i_SAMPLE|.
-OPENSSL_EXPORT PKCS7 *d2i_PKCS7(PKCS7 **out, const uint8_t **inp,
-                                size_t len);
+OPENSSL_EXPORT PKCS7 *d2i_PKCS7(PKCS7 **out, const uint8_t **inp, size_t len);
 
 // d2i_PKCS7_bio behaves like |d2i_PKCS7| but reads the input from |bio|.  If
 // the length of the object is indefinite the full contents of |bio| are read.
@@ -245,8 +244,10 @@ OPENSSL_EXPORT int PKCS7_type_is_signedAndEnveloped(const PKCS7 *p7);
 //
 // Note this function only implements a subset of the corresponding OpenSSL
 // function. It is provided for backwards compatibility only.
-OPENSSL_EXPORT PKCS7 *PKCS7_sign(X509 *sign_cert, EVP_PKEY *pkey,
-                                 STACK_OF(X509) *certs, BIO *data, int flags);
+OPENSSL_EXPORT OPENSSL_DEPRECATED PKCS7 *PKCS7_sign(X509 *sign_cert,
+                                                    EVP_PKEY *pkey,
+                                                    STACK_OF(X509) *certs,
+                                                    BIO *data, int flags);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -82,6 +82,9 @@ OPENSSL_EXPORT void RAND_seed(const void *buf, int num);
 // entropy and mix them into the entropy pool. AWS-LC sources entropy for the
 // consuming application and the following functions have been deprecated as
 // no-ops. Consumers should call |RAND_bytes| directly.
+//
+// TODO: Add |OPENSSL_DEPRECATED| to the ones that are missing. curl and
+//       tpm2-tss defines -Wno-deprecated-declarations and depends on them.
 
 // RAND_load_file returns a nonnegative number.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_load_file(const char *path,
@@ -105,7 +108,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_egd(const char *);
 OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_poll(void);
 
 // RAND_status returns one.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_status(void);
+OPENSSL_EXPORT int RAND_status(void);
 
 // RAND_cleanup does nothing.
 OPENSSL_EXPORT OPENSSL_DEPRECATED void RAND_cleanup(void);
@@ -126,13 +129,13 @@ struct rand_meth_st {
 OPENSSL_EXPORT OPENSSL_DEPRECATED RAND_METHOD *RAND_SSLeay(void);
 
 // RAND_OpenSSL returns a pointer to a dummy |RAND_METHOD|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED RAND_METHOD *RAND_OpenSSL(void);
+OPENSSL_EXPORT RAND_METHOD *RAND_OpenSSL(void);
 
 // RAND_get_rand_method returns |RAND_SSLeay()|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED const RAND_METHOD *RAND_get_rand_method(void);
+OPENSSL_EXPORT const RAND_METHOD *RAND_get_rand_method(void);
 
 // RAND_set_rand_method returns one.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_set_rand_method(const RAND_METHOD *);
+OPENSSL_EXPORT int RAND_set_rand_method(const RAND_METHOD *);
 
 // RAND_keep_random_devices_open does nothing.
 OPENSSL_EXPORT OPENSSL_DEPRECATED void RAND_keep_random_devices_open(int a);

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -84,55 +84,58 @@ OPENSSL_EXPORT void RAND_seed(const void *buf, int num);
 // no-ops. Consumers should call |RAND_bytes| directly.
 
 // RAND_load_file returns a nonnegative number.
-OPENSSL_EXPORT int RAND_load_file(const char *path, long num);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_load_file(const char *path,
+                                                     long num);
 
 // RAND_write_file does nothing and returns negative 1.
-OPENSSL_EXPORT int RAND_write_file(const char *file);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_write_file(const char *file);
 
 // RAND_file_name returns NULL.
-OPENSSL_EXPORT const char *RAND_file_name(char *buf, size_t num);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const char *RAND_file_name(char *buf,
+                                                             size_t num);
 
 // RAND_add does nothing.
-OPENSSL_EXPORT void RAND_add(const void *buf, int num, double entropy);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void RAND_add(const void *buf, int num,
+                                                double entropy);
 
 // RAND_egd returns 255.
-OPENSSL_EXPORT int RAND_egd(const char *);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_egd(const char *);
 
 // RAND_poll returns one.
-OPENSSL_EXPORT int RAND_poll(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_poll(void);
 
 // RAND_status returns one.
-OPENSSL_EXPORT int RAND_status(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_status(void);
 
 // RAND_cleanup does nothing.
-OPENSSL_EXPORT void RAND_cleanup(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void RAND_cleanup(void);
 
 // rand_meth_st is typedefed to |RAND_METHOD| in base.h. It isn't used; it
 // exists only to be the return type of |RAND_SSLeay|. It's
 // external so that variables of this type can be initialized.
 struct rand_meth_st {
-  void (*seed) (const void *buf, int num);
-  int (*bytes) (uint8_t *buf, size_t num);
-  void (*cleanup) (void);
-  void (*add) (const void *buf, int num, double entropy);
-  int (*pseudorand) (uint8_t *buf, size_t num);
-  int (*status) (void);
+  void (*seed)(const void *buf, int num);
+  int (*bytes)(uint8_t *buf, size_t num);
+  void (*cleanup)(void);
+  void (*add)(const void *buf, int num, double entropy);
+  int (*pseudorand)(uint8_t *buf, size_t num);
+  int (*status)(void);
 };
 
 // RAND_SSLeay returns a pointer to a dummy |RAND_METHOD|.
-OPENSSL_EXPORT RAND_METHOD *RAND_SSLeay(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED RAND_METHOD *RAND_SSLeay(void);
 
 // RAND_OpenSSL returns a pointer to a dummy |RAND_METHOD|.
-OPENSSL_EXPORT RAND_METHOD *RAND_OpenSSL(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED RAND_METHOD *RAND_OpenSSL(void);
 
 // RAND_get_rand_method returns |RAND_SSLeay()|.
-OPENSSL_EXPORT const RAND_METHOD *RAND_get_rand_method(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const RAND_METHOD *RAND_get_rand_method(void);
 
 // RAND_set_rand_method returns one.
-OPENSSL_EXPORT int RAND_set_rand_method(const RAND_METHOD *);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_set_rand_method(const RAND_METHOD *);
 
 // RAND_keep_random_devices_open does nothing.
-OPENSSL_EXPORT void RAND_keep_random_devices_open(int a);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void RAND_keep_random_devices_open(int a);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -75,6 +75,14 @@ OPENSSL_EXPORT int RAND_pseudo_bytes(uint8_t *buf, size_t len);
 // descriptors etc are opened.
 OPENSSL_EXPORT void RAND_seed(const void *buf, int num);
 
+
+// General No-op Functions [Deprecated].
+//
+// OpenSSL historically allowed applications to do various operations to gather
+// entropy and mix them into the entropy pool. AWS-LC sources entropy for the
+// consuming application and the following functions have been deprecated as
+// no-ops. Consumers should call |RAND_bytes| directly.
+
 // RAND_load_file returns a nonnegative number.
 OPENSSL_EXPORT int RAND_load_file(const char *path, long num);
 

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -83,8 +83,8 @@ OPENSSL_EXPORT void RAND_seed(const void *buf, int num);
 // consuming application and the following functions have been deprecated as
 // no-ops. Consumers should call |RAND_bytes| directly.
 //
-// TODO: Add |OPENSSL_DEPRECATED| to the ones that are missing. curl and
-//       tpm2-tss defines -Wno-deprecated-declarations and depends on them.
+// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED| to the ones that are missing.
+// curl and tpm2-tss defines -Wnerror and depend on them.
 
 // RAND_load_file returns a nonnegative number.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_load_file(const char *path,

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -3078,6 +3078,10 @@ OPENSSL_EXPORT int SSL_set_verify_algorithm_prefs(SSL *ssl,
 // SSL_set_hostflags calls |X509_VERIFY_PARAM_set_hostflags| on the
 // |X509_VERIFY_PARAM| associated with this |SSL*|. The |flags| argument
 // should be one of the |X509_CHECK_*| constants.
+//
+// |X509_V_FLAG_X509_STRICT| is always ON by default and
+// |X509_V_FLAG_ALLOW_PROXY_CERTS| is always OFF. Both are non-configurable.
+// See |x509.h| for more details.
 OPENSSL_EXPORT void SSL_set_hostflags(SSL *ssl, unsigned flags);
 
 
@@ -4931,93 +4935,7 @@ OPENSSL_EXPORT int SSL_used_hello_retry_request(const SSL *ssl);
 OPENSSL_EXPORT void SSL_set_jdk11_workaround(SSL *ssl, int enable);
 
 
-// Deprecated functions.
-
-// SSL_library_init calls |CRYPTO_library_init| and returns one.
-OPENSSL_EXPORT int SSL_library_init(void);
-
-// SSL_CIPHER_description writes a description of |cipher| into |buf| and
-// returns |buf|. If |buf| is NULL, it returns a newly allocated string, to be
-// freed with |OPENSSL_free|, or NULL on error.
-//
-// The description includes a trailing newline and has the form:
-// AES128-SHA              Kx=RSA      Au=RSA  Enc=AES(128)  Mac=SHA1
-//
-// Consider |SSL_CIPHER_standard_name| or |SSL_CIPHER_get_name| instead.
-OPENSSL_EXPORT const char *SSL_CIPHER_description(const SSL_CIPHER *cipher,
-                                                  char *buf, int len);
-
-// SSL_CIPHER_get_version returns the string "TLSv1/SSLv3".
-OPENSSL_EXPORT const char *SSL_CIPHER_get_version(const SSL_CIPHER *cipher);
-
-typedef void COMP_METHOD;
-typedef struct ssl_comp_st SSL_COMP;
-
-// SSL_COMP_get_compression_methods returns NULL.
-OPENSSL_EXPORT STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
-
-// SSL_COMP_add_compression_method returns one.
-OPENSSL_EXPORT int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm);
-
-// SSL_COMP_get_name returns NULL.
-OPENSSL_EXPORT const char *SSL_COMP_get_name(const COMP_METHOD *comp);
-
-// SSL_COMP_get0_name returns the |name| member of |comp|.
-OPENSSL_EXPORT const char *SSL_COMP_get0_name(const SSL_COMP *comp);
-
-// SSL_COMP_get_id returns the |id| member of |comp|.
-OPENSSL_EXPORT int SSL_COMP_get_id(const SSL_COMP *comp);
-
-// SSL_COMP_free_compression_methods does nothing.
-OPENSSL_EXPORT void SSL_COMP_free_compression_methods(void);
-
-// SSLv23_method calls |TLS_method|.
-OPENSSL_EXPORT const SSL_METHOD *SSLv23_method(void);
-
-// These version-specific methods behave exactly like |TLS_method| and
-// |DTLS_method| except they also call |SSL_CTX_set_min_proto_version| and
-// |SSL_CTX_set_max_proto_version| to lock connections to that protocol
-// version.
-OPENSSL_EXPORT const SSL_METHOD *TLSv1_method(void);
-OPENSSL_EXPORT const SSL_METHOD *TLSv1_1_method(void);
-OPENSSL_EXPORT const SSL_METHOD *TLSv1_2_method(void);
-OPENSSL_EXPORT const SSL_METHOD *DTLSv1_method(void);
-OPENSSL_EXPORT const SSL_METHOD *DTLSv1_2_method(void);
-
-// These client- and server-specific methods call their corresponding generic
-// methods.
-OPENSSL_EXPORT const SSL_METHOD *TLS_server_method(void);
-OPENSSL_EXPORT const SSL_METHOD *TLS_client_method(void);
-OPENSSL_EXPORT const SSL_METHOD *SSLv23_server_method(void);
-OPENSSL_EXPORT const SSL_METHOD *SSLv23_client_method(void);
-OPENSSL_EXPORT const SSL_METHOD *TLSv1_server_method(void);
-OPENSSL_EXPORT const SSL_METHOD *TLSv1_client_method(void);
-OPENSSL_EXPORT const SSL_METHOD *TLSv1_1_server_method(void);
-OPENSSL_EXPORT const SSL_METHOD *TLSv1_1_client_method(void);
-OPENSSL_EXPORT const SSL_METHOD *TLSv1_2_server_method(void);
-OPENSSL_EXPORT const SSL_METHOD *TLSv1_2_client_method(void);
-OPENSSL_EXPORT const SSL_METHOD *DTLS_server_method(void);
-OPENSSL_EXPORT const SSL_METHOD *DTLS_client_method(void);
-OPENSSL_EXPORT const SSL_METHOD *DTLSv1_server_method(void);
-OPENSSL_EXPORT const SSL_METHOD *DTLSv1_client_method(void);
-OPENSSL_EXPORT const SSL_METHOD *DTLSv1_2_server_method(void);
-OPENSSL_EXPORT const SSL_METHOD *DTLSv1_2_client_method(void);
-
-// SSL_clear resets |ssl| to allow another connection and returns one on success
-// or zero on failure. It returns most configuration state but releases memory
-// associated with the current connection.
-//
-// Free |ssl| and create a new one instead.
-OPENSSL_EXPORT int SSL_clear(SSL *ssl);
-
-// SSL_CTX_set_tmp_rsa_callback does nothing.
-OPENSSL_EXPORT void SSL_CTX_set_tmp_rsa_callback(
-    SSL_CTX *ctx, RSA *(*cb)(SSL *ssl, int is_export, int keylength));
-
-// SSL_set_tmp_rsa_callback does nothing.
-OPENSSL_EXPORT void SSL_set_tmp_rsa_callback(SSL *ssl,
-                                             RSA *(*cb)(SSL *ssl, int is_export,
-                                                        int keylength));
+// SSL Stat Counters.
 
 // SSL_CTX_sess_connect returns the number of started SSL/TLS handshakes in
 // client mode.
@@ -5064,23 +4982,70 @@ OPENSSL_EXPORT int SSL_CTX_sess_timeouts(const SSL_CTX *ctx);
 // because the maximum session cache size was exceeded.
 OPENSSL_EXPORT int SSL_CTX_sess_cache_full(const SSL_CTX *ctx);
 
+
+// Deprecated functions.
+
+// SSL_library_init calls |CRYPTO_library_init| and returns one.
+OPENSSL_EXPORT int SSL_library_init(void);
+
+// SSL_CIPHER_description writes a description of |cipher| into |buf| and
+// returns |buf|. If |buf| is NULL, it returns a newly allocated string, to be
+// freed with |OPENSSL_free|, or NULL on error.
+//
+// The description includes a trailing newline and has the form:
+// AES128-SHA              Kx=RSA      Au=RSA  Enc=AES(128)  Mac=SHA1
+//
+// Consider |SSL_CIPHER_standard_name| or |SSL_CIPHER_get_name| instead.
+OPENSSL_EXPORT const char *SSL_CIPHER_description(const SSL_CIPHER *cipher,
+                                                  char *buf, int len);
+
+// SSL_CIPHER_get_version returns the string "TLSv1/SSLv3".
+OPENSSL_EXPORT const char *SSL_CIPHER_get_version(const SSL_CIPHER *cipher);
+
+// SSLv23_method calls |TLS_method|.
+OPENSSL_EXPORT const SSL_METHOD *SSLv23_method(void);
+
+// These version-specific methods behave exactly like |TLS_method| and
+// |DTLS_method| except they also call |SSL_CTX_set_min_proto_version| and
+// |SSL_CTX_set_max_proto_version| to lock connections to that protocol
+// version.
+OPENSSL_EXPORT const SSL_METHOD *TLSv1_method(void);
+OPENSSL_EXPORT const SSL_METHOD *TLSv1_1_method(void);
+OPENSSL_EXPORT const SSL_METHOD *TLSv1_2_method(void);
+OPENSSL_EXPORT const SSL_METHOD *DTLSv1_method(void);
+OPENSSL_EXPORT const SSL_METHOD *DTLSv1_2_method(void);
+
+// These client- and server-specific methods call their corresponding generic
+// methods.
+OPENSSL_EXPORT const SSL_METHOD *TLS_server_method(void);
+OPENSSL_EXPORT const SSL_METHOD *TLS_client_method(void);
+OPENSSL_EXPORT const SSL_METHOD *SSLv23_server_method(void);
+OPENSSL_EXPORT const SSL_METHOD *SSLv23_client_method(void);
+OPENSSL_EXPORT const SSL_METHOD *TLSv1_server_method(void);
+OPENSSL_EXPORT const SSL_METHOD *TLSv1_client_method(void);
+OPENSSL_EXPORT const SSL_METHOD *TLSv1_1_server_method(void);
+OPENSSL_EXPORT const SSL_METHOD *TLSv1_1_client_method(void);
+OPENSSL_EXPORT const SSL_METHOD *TLSv1_2_server_method(void);
+OPENSSL_EXPORT const SSL_METHOD *TLSv1_2_client_method(void);
+OPENSSL_EXPORT const SSL_METHOD *DTLS_server_method(void);
+OPENSSL_EXPORT const SSL_METHOD *DTLS_client_method(void);
+OPENSSL_EXPORT const SSL_METHOD *DTLSv1_server_method(void);
+OPENSSL_EXPORT const SSL_METHOD *DTLSv1_client_method(void);
+OPENSSL_EXPORT const SSL_METHOD *DTLSv1_2_server_method(void);
+OPENSSL_EXPORT const SSL_METHOD *DTLSv1_2_client_method(void);
+
+// SSL_clear resets |ssl| to allow another connection and returns one on success
+// or zero on failure. It returns most configuration state but releases memory
+// associated with the current connection.
+//
+// Free |ssl| and create a new one instead.
+OPENSSL_EXPORT int SSL_clear(SSL *ssl);
+
 // SSL_cutthrough_complete calls |SSL_in_false_start|.
 OPENSSL_EXPORT int SSL_cutthrough_complete(const SSL *ssl);
 
 // SSL_num_renegotiations calls |SSL_total_renegotiations|.
 OPENSSL_EXPORT int SSL_num_renegotiations(const SSL *ssl);
-
-// SSL_CTX_need_tmp_RSA returns zero.
-OPENSSL_EXPORT int SSL_CTX_need_tmp_RSA(const SSL_CTX *ctx);
-
-// SSL_need_tmp_RSA returns zero.
-OPENSSL_EXPORT int SSL_need_tmp_RSA(const SSL *ssl);
-
-// SSL_CTX_set_tmp_rsa returns one.
-OPENSSL_EXPORT int SSL_CTX_set_tmp_rsa(SSL_CTX *ctx, const RSA *rsa);
-
-// SSL_set_tmp_rsa returns one.
-OPENSSL_EXPORT int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 
 // SSL_CTX_get_read_ahead returns zero.
 OPENSSL_EXPORT int SSL_CTX_get_read_ahead(const SSL_CTX *ctx);
@@ -5093,18 +5058,6 @@ OPENSSL_EXPORT int SSL_get_read_ahead(const SSL *ssl);
 
 // SSL_set_read_ahead returns one.
 OPENSSL_EXPORT int SSL_set_read_ahead(SSL *ssl, int yes);
-
-// SSL_set_state does nothing.
-OPENSSL_EXPORT void SSL_set_state(SSL *ssl, int state);
-
-// SSL_get_shared_ciphers writes an empty string to |buf| and returns a
-// pointer to |buf|, or NULL if |len| is less than or equal to zero.
-OPENSSL_EXPORT char *SSL_get_shared_ciphers(const SSL *ssl, char *buf, int len);
-
-// SSL_get_shared_sigalgs returns zero.
-OPENSSL_EXPORT int SSL_get_shared_sigalgs(SSL *ssl, int idx, int *psign,
-                                          int *phash, int *psignandhash,
-                                          uint8_t *rsig, uint8_t *rhash);
 
 // SSL_MODE_HANDSHAKE_CUTTHROUGH is the same as SSL_MODE_ENABLE_FALSE_START.
 #define SSL_MODE_HANDSHAKE_CUTTHROUGH SSL_MODE_ENABLE_FALSE_START
@@ -5130,12 +5083,6 @@ OPENSSL_EXPORT int i2d_SSL_SESSION_bio(BIO *bio, const SSL_SESSION *session);
 // frees |*out| and sets |*out| to the new |SSL_SESSION|.
 OPENSSL_EXPORT SSL_SESSION *d2i_SSL_SESSION_bio(BIO *bio, SSL_SESSION **out);
 
-// ERR_load_SSL_strings does nothing.
-OPENSSL_EXPORT void ERR_load_SSL_strings(void);
-
-// SSL_load_error_strings does nothing.
-OPENSSL_EXPORT void SSL_load_error_strings(void);
-
 // SSL_CTX_set_tlsext_use_srtp calls |SSL_CTX_set_srtp_profiles|. It returns
 // zero on success and one on failure.
 //
@@ -5150,33 +5097,6 @@ OPENSSL_EXPORT int SSL_CTX_set_tlsext_use_srtp(SSL_CTX *ctx,
 // WARNING: this function is dangerous because it breaks the usual return value
 // convention. Use |SSL_set_srtp_profiles| instead.
 OPENSSL_EXPORT int SSL_set_tlsext_use_srtp(SSL *ssl, const char *profiles);
-
-// SSL_get_current_compression returns NULL.
-OPENSSL_EXPORT const COMP_METHOD *SSL_get_current_compression(SSL *ssl);
-
-// SSL_get_current_expansion returns NULL.
-OPENSSL_EXPORT const COMP_METHOD *SSL_get_current_expansion(SSL *ssl);
-
-// SSL_get_server_tmp_key returns zero.
-OPENSSL_EXPORT int SSL_get_server_tmp_key(SSL *ssl, EVP_PKEY **out_key);
-
-// SSL_CTX_set_tmp_dh returns 1.
-OPENSSL_EXPORT int SSL_CTX_set_tmp_dh(SSL_CTX *ctx, const DH *dh);
-
-// SSL_set_tmp_dh returns 1.
-OPENSSL_EXPORT int SSL_set_tmp_dh(SSL *ssl, const DH *dh);
-
-// SSL_CTX_set_tmp_dh_callback does nothing.
-OPENSSL_EXPORT void SSL_CTX_set_tmp_dh_callback(
-    SSL_CTX *ctx, DH *(*cb)(SSL *ssl, int is_export, int keylength));
-
-// SSL_set_tmp_dh_callback does nothing.
-OPENSSL_EXPORT void SSL_set_tmp_dh_callback(SSL *ssl,
-                                            DH *(*cb)(SSL *ssl, int is_export,
-                                                      int keylength));
-
-// SSL_CTX_set_dh_auto does nothing and returns 0 for error.
-OPENSSL_EXPORT long SSL_CTX_set_dh_auto(SSL_CTX *ctx, int onoff);
 
 // SSL_CTX_set1_sigalgs takes |num_values| ints and interprets them as pairs
 // where the first is the nid of a hash function and the second is an
@@ -5226,41 +5146,6 @@ OPENSSL_EXPORT int SSL_CTX_set1_sigalgs_list(SSL_CTX *ctx, const char *str);
 // more convenient to codesearch for specific algorithm values.
 OPENSSL_EXPORT int SSL_set1_sigalgs_list(SSL *ssl, const char *str);
 
-// SSL_CTX_get_security_level returns 0. This is only to maintain compatibility
-// with OpenSSL and no security assumptions should be based on the number this
-// function returns.
-//
-// Per OpenSSL's definition of Level 0, 1, and 2:
-//
-// Level 0:
-// Everything is permitted. This retains compatibility with previous versions of
-// OpenSSL.
-//
-// Level 1
-// The security level corresponds to a minimum of 80 bits of security. Any
-// parameters offering below 80 bits of security are excluded. As a result RSA,
-// DSA and DH keys shorter than 1024 bits and ECC keys shorter than 160 bits are
-// prohibited. All export cipher suites are prohibited since they all offer less
-// than 80 bits of security. SSL version 2 is prohibited. Any cipher suite using
-// MD5 for the MAC is also prohibited.
-//
-// Level 2
-// Security level set to 112 bits of security. As a result RSA, DSA and DH keys
-// shorter than 2048 bits and ECC keys shorter than 224 bits are prohibited. In
-// addition to the level 1 exclusions any cipher suite using RC4 is also
-// prohibited. SSL version 3 is also not allowed. Compression is disabled.
-//
-// AWS-LC's libssl doesn't support SSLv2 or SSLv3, and we have no support for MD5
-// or RC4 related cipher suites. However, we don't directly prohibit 512 bit RSA
-// keys like Level 1 in OpenSSL states. Since this function is only retained for
-// OpenSSL compatibility, we set the returned value to 0. This may change if
-// we're asked to support actual Security level setting in AWS-LC.
-OPENSSL_EXPORT int SSL_CTX_get_security_level(const SSL_CTX *ctx);
-
-// SSL_CTX_set_security_level does nothing. See documentation in
-// |SSL_CTX_get_security_level| about implied security levels for AWS-LC.
-OPENSSL_EXPORT void SSL_CTX_set_security_level(const SSL_CTX *ctx, int level);
-
 // SSL_SESSION_print prints the contents of |sess| to |bp|.
 OPENSSL_EXPORT int SSL_SESSION_print(BIO *bp, const SSL_SESSION *sess);
 
@@ -5288,48 +5173,6 @@ OPENSSL_EXPORT int SSL_SESSION_print(BIO *bp, const SSL_SESSION *sess);
 #define SSL_get_timeout(session) SSL_SESSION_get_timeout(session)
 #define SSL_set_timeout(session, timeout) \
   SSL_SESSION_set_timeout((session), (timeout))
-
-struct ssl_comp_st {
-  int id;
-  const char *name;
-  char *method;
-};
-
-DEFINE_STACK_OF(SSL_COMP)
-
-// The following flags do nothing and are included only to make it easier to
-// compile code with BoringSSL.
-#define SSL_MODE_AUTO_RETRY 0
-#define SSL_MODE_RELEASE_BUFFERS 0
-#define SSL_MODE_SEND_CLIENTHELLO_TIME 0
-#define SSL_MODE_SEND_SERVERHELLO_TIME 0
-#define SSL_OP_ALL 0
-#define SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION 0
-#define SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS 0
-#define SSL_OP_EPHEMERAL_RSA 0
-#define SSL_OP_LEGACY_SERVER_CONNECT 0
-#define SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER 0
-#define SSL_OP_MICROSOFT_SESS_ID_BUG 0
-#define SSL_OP_MSIE_SSLV2_RSA_PADDING 0
-#define SSL_OP_NETSCAPE_CA_DN_BUG 0
-#define SSL_OP_NETSCAPE_CHALLENGE_BUG 0
-#define SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG 0
-#define SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG 0
-#define SSL_OP_NO_COMPRESSION 0
-#define SSL_OP_NO_RENEGOTIATION 0  // ssl_renegotiate_never is the default
-#define SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION 0
-#define SSL_OP_NO_SSLv2 0
-#define SSL_OP_NO_SSLv3 0
-#define SSL_OP_PKCS1_CHECK_1 0
-#define SSL_OP_PKCS1_CHECK_2 0
-#define SSL_OP_SINGLE_DH_USE 0
-#define SSL_OP_SINGLE_ECDH_USE 0
-#define SSL_OP_SSLEAY_080_CLIENT_DH_BUG 0
-#define SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG 0
-#define SSL_OP_TLS_BLOCK_PADDING_BUG 0
-#define SSL_OP_TLS_D5_BUG 0
-#define SSL_OP_TLS_ROLLBACK_BUG 0
-#define SSL_VERIFY_CLIENT_ONCE 0
 
 // SSL_cache_hit calls |SSL_session_reused|.
 OPENSSL_EXPORT int SSL_cache_hit(SSL *ssl);
@@ -5514,12 +5357,6 @@ OPENSSL_EXPORT const BIO_METHOD *BIO_f_ssl(void);
 // other than one on error.
 OPENSSL_EXPORT long BIO_set_ssl(BIO *bio, SSL *ssl, int take_owership);
 
-// SSL_CTX_set_ecdh_auto returns one.
-#define SSL_CTX_set_ecdh_auto(ctx, onoff) 1
-
-// SSL_set_ecdh_auto returns one.
-#define SSL_set_ecdh_auto(ssl, onoff) 1
-
 // SSL_get_session returns a non-owning pointer to |ssl|'s session. For
 // historical reasons, which session it returns depends on |ssl|'s state.
 //
@@ -5668,6 +5505,275 @@ OPENSSL_EXPORT int SSL_CTX_set1_curves_list(SSL_CTX *ctx, const char *curves);
 
 // SSL_set1_curves_list calls |SSL_set1_groups_list|.
 OPENSSL_EXPORT int SSL_set1_curves_list(SSL *ssl, const char *curves);
+
+
+// No-op Configuration Flags
+//
+// The following flags do nothing and are included only to make it easier to
+// compile code with AWS-LC. Flags defined within this section are not
+// configurable and the state of AWS-LC does not change when used.
+
+// SSL_MODE_AUTO_RETRY is ON by default in AWS-LC and OpenSSL. This will let
+// the application automatically retry if the transport is blocking.
+// Read/write operations will only return after the handshake and successful
+// completion.
+#define SSL_MODE_AUTO_RETRY 0
+
+// SSL_MODE_RELEASE_BUFFERS is ON by default in AWS-LC. When a read/write
+// buffer is no longer needed for a given SSL, the memory holding it is
+// released.
+#define SSL_MODE_RELEASE_BUFFERS 0
+
+// SSL_MODE_SEND_CLIENTHELLO_TIME is OFF by default in AWS-LC. Turning this ON
+// in OpenSSL sends the current time in the Random fields of the ClientHello
+// records is sent.
+#define SSL_MODE_SEND_CLIENTHELLO_TIME 0
+
+// SSL_MODE_SEND_SERVERHELLO_TIME is ON by default in AWS-LC. The current time
+// in the Random fields of the ServerHello records is sent.
+#define SSL_MODE_SEND_SERVERHELLO_TIME 0
+
+// SSL_OP_ALL is OFF by default in AWS-LC. Turning this ON in OpenSSL enables
+// all the less harmless bug workarounds that OpenSSL has had historically.
+//
+// See https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html
+// for more details.
+#define SSL_OP_ALL 0
+
+// SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION is OFF by default in AWS-LC.
+// Turning this ON in OpenSSL allows legacy insecure renegotiation for
+// unpatched clients and servers and is intentionally not supported in AWS-LC.
+#define SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION 0
+
+// SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS is ON by default in AWS-LC. This
+// disables a countermeasure against a SSL 3.0/TLS 1.0 protocol vulnerability
+// affecting CBC ciphers, which cannot be handled by some broken SSL
+// implementations.
+#define SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS 0
+
+// SSL_OP_LEGACY_SERVER_CONNECT is OFF by default in AWS-LC. Turning this ON in
+// OpenSSL allows  legacy insecure renegotiation between OpenSSL and unpatched
+// servers "only" and is intentionally not supported in AWS-LC.
+#define SSL_OP_LEGACY_SERVER_CONNECT 0
+
+// SSL_OP_NO_COMPRESSION is ON by default in AWS-LC. AWS-LC intentionally does
+// not support TLS record compressions.
+#define SSL_OP_NO_COMPRESSION 0
+
+// SSL_OP_NO_RENEGOTIATION is ON by default in AWS-LC. This disables all
+// renegotiation in TLSv1.2 and earlier.
+// To enable renegotiation, use |SSL_set_renegotiate_mode|.
+#define SSL_OP_NO_RENEGOTIATION 0  // ssl_renegotiate_never is the default
+
+// SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION is ON by default in AWS-LC.
+// This always starts a new session when performing renegotiation as a server
+// (i.e., session resumption requests are only accepted in the initial
+// handshake).
+// There is no support for renegototiation for a server in AWS-LC
+#define SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION 0
+
+// SSL_OP_NO_SSLv2 is ON by default in AWS-LC. There is no support for SSLv2 in
+// AWS-LC
+#define SSL_OP_NO_SSLv2 0
+
+// SSL_OP_NO_SSLv2 is ON by default in AWS-LC. There is no support for SSLv3 in
+// AWS-LC
+#define SSL_OP_NO_SSLv3 0
+
+// SSL_OP_TLS_ROLLBACK_BUG is OFF by default in AWS-LC. Turning this ON in
+// OpenSSL disables version rollback attack detection and is intentionally not
+// supported in AWS-LC.
+#define SSL_OP_TLS_ROLLBACK_BUG 0
+
+// SSL_VERIFY_CLIENT_ONCE is OFF by default in AWS-LC. Turning this ON in
+// OpenSSL only requests a client certificate on the initial TLS handshake and
+// is intentionally not supported in AWS-LC.
+#define SSL_VERIFY_CLIENT_ONCE 0
+
+// The following have no effect in both AWS-LC and OpenSSL.
+#define SSL_OP_EPHEMERAL_RSA 0
+#define SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER 0
+#define SSL_OP_MICROSOFT_SESS_ID_BUG 0
+#define SSL_OP_MSIE_SSLV2_RSA_PADDING 0
+#define SSL_OP_NETSCAPE_CA_DN_BUG 0
+#define SSL_OP_NETSCAPE_CHALLENGE_BUG 0
+#define SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG 0
+#define SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG 0
+#define SSL_OP_PKCS1_CHECK_1 0
+#define SSL_OP_PKCS1_CHECK_2 0
+#define SSL_OP_SINGLE_DH_USE 0
+#define SSL_OP_SINGLE_ECDH_USE 0
+#define SSL_OP_SSLEAY_080_CLIENT_DH_BUG 0
+#define SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG 0
+#define SSL_OP_TLS_BLOCK_PADDING_BUG 0
+#define SSL_OP_TLS_D5_BUG 0
+
+
+// |SSL_COMP| and |COMP_METHOD| No-ops [Deprecated].
+//
+// Support for SSL compression has been completely removed and the following
+// functions are only provided as no-ops for easier compatibility.
+
+typedef void COMP_METHOD;
+typedef struct ssl_comp_st SSL_COMP;
+
+// SSL_COMP_get_compression_methods returns NULL.
+OPENSSL_EXPORT STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
+
+// SSL_COMP_add_compression_method returns one.
+OPENSSL_EXPORT int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm);
+
+// SSL_COMP_get_name returns NULL.
+OPENSSL_EXPORT const char *SSL_COMP_get_name(const COMP_METHOD *comp);
+
+// SSL_COMP_get0_name returns the |name| member of |comp|.
+OPENSSL_EXPORT const char *SSL_COMP_get0_name(const SSL_COMP *comp);
+
+// SSL_COMP_get_id returns the |id| member of |comp|.
+OPENSSL_EXPORT int SSL_COMP_get_id(const SSL_COMP *comp);
+
+// SSL_COMP_free_compression_methods does nothing.
+OPENSSL_EXPORT void SSL_COMP_free_compression_methods(void);
+
+// SSL_get_current_compression returns NULL.
+OPENSSL_EXPORT const COMP_METHOD *SSL_get_current_compression(SSL *ssl);
+
+// SSL_get_current_expansion returns NULL.
+OPENSSL_EXPORT const COMP_METHOD *SSL_get_current_expansion(SSL *ssl);
+
+struct ssl_comp_st {
+  int id;
+  const char *name;
+  char *method;
+};
+
+DEFINE_STACK_OF(SSL_COMP)
+
+
+// FFDH Ciphersuite No-ops [Deprecated].
+//
+// AWS-LC does not support the use of FFDH cipher suites in libssl. The
+// following functions are only provided as no-ops for easier compatibility.
+
+// SSL_get_server_tmp_key returns zero. This was deprecated as part of the
+// removal of |EVP_PKEY_DH|.
+OPENSSL_EXPORT int SSL_get_server_tmp_key(SSL *ssl, EVP_PKEY **out_key);
+
+// SSL_CTX_set_tmp_dh returns 1.
+OPENSSL_EXPORT int SSL_CTX_set_tmp_dh(SSL_CTX *ctx, const DH *dh);
+
+// SSL_set_tmp_dh returns 1.
+OPENSSL_EXPORT int SSL_set_tmp_dh(SSL *ssl, const DH *dh);
+
+// SSL_CTX_set_tmp_dh_callback does nothing.
+OPENSSL_EXPORT void SSL_CTX_set_tmp_dh_callback(
+    SSL_CTX *ctx, DH *(*cb)(SSL *ssl, int is_export, int keylength));
+
+// SSL_set_tmp_dh_callback does nothing.
+OPENSSL_EXPORT void SSL_set_tmp_dh_callback(SSL *ssl,
+                                            DH *(*cb)(SSL *ssl, int is_export,
+                                                      int keylength));
+
+// SSL_CTX_set_dh_auto does nothing and returns 0 for error.
+OPENSSL_EXPORT long SSL_CTX_set_dh_auto(SSL_CTX *ctx, int onoff);
+
+
+// Security Levels No-ops [Deprecated].
+//
+// OpenSSL has the option to set “security levels”. Security levels can be defined
+// either at compile time with "-DOPENSSL_TLS_SECURITY_LEVEL=level" or at runtime
+// with |SSL_CTX_set_security_level|. AWS-LC does not support this and the
+// security level APIs are no-ops within AWS-LC. AWS-LC intentionally limits the
+// knobs a consumer can tweak in regards to security. 
+
+// SSL_CTX_get_security_level returns 0. This is only to maintain compatibility
+// with OpenSSL and no security assumptions should be based on the number this
+// function returns.
+//
+// Per OpenSSL's definition of Level 0, 1, and 2:
+//
+// Level 0:
+// Everything is permitted. This retains compatibility with previous versions of
+// OpenSSL.
+//
+// Level 1
+// The security level corresponds to a minimum of 80 bits of security. Any
+// parameters offering below 80 bits of security are excluded. As a result RSA,
+// DSA and DH keys shorter than 1024 bits and ECC keys shorter than 160 bits are
+// prohibited. All export cipher suites are prohibited since they all offer less
+// than 80 bits of security. SSL version 2 is prohibited. Any cipher suite using
+// MD5 for the MAC is also prohibited.
+//
+// Level 2
+// Security level set to 112 bits of security. As a result RSA, DSA and DH keys
+// shorter than 2048 bits and ECC keys shorter than 224 bits are prohibited. In
+// addition to the level 1 exclusions any cipher suite using RC4 is also
+// prohibited. SSL version 3 is also not allowed. Compression is disabled.
+//
+// AWS-LC's libssl doesn't support SSLv2 or SSLv3 and we have no support for MD5
+// or RC4 related cipher suites. However, we don't directly prohibit 512 bit RSA
+// keys like Level 1 in OpenSSL states. Since this function is only retained for
+// OpenSSL compatibility, we set the returned value to 0.
+OPENSSL_EXPORT int SSL_CTX_get_security_level(const SSL_CTX *ctx);
+
+// SSL_CTX_set_security_level does nothing. See documentation in
+// |SSL_CTX_get_security_level| about implied security levels for AWS-LC.
+OPENSSL_EXPORT void SSL_CTX_set_security_level(const SSL_CTX *ctx, int level);
+
+
+// General No-op Functions [Deprecated].
+
+// SSL_set_state does nothing.
+OPENSSL_EXPORT void SSL_set_state(SSL *ssl, int state);
+
+// SSL_get_shared_ciphers writes an empty string to |buf| and returns a
+// pointer to |buf|, or NULL if |len| is less than or equal to zero.
+OPENSSL_EXPORT char *SSL_get_shared_ciphers(const SSL *ssl, char *buf, int len);
+
+// SSL_get_shared_sigalgs returns zero.
+OPENSSL_EXPORT int SSL_get_shared_sigalgs(SSL *ssl, int idx, int *psign,
+                                          int *phash, int *psignandhash,
+                                          uint8_t *rsig, uint8_t *rhash);
+
+// SSL_CTX_set_ecdh_auto returns one. This is also a no-op in OpenSSL.
+#define SSL_CTX_set_ecdh_auto(ctx, onoff) 1
+
+// SSL_set_ecdh_auto returns one. This is also a no-op in OpenSSL.
+#define SSL_set_ecdh_auto(ssl, onoff) 1
+
+// ERR_load_SSL_strings does nothing in AWS-LC and OpenSSL.
+OPENSSL_EXPORT void ERR_load_SSL_strings(void);
+
+// SSL_load_error_strings does nothing in AWS-LC and OpenSSL.
+OPENSSL_EXPORT void SSL_load_error_strings(void);
+
+
+// SSL TMP_RSA No-ops [Deprecated].
+//
+// Support for these methods was intentionally removed due to them being the 
+// center of the FREAK attack. These functions are also no-ops in OpenSSL.
+// FREAK Attack: https://freakattack.com/
+
+// SSL_CTX_set_tmp_rsa_callback does nothing.
+OPENSSL_EXPORT void SSL_CTX_set_tmp_rsa_callback(
+    SSL_CTX *ctx, RSA *(*cb)(SSL *ssl, int is_export, int keylength));
+
+// SSL_set_tmp_rsa_callback does nothing.
+OPENSSL_EXPORT void SSL_set_tmp_rsa_callback(SSL *ssl,
+                                             RSA *(*cb)(SSL *ssl, int is_export,
+                                                        int keylength));
+
+// SSL_CTX_need_tmp_RSA returns zero.
+OPENSSL_EXPORT int SSL_CTX_need_tmp_RSA(const SSL_CTX *ctx);
+
+// SSL_need_tmp_RSA returns zero.
+OPENSSL_EXPORT int SSL_need_tmp_RSA(const SSL *ssl);
+
+// SSL_CTX_set_tmp_rsa returns one.
+OPENSSL_EXPORT int SSL_CTX_set_tmp_rsa(SSL_CTX *ctx, const RSA *rsa);
+
+// SSL_set_tmp_rsa returns one.
+OPENSSL_EXPORT int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 
 
 // Nodejs compatibility section (hidden).

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5675,8 +5675,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_get_server_tmp_key(
 
 // SSL_CTX_set_tmp_dh returns 1.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
-//       and depends on this.
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
 OPENSSL_EXPORT int SSL_CTX_set_tmp_dh(SSL_CTX *ctx, const DH *dh);
 
 // SSL_set_tmp_dh returns 1.
@@ -5748,8 +5747,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_state(SSL *ssl, int state);
 // SSL_get_shared_ciphers writes an empty string to |buf| and returns a
 // pointer to |buf|, or NULL if |len| is less than or equal to zero.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
-//       and depends on this.
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
 OPENSSL_EXPORT char *SSL_get_shared_ciphers(const SSL *ssl, char *buf, int len);
 
 // SSL_get_shared_sigalgs returns zero.
@@ -5768,8 +5766,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void ERR_load_SSL_strings(void);
 
 // SSL_load_error_strings does nothing in AWS-LC and OpenSSL.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
-//       and depends on this.
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
 OPENSSL_EXPORT void SSL_load_error_strings(void);
 
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5674,8 +5674,10 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_get_server_tmp_key(
     SSL *ssl, EVP_PKEY **out_key);
 
 // SSL_CTX_set_tmp_dh returns 1.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_CTX_set_tmp_dh(SSL_CTX *ctx,
-                                                         const DH *dh);
+//
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
+//       and depends on this.
+OPENSSL_EXPORT int SSL_CTX_set_tmp_dh(SSL_CTX *ctx, const DH *dh);
 
 // SSL_set_tmp_dh returns 1.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_dh(SSL *ssl, const DH *dh);
@@ -5689,7 +5691,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_tmp_dh_callback(
     SSL *ssl, DH *(*cb)(SSL *ssl, int is_export, int keylength));
 
 // SSL_CTX_set_dh_auto does nothing and returns 0 for error.
-OPENSSL_EXPORT long SSL_CTX_set_dh_auto(SSL_CTX *ctx, int onoff);
+OPENSSL_EXPORT OPENSSL_DEPRECATED long SSL_CTX_set_dh_auto(SSL_CTX *ctx,
+                                                           int onoff);
 
 
 // Security Levels No-ops [Deprecated].
@@ -5744,9 +5747,10 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_state(SSL *ssl, int state);
 
 // SSL_get_shared_ciphers writes an empty string to |buf| and returns a
 // pointer to |buf|, or NULL if |len| is less than or equal to zero.
-OPENSSL_EXPORT OPENSSL_DEPRECATED char *SSL_get_shared_ciphers(const SSL *ssl,
-                                                               char *buf,
-                                                               int len);
+//
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
+//       and depends on this.
+OPENSSL_EXPORT char *SSL_get_shared_ciphers(const SSL *ssl, char *buf, int len);
 
 // SSL_get_shared_sigalgs returns zero.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_get_shared_sigalgs(
@@ -5763,7 +5767,10 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_get_shared_sigalgs(
 OPENSSL_EXPORT OPENSSL_DEPRECATED void ERR_load_SSL_strings(void);
 
 // SSL_load_error_strings does nothing in AWS-LC and OpenSSL.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_load_error_strings(void);
+//
+// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Wno-deprecated-declarations
+//       and depends on this.
+OPENSSL_EXPORT void SSL_load_error_strings(void);
 
 
 // SSL TMP_RSA No-ops [Deprecated].

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -482,9 +482,9 @@ OPENSSL_EXPORT int SSL_write_ex(SSL *s, const void *buf, size_t num,
 // keys for this connection will be updated and the peer will be informed of the
 // change.
 // If |request_type| is set to |SSL_KEY_UPDATE_REQUESTED|, then the sending keys
-// for this connection will be updated and the peer will be informed of the change
-// along with a request for the peer to additionally update its sending keys.
-// RFC: https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.3
+// for this connection will be updated and the peer will be informed of the
+// change along with a request for the peer to additionally update its sending
+// keys. RFC: https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.3
 //
 // Note that this function does not _send_ the message itself. The next call to
 // |SSL_write| will cause the message to be sent. |SSL_write| may be called with
@@ -1780,8 +1780,8 @@ OPENSSL_EXPORT STACK_OF(X509) *SSL_get_peer_full_cert_chain(const SSL *ssl);
 // SSL_get0_verified_chain returns the verified certificate chain of the peer
 // including the peer's end entity certificate. It must be called after a
 // session has been successfully established. If peer verification was not
-// successful (as indicated by |SSL_get_verify_result| not returning |X509_V_OK|)
-// the result will be null. If a verification callback was set with
+// successful (as indicated by |SSL_get_verify_result| not returning
+// |X509_V_OK|) the result will be null. If a verification callback was set with
 // |SSL_CTX_set_cert_verify_callback| or |SSL_set_custom_verify|
 // this function's behavior is undefined.
 OPENSSL_EXPORT STACK_OF(X509) *SSL_get0_verified_chain(const SSL *ssl);
@@ -4045,7 +4045,8 @@ enum ssl_early_data_reason_t BORINGSSL_ENUM_INT {
   ssl_early_data_alps_mismatch = 14,
   // The value of the largest entry.
   ssl_early_data_unsupported_with_custom_extension = 15,
-  ssl_early_data_reason_max_value = ssl_early_data_unsupported_with_custom_extension,
+  ssl_early_data_reason_max_value =
+      ssl_early_data_unsupported_with_custom_extension,
 };
 
 // SSL_get_early_data_reason returns details why 0-RTT was accepted or rejected
@@ -4779,7 +4780,10 @@ OPENSSL_EXPORT int SSL_was_key_usage_invalid(const SSL *ssl);
 // OSSL_HANDSHAKE_STATE enumerates possible TLS states returned from
 // |SSL_get_state| and |SSL_state|. TLS_ST_* are aliases for |SSL_ST_*| for
 // OpenSSL 1.1.0 compatibility.
-typedef enum {TLS_ST_OK = SSL_ST_OK, TLS_ST_BEFORE = SSL_ST_INIT} OSSL_HANDSHAKE_STATE;
+typedef enum {
+  TLS_ST_OK = SSL_ST_OK,
+  TLS_ST_BEFORE = SSL_ST_INIT
+} OSSL_HANDSHAKE_STATE;
 
 // SSL_CB_* are possible values for the |type| parameter in the info
 // callback and the bitmasks that make them up.
@@ -5451,7 +5455,9 @@ OPENSSL_EXPORT int SSL_CTX_set_tlsext_status_cb(SSL_CTX *ctx,
                                                                 void *arg));
 
 // SSL_CTX_get_tlsext_status_cb returns the legacy OpenSSL OCSP callback if set.
-OPENSSL_EXPORT int SSL_CTX_get_tlsext_status_cb(SSL_CTX *ctx, int (**callback)(SSL *, void *));
+OPENSSL_EXPORT int SSL_CTX_get_tlsext_status_cb(SSL_CTX *ctx,
+                                                int (**callback)(SSL *,
+                                                                 void *));
 
 // SSL_CTX_set_tlsext_status_arg sets additional data for
 // |SSL_CTX_set_tlsext_status_cb|'s callback and returns one.
@@ -5480,7 +5486,8 @@ OPENSSL_EXPORT int SSL_CTX_set_tlsext_status_arg(SSL_CTX *ctx, void *arg);
 #define SSL_CURVE_SECP384R1 SSL_GROUP_SECP384R1
 #define SSL_CURVE_SECP521R1 SSL_GROUP_SECP521R1
 #define SSL_CURVE_X25519 SSL_GROUP_X25519
-#define SSL_CURVE_SECP256R1_KYBER768_DRAFT00 SSL_GROUP_SECP256R1_KYBER768_DRAFT00
+#define SSL_CURVE_SECP256R1_KYBER768_DRAFT00 \
+  SSL_GROUP_SECP256R1_KYBER768_DRAFT00
 #define SSL_CURVE_X25519_KYBER768_DRAFT00 SSL_GROUP_X25519_KYBER768_DRAFT00
 
 // SSL_get_curve_id calls |SSL_get_group_id|.
@@ -5618,28 +5625,34 @@ typedef void COMP_METHOD;
 typedef struct ssl_comp_st SSL_COMP;
 
 // SSL_COMP_get_compression_methods returns NULL.
-OPENSSL_EXPORT STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED STACK_OF(SSL_COMP) *
+SSL_COMP_get_compression_methods(void);
 
 // SSL_COMP_add_compression_method returns one.
-OPENSSL_EXPORT int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_COMP_add_compression_method(
+    int id, COMP_METHOD *cm);
 
 // SSL_COMP_get_name returns NULL.
-OPENSSL_EXPORT const char *SSL_COMP_get_name(const COMP_METHOD *comp);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const char *SSL_COMP_get_name(
+    const COMP_METHOD *comp);
 
 // SSL_COMP_get0_name returns the |name| member of |comp|.
-OPENSSL_EXPORT const char *SSL_COMP_get0_name(const SSL_COMP *comp);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const char *SSL_COMP_get0_name(
+    const SSL_COMP *comp);
 
 // SSL_COMP_get_id returns the |id| member of |comp|.
-OPENSSL_EXPORT int SSL_COMP_get_id(const SSL_COMP *comp);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_COMP_get_id(const SSL_COMP *comp);
 
 // SSL_COMP_free_compression_methods does nothing.
-OPENSSL_EXPORT void SSL_COMP_free_compression_methods(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_COMP_free_compression_methods(void);
 
 // SSL_get_current_compression returns NULL.
-OPENSSL_EXPORT const COMP_METHOD *SSL_get_current_compression(SSL *ssl);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const COMP_METHOD *
+SSL_get_current_compression(SSL *ssl);
 
 // SSL_get_current_expansion returns NULL.
-OPENSSL_EXPORT const COMP_METHOD *SSL_get_current_expansion(SSL *ssl);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const COMP_METHOD *SSL_get_current_expansion(
+    SSL *ssl);
 
 struct ssl_comp_st {
   int id;
@@ -5657,22 +5670,23 @@ DEFINE_STACK_OF(SSL_COMP)
 
 // SSL_get_server_tmp_key returns zero. This was deprecated as part of the
 // removal of |EVP_PKEY_DH|.
-OPENSSL_EXPORT int SSL_get_server_tmp_key(SSL *ssl, EVP_PKEY **out_key);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_get_server_tmp_key(
+    SSL *ssl, EVP_PKEY **out_key);
 
 // SSL_CTX_set_tmp_dh returns 1.
-OPENSSL_EXPORT int SSL_CTX_set_tmp_dh(SSL_CTX *ctx, const DH *dh);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_CTX_set_tmp_dh(SSL_CTX *ctx,
+                                                         const DH *dh);
 
 // SSL_set_tmp_dh returns 1.
-OPENSSL_EXPORT int SSL_set_tmp_dh(SSL *ssl, const DH *dh);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_dh(SSL *ssl, const DH *dh);
 
 // SSL_CTX_set_tmp_dh_callback does nothing.
-OPENSSL_EXPORT void SSL_CTX_set_tmp_dh_callback(
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_CTX_set_tmp_dh_callback(
     SSL_CTX *ctx, DH *(*cb)(SSL *ssl, int is_export, int keylength));
 
 // SSL_set_tmp_dh_callback does nothing.
-OPENSSL_EXPORT void SSL_set_tmp_dh_callback(SSL *ssl,
-                                            DH *(*cb)(SSL *ssl, int is_export,
-                                                      int keylength));
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_tmp_dh_callback(
+    SSL *ssl, DH *(*cb)(SSL *ssl, int is_export, int keylength));
 
 // SSL_CTX_set_dh_auto does nothing and returns 0 for error.
 OPENSSL_EXPORT long SSL_CTX_set_dh_auto(SSL_CTX *ctx, int onoff);
@@ -5680,11 +5694,11 @@ OPENSSL_EXPORT long SSL_CTX_set_dh_auto(SSL_CTX *ctx, int onoff);
 
 // Security Levels No-ops [Deprecated].
 //
-// OpenSSL has the option to set “security levels”. Security levels can be defined
-// either at compile time with "-DOPENSSL_TLS_SECURITY_LEVEL=level" or at runtime
-// with |SSL_CTX_set_security_level|. AWS-LC does not support this and the
-// security level APIs are no-ops within AWS-LC. AWS-LC intentionally limits the
-// knobs a consumer can tweak in regards to security. 
+// OpenSSL has the option to set “security levels”. Security levels can be
+// defined either at compile time with "-DOPENSSL_TLS_SECURITY_LEVEL=level" or
+// at runtime with |SSL_CTX_set_security_level|. AWS-LC does not support this
+// and the security level APIs are no-ops within AWS-LC. AWS-LC intentionally
+// limits the knobs a consumer can tweak in regards to security.
 
 // SSL_CTX_get_security_level returns 0. This is only to maintain compatibility
 // with OpenSSL and no security assumptions should be based on the number this
@@ -5714,26 +5728,30 @@ OPENSSL_EXPORT long SSL_CTX_set_dh_auto(SSL_CTX *ctx, int onoff);
 // or RC4 related cipher suites. However, we don't directly prohibit 512 bit RSA
 // keys like Level 1 in OpenSSL states. Since this function is only retained for
 // OpenSSL compatibility, we set the returned value to 0.
-OPENSSL_EXPORT int SSL_CTX_get_security_level(const SSL_CTX *ctx);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_CTX_get_security_level(
+    const SSL_CTX *ctx);
 
 // SSL_CTX_set_security_level does nothing. See documentation in
 // |SSL_CTX_get_security_level| about implied security levels for AWS-LC.
-OPENSSL_EXPORT void SSL_CTX_set_security_level(const SSL_CTX *ctx, int level);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_CTX_set_security_level(
+    const SSL_CTX *ctx, int level);
 
 
 // General No-op Functions [Deprecated].
 
 // SSL_set_state does nothing.
-OPENSSL_EXPORT void SSL_set_state(SSL *ssl, int state);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_state(SSL *ssl, int state);
 
 // SSL_get_shared_ciphers writes an empty string to |buf| and returns a
 // pointer to |buf|, or NULL if |len| is less than or equal to zero.
-OPENSSL_EXPORT char *SSL_get_shared_ciphers(const SSL *ssl, char *buf, int len);
+OPENSSL_EXPORT OPENSSL_DEPRECATED char *SSL_get_shared_ciphers(const SSL *ssl,
+                                                               char *buf,
+                                                               int len);
 
 // SSL_get_shared_sigalgs returns zero.
-OPENSSL_EXPORT int SSL_get_shared_sigalgs(SSL *ssl, int idx, int *psign,
-                                          int *phash, int *psignandhash,
-                                          uint8_t *rsig, uint8_t *rhash);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_get_shared_sigalgs(
+    SSL *ssl, int idx, int *psign, int *phash, int *psignandhash, uint8_t *rsig,
+    uint8_t *rhash);
 
 // SSL_CTX_set_ecdh_auto returns one. This is also a no-op in OpenSSL.
 #define SSL_CTX_set_ecdh_auto(ctx, onoff) 1
@@ -5742,38 +5760,38 @@ OPENSSL_EXPORT int SSL_get_shared_sigalgs(SSL *ssl, int idx, int *psign,
 #define SSL_set_ecdh_auto(ssl, onoff) 1
 
 // ERR_load_SSL_strings does nothing in AWS-LC and OpenSSL.
-OPENSSL_EXPORT void ERR_load_SSL_strings(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void ERR_load_SSL_strings(void);
 
 // SSL_load_error_strings does nothing in AWS-LC and OpenSSL.
-OPENSSL_EXPORT void SSL_load_error_strings(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_load_error_strings(void);
 
 
 // SSL TMP_RSA No-ops [Deprecated].
 //
-// Support for these methods was intentionally removed due to them being the 
+// Support for these methods was intentionally removed due to them being the
 // center of the FREAK attack. These functions are also no-ops in OpenSSL.
 // FREAK Attack: https://freakattack.com/
 
 // SSL_CTX_set_tmp_rsa_callback does nothing.
-OPENSSL_EXPORT void SSL_CTX_set_tmp_rsa_callback(
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_CTX_set_tmp_rsa_callback(
     SSL_CTX *ctx, RSA *(*cb)(SSL *ssl, int is_export, int keylength));
 
 // SSL_set_tmp_rsa_callback does nothing.
-OPENSSL_EXPORT void SSL_set_tmp_rsa_callback(SSL *ssl,
-                                             RSA *(*cb)(SSL *ssl, int is_export,
-                                                        int keylength));
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_tmp_rsa_callback(
+    SSL *ssl, RSA *(*cb)(SSL *ssl, int is_export, int keylength));
 
 // SSL_CTX_need_tmp_RSA returns zero.
-OPENSSL_EXPORT int SSL_CTX_need_tmp_RSA(const SSL_CTX *ctx);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_CTX_need_tmp_RSA(const SSL_CTX *ctx);
 
 // SSL_need_tmp_RSA returns zero.
-OPENSSL_EXPORT int SSL_need_tmp_RSA(const SSL *ssl);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_need_tmp_RSA(const SSL *ssl);
 
 // SSL_CTX_set_tmp_rsa returns one.
-OPENSSL_EXPORT int SSL_CTX_set_tmp_rsa(SSL_CTX *ctx, const RSA *rsa);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_CTX_set_tmp_rsa(SSL_CTX *ctx,
+                                                          const RSA *rsa);
 
 // SSL_set_tmp_rsa returns one.
-OPENSSL_EXPORT int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 
 
 // Nodejs compatibility section (hidden).

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5675,7 +5675,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_get_server_tmp_key(
 
 // SSL_CTX_set_tmp_dh returns 1.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
+// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. nginx defines -Werror and
+// depends on this.
 OPENSSL_EXPORT int SSL_CTX_set_tmp_dh(SSL_CTX *ctx, const DH *dh);
 
 // SSL_set_tmp_dh returns 1.
@@ -5747,7 +5748,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_state(SSL *ssl, int state);
 // SSL_get_shared_ciphers writes an empty string to |buf| and returns a
 // pointer to |buf|, or NULL if |len| is less than or equal to zero.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
+// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. nginx defines -Werror and
+// depends on this.
 OPENSSL_EXPORT char *SSL_get_shared_ciphers(const SSL *ssl, char *buf, int len);
 
 // SSL_get_shared_sigalgs returns zero.
@@ -5766,7 +5768,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void ERR_load_SSL_strings(void);
 
 // SSL_load_error_strings does nothing in AWS-LC and OpenSSL.
 //
-// TODO: Add |OPENSSL_DEPRECATED|. nginx defines -Werror and depends on this.
+// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. nginx defines -Werror and
+// depends on this.
 OPENSSL_EXPORT void SSL_load_error_strings(void);
 
 

--- a/include/openssl/thread.h
+++ b/include/openssl/thread.h
@@ -116,7 +116,7 @@ OPENSSL_EXPORT int AWSLC_thread_local_clear(void);
 // calls to |AWSLC_thread_local_clear|.
 OPENSSL_EXPORT int AWSLC_thread_local_shutdown(void);
 
-// Deprecated functions.
+// General No-op Functions [Deprecated].
 //
 // Historically, OpenSSL required callers to provide locking callbacks.
 // BoringSSL is thread-safe by default, but some old code calls these functions

--- a/include/openssl/thread.h
+++ b/include/openssl/thread.h
@@ -89,7 +89,7 @@ typedef pthread_rwlock_t CRYPTO_MUTEX;
 // by thread_pthread.c.
 typedef union crypto_mutex_st {
   double alignment;
-  uint8_t padding[3*sizeof(int) + 5*sizeof(unsigned) + 16 + 8];
+  uint8_t padding[3 * sizeof(int) + 5 * sizeof(unsigned) + 16 + 8];
 } CRYPTO_MUTEX;
 #endif
 
@@ -132,40 +132,43 @@ OPENSSL_EXPORT int AWSLC_thread_local_shutdown(void);
 // CRYPTO_num_locks returns one. (This is non-zero that callers who allocate
 // sizeof(lock) times this value don't get zero and then fail because malloc(0)
 // returned NULL.)
-OPENSSL_EXPORT int CRYPTO_num_locks(void);
+OPENSSL_EXPORT OPENSSL_DEPRECATED int CRYPTO_num_locks(void);
 
 // CRYPTO_set_locking_callback does nothing.
-OPENSSL_EXPORT void CRYPTO_set_locking_callback(
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_set_locking_callback(
     void (*func)(int mode, int lock_num, const char *file, int line));
 
 // CRYPTO_set_add_lock_callback does nothing.
-OPENSSL_EXPORT void CRYPTO_set_add_lock_callback(int (*func)(
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_set_add_lock_callback(int (*func)(
     int *num, int amount, int lock_num, const char *file, int line));
 
 // CRYPTO_get_locking_callback returns NULL.
-OPENSSL_EXPORT void (*CRYPTO_get_locking_callback(void))(int mode, int lock_num,
-                                                         const char *file,
-                                                         int line);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void (*CRYPTO_get_locking_callback(void))(
+    int mode, int lock_num, const char *file, int line);
 
 // CRYPTO_get_lock_name returns a fixed, dummy string.
-OPENSSL_EXPORT const char *CRYPTO_get_lock_name(int lock_num);
+OPENSSL_EXPORT OPENSSL_DEPRECATED const char *CRYPTO_get_lock_name(
+    int lock_num);
 
 // CRYPTO_THREADID_set_callback returns one.
-OPENSSL_EXPORT int CRYPTO_THREADID_set_callback(
+OPENSSL_EXPORT OPENSSL_DEPRECATED int CRYPTO_THREADID_set_callback(
     void (*threadid_func)(CRYPTO_THREADID *threadid));
 
 // CRYPTO_THREADID_set_numeric does nothing.
-OPENSSL_EXPORT void CRYPTO_THREADID_set_numeric(CRYPTO_THREADID *id,
-                                                unsigned long val);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_THREADID_set_numeric(
+    CRYPTO_THREADID *id, unsigned long val);
 
 // CRYPTO_THREADID_set_pointer does nothing.
-OPENSSL_EXPORT void CRYPTO_THREADID_set_pointer(CRYPTO_THREADID *id, void *ptr);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_THREADID_set_pointer(
+    CRYPTO_THREADID *id, void *ptr);
 
 // CRYPTO_THREADID_current does nothing.
-OPENSSL_EXPORT void CRYPTO_THREADID_current(CRYPTO_THREADID *id);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_THREADID_current(
+    CRYPTO_THREADID *id);
 
 // CRYPTO_set_id_callback does nothing.
-OPENSSL_EXPORT void CRYPTO_set_id_callback(unsigned long (*func)(void));
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_set_id_callback(
+    unsigned long (*func)(void));
 
 typedef struct {
   int references;
@@ -173,30 +176,32 @@ typedef struct {
 } CRYPTO_dynlock;
 
 // CRYPTO_set_dynlock_create_callback does nothing.
-OPENSSL_EXPORT void CRYPTO_set_dynlock_create_callback(
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_set_dynlock_create_callback(
     struct CRYPTO_dynlock_value *(*dyn_create_function)(const char *file,
                                                         int line));
 
 // CRYPTO_set_dynlock_lock_callback does nothing.
-OPENSSL_EXPORT void CRYPTO_set_dynlock_lock_callback(void (*dyn_lock_function)(
-    int mode, struct CRYPTO_dynlock_value *l, const char *file, int line));
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_set_dynlock_lock_callback(
+    void (*dyn_lock_function)(int mode, struct CRYPTO_dynlock_value *l,
+                              const char *file, int line));
 
 // CRYPTO_set_dynlock_destroy_callback does nothing.
-OPENSSL_EXPORT void CRYPTO_set_dynlock_destroy_callback(
+OPENSSL_EXPORT OPENSSL_DEPRECATED void CRYPTO_set_dynlock_destroy_callback(
     void (*dyn_destroy_function)(struct CRYPTO_dynlock_value *l,
                                  const char *file, int line));
 
 // CRYPTO_get_dynlock_create_callback returns NULL.
-OPENSSL_EXPORT struct CRYPTO_dynlock_value *(
+OPENSSL_EXPORT OPENSSL_DEPRECATED struct CRYPTO_dynlock_value *(
     *CRYPTO_get_dynlock_create_callback(void))(const char *file, int line);
 
 // CRYPTO_get_dynlock_lock_callback returns NULL.
-OPENSSL_EXPORT void (*CRYPTO_get_dynlock_lock_callback(void))(
-    int mode, struct CRYPTO_dynlock_value *l, const char *file, int line);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void (*CRYPTO_get_dynlock_lock_callback(
+    void))(int mode, struct CRYPTO_dynlock_value *l, const char *file,
+           int line);
 
 // CRYPTO_get_dynlock_destroy_callback returns NULL.
-OPENSSL_EXPORT void (*CRYPTO_get_dynlock_destroy_callback(void))(
-    struct CRYPTO_dynlock_value *l, const char *file, int line);
+OPENSSL_EXPORT OPENSSL_DEPRECATED void (*CRYPTO_get_dynlock_destroy_callback(
+    void))(struct CRYPTO_dynlock_value *l, const char *file, int line);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2980,10 +2980,11 @@ OPENSSL_EXPORT void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
 // X509_V_FLAG_IGNORE_CRITICAL ignores unhandled critical extensions.
 #define X509_V_FLAG_IGNORE_CRITICAL 0x10
 // X509_V_FLAG_X509_STRICT does nothing as its functionality has been enabled by
-// default.
+// default. In OpenSSL, enabling this disables workarounds for some broken
+// certificates and makes the verification strictly apply X509 rules.
 #define X509_V_FLAG_X509_STRICT 0x00
 // X509_V_FLAG_ALLOW_PROXY_CERTS does nothing as proxy certificate support has
-// been removed.
+// been removed. Proxy certificate support has been removed from AWS-LC.
 #define X509_V_FLAG_ALLOW_PROXY_CERTS 0x40
 // X509_V_FLAG_POLICY_CHECK enables policy checking.
 #define X509_V_FLAG_POLICY_CHECK 0x80
@@ -3006,6 +3007,7 @@ OPENSSL_EXPORT void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
 #define X509_V_FLAG_CHECK_SS_SIGNATURE 0x4000
 // X509_V_FLAG_TRUSTED_FIRST flag causes chain construction to look for issuers
 // in the trust store before looking at the untrusted certificates provided.
+// This is ON by default in both AWS-LC and OpenSSL.
 #define X509_V_FLAG_TRUSTED_FIRST 0x8000
 
 // X509_V_FLAG_PARTIAL_CHAIN allows partial chains if at least one certificate

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -940,22 +940,45 @@ OPENSSL_EXPORT STACK_OF(OPENSSL_STRING) *X509_get1_email(X509 *x);
 OPENSSL_EXPORT STACK_OF(OPENSSL_STRING) *X509_REQ_get1_email(X509_REQ *x);
 OPENSSL_EXPORT void X509_email_free(STACK_OF(OPENSSL_STRING) *sk);
 OPENSSL_EXPORT STACK_OF(OPENSSL_STRING) *X509_get1_ocsp(X509 *x);
-// Flags for X509_check_* functions
 
-// Deprecated: this flag does nothing
-#define X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT 0
-// Disable wildcard matching for dnsName fields and common name.
+
+// X509_check_* functions
+//
+// See https://www.openssl.org/docs/manmaster/man3/X509_check_host.html
+// for more details.
+
+// X509_CHECK_FLAG_NO_WILDCARDS disables wildcard matching for dnsName fields
+// and common name. This only applies to |X509_check_host|.
 #define X509_CHECK_FLAG_NO_WILDCARDS 0x2
-// X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS does nothing, but is necessary in
-// OpenSSL to enable standard wildcard matching. In BoringSSL, this behavior is
-// always enabled.
-#define X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS 0
-// Deprecated: this flag does nothing
-#define X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS 0
-// Deprecated: this flag does nothing
-#define X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS 0
-// Skip the subject common name fallback if subjectAltNames is missing.
+
+// X509_CHECK_FLAG_NEVER_CHECK_SUBJECT skips the subject common name fallback
+// if subjectAltNames is missing.
 #define X509_CHECK_FLAG_NEVER_CHECK_SUBJECT 0x20
+
+// X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS does nothing, but is necessary in
+// OpenSSL to enable standard wildcard matching. In AWS-LC, this behavior is
+// always enabled. This only applies to |X509_check_host| in OpenSSL.
+#define X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS 0
+
+// X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT is deprecated and does nothing.
+// Enabling this in OpenSSL considers the subject DN even if the certificate
+// contains at least one subject alternative name of the right type; the
+// default is to ignore the subject DN when at least one corresponding subject
+// alternative names is present.
+#define X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT 0
+
+// X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS is deprecated and does nothing.
+// This only applies to |X509_check_host|. When used in OpenSSL, it allows a
+// "*" that constitutes the complete label of a DNS name (e.g.
+// "*.example.com") to match more than one label in |chk|.
+#define X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS 0
+
+// X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS is deprecated and does nothing.
+// This only applies to |X509_check_host|. When used in OpenSSL, it
+// restricts name values which start with ".", that would otherwise match
+// any sub-domain in the peer certificate, to only match direct child
+// sub-domains.
+#define X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS 0
 
 // X509_check_host checks if |x| has a Common Name or Subject Alternate name
 // that matches the |chk| string up to |chklen|. If |chklen| is 0

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2558,7 +2558,12 @@ static bool parseStringVectorToIntegerVector(
 }
 
 bool Speed(const std::vector<std::string> &args) {
-#if AWSLC_API_VERSION > 16
+#if AWSLC_API_VERSION > 27
+  OPENSSL_BEGIN_ALLOW_DEPRECATED
+  // We started marking this as deprecated.
+  EVP_MD_unstable_sha3_enable(true);
+  OPENSSL_END_ALLOW_DEPRECATED
+#elif AWSLC_API_VERSION > 16
   // For mainline AWS-LC this is a no-op, however if speed.cc built with an old
   // branch of AWS-LC SHA3 might be disabled by default and fail the benchmark.
   EVP_MD_unstable_sha3_enable(true);


### PR DESCRIPTION
### Description of changes: 
Update porting guide for AWS-LC. This is the second phase which includes updated function documentation.

### Call-outs:
Originally, this was to include links to the corresponding functions/sections in the new tables as well, but we can't actually provide correct links until we have the correct commit hash in main.
A third phase will link the tables to the corresponding section.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
