### PR TITLE
Fix overscoped json policies in CI

### DIFF
--- a/tests/ci/cdk/cdk/windows_docker_image_build_stack.py
+++ b/tests/ci/cdk/cdk/windows_docker_image_build_stack.py
@@ -47,6 +47,8 @@ class WindowsDockerImageBuildStack(Stack):
                         ])
 
         # Define Windows EC2 instance, where the SSM document will be executed.
+        # TODO: This AMI does not have docker installed by default anymore. Find another Windows machine
+        #       that has docker by default or update the ssm document to properly install docker.
         machine_image = ec2.MachineImage.latest_windows(
             ec2.WindowsVersion.WINDOWS_SERVER_2019_ENGLISH_FULL_BASE)
         vpc = ec2.Vpc(scope=self, id="{}-vpc".format(id))

--- a/tests/ci/cdk/run-cdk.sh
+++ b/tests/ci/cdk/run-cdk.sh
@@ -67,8 +67,10 @@ function create_linux_docker_img_build_stack() {
   destroy_docker_img_build_stack
   # Deploy aws-lc ci stacks.
   # When repeatedly deploy, error 'EIP failed Reason: Maximum number of addresses has been reached' can happen.
-  # https://forums.aws.amazon.com/thread.jspa?messageID=952368
-  # Workaround: go to AWS EIP console, release unused IP.
+  #
+  # Workaround: The default quota amount is 5 EIP addresses. Go to
+  # https://us-west-2.console.aws.amazon.com/servicequotas/home/services/ec2/quotas and request a quota
+  # increase for "EC2-VPC Elastic IPs".
   cdk deploy aws-lc-docker-image-build-linux --require-approval never
 }
 
@@ -77,8 +79,10 @@ function create_win_docker_img_build_stack() {
   destroy_docker_img_build_stack
   # Deploy aws-lc ci stacks.
   # When repeatedly deploy, error 'EIP failed Reason: Maximum number of addresses has been reached' can happen.
-  # https://forums.aws.amazon.com/thread.jspa?messageID=952368
-  # Workaround: go to AWS EIP console, release unused IP.
+  #
+  # Workaround: The default quota amount is 5 EIP addresses. Go to
+  # https://us-west-2.console.aws.amazon.com/servicequotas/home/services/ec2/quotas and request a quota
+  # increase for "EC2-VPC Elastic IPs".
   cdk deploy aws-lc-docker-image-build-windows --require-approval never
 }
 

--- a/tests/ci/cdk/util/iam_policies.py
+++ b/tests/ci/cdk/util/iam_policies.py
@@ -23,7 +23,7 @@ def ec2_policies_in_json(ec2_role_name, ec2_security_group_id, ec2_subnet_id, ec
                     "ec2:DescribeInstances",
                 ],
                 "Resource": [
-                    "arn:aws:iam::{}:role/*".format(AWS_ACCOUNT, ec2_role_name),
+                    "arn:aws:iam::{}:role/{}".format(AWS_ACCOUNT, ec2_role_name),
                     "arn:aws:ec2:{}:{}:instance/*".format(AWS_REGION, AWS_ACCOUNT),
                     "arn:aws:ec2:{}::image/*".format(AWS_REGION),
                     "arn:aws:ec2:{}:{}:network-interface/*".format(AWS_REGION, AWS_ACCOUNT),

--- a/tests/ci/run_ec2_test_framework.sh
+++ b/tests/ci/run_ec2_test_framework.sh
@@ -31,7 +31,7 @@ generate_ssm_document_file() {
 create_ec2_instances() {
   local instance_id
   instance_id="$(aws ec2 run-instances --image-id "$1" --count 1 \
-    --instance-type "$2" --security-group-ids "${sg_id}" --subnet-id "${subnet_id}" \
+    --instance-type "$2" --security-group-ids "${EC2_SECURITY_GROUP_ID}" --subnet-id "${EC2_SUBNET_ID}" \
     --block-device-mappings 'DeviceName="/dev/sda1",Ebs={DeleteOnTermination=True,VolumeSize=200}' \
     --tag-specifications 'ResourceType="instance",Tags=[{Key="Name",Value="ec2-test-'"$CODEBUILD_WEBHOOK_TRIGGER"'"}]' \
     --iam-instance-profile Name=aws-lc-ci-ec2-test-framework-ec2-profile \
@@ -52,11 +52,6 @@ export ec2_ami_id="$1"
 export ec2_instance_type="$2"
 export ecr_docker_tag="$3"
 export s3_bucket_name="aws-lc-codebuild"
-
-# Get resources for ec2 instances. These were created with the cdk script.
-vpc_id="$(aws ec2 describe-vpcs --filter Name=tag:Name,Values=aws-lc-ci-ec2-test-framework/aws-lc-ci-ec2-test-framework-ec2-vpc --query Vpcs[*].VpcId --output text)"
-sg_id="$(aws ec2 describe-security-groups --filter Name=vpc-id,Values="${vpc_id}" --filter Name=group-name,Values=codebuild_ec2_sg --query SecurityGroups[*].GroupId --output text)"
-subnet_id="$(aws ec2 describe-subnets --filter Name=vpc-id,Values="${vpc_id}" --filter Name=state,Values=available --filter Name=tag:Name,Values=aws-lc-ci-ec2-test-framework/aws-lc-ci-ec2-test-framework-ec2-vpc/PrivateSubnet1 --query Subnets[*].SubnetId --output text)"
 
 # create the ssm documents that will be used for the various ssm commands
 generate_ssm_document_file


### PR DESCRIPTION
### Issues:
Resolves `V1177876714`

### Description of changes: 
There were a few overscoped IAM policies in our CI. Best practice is to minimize permissions, so we're enforcing that here.
* I've moved some of the ec2 resource creations to cdk instead of the original cli methods. The framework should be able to access these via Codebuild environment variables.
* I checked our S3 bucket policies, but discovered that the automated windows docker doesn't work anymore. This was due to docker not being installed by default. The new minimal S3 permissions work, but I've left a TODO to fix this later on.

### Call-outs:
N/A

### Testing:
"Works in my account": https://github.com/samuel40791765/aws-lc/pull/31

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
