### PR TITLE
Update the BoringSSL benchmark to install libdecrepit

### DIFF
--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -66,7 +66,7 @@ function build_openssl {
 function build_boringssl {
   git clone --depth 1 https://github.com/google/boringssl.git "${scratch_folder}/boringssl"
   pushd "${scratch_folder}/boringssl"
-  echo "install_if_enabled(TARGETS decrepit EXPORT OpenSSLTargets ${INSTALL_DESTINATION_DEFAULT})" >> decrepit/CMakeLists.txt
+  echo "install_if_enabled(TARGETS decrepit EXPORT OpenSSLTargets ${INSTALL_DESTINATION_DEFAULT})" >> CMakeLists.txt
   cmake -GNinja \
       -DCMAKE_INSTALL_PREFIX="${install_dir}/boringssl" \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo .


### PR DESCRIPTION
### Description of changes: 
BoringSSL does not install libdecrepit by default, so our benchmark patches the file to install it to simplify our testing. They recently moved this to sources.cmake and the top level CMakeList.txt in https://github.com/google/boringssl/commit/0cb032aa4c677ad432dc422276d7b963c6acbb58. This causes issues for CI which now doesn't install libdecrepit and then fails to link the AES XTS implementation from libdecrepit. This change updates that.

### Testing:
Ran locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
