### PR TITLE
Add integration CI for tpm2-tools

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Install OS Dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang autoconf-archive libcmocka0 libcmocka-dev procps iproute2 build-essential git pkg-config gcc libtool automake libssl-dev uthash-dev autoconf doxygen libjson-c-dev libini-config-dev libcurl4-openssl-dev uuid-dev libltdl-dev libusb-1.0-0-dev libftdi-dev
+          sudo apt-get update && sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang autoconf-archive libcmocka0 libcmocka-dev procps iproute2 build-essential git pkg-config gcc libtool automake libssl-dev uthash-dev autoconf doxygen libjson-c-dev libini-config-dev libcurl4-openssl-dev uuid-dev libltdl-dev libusb-1.0-0-dev libftdi-dev libglib2.0-dev pandoc
       - uses: actions/checkout@v3
       - name: Run integration build
         run: |

--- a/tests/ci/integration/run_tpm2_tss_integration.sh
+++ b/tests/ci/integration/run_tpm2_tss_integration.sh
@@ -24,6 +24,10 @@ source tests/ci/common_posix_setup.sh
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SCRATCH_FOLDER=${SYS_ROOT}/"TPM2_TSS_SCRATCH"
 TPM2_TSS_SRC_FOLDER="${SCRATCH_FOLDER}/tpm2-tss"
+TPM2_TSS_INSTALL_FOLDER="${SCRATCH_FOLDER}/tpm2-tss-install"
+TPM2_ABRMD_SRC_FOLDER="${SCRATCH_FOLDER}/tpm2-abrmd"
+TPM2_ABRMD_INSTALL_FOLDER="${SCRATCH_FOLDER}/tpm2-abrmd-install"
+TPM2_TOOLS_SRC_FOLDER="${SCRATCH_FOLDER}/tpm2-tools"
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
 CURL_SRC_FOLDER="${SCRATCH_FOLDER}/curl"
@@ -46,15 +50,36 @@ function tpm2_tss_build() {
   git apply "${SCRIPT_DIR}/tpm2_tss_patch/aws-lc-tpm2-tss.patch"
   export PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig:${CURL_INSTALL_FOLDER}/lib/pkgconfig"
   /bin/sh ./bootstrap
-  ./configure --enable-unit --with-crypto=ossl CFLAGS="-g -ggdb -O0 -I\"${AWS_LC_INSTALL_FOLDER}\"/include -I\"${CURL_INSTALL_FOLDER}\"/include -L\"${AWS_LC_INSTALL_FOLDER}\"/lib -L\"${CURL_INSTALL_FOLDER}\"/lib" LT_SYS_LIBRARY_PATH="${LD_LIBRARY_PATH}"
+  ./configure --enable-unit --with-crypto=ossl --prefix="${TPM2_TSS_INSTALL_FOLDER}"
   make -j "${NUM_CPU_THREADS}" all VERBOSE=1
   make -j "${NUM_CPU_THREADS}" check VERBOSE=1
   ldd "${TPM2_TSS_SRC_FOLDER}/test/unit/.libs/fapi-get-web-cert" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
+  make -j "${NUM_CPU_THREADS}" install
+}
+
+function tpm2_abrmd_build() {
+  export PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig:${TPM2_TSS_INSTALL_FOLDER}/lib/pkgconfig"
+  /bin/sh ./bootstrap
+  ./configure --enable-unit --with-crypto=ossl --prefix="${TPM2_ABRMD_INSTALL_FOLDER}" 
+  make -j "${NUM_CPU_THREADS}" all VERBOSE=1
+  make -j "${NUM_CPU_THREADS}" check VERBOSE=1
+  make -j "${NUM_CPU_THREADS}" install
+}
+
+function tpm2_tools_build() {
+  git apply "${SCRIPT_DIR}/tpm2_tools_patch/aws-lc-tpm2-tools.patch"
+  export PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig:${TPM2_TSS_INSTALL_FOLDER}/lib/pkgconfig:${TPM2_ABRMD_INSTALL_FOLDER}/lib/pkgconfig"
+  /bin/sh ./bootstrap
+  ./configure --with-crypto=ossl
+  make -j "${NUM_CPU_THREADS}" all VERBOSE=1
+  make -j "${NUM_CPU_THREADS}" check VERBOSE=1
 }
 
 # Get latest curl and tpm2-tss
 git clone https://github.com/curl/curl.git "${CURL_SRC_FOLDER}"
 git clone https://github.com/tpm2-software/tpm2-tss.git "${TPM2_TSS_SRC_FOLDER}"
+git clone https://github.com/tpm2-software/tpm2-abrmd.git "${TPM2_ABRMD_SRC_FOLDER}"
+git clone https://github.com/tpm2-software/tpm2-tools.git "${TPM2_TOOLS_SRC_FOLDER}"
 mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${CURL_BUILD_FOLDER}" "${CURL_INSTALL_FOLDER}"
 ls
 
