### PR TITLE
Attempt to fix rust sanity check

### DIFF
--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -69,5 +69,5 @@ jobs:
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Cross-compile arm-linux-androideabi
-        working-directory: ./aws-lc-rs/aws-lc-rs
-        run: cross test --release --features bindgen,unstable --target arm-linux-androideabi
+        working-directory: ./aws-lc-rs
+        run: cross test -p aws-lc-rs --release --features bindgen,unstable --target arm-linux-androideabi


### PR DESCRIPTION
Rust sanity check seems to be broken with removed docker functionalities from ubuntu-latest.
