### PR TITLE
Update go.cmake to use PROJECT_SOURCE_DIR

### DIFF
--- a/cmake/go.cmake
+++ b/cmake/go.cmake
@@ -15,7 +15,7 @@ if(NOT GO_EXECUTABLE AND NOT DISABLE_GO)
 endif()
 
 function(go_executable dest package)
-  set(godeps "${CMAKE_SOURCE_DIR}/util/godeps.go")
+  set(godeps "${PROJECT_SOURCE_DIR}/util/godeps.go")
   if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
     # The DEPFILE parameter to add_custom_command only works with Ninja. Query
     # the sources at configure time. Additionally, everything depends on go.mod.
@@ -32,7 +32,7 @@ function(go_executable dest package)
                        COMMAND ${GO_EXECUTABLE} build
                                -o ${CMAKE_CURRENT_BINARY_DIR}/${dest} ${package}
                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                       DEPENDS ${sources} ${CMAKE_SOURCE_DIR}/go.mod)
+                       DEPENDS ${sources} ${PROJECT_SOURCE_DIR}/go.mod)
   else()
     # Ninja expects the target in the depfile to match the output. This is a
     # relative path from the build directory.
@@ -52,7 +52,7 @@ function(go_executable dest package)
                          COMMAND ${GO_EXECUTABLE} build
                          -o ${CMAKE_CURRENT_BINARY_DIR}/${dest} ${package}
                          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                         DEPENDS ${CMAKE_SOURCE_DIR}/go.mod)
+                         DEPENDS ${PROJECT_SOURCE_DIR}/go.mod)
     else()
       set(depfile "${CMAKE_CURRENT_BINARY_DIR}/${dest}.d")
       add_custom_command(OUTPUT ${dest}
@@ -61,7 +61,7 @@ function(go_executable dest package)
                          COMMAND ${GO_EXECUTABLE} run ${godeps} -format depfile
                          -target ${target} -pkg ${package} -out ${depfile}
                          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                         DEPENDS ${godeps} ${CMAKE_SOURCE_DIR}/go.mod
+                         DEPENDS ${godeps} ${PROJECT_SOURCE_DIR}/go.mod
                          DEPFILE ${depfile})
     endif()
   endif()


### PR DESCRIPTION

### Issues:
Resolves P120917801

### Description of changes: 
[CMAKE_SOURCE_DIR](https://cmake.org/cmake/help/latest/variable/CMAKE_SOURCE_DIR.html) points to the top of the CMake source tree, [PROJECT_SOURCE_DIR](https://cmake.org/cmake/help/latest/variable/PROJECT_SOURCE_DIR.html) points to the directory of the last `project()` call. When building AWS-LC by itself the two are the same directory. However, if a consumer builds AWS-LC with a call to `add_subdirectory` the paths will be different. With CMAKE_SOURCE_DIR the path to our go.mod will be wrong and point to the customer's root folder which doesn't have our go.mod and fails to build.

### Call-outs:
This shouldn't change the behavior when building AWS-LC directly. Besides the custom EC benchmark this is the last usage of CMAKE_SOURCE_DIR and everything else works for the SDK.

### Testing:
Manually tested locally by modifying the CRT's build options. I can't update `run_crt_integration.sh` yet because there changes to use the FIPS build are not checked in yet. 

```
git clone https://github.com/awslabs/aws-crt-java.git
cd aws-crt-java
git submodule update --init --recursive

# Modify crt/aws-lc/cmake/go.cmake with this change
# Modify crt/cmake/modules/aws-lc.cmake to enable FIPS, Perl, and Go
mvn compile
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
