### PR TITLE
Ignore march for FIPS static and add gcc-11 FIPS CI

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -308,6 +308,12 @@ if(FIPS_DELOCATE)
     message(FATAL_ERROR "Can't set both delocate and shared mode for FIPS build")
   endif()
 
+  # Defining "-march" can emit unanticipated assembly code that the delocater does not
+  # recognize. There may be some architecture optimizations that consumers wish to
+  # use (CryptoAlg-2396), but we're disabling the option to improve usability for now.
+  string(REGEX REPLACE "-march=[^ ]*" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  string(REGEX REPLACE "-march=[^ ]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
   if(OPENSSL_NO_ASM)
     # If OPENSSL_NO_ASM was defined then ASM will not have been enabled, but in
     # FIPS mode we have to have it because the module build requires going via

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -125,6 +125,26 @@ batch:
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_tests_with_sde_asan.sh"
 
+    - identifier: ubuntu2204_gcc10x_x86_64
+      buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-10x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/run_posix_tests.sh"
+
+    - identifier: ubuntu2204_gcc10x_x86_64_fips
+      buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-10x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/run_fips_tests.sh"
+
     - identifier: ubuntu2204_gcc11x_x86_64
       buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
       env:

--- a/tests/ci/docker_images/linux-x86/build_images.sh
+++ b/tests/ci/docker_images/linux-x86/build_images.sh
@@ -26,6 +26,7 @@ docker build -t ubuntu-20.04:android -f ubuntu-20.04_android/Dockerfile ../
 docker build -t ubuntu-20.04:clang-7x-bm-framework ubuntu-20.04_clang-7x-bm-framework
 docker build -t ubuntu-22.04:base -f ubuntu-22.04_base/Dockerfile ../dependencies
 docker build -t ubuntu-22.04:clang-14x-sde ubuntu-22.04_clang-14x-sde
+docker build -t ubuntu-22.04:gcc-10x ubuntu-22.04_gcc-10x
 docker build -t ubuntu-22.04:gcc-11x ubuntu-22.04_gcc-11x
 docker build -t ubuntu-22.04:gcc-12x ubuntu-22.04_gcc-12x
 docker build -t amazonlinux-2:base -f amazonlinux-2_base/Dockerfile ../dependencies

--- a/tests/ci/docker_images/linux-x86/push_images.sh
+++ b/tests/ci/docker_images/linux-x86/push_images.sh
@@ -29,6 +29,7 @@ tag_and_push_img 'ubuntu-20.04:clang-10x_formal-verification-saw-aarch64' "${ECS
 tag_and_push_img 'ubuntu-20.04:gcc-7x' "${ECS_REPO}:ubuntu-20.04_gcc-7x"
 tag_and_push_img 'ubuntu-20.04:gcc-8x' "${ECS_REPO}:ubuntu-20.04_gcc-8x"
 tag_and_push_img 'ubuntu-22.04:clang-14x-sde' "${ECS_REPO}:ubuntu-22.04_clang-14x-sde"
+tag_and_push_img 'ubuntu-22.04:gcc-10x' "${ECS_REPO}:ubuntu-22.04_gcc-10x"
 tag_and_push_img 'ubuntu-22.04:gcc-11x' "${ECS_REPO}:ubuntu-22.04_gcc-11x"
 tag_and_push_img 'ubuntu-22.04:gcc-12x' "${ECS_REPO}:ubuntu-22.04_gcc-12x"
 tag_and_push_img 'ubuntu-22.04:clang-14x_formal-verification-nsym-aarch64' "${ECS_REPO}:ubuntu-22.04_clang-14x_formal-verification-nsym-aarch64"

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-10x/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-10x/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+FROM ubuntu-22.04:base
+
+SHELL ["/bin/bash", "-c"]
+
+RUN set -ex && \
+    apt-get update && \
+    apt-get -y --no-install-recommends upgrade && \
+    apt-get -y --no-install-recommends install \
+    gcc-10 g++-10 && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+ENV CC=gcc-10
+ENV CXX=g++-10


### PR DESCRIPTION
### Issues:
Addresses `P125414272`

### Description of changes: 
Some downstream consumers were defining `march`, which doesn't mesh well with the static FIPS build. This disables the option for now to improve usability. This may cause them to miss out on some potential CPU optimizations from the compiler, but this is better than having them break in unanticipated situations.

This change also adds a new CI dimension for gcc-10 with non-fips/fips.

### Call-outs:
Support for actually supporting `march` environments is tracked in `CryptoAlg-2396`

### Testing:
New CI for gcc-10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
