### PR TITLE
allow empty lists in SSL_CTX_set_ciphersuites

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1684,7 +1684,10 @@ OPENSSL_EXPORT int SSL_CTX_set_strict_cipher_list(SSL_CTX *ctx,
 // |str| as a cipher string. It returns one on success and zero on failure.
 //
 // Prefer to use |SSL_CTX_set_strict_cipher_list|. This function tolerates
-// garbage inputs, unless an empty cipher list results.
+// garbage inputs, unless an empty cipher list results. However, an empty
+// string which also results in an empty cipher list, is allowed. This
+// behavior is strongly advised against and only meant for OpenSSL
+// compatibility.
 //
 // Note: this API only sets the TLSv1.2 and below ciphers.
 // Use |SSL_CTX_set_ciphersuites| to configure TLS 1.3 specific ciphers.
@@ -1704,7 +1707,9 @@ OPENSSL_EXPORT int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str);
 // a cipher string. It returns one on success and zero on failure.
 //
 // Prefer to use |SSL_set_strict_cipher_list|. This function tolerates garbage
-// inputs, unless an empty cipher list results.
+// inputs, unless an empty cipher list results. However, an empty string which
+// also results in an empty cipher list, is allowed. This behavior is strongly
+// advised against and only meant for OpenSSL compatibility.
 OPENSSL_EXPORT int SSL_set_cipher_list(SSL *ssl, const char *str);
 
 // SSL_CTX_get_ciphers returns the cipher list for |ctx|, in order of

--- a/ssl/ssl_cipher.cc
+++ b/ssl/ssl_cipher.cc
@@ -1336,9 +1336,11 @@ bool ssl_create_cipher_list(UniquePtr<SSLCipherPreferenceList> *out_cipher_list,
 
   *out_cipher_list = std::move(pref_list);
 
-  // Configuring an empty cipher list is an error but still updates the
-  // output.
-  if (sk_SSL_CIPHER_num((*out_cipher_list)->ciphers.get()) == 0) {
+  // Configuring an empty cipher list is an error when |strict| is true, but
+  // still updates the output. When otherwise, OpenSSL explicitly allows an
+  // empty list.
+  if ((strict || (*rule_str != '\0')) &&
+      sk_SSL_CIPHER_num((*out_cipher_list)->ciphers.get()) == 0) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_NO_CIPHER_MATCH);
     return false;
   }

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -5758,15 +5758,16 @@ TEST(SSLTest, EmptyCipherList) {
   // Configuring the empty cipher list with |SSL_CTX_set_cipher_list|
   // succeeds.
   EXPECT_TRUE(SSL_CTX_set_cipher_list(ctx.get(), ""));
-
   // The cipher list is updated to empty.
+  EXPECT_EQ(0u, sk_SSL_CIPHER_num(SSL_CTX_get_ciphers(ctx.get())));
+
+  // Configuring the empty cipher list with |SSL_CTX_set_ciphersuites|
+  // also succeeds.
+  EXPECT_TRUE(SSL_CTX_set_ciphersuites(ctx.get(), ""));
   EXPECT_EQ(0u, sk_SSL_CIPHER_num(SSL_CTX_get_ciphers(ctx.get())));
 
   // Configuring the empty cipher list with |SSL_CTX_set_strict_cipher_list|
   // fails.
-  EXPECT_FALSE(SSL_CTX_set_strict_cipher_list(ctx.get(), ""));
-  ERR_clear_error();
-
   EXPECT_FALSE(SSL_CTX_set_strict_cipher_list(ctx.get(), ""));
   ERR_clear_error();
 

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -548,8 +548,6 @@ static const char *kBadRules[] = {
   "[+RSA]",
   // Unknown directive.
   "@BOGUS",
-  // Empty cipher lists error at SSL_CTX_set_cipher_list.
-  "",
   "BOGUS",
   // COMPLEMENTOFDEFAULT is empty.
   "COMPLEMENTOFDEFAULT",
@@ -5757,12 +5755,19 @@ TEST(SSLTest, EmptyCipherList) {
   // Initially, the cipher list is not empty.
   EXPECT_NE(0u, sk_SSL_CIPHER_num(SSL_CTX_get_ciphers(ctx.get())));
 
-  // Configuring the empty cipher list fails.
-  EXPECT_FALSE(SSL_CTX_set_cipher_list(ctx.get(), ""));
+  // Configuring the empty cipher list with |SSL_CTX_set_cipher_list|
+  // succeeds.
+  EXPECT_TRUE(SSL_CTX_set_cipher_list(ctx.get(), ""));
+
+  // The cipher list is updated to empty.
+  EXPECT_EQ(0u, sk_SSL_CIPHER_num(SSL_CTX_get_ciphers(ctx.get())));
+
+  // Configuring the empty cipher list with |SSL_CTX_set_strict_cipher_list|
+  // fails.
+  EXPECT_FALSE(SSL_CTX_set_strict_cipher_list(ctx.get(), ""));
   ERR_clear_error();
 
-  // Configuring the empty cipher list fails.
-  EXPECT_FALSE(SSL_CTX_set_ciphersuites(ctx.get(), ""));
+  EXPECT_FALSE(SSL_CTX_set_strict_cipher_list(ctx.get(), ""));
   ERR_clear_error();
 
   // But the cipher list is still updated to empty.


### PR DESCRIPTION
### Description of changes: 
MySQL deprecated the usage of weaker ciphers in their test suite: https://github.com/mysql/mysql-server/commit/bc14366ba3d1127ee6b1e0c84c21033e01b67a36 This brought an additional gap to light, where OpenSSL allows the setting of empty strings in the Ciphersuite string configuration. This is known behavior [since 1.1.1](https://github.com/openssl/openssl/blame/OpenSSL_1_1_1/ssl/ssl_ciph.c#L1311-L1315) and still [exists today](https://github.com/openssl/openssl/blob/master/ssl/ssl_ciph.c#L1348C27-L1353).

I've reconfigured the behavior for `SSL_[CTX]_set_cipher_list` which is our OpenSSL compat layer, but kept the same behavior for `SSL_[CTX]_set_strict_cipher_list`.

### Call-outs:
N/A

### Testing:
Test tweaking

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
