### PR TITLE
Various minor functions to support mysql 8.3

### DIFF
--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -338,6 +338,10 @@ int OPENSSL_sk_find(const OPENSSL_STACK *sk, size_t *out_index, const void *p,
   return 0;  // Not found.
 }
 
+int OPENSSL_sk_unshift(OPENSSL_STACK *sk, void *data) {
+    return (int)OPENSSL_sk_insert(sk, data, 0);
+}
+
 void *OPENSSL_sk_shift(OPENSSL_STACK *sk) {
   if (sk == NULL) {
     return NULL;

--- a/crypto/stack/stack_test.cc
+++ b/crypto/stack/stack_test.cc
@@ -153,6 +153,16 @@ TEST(StackTest, Basic) {
   EXPECT_EQ(raw, removed.get());
   ExpectStackEquals(sk.get(), {1, 2, 4, 5, 7});
 
+  // Test using "unshift" to insert at the beginning.
+  value = TEST_INT_new(8);
+  ASSERT_TRUE(value);
+  ASSERT_TRUE(sk_TEST_INT_unshift(sk.get(), value.get()));
+  value.release();  // sk_TEST_INT_unshift takes ownership on success.
+  ExpectStackEquals(sk.get(), {8, 1, 2, 4, 5, 7});
+  removed.reset(sk_TEST_INT_shift(sk.get()));
+  EXPECT_EQ(8, *removed);
+  ExpectStackEquals(sk.get(), {1, 2, 4, 5, 7});
+
   // Deleting is a no-op is the object is not found.
   value = TEST_INT_new(100);
   ASSERT_TRUE(value);

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -78,6 +78,7 @@ X509_NAME *X509_REQ_get_subject_name(const X509_REQ *req) {
 
 EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *req) {
   if ((req == NULL) || (req->req_info == NULL)) {
+    OPENSSL_PUT_ERROR(X509, ERR_R_PASSED_NULL_PARAMETER);
     return NULL;
   }
   return (X509_PUBKEY_get(req->req_info->pubkey));
@@ -85,6 +86,7 @@ EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *req) {
 
 EVP_PKEY *X509_REQ_get0_pubkey(X509_REQ *req) {
   if ((req == NULL) || (req->req_info == NULL)) {
+    OPENSSL_PUT_ERROR(X509, ERR_R_PASSED_NULL_PARAMETER);
     return NULL;
   }
   return (X509_PUBKEY_get0(req->req_info->pubkey));

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -83,6 +83,13 @@ EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *req) {
   return (X509_PUBKEY_get(req->req_info->pubkey));
 }
 
+EVP_PKEY *X509_REQ_get0_pubkey(X509_REQ *req) {
+  if ((req == NULL) || (req->req_info == NULL)) {
+    return NULL;
+  }
+  return (X509_PUBKEY_get0(req->req_info->pubkey));
+}
+
 int X509_REQ_check_private_key(X509_REQ *x, EVP_PKEY *k) {
   EVP_PKEY *xk = NULL;
   int ok = 0;

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2947,6 +2947,10 @@ OPENSSL_EXPORT int SSL_set_trust(SSL *ssl, int trust);
 // See also |SSL_MODE_NO_AUTO_CHAIN|.
 OPENSSL_EXPORT void SSL_CTX_set_cert_store(SSL_CTX *ctx, X509_STORE *store);
 
+// SSL_CTX_set1_cert_store is like |SSL_CTX_set_cert_store|, but does not take
+// additional ownership of |store|.
+OPENSSL_EXPORT void SSL_CTX_set1_cert_store(SSL_CTX *ctx, X509_STORE *store);
+
 // SSL_CTX_get_cert_store returns |ctx|'s certificate store.
 OPENSSL_EXPORT X509_STORE *SSL_CTX_get_cert_store(const SSL_CTX *ctx);
 

--- a/include/openssl/stack.h
+++ b/include/openssl/stack.h
@@ -168,7 +168,7 @@ void sk_SAMPLE_pop_free(STACK_OF(SAMPLE) *sk, sk_SAMPLE_free_func free_func);
 
 // sk_SAMPLE_insert inserts |p| into the stack at index |where|, moving existing
 // elements if needed. It returns the length of the new stack, or zero on
-// error.
+// error. Ownership of |p| is taken by |sk|.
 size_t sk_SAMPLE_insert(STACK_OF(SAMPLE) *sk, SAMPLE *p, size_t where);
 
 // sk_SAMPLE_delete removes the pointer at index |where|, moving other elements
@@ -209,6 +209,10 @@ int sk_SAMPLE_find(const STACK_OF(SAMPLE) *sk, const SAMPLE *p);
 // and returns one. Otherwise, it returns zero.
 int sk_SAMPLE_find_awslc(const STACK_OF(SAMPLE) *sk, size_t *out_index,
         const SAMPLE *p);
+
+// sk_SAMPLE_unshift inserts |p| as the first element of |sk| and takes
+// ownership of |p|. It is equivalent to "sk_SAMPLE_insert(sk, p, 0)".
+SAMPLE *sk_SAMPLE_unshift(STACK_OF(SAMPLE) *sk, SAMPLE *p);
 
 // sk_SAMPLE_shift removes and returns the first element in |sk|, or NULL if
 // |sk| is empty.
@@ -318,6 +322,7 @@ OPENSSL_EXPORT void OPENSSL_sk_delete_if(
 OPENSSL_EXPORT int OPENSSL_sk_find(const OPENSSL_STACK *sk, size_t *out_index,
                                    const void *p,
                                    OPENSSL_sk_call_cmp_func call_cmp_func);
+OPENSSL_EXPORT int OPENSSL_sk_unshift(OPENSSL_STACK *sk, void *data);
 OPENSSL_EXPORT void *OPENSSL_sk_shift(OPENSSL_STACK *sk);
 OPENSSL_EXPORT size_t OPENSSL_sk_push(OPENSSL_STACK *sk, void *p);
 OPENSSL_EXPORT void *OPENSSL_sk_pop(OPENSSL_STACK *sk);
@@ -515,6 +520,10 @@ BSSL_NAMESPACE_END
       return -1;                                                               \
     }                                                                          \
     return (int) out_index;                                                    \
+  }                                                                            \
+                                                                               \
+  OPENSSL_INLINE int sk_##name##_unshift(STACK_OF(name) *sk, ptrtype p) {      \
+    return OPENSSL_sk_unshift((OPENSSL_STACK *)sk, (void *)p);                 \
   }                                                                            \
                                                                                \
   OPENSSL_INLINE ptrtype sk_##name##_shift(STACK_OF(name) *sk) {               \

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -749,6 +749,10 @@ OPENSSL_EXPORT X509_NAME *X509_REQ_get_subject_name(const X509_REQ *req);
 // |EVP_PKEY_free| when done.
 OPENSSL_EXPORT EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *req);
 
+// X509_REQ_get0_pubkey is like |X509_REQ_get_pubkey|, but directly returns the
+// reference to |req|. The caller must not free the result after use.
+OPENSSL_EXPORT EVP_PKEY *X509_REQ_get0_pubkey(X509_REQ *req);
+
 // X509_REQ_get_attr_count returns the number of attributes in |req|.
 OPENSSL_EXPORT int X509_REQ_get_attr_count(const X509_REQ *req);
 

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -160,13 +160,15 @@ BSSL_NAMESPACE_BEGIN
 // installed. Calling an X509-based method on an |ssl| with a different method
 // will likely misbehave and possibly crash or leak memory.
 static void check_ssl_x509_method(const SSL *ssl) {
-  assert(ssl == NULL || ssl->ctx->x509_method == &ssl_crypto_x509_method);
+  assert(ssl == NULL || (ssl != NULL && ssl->ctx != NULL &&
+                         ssl->ctx->x509_method == &ssl_crypto_x509_method));
 }
 
 // check_ssl_ctx_x509_method acts like |check_ssl_x509_method|, but for an
 // |SSL_CTX|.
 static void check_ssl_ctx_x509_method(const SSL_CTX *ctx) {
-  assert(ctx == NULL || ctx->x509_method == &ssl_crypto_x509_method);
+  assert(ctx == NULL ||
+         (ctx != NULL && ctx->x509_method == &ssl_crypto_x509_method));
 }
 
 // x509_to_buffer returns a |CRYPTO_BUFFER| that contains the serialised

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -160,15 +160,15 @@ BSSL_NAMESPACE_BEGIN
 // installed. Calling an X509-based method on an |ssl| with a different method
 // will likely misbehave and possibly crash or leak memory.
 static void check_ssl_x509_method(const SSL *ssl) {
-  assert(ssl == NULL || (ssl != NULL && ssl->ctx != NULL &&
-                         ssl->ctx->x509_method == &ssl_crypto_x509_method));
+  assert(ssl == nullptr || (ssl != nullptr && ssl->ctx != nullptr &&
+                            ssl->ctx->x509_method == &ssl_crypto_x509_method));
 }
 
 // check_ssl_ctx_x509_method acts like |check_ssl_x509_method|, but for an
 // |SSL_CTX|.
 static void check_ssl_ctx_x509_method(const SSL_CTX *ctx) {
-  assert(ctx == NULL ||
-         (ctx != NULL && ctx->x509_method == &ssl_crypto_x509_method));
+  assert(ctx == nullptr ||
+         (ctx != nullptr && ctx->x509_method == &ssl_crypto_x509_method));
 }
 
 // x509_to_buffer returns a |CRYPTO_BUFFER| that contains the serialised

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -160,15 +160,13 @@ BSSL_NAMESPACE_BEGIN
 // installed. Calling an X509-based method on an |ssl| with a different method
 // will likely misbehave and possibly crash or leak memory.
 static void check_ssl_x509_method(const SSL *ssl) {
-  assert(ssl == nullptr || (ssl != nullptr && ssl->ctx != nullptr &&
-                            ssl->ctx->x509_method == &ssl_crypto_x509_method));
+  assert(ssl == NULL || ssl->ctx->x509_method == &ssl_crypto_x509_method);
 }
 
 // check_ssl_ctx_x509_method acts like |check_ssl_x509_method|, but for an
 // |SSL_CTX|.
 static void check_ssl_ctx_x509_method(const SSL_CTX *ctx) {
-  assert(ctx == nullptr ||
-         (ctx != nullptr && ctx->x509_method == &ssl_crypto_x509_method));
+  assert(ctx == NULL || ctx->x509_method == &ssl_crypto_x509_method);
 }
 
 // x509_to_buffer returns a |CRYPTO_BUFFER| that contains the serialised
@@ -762,12 +760,14 @@ X509_STORE *SSL_CTX_get_cert_store(const SSL_CTX *ctx) {
 }
 
 void SSL_CTX_set_cert_store(SSL_CTX *ctx, X509_STORE *store) {
+  assert(ctx != nullptr);
   check_ssl_ctx_x509_method(ctx);
   X509_STORE_free(ctx->cert_store);
   ctx->cert_store = store;
 }
 
 void SSL_CTX_set1_cert_store(SSL_CTX *ctx, X509_STORE *store) {
+  assert(ctx != nullptr);
   check_ssl_ctx_x509_method(ctx);
   if (store != nullptr) {
     X509_STORE_up_ref(store);

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -765,6 +765,14 @@ void SSL_CTX_set_cert_store(SSL_CTX *ctx, X509_STORE *store) {
   ctx->cert_store = store;
 }
 
+void SSL_CTX_set1_cert_store(SSL_CTX *ctx, X509_STORE *store) {
+  check_ssl_ctx_x509_method(ctx);
+  if (store != nullptr) {
+    X509_STORE_up_ref(store);
+  }
+  SSL_CTX_set_cert_store(ctx, store);
+}
+
 static int ssl_use_certificate(CERT *cert, X509 *x) {
   if (x == nullptr) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_PASSED_NULL_PARAMETER);


### PR DESCRIPTION
### Issues:
Addresses `V1073444663`

### Description of changes: 
MySQL 8.3 depends on some minor symbols that wrap around our existing functionality. 
1. `sk_X509_unshift`: https://github.com/mysql/mysql-server/blob/mysql-cluster-8.3.0/storage/ndb/src/common/util/NodeCertificate.cpp#L1167-L1173
2. `X509_REQ_get0_pubkey`: https://github.com/mysql/mysql-server/blob/824e2b4064053f7daf17d7f3f84b7a3ed92e5fb4/storage/ndb/src/common/util/NodeCertificate.cpp#L526
3. `SSL_CTX_set1_cert_store`: https://github.com/mysql/mysql-server/blob/824e2b4064053f7daf17d7f3f84b7a3ed92e5fb4/storage/ndb/src/common/util/TlsKeyManager.cpp#L204

There are more symbols incoming, these only encapsulate the less complicated ones.

### Call-outs:
N/A

### Testing:
Build still needs to be fixed for MySQL 8.3, along with a couple more symbols.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
