### PR TITLE
Only enable dilithium and secp256k1 benchmark if AWS-LC API supports it

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -573,7 +573,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_clang-14x-sde_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_gcc-8x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_benchmark_build_tests.sh"
 

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -573,7 +573,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_gcc-8x_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_gcc-7x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_benchmark_build_tests.sh"
 

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -573,7 +573,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_gcc-7x_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_clang-14x-sde_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_benchmark_build_tests.sh"
 

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -29,19 +29,20 @@ function build_aws_lc_fips {
   popd
 }
 
-function build_aws_lc_fips_2022 {
-    echo "building the fips-2022-11-02 branch of aws-lc in FIPS mode"
-    git clone --depth 1 --branch fips-2022-11-02 https://github.com/aws/aws-lc.git "${scratch_folder}/aws-lc-fips-2022-11-02"
-    pushd "${scratch_folder}/aws-lc-fips-2022-11-02"
+function build_aws_lc_branch {
+    branch="$1"
+    echo "building the ${branch} branch of aws-lc in FIPS mode"
+    git clone --depth 1 --branch $branch https://github.com/aws/aws-lc.git "${scratch_folder}/aws-lc-${branch}"
+    pushd "${scratch_folder}/aws-lc-${branch}"
     cmake -GNinja \
-        -DCMAKE_INSTALL_PREFIX="${install_dir}/aws-lc-fips-2022-11-02" \
+        -DCMAKE_INSTALL_PREFIX="${install_dir}/aws-lc-${branch}" \
         -DFIPS=1 \
         -DENABLE_DILITHIUM=ON \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DBUILD_TESTING=OFF
     ninja install
     popd
-    rm -rf "${scratch_folder}/aws-lc-fips-2022-11-02"
+    rm -rf "${scratch_folder}/aws-lc-${branch}"
 }
 
 function build_openssl {
@@ -77,7 +78,8 @@ function build_boringssl {
 build_aws_lc_fips
 "${BUILD_ROOT}/tool/bssl" speed -timeout_ms 10
 
-build_aws_lc_fips_2022
+build_aws_lc_branch fips-2022-11-02
+build_aws_lc_branch fips-2021-10-20
 build_openssl $openssl_1_0_2_branch
 build_openssl $openssl_1_1_1_branch
 build_openssl $openssl_3_1_branch
@@ -86,14 +88,16 @@ build_openssl $openssl_master_branch
 build_boringssl
 
 run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=14 -DCMAKE_C_STANDARD=11 -DBENCHMARK_LIBS="\
-aws-lc-fips:${install_dir}/aws-lc-fips-2022-11-02;\
+aws-lc-fips-2021:${install_dir}/aws-lc-fips-2021-10-20;\
+aws-lc-fips-2022:${install_dir}/aws-lc-fips-2022-11-02;\
 open102:${install_dir}/openssl-${openssl_1_0_2_branch};\
 open111:${install_dir}/openssl-${openssl_1_1_1_branch};\
 open31:${install_dir}/openssl-${openssl_3_1_branch};\
 open32:${install_dir}/openssl-${openssl_3_2_branch};\
 openmaster:${install_dir}/openssl-${openssl_master_branch};\
 boringssl:${install_dir}/boringssl;"
-"${BUILD_ROOT}/tool/aws-lc-fips" -timeout_ms 10
+"${BUILD_ROOT}/tool/aws-lc-fips-2021" -timeout_ms 10
+"${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10
 "${BUILD_ROOT}/tool/open102" -timeout_ms 10
 "${BUILD_ROOT}/tool/open111" -timeout_ms 10
 "${BUILD_ROOT}/tool/open31" -timeout_ms 10

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -40,7 +40,8 @@ function build_aws_lc_branch {
         -DFIPS=1 \
         -DENABLE_DILITHIUM=ON \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DBUILD_SHARED_LIBS=1
+        -DBUILD_SHARED_LIBS=1 \
+        -DBUILD_TESTING=OFF
     ninja install
     popd
     rm -rf "${scratch_folder}/aws-lc-${branch}"

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -78,7 +78,6 @@ function build_boringssl {
 build_aws_lc_fips
 "${BUILD_ROOT}/tool/bssl" speed -timeout_ms 10
 
-build_aws_lc_branch fips-2022-11-02
 build_aws_lc_branch fips-2021-10-20
 build_openssl $openssl_1_0_2_branch
 build_openssl $openssl_1_1_1_branch
@@ -87,8 +86,7 @@ build_openssl $openssl_3_2_branch
 build_openssl $openssl_master_branch
 build_boringssl
 
-run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=14 -DCMAKE_C_STANDARD=11 -DBENCHMARK_LIBS="\
-aws-lc-fips-2021:${install_dir}/aws-lc-fips-2021-10-20;\
+run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=14 -DCMAKE_C_STANDARD=11 -DENABLE_DILITHIUM=ON -DBENCHMARK_LIBS="\
 aws-lc-fips-2022:${install_dir}/aws-lc-fips-2022-11-02;\
 open102:${install_dir}/openssl-${openssl_1_0_2_branch};\
 open111:${install_dir}/openssl-${openssl_1_1_1_branch};\
@@ -96,7 +94,6 @@ open31:${install_dir}/openssl-${openssl_3_1_branch};\
 open32:${install_dir}/openssl-${openssl_3_2_branch};\
 openmaster:${install_dir}/openssl-${openssl_master_branch};\
 boringssl:${install_dir}/boringssl;"
-"${BUILD_ROOT}/tool/aws-lc-fips-2021" -timeout_ms 10
 "${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10
 "${BUILD_ROOT}/tool/open102" -timeout_ms 10
 "${BUILD_ROOT}/tool/open111" -timeout_ms 10

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -23,6 +23,7 @@ function build_aws_lc_fips {
       -DFIPS=1 \
       -DENABLE_DILITHIUM=ON \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DBUILD_SHARED_LIBS=1 \
       -DBUILD_TESTING=OFF
   pushd "$BUILD_ROOT"
   ninja install
@@ -39,6 +40,7 @@ function build_aws_lc_branch {
         -DFIPS=1 \
         -DENABLE_DILITHIUM=ON \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DBUILD_SHARED_LIBS=1 \
         -DBUILD_TESTING=OFF
     ninja install
     popd
@@ -79,6 +81,7 @@ build_aws_lc_fips
 "${BUILD_ROOT}/tool/bssl" speed -timeout_ms 10
 
 build_aws_lc_branch fips-2021-10-20
+build_aws_lc_branch fips-2022-11-02
 build_openssl $openssl_1_0_2_branch
 build_openssl $openssl_1_1_1_branch
 build_openssl $openssl_3_1_branch
@@ -87,6 +90,7 @@ build_openssl $openssl_master_branch
 build_boringssl
 
 run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=14 -DCMAKE_C_STANDARD=11 -DENABLE_DILITHIUM=ON -DBENCHMARK_LIBS="\
+aws-lc-fips-2021:${install_dir}/aws-lc-fips-2021-10-20;\
 aws-lc-fips-2022:${install_dir}/aws-lc-fips-2022-11-02;\
 open102:${install_dir}/openssl-${openssl_1_0_2_branch};\
 open111:${install_dir}/openssl-${openssl_1_1_1_branch};\
@@ -94,6 +98,7 @@ open31:${install_dir}/openssl-${openssl_3_1_branch};\
 open32:${install_dir}/openssl-${openssl_3_2_branch};\
 openmaster:${install_dir}/openssl-${openssl_master_branch};\
 boringssl:${install_dir}/boringssl;"
+"${BUILD_ROOT}/tool/aws-lc-fips-2021" -timeout_ms 10
 "${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10
 "${BUILD_ROOT}/tool/open102" -timeout_ms 10
 "${BUILD_ROOT}/tool/open111" -timeout_ms 10

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -40,8 +40,7 @@ function build_aws_lc_branch {
         -DFIPS=1 \
         -DENABLE_DILITHIUM=ON \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DBUILD_SHARED_LIBS=1 \
-        -DBUILD_TESTING=OFF
+        -DBUILD_SHARED_LIBS=1
     ninja install
     popd
     rm -rf "${scratch_folder}/aws-lc-${branch}"
@@ -98,14 +97,14 @@ open31:${install_dir}/openssl-${openssl_3_1_branch};\
 open32:${install_dir}/openssl-${openssl_3_2_branch};\
 openmaster:${install_dir}/openssl-${openssl_master_branch};\
 boringssl:${install_dir}/boringssl;"
-"${BUILD_ROOT}/tool/aws-lc-fips-2021" -timeout_ms 10
-"${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10
-"${BUILD_ROOT}/tool/open102" -timeout_ms 10
-"${BUILD_ROOT}/tool/open111" -timeout_ms 10
-"${BUILD_ROOT}/tool/open31" -timeout_ms 10
-"${BUILD_ROOT}/tool/open32" -timeout_ms 10
-"${BUILD_ROOT}/tool/openmaster" -timeout_ms 10
-"${BUILD_ROOT}/tool/boringssl" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2021-10-20/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2021" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2022/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_1_0_2_branch}/lib" "${BUILD_ROOT}/tool/open102" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_1_1_1_branch}/lib" "${BUILD_ROOT}/tool/open111" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_3_1_branch}/lib" "${BUILD_ROOT}/tool/open31" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_3_2_branch}/lib" "${BUILD_ROOT}/tool/open32" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_master_branch}/lib" "${BUILD_ROOT}/tool/openmaster" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/boringssl" "${BUILD_ROOT}/tool/boringssl/lib" -timeout_ms 10
 
 echo "Testing ossl_bm with OpenSSL 1.0 with the legacy build option"
 run_build -DOPENSSL_1_0_INSTALL_DIR="${install_dir}/openssl-${openssl_1_0_2_branch}" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -31,6 +31,10 @@ function build_aws_lc_fips {
 }
 
 function build_aws_lc_branch {
+    if [ $# -eq 0 ]; then
+        echo "Branch not specified"
+        exit 1
+    fi
     branch="$1"
     echo "building the ${branch} branch of aws-lc in FIPS mode"
     git clone --depth 1 --branch $branch https://github.com/aws/aws-lc.git "${scratch_folder}/aws-lc-${branch}"

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -108,7 +108,7 @@ LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_1_1_1_branch}/lib" "${BUILD_RO
 LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_3_1_branch}/lib" "${BUILD_ROOT}/tool/open31" -timeout_ms 10
 LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_3_2_branch}/lib" "${BUILD_ROOT}/tool/open32" -timeout_ms 10
 LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_master_branch}/lib" "${BUILD_ROOT}/tool/openmaster" -timeout_ms 10
-LD_LIBRARY_PATH="${install_dir}/boringssl" "${BUILD_ROOT}/tool/boringssl/lib" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/boringssl" "${BUILD_ROOT}/tool/boringssl" -timeout_ms 10
 
 echo "Testing ossl_bm with OpenSSL 1.0 with the legacy build option"
 run_build -DOPENSSL_1_0_INSTALL_DIR="${install_dir}/openssl-${openssl_1_0_2_branch}" -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -40,8 +40,7 @@ function build_aws_lc_branch {
         -DFIPS=1 \
         -DENABLE_DILITHIUM=ON \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DBUILD_SHARED_LIBS=1 \
-        -DBUILD_TESTING=OFF
+        -DBUILD_SHARED_LIBS=1
     ninja install
     popd
     rm -rf "${scratch_folder}/aws-lc-${branch}"

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1274,7 +1274,7 @@ curve_config supported_curves[] = {{"P-224", NID_secp224r1},
                                    {"P-256", NID_X9_62_prime256v1},
                                    {"P-384", NID_secp384r1},
                                    {"P-521", NID_secp521r1},
-#if !defined(OPENSSL_IS_BORINGSSL)
+#if (!defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION > 16
                                    {"secp256k1", NID_secp256k1},
 #endif
 };
@@ -1288,6 +1288,7 @@ static bool SpeedECDHCurve(const std::string &name, int nid,
   BM_NAMESPACE::UniquePtr<EC_KEY> peer_key(EC_KEY_new_by_curve_name(nid));
   if (!peer_key ||
       !EC_KEY_generate_key(peer_key.get())) {
+    fprintf(stderr, "NID %d for %s not supported.\n", nid, name.c_str());
     return false;
   }
 

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -842,7 +842,7 @@ static bool SpeedKEM(std::string selected) {
          SpeedSingleKEM("Kyber1024_R3", NID_KYBER1024_R3, selected);
 }
 
-#if defined(ENABLE_DILITHIUM)
+#if defined(ENABLE_DILITHIUM) && AWSLC_API_VERSION > 20
 
 static bool SpeedDigestSignNID(const std::string &name, int nid,
                             const std::string &selected) {

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2668,7 +2668,7 @@ bool Speed(const std::vector<std::string> &args) {
        !SpeedHash(EVP_sha384(), "SHA-384", selected) ||
        !SpeedHash(EVP_sha512(), "SHA-512", selected) ||
        // OpenSSL 1.0 and BoringSSL don't support SHA3.
-#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK)) || AWSLC_API_VERSION > 16
+#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION > 16
        !SpeedHash(EVP_sha3_224(), "SHA3-224", selected) ||
        !SpeedHash(EVP_sha3_256(), "SHA3-256", selected) ||
        !SpeedHash(EVP_sha3_384(), "SHA3-384", selected) ||


### PR DESCRIPTION
### Description of changes: 
Handle newer versions of speed.cc being built with older versions of AWS-LC that don't have dilithium or secp256k1. This is the same check we have [down below](https://github.com/aws/aws-lc/blob/main/tool/speed.cc#L2718) but forgot this spot.

### Call-outs:
This is helpful for the canary.

### Testing:
Trying to test locally but running into compiler/delocate issues. The new check in the CI should handle this all.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
