### PR TITLE
aws-lc-rs CI step must use CMake to build

### DIFF
--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -9,6 +9,7 @@ concurrency:
   cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org,direct
+  AWS_LC_SYS_CMAKE_BUILDER: 1
 jobs:
   standard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description of changes: 
* The aws-lc-rs CI step must use CMake to perform the build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
