### PR TITLE
RSA key check consolidation part 1b

### DIFF
--- a/crypto/fipsmodule/rsa/internal.h
+++ b/crypto/fipsmodule/rsa/internal.h
@@ -233,7 +233,6 @@ int rsa_digestverify_no_self_test(const EVP_MD *md, const uint8_t *input,
 
 // ------ DO NOT USE! -------
 // These functions are work-in-progress to consolidate the RSA key checking.
-OPENSSL_EXPORT int wip_do_not_use_rsa_check_key(const RSA *key);
 OPENSSL_EXPORT int wip_do_not_use_rsa_check_key_fips(const RSA *key);
 
 #if defined(__cplusplus)

--- a/crypto/fipsmodule/rsa/internal.h
+++ b/crypto/fipsmodule/rsa/internal.h
@@ -67,12 +67,6 @@
 extern "C" {
 #endif
 
-typedef enum {
-  RSA_STRIPPED_KEY,
-  RSA_CRT_KEY,
-  RSA_PUBLIC_KEY
-} rsa_asn1_key_encoding_t;
-
 typedef struct bn_blinding_st BN_BLINDING;
 
 struct rsa_st {
@@ -173,10 +167,6 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(uint8_t *out, size_t *out_len,
 int RSA_padding_add_none(uint8_t *to, size_t to_len, const uint8_t *from,
                          size_t from_len);
 
-// rsa_check_public_key checks that |rsa|'s public modulus and exponent are
-// within DoS bounds.
-int rsa_check_public_key(const RSA *rsa, rsa_asn1_key_encoding_t key_enc_type);
-
 // RSA_private_transform calls either the method-specific |private_transform|
 // function (if given) or the generic one. See the comment for
 // |private_transform| in |rsa_meth_st|.
@@ -193,8 +183,6 @@ void rsa_invalidate_key(RSA *rsa);
 // This constant is exported for test purposes.
 extern const BN_ULONG kBoringSSLRSASqrtTwo[];
 extern const size_t kBoringSSLRSASqrtTwoLen;
-
-int RSA_validate_key(const RSA *rsa, rsa_asn1_key_encoding_t key_enc_type);
 
 // Functions that avoid self-tests.
 //
@@ -230,6 +218,10 @@ int rsa_digestsign_no_self_test(const EVP_MD *md, const uint8_t *input,
 int rsa_digestverify_no_self_test(const EVP_MD *md, const uint8_t *input,
                                   size_t in_len, const uint8_t *sig,
                                   size_t sig_len, RSA *rsa);
+
+// Performs several checks on the public component of the given RSA key.
+// See the implemetation in |rsa.c| for details.
+int is_public_component_of_rsa_key_good(const RSA *key);
 
 // ------ DO NOT USE! -------
 // These functions are work-in-progress to consolidate the RSA key checking.

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -1042,7 +1042,7 @@ int RSA_check_key(const RSA *key) {
   }
 
   // Nothing else to check for public keys (n, e) and private keys in minimal
-  // or stripped format, (n, e, d) and (n, d).
+  // or stripped format, (n, e, d) and (n, d), resp.
   if (key_type == RSA_KEY_TYPE_FOR_CHECKING_PUBLIC ||
       key_type == RSA_KEY_TYPE_FOR_CHECKING_PRIVATE_MIN ||
       key_type == RSA_KEY_TYPE_FOR_CHECKING_PRIVATE_STRIP) {

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -910,7 +910,7 @@ int is_public_component_of_rsa_key_good(const RSA *key) {
     return 0;
   }
 
-  // Stripped private  keys do not have the public exponent e, so the remaining
+  // Stripped private keys do not have the public exponent e, so the remaining
   // checks in this function are not applicable.
   if (key->e == NULL) {
     return 1;

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -884,7 +884,7 @@ int RSA_blinding_on(RSA *rsa, BN_CTX *ctx) {
 //
 // Performs several checks on the public component of the given RSA key.
 // The key must have at least the public modulus n, the public exponent e is
-// optional (this is to support degenerate case of JCA stripped private keys
+// optional (this is to support the special case of JCA stripped private keys
 // that are missing e).
 //
 // The checks:
@@ -1011,7 +1011,7 @@ static enum rsa_key_type_for_checking determine_key_type_for_checking(const RSA 
 // where p and q are the prime factors of n. Some keys store additional
 // precomputed private parameters
 //     (dmp1, dmq1, iqmp).
-// Additionally, we support checking degenerate private keys that JCA supports
+// Additionally, we support checking stripped private keys that JCA supports
 // that consist of (n, d).
 //
 // The function performs the following checks (when possible): 

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -906,11 +906,6 @@ out:
   return ok;
 }
 
-int RSA_check_key(const RSA *key) {
-  return RSA_validate_key(key, RSA_CRT_KEY);
-}
-
-
 // This is the product of the 132 smallest odd primes, from 3 to 751.
 static const BN_ULONG kSmallFactorsLimbs[] = {
     TOBN(0xc4309333, 0x3ef4e3e1), TOBN(0x71161eb6, 0xcd2d655f),
@@ -1175,7 +1170,7 @@ static enum rsa_key_type_for_checking determine_key_type_for_checking(const RSA 
 //
 // Note: see the rsa_key_type_for_checking enum for details on types of keys
 // the function can work with.
-int wip_do_not_use_rsa_check_key(const RSA *key) {
+int RSA_check_key(const RSA *key) {
 
   enum rsa_key_type_for_checking key_type = determine_key_type_for_checking(key);
   if (key_type == RSA_KEY_TYPE_FOR_CHECKING_INVALID) {

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -1011,7 +1011,7 @@ static enum rsa_key_type_for_checking determine_key_type_for_checking(const RSA 
 // where p and q are the prime factors of n. Some keys store additional
 // precomputed private parameters
 //     (dmp1, dmq1, iqmp).
-// Additionally, we support checking degenerate private keys that JCA support
+// Additionally, we support checking degenerate private keys that JCA supports
 // that consist of (n, d).
 //
 // The function performs the following checks (when possible): 

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -743,169 +743,6 @@ err:
   return ret;
 }
 
-static int check_mod_inverse(int *out_ok, const BIGNUM *a, const BIGNUM *ainv,
-                             const BIGNUM *m, unsigned m_min_bits,
-                             BN_CTX *ctx) {
-  if (BN_is_negative(ainv) || BN_cmp(ainv, m) >= 0) {
-    *out_ok = 0;
-    return 1;
-  }
-
-  // Note |bn_mul_consttime| and |bn_div_consttime| do not scale linearly, but
-  // checking |ainv| is in range bounds the running time, assuming |m|'s bounds
-  // were checked by the caller.
-  BN_CTX_start(ctx);
-  BIGNUM *tmp = BN_CTX_get(ctx);
-  int ret = tmp != NULL &&
-            bn_mul_consttime(tmp, a, ainv, ctx) &&
-            bn_div_consttime(NULL, tmp, tmp, m, m_min_bits, ctx);
-  if (ret) {
-    *out_ok = BN_is_one(tmp);
-  }
-  BN_CTX_end(ctx);
-  return ret;
-}
-
-int RSA_validate_key(const RSA *key, rsa_asn1_key_encoding_t key_enc_type) {
-  // TODO(davidben): RSA key initialization is spread across
-  // |rsa_check_public_key|, |RSA_check_key|, |freeze_private_key|, and
-  // |BN_MONT_CTX_set_locked| as a result of API issues. See
-  // https://crbug.com/boringssl/316. As a result, we inconsistently check RSA
-  // invariants. We should fix this and integrate that logic.
-
-  if (RSA_is_opaque(key)) {
-    // Opaque keys can't be checked.
-    return 1;
-  }
-
-  if ((key->p != NULL) != (key->q != NULL)) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_ONLY_ONE_OF_P_Q_GIVEN);
-    return 0;
-  }
-
-  // Previously, we ensured that |key->d| is bounded by |key->n|.
-  // This ensures bounds on |RSA_bits| translate to bounds on
-  // the running time of private key operations.
-  // However, due to some users (V804729436) having to deal with private keys
-  // that are valid but violate this condition we had to remove it.
-  // The main concern for keys that violate the condition (the potential
-  // DoS attack vector) is somewhat alleviated with the hard limit on
-  // the size of RSA keys we allow.
-  // This behavior is in line with OpenSSL that doesn't impose the condition.
-  if (key->d != NULL && BN_is_negative(key->d)) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_D_OUT_OF_RANGE);
-    return 0;
-  }
-
-  if (!rsa_check_public_key(key, key_enc_type)) {
-    return 0;
-  }
-
-  if (key_enc_type == RSA_STRIPPED_KEY) {
-    // stripped keys doesn't have more parameters we can verify.
-    return 1;
-  }
-
-  if (key->d == NULL || key->p == NULL) {
-    // For a public key, or without p and q, there's nothing that can be
-    // checked.
-    return 1;
-  }
-
-  BN_CTX *ctx = BN_CTX_new();
-  if (ctx == NULL) {
-    return 0;
-  }
-
-  BIGNUM tmp, de, pm1, qm1, dmp1, dmq1;
-  int ok = 0;
-  BN_init(&tmp);
-  BN_init(&de);
-  BN_init(&pm1);
-  BN_init(&qm1);
-  BN_init(&dmp1);
-  BN_init(&dmq1);
-
-  // Check that p * q == n. Before we multiply, we check that p and q are in
-  // bounds, to avoid a DoS vector in |bn_mul_consttime| below. Note that
-  // n was bound by |rsa_check_public_key|. This also implicitly checks p and q
-  // are odd, which is a necessary condition for Montgomery reduction.
-  if (BN_is_negative(key->p) || BN_cmp(key->p, key->n) >= 0 ||
-      BN_is_negative(key->q) || BN_cmp(key->q, key->n) >= 0) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_N_NOT_EQUAL_P_Q);
-    goto out;
-  }
-  if (!bn_mul_consttime(&tmp, key->p, key->q, ctx)) {
-    OPENSSL_PUT_ERROR(RSA, ERR_LIB_BN);
-    goto out;
-  }
-  if (BN_cmp(&tmp, key->n) != 0) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_N_NOT_EQUAL_P_Q);
-    goto out;
-  }
-
-  // d must be an inverse of e mod the Carmichael totient, lcm(p-1, q-1), but it
-  // may be unreduced because other implementations use the Euler totient. We
-  // simply check that d * e is one mod p-1 and mod q-1. Note d and e were bound
-  // by earlier checks in this function.
-  if (!bn_usub_consttime(&pm1, key->p, BN_value_one()) ||
-      !bn_usub_consttime(&qm1, key->q, BN_value_one())) {
-    OPENSSL_PUT_ERROR(RSA, ERR_LIB_BN);
-    goto out;
-  }
-  const unsigned pm1_bits = BN_num_bits(&pm1);
-  const unsigned qm1_bits = BN_num_bits(&qm1);
-  if (!bn_mul_consttime(&de, key->d, key->e, ctx) ||
-      !bn_div_consttime(NULL, &tmp, &de, &pm1, pm1_bits, ctx) ||
-      !bn_div_consttime(NULL, &de, &de, &qm1, qm1_bits, ctx)) {
-    OPENSSL_PUT_ERROR(RSA, ERR_LIB_BN);
-    goto out;
-  }
-
-  if (!BN_is_one(&tmp) || !BN_is_one(&de)) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_D_E_NOT_CONGRUENT_TO_1);
-    goto out;
-  }
-
-  int has_crt_values = key->dmp1 != NULL;
-  if (has_crt_values != (key->dmq1 != NULL) ||
-      has_crt_values != (key->iqmp != NULL)) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_INCONSISTENT_SET_OF_CRT_VALUES);
-    goto out;
-  }
-
-  if (has_crt_values) {
-    int dmp1_ok, dmq1_ok, iqmp_ok;
-    if (!check_mod_inverse(&dmp1_ok, key->e, key->dmp1, &pm1, pm1_bits, ctx) ||
-        !check_mod_inverse(&dmq1_ok, key->e, key->dmq1, &qm1, qm1_bits, ctx) ||
-        // |p| is odd, so |pm1| and |p| have the same bit width. If they didn't,
-        // we only need a lower bound anyway.
-        !check_mod_inverse(&iqmp_ok, key->q, key->iqmp, key->p, pm1_bits,
-                           ctx)) {
-      OPENSSL_PUT_ERROR(RSA, ERR_LIB_BN);
-      goto out;
-    }
-
-    if (!dmp1_ok || !dmq1_ok || !iqmp_ok) {
-      OPENSSL_PUT_ERROR(RSA, RSA_R_CRT_VALUES_INCORRECT);
-      goto out;
-    }
-  }
-
-  ok = 1;
-
-out:
-  BN_free(&tmp);
-  BN_free(&de);
-  BN_free(&pm1);
-  BN_free(&qm1);
-  BN_free(&dmp1);
-  BN_free(&dmq1);
-  BN_CTX_free(ctx);
-
-  return ok;
-}
-
 // This is the product of the 132 smallest odd primes, from 3 to 751.
 static const BN_ULONG kSmallFactorsLimbs[] = {
     TOBN(0xc4309333, 0x3ef4e3e1), TOBN(0x71161eb6, 0xcd2d655f),
@@ -970,7 +807,7 @@ int RSA_check_fips(RSA *key) {
     return 0;
   }
 
-  if (!RSA_validate_key(key, RSA_CRT_KEY)) {
+  if (!RSA_check_key(key)) {
     return 0;
   }
 
@@ -1043,20 +880,25 @@ int RSA_blinding_on(RSA *rsa, BN_CTX *ctx) {
   return 1;
 }
 
-// ------ WORK IN PROGRESS, DO NOT USE ------
+// ------------- KEY CHECKING FUNCTIONS ----------------
 //
 // Performs several checks on the public component of the given RSA key.
-// This function is a helper function meant to be used only within
-// |RSA_check_key|, do not use it for any other purpose.
+// The key must have at least the public modulus n, the public exponent e is
+// optional (this is to support degenerate case of JCA stripped private keys
+// that are missing e).
+//
 // The checks:
 //   - n fits in 16k bits,
 //   - 1 < log(e, 2) <= 33,
 //   - n and e are odd,
 //   - n > e.
-static int is_public_component_of_rsa_key_good(const RSA *key) {
-  // The caller ensures `key->n != NULL`.
-  unsigned int n_bits = BN_num_bits(key->n);
+int is_public_component_of_rsa_key_good(const RSA *key) {
+  if (key->n == NULL) {
+    OPENSSL_PUT_ERROR(RSA, RSA_R_VALUE_MISSING);
+    return 0;
+  }
 
+  unsigned int n_bits = BN_num_bits(key->n);
   if (n_bits > 16 * 1024) {
     OPENSSL_PUT_ERROR(RSA, RSA_R_MODULUS_TOO_LARGE);
     return 0;
@@ -1075,7 +917,6 @@ static int is_public_component_of_rsa_key_good(const RSA *key) {
   }
 
   unsigned int e_bits = BN_num_bits(key->e);
-
   // Mitigate DoS attacks by limiting the exponent size. 33 bits was chosen as
   // the limit based on the recommendations in:
   //   - https://www.imperialviolet.org/2012/03/16/rsae.html
@@ -1170,6 +1011,8 @@ static enum rsa_key_type_for_checking determine_key_type_for_checking(const RSA 
 // where p and q are the prime factors of n. Some keys store additional
 // precomputed private parameters
 //     (dmp1, dmq1, iqmp).
+// Additionally, we support checking degenerate private keys that JCA support
+// that consist of (n, d).
 //
 // The function performs the following checks (when possible): 
 //   - n fits in 16k bits,

--- a/crypto/fipsmodule/rsa/rsa_impl.c
+++ b/crypto/fipsmodule/rsa/rsa_impl.c
@@ -72,68 +72,6 @@
 #include "../delocate.h"
 #include "../rand/fork_detect.h"
 
-
-int rsa_check_public_key(const RSA *rsa, rsa_asn1_key_encoding_t key_enc_type) {
-  // Despite its name, this function is used for validating all RSA keys. |n|
-  // is required for all keys, but stripped private keys do not have |e|.
-  if (rsa->n == NULL || (key_enc_type != RSA_STRIPPED_KEY && rsa->e == NULL)) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_VALUE_MISSING);
-    return 0;
-  }
-
-  unsigned n_bits = BN_num_bits(rsa->n);
-  if (n_bits > 16 * 1024) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_MODULUS_TOO_LARGE);
-    return 0;
-  }
-
-  // RSA moduli must be odd. In addition to being necessary for RSA in general,
-  // we cannot setup Montgomery reduction with even moduli.
-  if (!BN_is_odd(rsa->n)) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_BAD_RSA_PARAMETERS);
-    return 0;
-  }
-
-  // Verify |n > e|. Comparing |n_bits| to |kMaxExponentBits| is a small
-  // shortcut to comparing |n| and |e| directly. In reality, |kMaxExponentBits|
-  // is much smaller than the minimum RSA key size that any application should
-  // accept.
-  static const unsigned kMaxExponentBits = 33;
-  if (n_bits <= kMaxExponentBits) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_KEY_SIZE_TOO_SMALL);
-    return 0;
-  }
-
-  if (key_enc_type == RSA_STRIPPED_KEY) {
-    // Stripped RSA key doesn't have |e| set. Nothing more to do here.
-    return 1;
-  }
-
-  // Slighty more thorough validation of |n > e|/
-  assert(BN_ucmp(rsa->n, rsa->e) > 0);
-
-  // Mitigate DoS attacks by limiting the exponent size. 33 bits was chosen as
-  // the limit based on the recommendations in [1] and [2]. Windows CryptoAPI
-  // doesn't support values larger than 32 bits [3], so it is unlikely that
-  // exponents larger than 32 bits are being used for anything Windows commonly
-  // does.
-  //
-  // [1] https://www.imperialviolet.org/2012/03/16/rsae.html
-  // [2] https://www.imperialviolet.org/2012/03/17/rsados.html
-  // [3] https://msdn.microsoft.com/en-us/library/aa387685(VS.85).aspx
-  unsigned e_bits = BN_num_bits(rsa->e);
-  if (e_bits > kMaxExponentBits ||
-      // Additionally reject e = 1 or even e. e must be odd to be relatively
-      // prime with phi(n).
-      e_bits < 2 ||
-      !BN_is_odd(rsa->e)) {
-    OPENSSL_PUT_ERROR(RSA, RSA_R_BAD_E_VALUE);
-    return 0;
-  }
-
-  return 1;
-}
-
 static int ensure_fixed_copy(BIGNUM **out, const BIGNUM *in, int width) {
   if (*out != NULL) {
     return 1;
@@ -296,7 +234,7 @@ int RSA_encrypt(RSA *rsa, size_t *out_len, uint8_t *out, size_t max_out,
                 const uint8_t *in, size_t in_len, int padding) {
   boringssl_ensure_rsa_self_test();
 
-  if (!rsa_check_public_key(rsa, RSA_PUBLIC_KEY)) {
+  if (!is_public_component_of_rsa_key_good(rsa)) {
     return 0;
   }
 
@@ -628,7 +566,7 @@ static int mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx);
 int rsa_verify_raw_no_self_test(RSA *rsa, size_t *out_len, uint8_t *out,
                                 size_t max_out, const uint8_t *in,
                                 size_t in_len, int padding) {
-  if (!rsa_check_public_key(rsa, RSA_PUBLIC_KEY)) {
+  if (!is_public_component_of_rsa_key_good(rsa)) {
     return 0;
   }
 
@@ -814,7 +752,7 @@ int rsa_default_private_transform(RSA *rsa, uint8_t *out, const uint8_t *in,
   // than the CRT attack, but there have likely been improvements since 1997.
   //
   // This check is cheap assuming |e| is small, which we require in
-  // |rsa_check_public_key|.
+  // |is_public_component_of_rsa_key_good|.
   if (rsa->e != NULL) {
     BIGNUM *vrfy = BN_CTX_get(ctx);
     if (vrfy == NULL ||
@@ -1199,8 +1137,8 @@ static int rsa_generate_key_impl(RSA *rsa, int bits, const BIGNUM *e_value,
 
   // Reject excessively large public exponents. Windows CryptoAPI and Go don't
   // support values larger than 32 bits, so match their limits for generating
-  // keys. (|rsa_check_public_key| uses a slightly more conservative value, but
-  // we don't need to support generating such keys.)
+  // keys. (|is_public_component_of_rsa_key_good| uses a slightly more
+  // conservative value, but we don't need to support generating such keys.)
   // https://github.com/golang/go/issues/3161
   // https://msdn.microsoft.com/en-us/library/aa387685(VS.85).aspx
   if (BN_num_bits(e_value) > 32) {
@@ -1333,7 +1271,7 @@ static int rsa_generate_key_impl(RSA *rsa, int bits, const BIGNUM *e_value,
   // The key generation process is complex and thus error-prone. It could be
   // disastrous to generate and then use a bad key so double-check that the key
   // makes sense.
-  if (!RSA_validate_key(rsa, RSA_CRT_KEY)) {
+  if (!RSA_check_key(rsa)) {
     OPENSSL_PUT_ERROR(RSA, RSA_R_INTERNAL_ERROR);
     goto err;
   }

--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -403,7 +403,6 @@ TEST_P(RSAEncryptTest, TestKey) {
   ASSERT_TRUE(key);
 
   EXPECT_TRUE(RSA_check_key(key.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(key.get()));
 
   uint8_t ciphertext[256];
 
@@ -472,7 +471,6 @@ TEST(RSATest, TestDecrypt) {
   ASSERT_TRUE(rsa);
 
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
 
   uint8_t out[256];
   size_t out_len;
@@ -535,7 +533,6 @@ TEST(RSATest, BadKey) {
 
   // Bad keys are detected.
   EXPECT_FALSE(RSA_check_key(key.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(key.get()));
   EXPECT_FALSE(RSA_check_fips(key.get()));
 
   // Bad keys may not be parsed.
@@ -564,7 +561,6 @@ TEST(RSATest, OnlyDGiven) {
 
   // Keys with only n, e, and d are functional.
   EXPECT_TRUE(RSA_check_key(key.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(key.get()));
 
   const uint8_t kDummyHash[32] = {0};
   uint8_t buf[64];
@@ -587,7 +583,6 @@ TEST(RSATest, OnlyDGiven) {
   // While keys defined only in terms of |n| and |d| must be functional, our
   // validation logic doesn't consider them "valid".
   EXPECT_FALSE(RSA_check_key(key2.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(key2.get()));
 
   ASSERT_LE(RSA_size(key2.get()), sizeof(buf));
   EXPECT_TRUE(RSA_sign(NID_sha256, kDummyHash, sizeof(kDummyHash), buf,
@@ -646,7 +641,6 @@ TEST(RSATest, OnlyDGiven) {
   ASSERT_FALSE(jcaKey->iqmp);
 
   EXPECT_FALSE(RSA_check_key(jcaKey.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(jcaKey.get()));
 
   ASSERT_LE(RSA_size(jcaKey.get()), sizeof(buf));
   EXPECT_TRUE(RSA_sign(NID_sha256, kDummyHash, sizeof(kDummyHash), buf,
@@ -907,59 +901,49 @@ TEST(RSATest, CheckKey) {
   // Missing n or e does not pass.
   ASSERT_TRUE(BN_hex2bn(&rsa->n, kN));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
 
   BN_free(rsa->n);
   rsa->n = nullptr;
   ASSERT_TRUE(BN_hex2bn(&rsa->e, kE));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
 
   // Public keys pass.
   ASSERT_TRUE(BN_hex2bn(&rsa->n, kN));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
 
   // Invalid e values (e = 1 or e odd).
   ASSERT_TRUE(BN_hex2bn(&rsa->e, "1"));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
 
   // Restore the valid public key values.
   ASSERT_TRUE(BN_hex2bn(&rsa->n, kN));
   ASSERT_TRUE(BN_hex2bn(&rsa->e, kE));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
 
   // Configuring d also passes.
   ASSERT_TRUE(BN_hex2bn(&rsa->d, kD));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
 
   // p and q must be provided together.
   ASSERT_TRUE(BN_hex2bn(&rsa->p, kP));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
 
   BN_free(rsa->p);
   rsa->p = nullptr;
   ASSERT_TRUE(BN_hex2bn(&rsa->q, kQ));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
 
   // Supplying p and q without CRT parameters passes.
   ASSERT_TRUE(BN_hex2bn(&rsa->p, kP));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
 
   // With p and q together, it is sufficient to check d against e.
   ASSERT_TRUE(BN_add_word(rsa->d, 1));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
 
   // Test another invalid d. p-1 is divisible by 3, so there is no valid value
@@ -977,7 +961,6 @@ TEST(RSATest, CheckKey) {
   ASSERT_TRUE(BN_set_word(rsa->e, 111));
   ASSERT_TRUE(BN_hex2bn(&rsa->d, kDBogus));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
   ASSERT_TRUE(BN_hex2bn(&rsa->e, kE));
 
@@ -994,7 +977,6 @@ TEST(RSATest, CheckKey) {
       "c62bbe81";
   ASSERT_TRUE(BN_hex2bn(&rsa->d, kDEuler));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
 
   // If d is out of range, d > n,  but otherwise valid, it is accepted.
   static const char kDgtN[] =
@@ -1008,70 +990,59 @@ TEST(RSATest, CheckKey) {
       "42e770c1";
   ASSERT_TRUE(BN_hex2bn(&rsa->d, kDgtN));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
   ASSERT_TRUE(BN_hex2bn(&rsa->d, kD));
 
   // CRT value must either all be provided or all missing.
   ASSERT_TRUE(BN_hex2bn(&rsa->dmp1, kDMP1));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
   BN_free(rsa->dmp1);
   rsa->dmp1 = nullptr;
 
   ASSERT_TRUE(BN_hex2bn(&rsa->dmq1, kDMQ1));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
   BN_free(rsa->dmq1);
   rsa->dmq1 = nullptr;
 
   ASSERT_TRUE(BN_hex2bn(&rsa->iqmp, kIQMP));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
 
   // The full key is accepted.
   ASSERT_TRUE(BN_hex2bn(&rsa->dmp1, kDMP1));
   ASSERT_TRUE(BN_hex2bn(&rsa->dmq1, kDMQ1));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
 
   // Incorrect CRT values are rejected.
   ASSERT_TRUE(BN_add_word(rsa->dmp1, 1));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
   ASSERT_TRUE(BN_sub_word(rsa->dmp1, 1));
 
   ASSERT_TRUE(BN_add_word(rsa->dmq1, 1));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
   ASSERT_TRUE(BN_sub_word(rsa->dmq1, 1));
 
   ASSERT_TRUE(BN_add_word(rsa->iqmp, 1));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
   ASSERT_TRUE(BN_sub_word(rsa->iqmp, 1));
 
   // Non-reduced CRT values are rejected.
   ASSERT_TRUE(BN_add(rsa->dmp1, rsa->dmp1, rsa->p));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
   ASSERT_TRUE(BN_sub(rsa->dmp1, rsa->dmp1, rsa->p));
 
   ASSERT_TRUE(BN_add(rsa->dmq1, rsa->dmq1, rsa->q));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
   ASSERT_TRUE(BN_sub(rsa->dmq1, rsa->dmq1, rsa->q));
 
   ASSERT_TRUE(BN_add(rsa->iqmp, rsa->iqmp, rsa->p));
   EXPECT_FALSE(RSA_check_key(rsa.get()));
-  EXPECT_FALSE(wip_do_not_use_rsa_check_key(rsa.get()));
   ERR_clear_error();
   ASSERT_TRUE(BN_sub(rsa->iqmp, rsa->iqmp, rsa->p));
 }
@@ -1132,7 +1103,6 @@ TEST(RSATest, KeygenFail) {
   // Generating a key over an existing key works, despite any cached state.
   EXPECT_TRUE(RSA_generate_key_ex(rsa.get(), 2048, e.get(), nullptr));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
   uint8_t *der3;
   size_t der3_len;
   ASSERT_TRUE(RSA_private_key_to_bytes(&der3, &der3_len, rsa.get()));
@@ -1227,7 +1197,6 @@ TEST(RSADeathTest, KeygenFailAndDie) {
   // Generating a key over an existing key works, despite any cached state.
   EXPECT_TRUE(RSA_generate_key_ex(rsa.get(), 2048, e.get(), nullptr));
   EXPECT_TRUE(RSA_check_key(rsa.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(rsa.get()));
   uint8_t *der3;
   size_t der3_len;
   ASSERT_TRUE(RSA_private_key_to_bytes(&der3, &der3_len, rsa.get()));
@@ -1354,7 +1323,6 @@ TEST(RSATest, OverwriteKey) {
   ASSERT_TRUE(key1);
 
   ASSERT_TRUE(RSA_check_key(key1.get()));
-  EXPECT_TRUE(wip_do_not_use_rsa_check_key(key1.get()));
   size_t len;
   std::vector<uint8_t> ciphertext(RSA_size(key1.get()));
   ASSERT_TRUE(RSA_encrypt(key1.get(), &len, ciphertext.data(),

--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -580,9 +580,7 @@ TEST(RSATest, OnlyDGiven) {
   ASSERT_TRUE(BN_hex2bn(&key2->d, kD));
   key2->flags |= RSA_FLAG_NO_BLINDING;
 
-  // While keys defined only in terms of |n| and |d| must be functional, our
-  // validation logic doesn't consider them "valid".
-  EXPECT_FALSE(RSA_check_key(key2.get()));
+  EXPECT_TRUE(RSA_check_key(key2.get()));
 
   ASSERT_LE(RSA_size(key2.get()), sizeof(buf));
   EXPECT_TRUE(RSA_sign(NID_sha256, kDummyHash, sizeof(kDummyHash), buf,
@@ -605,17 +603,8 @@ TEST(RSATest, OnlyDGiven) {
   // https://github.com/corretto/amazon-corretto-crypto-provider/blob/develop/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java#L512-L529
   // https://github.com/corretto/amazon-corretto-crypto-provider/blob/develop/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java#L290-L302
   //
-  // Also, note that here and in the previous test we expect RSA_check_key to
-  // return false for JCA-style keys. The current implementation does not
-  // consider JCA-style keys to be valid. We deliberately made this decision to
-  // avoid introducing potentially dangerous modifications to key validation
-  // and generation logic. Instead, we detect JCA-style keys only when parsing
-  // from DER and special case that.
-  //
   // At some point in the future, we will likely want to standardize on one of
-  // of NULL/0 for indicating parameter absence across the codebase, as well as
-  // fix up |RSA_check_key| to accurately account for all the different types
-  // of RSA keys that we support.
+  // of NULL/0 for indicating parameter absence across the codebase.
   ASSERT_TRUE(BN_hex2bn(&key2->e, "0"));
   ASSERT_TRUE(BN_hex2bn(&key2->p, "0"));
   ASSERT_TRUE(BN_hex2bn(&key2->q, "0"));
@@ -640,7 +629,7 @@ TEST(RSATest, OnlyDGiven) {
   ASSERT_FALSE(jcaKey->dmq1);
   ASSERT_FALSE(jcaKey->iqmp);
 
-  EXPECT_FALSE(RSA_check_key(jcaKey.get()));
+  EXPECT_TRUE(RSA_check_key(jcaKey.get()));
 
   ASSERT_LE(RSA_size(jcaKey.get()), sizeof(buf));
   EXPECT_TRUE(RSA_sign(NID_sha256, kDummyHash, sizeof(kDummyHash), buf,

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -471,6 +471,7 @@ OPENSSL_EXPORT RSA *RSAPublicKey_dup(const RSA *rsa);
 // |rsa| into it. It returns the fresh |RSA| object, or NULL on error.
 OPENSSL_EXPORT RSA *RSAPrivateKey_dup(const RSA *rsa);
 
+// TODO(dkostic): update
 // RSA_check_key performs basic validity tests on |rsa|. It returns one if
 // they pass and zero otherwise. Opaque keys and public keys always pass. If it
 // returns zero then a more detailed error is available on the error queue.

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -471,10 +471,9 @@ OPENSSL_EXPORT RSA *RSAPublicKey_dup(const RSA *rsa);
 // |rsa| into it. It returns the fresh |RSA| object, or NULL on error.
 OPENSSL_EXPORT RSA *RSAPrivateKey_dup(const RSA *rsa);
 
-// TODO(dkostic): update
 // RSA_check_key performs basic validity tests on |rsa|. It returns one if
-// they pass and zero otherwise. Opaque keys and public keys always pass. If it
-// returns zero then a more detailed error is available on the error queue.
+// they pass and zero otherwise. If it returns zero then a more detailed error
+// is available on the error queue.
 OPENSSL_EXPORT int RSA_check_key(const RSA *rsa);
 
 // RSA_check_fips performs public key validity tests on |key|. It returns one if


### PR DESCRIPTION
### Issues:
CryptoAlg-2280

### Description of changes: 
This is the second PR in a series of PRs that will attempt to
consolidate the RSA key checking in AWS-LC. In this PR:
  - replace RSA_check_key with the new implementation from #1349:
    (0a470e450c6f5492478319abefc6daa0e9999954)
  - add support for stripped private keys (JCA),
  - remove RSA_validate_key

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
