### PR TITLE
Always install libdecrepit for BoringSSL benchmark

### DIFF
--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -66,7 +66,7 @@ function build_openssl {
 function build_boringssl {
   git clone --depth 1 https://github.com/google/boringssl.git "${scratch_folder}/boringssl"
   pushd "${scratch_folder}/boringssl"
-  echo "install_if_enabled(TARGETS decrepit EXPORT OpenSSLTargets ${INSTALL_DESTINATION_DEFAULT})" >> CMakeLists.txt
+  echo "install(TARGETS decrepit EXPORT OpenSSLTargets ${INSTALL_DESTINATION_DEFAULT})" >> CMakeLists.txt
   cmake -GNinja \
       -DCMAKE_INSTALL_PREFIX="${install_dir}/boringssl" \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo .


### PR DESCRIPTION
### Description of changes: 
https://github.com/google/boringssl/commit/2d7f6c6e65a49c04b5ef545f1f3b979a74f89c2c changed how BoringSSL handles installing targets, update our small patch to use the latest way to install libdecrepit

### Testing:
This is to unblock the failing CI. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
