### PR TITLE
Update return value from EVP_Encode_Update in one error case

### DIFF
--- a/crypto/base64/base64.c
+++ b/crypto/base64/base64.c
@@ -193,7 +193,7 @@ int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, uint8_t *out, int *out_len,
   if (total > INT_MAX) {
     // We cannot signal an error, but we can at least avoid making *out_len
     // negative.
-    total = 0;
+    *out_len = 0;
     return 0;
   }
   *out_len = (int)total;


### PR DESCRIPTION
### Issues:
Resolves #P121857409

### Description of changes: 
Coverity pointed that total was not used in this `if` statement which returns right away. It was because of introducing the return statements in https://github.com/aws/aws-lc/commit/6d9a7675d1f7c2f159b76e4ade309220d54d96f4.
The comments indicate that the intention is to update out_len as on line 180.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

