### PR TITLE
Add ASN1_i2d_bio and ASN1_i2d_bio_of back

### DIFF
--- a/crypto/asn1/a_i2d_fp.c
+++ b/crypto/asn1/a_i2d_fp.c
@@ -88,23 +88,9 @@ int ASN1_i2d_bio(i2d_of_void *i2d, BIO *out, void *in) {
     return 0;
   }
 
-  int idx=0;
-  for (;;) {
-    int written = BIO_write(out, &(buffer[idx]), size);
-    assert(written <= size);
-    if (written == size) {
-      break;
-    }
-    if (written <= 0) {
-      OPENSSL_PUT_ERROR(ASN1, ASN1_R_BUFFER_TOO_SMALL);
-      OPENSSL_free(buffer);
-      return 0;
-    }
-    idx += written;
-    size -= written;
-  }
+  ret = BIO_write_all(out, buffer, size);
   OPENSSL_free(buffer);
-  return 1;
+  return ret;
 }
 
 int ASN1_item_i2d_fp(const ASN1_ITEM *it, FILE *out, void *x) {

--- a/crypto/asn1/a_i2d_fp.c
+++ b/crypto/asn1/a_i2d_fp.c
@@ -71,7 +71,7 @@ int ASN1_i2d_bio(i2d_of_void *i2d, BIO *out, void *in) {
 
   int size = i2d(in, NULL);
   if (size <= 0) {
-    OPENSSL_PUT_ERROR(ASN1, ERR_R_MALLOC_FAILURE);
+    OPENSSL_PUT_ERROR(ASN1, ERR_R_INTERNAL_ERROR);
     return 0;
   }
 
@@ -85,6 +85,7 @@ int ASN1_i2d_bio(i2d_of_void *i2d, BIO *out, void *in) {
   int ret = i2d(in, &outp);
   if (ret < 0 || ret > size) {
     OPENSSL_PUT_ERROR(ASN1, ASN1_R_BUFFER_TOO_SMALL);
+    OPENSSL_free(buffer);
     return 0;
   }
 

--- a/crypto/asn1/asn1_test.cc
+++ b/crypto/asn1/asn1_test.cc
@@ -2471,6 +2471,10 @@ TEST(ASN1Test, Recursive) {
   ASN1_LINKED_LIST_free(list);
 }
 
+static int i2d_ASN1_LINKED_LIST_void(const void *a, unsigned char **out) {
+  return i2d_ASN1_LINKED_LIST((ASN1_LINKED_LIST *)a, out);
+}
+
 TEST(ASN1Test, BIO) {
   bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
   bssl::UniquePtr<uint8_t> data;
@@ -2487,8 +2491,7 @@ TEST(ASN1Test, BIO) {
 
   const uint8_t *out;
   size_t out_len;
-  EXPECT_TRUE(
-      ASN1_i2d_bio_of(ASN1_LINKED_LIST, i2d_ASN1_LINKED_LIST, bio.get(), list));
+  EXPECT_TRUE(ASN1_i2d_bio(i2d_ASN1_LINKED_LIST_void, bio.get(), list));
   ASSERT_TRUE(BIO_mem_contents(bio.get(), &out, &out_len));
 
   EXPECT_EQ(Bytes(out, out_len), Bytes(expected, expected_len));

--- a/crypto/asn1/asn1_test.cc
+++ b/crypto/asn1/asn1_test.cc
@@ -2471,6 +2471,31 @@ TEST(ASN1Test, Recursive) {
   ASN1_LINKED_LIST_free(list);
 }
 
+TEST(ASN1Test, BIO) {
+  bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
+  bssl::UniquePtr<uint8_t> data;
+  size_t len;
+  ASSERT_TRUE(MakeLinkedList(&data, &len, 5));
+  const uint8_t *ptr = data.get();
+  ASN1_LINKED_LIST *list = d2i_ASN1_LINKED_LIST(nullptr, &ptr, len);
+  EXPECT_TRUE(list);
+
+  // Retrieve expected bytes.
+  uint8_t *expected = nullptr;
+  int expected_len = i2d_ASN1_LINKED_LIST(list, &expected);
+  ASSERT_GT(expected_len, 0);
+
+  const uint8_t *out;
+  size_t out_len;
+  EXPECT_TRUE(
+      ASN1_i2d_bio_of(ASN1_LINKED_LIST, i2d_ASN1_LINKED_LIST, bio.get(), list));
+  ASSERT_TRUE(BIO_mem_contents(bio.get(), &out, &out_len));
+
+  EXPECT_EQ(Bytes(out, out_len), Bytes(expected, expected_len));
+  OPENSSL_free(expected);
+  ASN1_LINKED_LIST_free(list);
+}
+
 struct IMPLICIT_CHOICE {
   ASN1_STRING *string;
 };

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -240,7 +240,9 @@ int BIO_write_all(BIO *bio, const void *data, size_t len) {
   const uint8_t *data_u8 = data;
   while (len > 0) {
     int ret = BIO_write(bio, data_u8, len > INT_MAX ? INT_MAX : (int)len);
+    assert(ret <= (int)len);
     if (ret <= 0) {
+      OPENSSL_PUT_ERROR(ASN1, ASN1_R_BUFFER_TOO_SMALL);
       return 0;
     }
     data_u8 += ret;

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -239,8 +239,9 @@ int BIO_write(BIO *bio, const void *in, int inl) {
 int BIO_write_all(BIO *bio, const void *data, size_t len) {
   const uint8_t *data_u8 = data;
   while (len > 0) {
-    int ret = BIO_write(bio, data_u8, len > INT_MAX ? INT_MAX : (int)len);
-    assert(ret <= (int)len);
+    const int write_len = ((len > INT_MAX) ? INT_MAX : (int)len);
+    int ret = BIO_write(bio, data_u8, write_len);
+    assert(ret <= write_len);
     if (ret <= 0) {
       OPENSSL_PUT_ERROR(ASN1, ASN1_R_BUFFER_TOO_SMALL);
       return 0;

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -271,7 +271,7 @@ int i2d_SAMPLE(const SAMPLE *in, uint8_t **outp);
 // |d2i| or |i2d| ASN1 functions of |type|.
 //
 // NOTE: |D2I_OF| and |I2D_OF_const| are not implemented.
-#define I2D_OF(type) int (*)(type *,unsigned char **)
+#define I2D_OF(type) int (*)(type *, unsigned char **)
 
 // CHECKED_I2D_OF casts a given pointer to i2d_of_void* and statically checks
 // that it was a pointer to |type|'s |i2d| function.
@@ -424,13 +424,24 @@ OPENSSL_EXPORT void *ASN1_item_d2i_bio(const ASN1_ITEM *it, BIO *in, void *out);
 OPENSSL_EXPORT int ASN1_item_i2d_fp(const ASN1_ITEM *it, FILE *out, void *in);
 OPENSSL_EXPORT int ASN1_item_i2d_bio(const ASN1_ITEM *it, BIO *out, void *in);
 
-// ASN1_i2d_bio writes the result to |out| like the functions above, but parses |in|
-// with |i2d|.
+// ASN1_i2d_bio writes the result to |out| like the functions above, but parses
+// |in| with |i2d|.
 //
-// Note: Use |ASN1_i2d_bio_of| instead.
+// WARNING: Prefer using type-specific functions. |i2d| is only valid with a
+// wrapper (see |d2i_of_void|).
 OPENSSL_EXPORT int ASN1_i2d_bio(i2d_of_void *i2d, BIO *out, void *in);
 
-// ASN1_i2d_bio_of statically checks |type| before calling |ASN1_i2d_bio|.
+// ASN1_i2d_bio_of statically checks |i2d| and |in| for |type| before casting
+// and calling |ASN1_i2d_bio|.
+//
+// DO NOT USE: This is only maintained for compatibility purposes. Calling a
+// function with a different pointer type is undefined behavior in C (see
+// |d2i_of_void|).
+// This macro forces the user to directly call the |i2d| ASN.1 function of
+// |type|. |i2d| functions of |type| are defined with parameters of |type *|,
+// but |i2d_of_void| expects the signature of a |const void *|. This inherently
+// forces the user to use undefined C behavior and will cause failures when
+// running against undefined behavior sanitizers in clang.
 #define ASN1_i2d_bio_of(type, i2d, out, in) \
     (ASN1_i2d_bio(CHECKED_I2D_OF(type, i2d), out, CHECKED_PTR_OF(type, in)))
 

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -267,6 +267,17 @@ int i2d_SAMPLE(const SAMPLE *in, uint8_t **outp);
 
 #endif  // Sample functions
 
+// The following macros are used to retrieve the function pointer of the
+// |d2i| or |i2d| ASN1 functions of |type|.
+//
+// NOTE: |D2I_OF| and |I2D_OF_const| are not implemented.
+#define I2D_OF(type) int (*)(type *,unsigned char **)
+
+// CHECKED_I2D_OF casts a given pointer to i2d_of_void* and statically checks
+// that it was a pointer to |type|'s |i2d| function.
+#define CHECKED_I2D_OF(type, i2d) \
+    ((i2d_of_void*) (1 ? i2d : ((I2D_OF(type))0)))
+
 // The following typedefs are sometimes used for pointers to functions like
 // |d2i_SAMPLE| and |i2d_SAMPLE|. Note, however, that these act on |void*|.
 // Calling a function with a different pointer type is undefined in C, so this
@@ -412,6 +423,16 @@ OPENSSL_EXPORT void *ASN1_item_d2i_bio(const ASN1_ITEM *it, BIO *in, void *out);
 // |ASN1_BOOLEAN|.
 OPENSSL_EXPORT int ASN1_item_i2d_fp(const ASN1_ITEM *it, FILE *out, void *in);
 OPENSSL_EXPORT int ASN1_item_i2d_bio(const ASN1_ITEM *it, BIO *out, void *in);
+
+// ASN1_i2d_bio writes the result to |out| like the functions above, but parses |in|
+// with |i2d|.
+//
+// Note: Use |ASN1_i2d_bio_of| instead.
+OPENSSL_EXPORT int ASN1_i2d_bio(i2d_of_void *i2d, BIO *out, void *in);
+
+// ASN1_i2d_bio_of statically checks |type| before calling |ASN1_i2d_bio|.
+#define ASN1_i2d_bio_of(type, i2d, out, in) \
+    (ASN1_i2d_bio(CHECKED_I2D_OF(type, i2d), out, CHECKED_PTR_OF(type, in)))
 
 // ASN1_item_unpack parses |oct|'s contents as |it|'s ASN.1 type. It returns a
 // newly-allocated instance of |it|'s C type on success, or NULL on error.

--- a/include/openssl/type_check.h
+++ b/include/openssl/type_check.h
@@ -104,6 +104,9 @@ extern "C" {
 // wpa_supplicant has been fixed.
 #define CHECKED_CAST(to, from, p) ((to) (1 ? (p) : (from)0))
 
+// CHECKED_PTR_OF casts a given pointer to void* and statically checks that it
+// was a pointer to |type|.
+#define CHECKED_PTR_OF(type, p) CHECKED_CAST(void*, type*, (p))
 
 #if defined(__cplusplus)
 }  // extern C


### PR DESCRIPTION
### Description of changes: 
tmp2-tools defines some of it's own ASN1 structures and [depends](https://github.com/tpm2-software/tpm2-tools/blob/beaecabac2e9c1f26afcb5658c2cdf244c6ad8cc/tools/misc/tpm2_certifyX509certutil.c#L51) on some removed functions & macros.
The removal of these were spread across https://github.com/aws/aws-lc/commit/792c1dc43eb888470b2ecb162be2acc5e0e1d61b and https://github.com/aws/aws-lc/commit/419144adce049b5341bd94d355c52d099eac56e3. 



### Call-outs:
N/A

### Testing:
Parsing and verifying the contents against our existing ASN1 functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