@@ -64,9 +89,22 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${AWS_LC_INSTALL_FOLDER}/lib/"
 curl_build
 
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${CURL_INSTALL_FOLDER}/lib/"
+export CFLAGS="-g -ggdb -O0 -I\"${AWS_LC_INSTALL_FOLDER}\"/include -I\"${CURL_INSTALL_FOLDER}\"/include -L\"${AWS_LC_INSTALL_FOLDER}\"/lib -L\"${CURL_INSTALL_FOLDER}\"/lib" LT_SYS_LIBRARY_PATH="${LD_LIBRARY_PATH}"
 
 pushd "${TPM2_TSS_SRC_FOLDER}"
 tpm2_tss_build
+popd
+
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${TPM2_TSS_INSTALL_FOLDER}/lib/"
+
+pushd "${TPM2_ABRMD_SRC_FOLDER}"
+tpm2_abrmd_build
+popd
+
+export PATH="${PATH:-}:${TPM2_ABRMD_INSTALL_FOLDER}/sbin/"
+
+pushd "${TPM2_TOOLS_SRC_FOLDER}"
+tpm2_tools_build
 popd
 
 popd

--- a/tests/ci/integration/tpm2_tools_patch/aws-lc-tpm2-tools.patch
+++ b/tests/ci/integration/tpm2_tools_patch/aws-lc-tpm2-tools.patch
@@ -1,0 +1,48 @@
+diff --git a/lib/tpm2_identity_util.c b/lib/tpm2_identity_util.c
+index fbf1e938..2c6448d3 100644
+--- a/lib/tpm2_identity_util.c
++++ b/lib/tpm2_identity_util.c
+@@ -91,7 +91,7 @@ static bool share_secret_with_tpm2_rsa_public_key(TPM2B_DIGEST *protection_seed,
+         goto error;
+     }
+ 
+-    rc = EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, newlabel, label_len);
++    rc = EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, (uint8_t*)newlabel, label_len);
+     if (rc <= 0) {
+         LOG_ERR("Failed EVP_PKEY_CTX_set0_rsa_oaep_label");
+         free(newlabel);
+diff --git a/lib/tpm2_openssl.c b/lib/tpm2_openssl.c
+index 516d8b63..48d75c7b 100644
+--- a/lib/tpm2_openssl.c
++++ b/lib/tpm2_openssl.c
+@@ -36,7 +36,7 @@ int tpm2_openssl_halgid_from_tpmhalg(TPMI_ALG_HASH algorithm) {
+         return NID_sha384;
+     case TPM2_ALG_SHA512:
+         return NID_sha512;
+-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
++#if OPENSSL_VERSION_NUMBER >= 0x10101000L && HAVE_EVP_SM3
+ 	case TPM2_ALG_SM3_256:
+ 		return NID_sm3;
+ #endif
+@@ -666,7 +666,7 @@ static const struct {
+     { TPM2_ECC_NIST_P256, NID_X9_62_prime256v1 },
+     { TPM2_ECC_NIST_P384, NID_secp384r1        },
+     { TPM2_ECC_NIST_P521, NID_secp521r1        },
+-#if OPENSSL_VERSION_NUMBER >= 0x10101003L
++#if OPENSSL_VERSION_NUMBER >= 0x10101003L && HAVE_EVP_SM3
+     { TPM2_ECC_SM2_P256,  NID_sm2              },
+ #endif
+     /*
+diff --git a/tools/misc/tpm2_checkquote.c b/tools/misc/tpm2_checkquote.c
+index e5f8ef41..10847523 100644
+--- a/tools/misc/tpm2_checkquote.c
++++ b/tools/misc/tpm2_checkquote.c
+@@ -80,7 +80,7 @@ static bool verify(void) {
+         return false;
+     }
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10101003L
++#if OPENSSL_VERSION_NUMBER >= 0x10101003L && HAVE_EVP_SM3
+ #if OPENSSL_VERSION_MAJOR < 3
+     if (ctx.halg == TPM2_ALG_SM3_256) {
+         ret = EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2);


### PR DESCRIPTION
### Description of changes: 
This builds upon the work we've done in https://github.com/aws/aws-lc/commit/c065ab2baa130de0d547b1064ca2fe904a83d547 and adds an integration CI for tpm2-tools.

This depends on https://github.com/aws/aws-lc/pull/1481 and https://github.com/aws/aws-lc/pull/1486 to work.

### Call-outs:
N/A

### Testing:
New CI dimension. Integration tests will be turned on once "tpm_server" is fixed ([test dependency requirement](https://github.com/tpm2-software/tpm2-tools/blob/c55288f0fab3d83ae1dee0bc022c393509f839fe/docs/INSTALL.md#optional-dependencies)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
