### PR TITLE
`rand_fork_unsafe_buffering_enabled` always 0 on Windows

### DIFF
--- a/crypto/rand_extra/forkunsafe.c
+++ b/crypto/rand_extra/forkunsafe.c
@@ -19,13 +19,13 @@
 #include "../fipsmodule/rand/internal.h"
 
 
+#if !defined(OPENSSL_WINDOWS)
 // g_buffering_enabled is true if fork-unsafe buffering has been enabled.
 static int g_buffering_enabled = 0;
 
 // g_lock protects |g_buffering_enabled|.
 static struct CRYPTO_STATIC_MUTEX g_lock = CRYPTO_STATIC_MUTEX_INIT;
 
-#if !defined(OPENSSL_WINDOWS)
 void RAND_enable_fork_unsafe_buffering(int fd) {
   // We no longer support setting the file-descriptor with this function.
   if (fd != -1) {
@@ -36,7 +36,6 @@ void RAND_enable_fork_unsafe_buffering(int fd) {
   g_buffering_enabled = 1;
   CRYPTO_STATIC_MUTEX_unlock_write(&g_lock);
 }
-#endif
 
 int rand_fork_unsafe_buffering_enabled(void) {
   CRYPTO_STATIC_MUTEX_lock_read(&g_lock);
@@ -44,3 +43,8 @@ int rand_fork_unsafe_buffering_enabled(void) {
   CRYPTO_STATIC_MUTEX_unlock_read(&g_lock);
   return ret;
 }
+#else
+int rand_fork_unsafe_buffering_enabled(void) {
+  return 0;
+}
+#endif


### PR DESCRIPTION
### Description of changes: 
The `g_buffering_enabled` can not be changed on Windows.  Removes unnecessary locking for this platform.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
