### PR TITLE
Align GitHub workflow/job run conditions

### DIFF
--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -1,5 +1,7 @@
 name: ABI Diff
 on:
+  push:
+    branches: [ '*' ]
   pull_request:
     branches: [ '*' ]
 concurrency:
@@ -10,6 +12,7 @@ env:
   GOPROXY: https://proxy.golang.org,direct
 jobs:
   libs:
+    if: github.repository_owner == 'aws'
     name: libcrypto and libssl
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -1,12 +1,12 @@
 name: General CI Tests
 on:
+  push:
+    branches: [ '*' ]
   pull_request:
     branches: [ '*' ]
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
-
 env:
   GOPROXY: https://proxy.golang.org,direct
   SDE_MIRROR_URL: "https://downloadmirror.intel.com/813591/sde-external-9.33.0-2024-01-07-win.tar.xz"
@@ -30,6 +30,7 @@ jobs:
           ninja -C test_build_dir run_tests
 
   macOS-x86:
+    if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     runs-on: macos-latest
     steps:
@@ -39,6 +40,7 @@ jobs:
           ./tests/ci/run_posix_tests.sh
 
   macOS-x86-FIPS:
+    if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     runs-on: macos-latest
     steps:
@@ -48,6 +50,7 @@ jobs:
           ./tests/ci/run_fips_tests.sh
 
   macOS-ARM:
+    if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     runs-on: macos-latest-xlarge
     steps:
@@ -60,6 +63,7 @@ jobs:
           ./tests/ci/run_posix_tests.sh
 
   macOS-ARM-FIPS:
+    if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     runs-on: macos-latest-xlarge
     steps:
@@ -73,6 +77,7 @@ jobs:
 
 
   MSVC-2019:
+    if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     runs-on: aws-lc_windows-2019_8-core
     steps:
@@ -87,6 +92,7 @@ jobs:
           .\tests\ci\run_windows_tests.bat "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 
   MSVC-2022:
+    if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     runs-on: aws-lc_windows-latest_8-core
     steps:
@@ -101,6 +107,7 @@ jobs:
           .\tests\ci\run_windows_tests.bat "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
 
   MSVC-SDE-64-bit:
+    if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     # TODO: Update this to run on windows-2022. windows-2022 (Windows 11) has phased out support for older processors.
     # https://learn.microsoft.com/en-us/windows-hardware/design/minimum/supported/windows-11-supported-intel-processors

--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -12,6 +12,7 @@ env:
   AWS_LC_SYS_CMAKE_BUILDER: 1
 jobs:
   standard:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,10 +1,9 @@
 name: CMake Compatability
 on:
-  pull_request:
-    branches: [ '*' ]
   push:
     branches: [ '*' ]
-
+  pull_request:
+    branches: [ '*' ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -13,6 +12,7 @@ env:
   GOPROXY: https://proxy.golang.org,direct
 jobs:
   cmake:
+    if: github.repository_owner == 'aws'
     name: CMake ${{ matrix.cmake.version}} build with ${{ matrix.generator}} FIPS=${{ matrix.fips }}
     strategy:
       matrix:

--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: code-cov-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   codecov-ci:

--- a/.github/workflows/cross-test.yml
+++ b/.github/workflows/cross-test.yml
@@ -5,10 +5,11 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ppc64be-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   ppc64-build-test:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
@@ -19,6 +20,7 @@ jobs:
       - name: PPC64 Build/Test
         run: tests/ci/run_cross_tests.sh ppc64 powerpc64-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_BUILD_TYPE=Release -DFIPS=1 -DBUILD_SHARED_LIBS=1"
   ppc32-non-fips-build-test:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
@@ -29,6 +31,7 @@ jobs:
       - name: PPC32 Build/Test
         run: tests/ci/run_cross_tests.sh ppc powerpc-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release"
   ppc32-fips-build-test:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
@@ -39,6 +42,7 @@ jobs:
       - name: PPC32 Build/Test
         run: tests/ci/run_cross_tests.sh ppc powerpc-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release -DFIPS=1 -DBUILD_SHARED_LIBS=1"
   ppc64le-build-test:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
@@ -49,6 +53,7 @@ jobs:
       - name: PPC64LE Build/Test
         run: tests/ci/run_cross_tests.sh ppc64le powerpc64le-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_BUILD_TYPE=Release -DFIPS=1 -DBUILD_SHARED_LIBS=1"
   riscv64-non-fips-build-test:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
@@ -66,6 +71,7 @@ jobs:
           CFLAGS: "-Wno-string-compare"
         run: tests/ci/run_cross_tests.sh riscv riscv64-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release"
   armv6-non-fips-build-test:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu
@@ -89,6 +95,7 @@ jobs:
 #      - name: armv6 Build/Test
 #        run: tests/ci/run_cross_tests.sh loongarch64 loongarch64-unknown-linux-gnu "-DCMAKE_BUILD_TYPE=Release"
   s390x-non-fips-build-test:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install qemu

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -11,6 +11,7 @@ env:
   CC: gcc
 jobs:
   haproxy:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies
@@ -22,6 +23,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_haproxy_integration.sh
   tpm2-tss:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies
@@ -32,6 +34,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_tpm2_tss_integration.sh
   grpc:
+    if: github.repository_owner == 'aws'
     env:
       DEBIAN_FRONTEND: noninteractive
       TZ: Etc/UTC
@@ -49,6 +52,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_grpc_integration.sh
   tcpdump:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies
@@ -60,6 +64,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_tcpdump_integration.sh
   trousers:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies
@@ -71,6 +76,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_trousers_integration.sh
   ntp:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies
@@ -82,6 +88,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_ntp_integration.sh
   socat:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies
@@ -92,6 +99,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_socat_integration.sh
   python-main:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies
@@ -103,6 +111,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_python_integration.sh main
   python-releases:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies
@@ -114,6 +123,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_python_integration.sh 3.10 3.11 3.12
   bind9:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies
@@ -125,6 +135,7 @@ jobs:
         run: |
           ./tests/ci/integration/run_bind9_integration.sh
   strongswan:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -1,16 +1,15 @@
 name: Windows Alternative Compilers
 on:
-  pull_request:
-    branches: [ '*' ]
   push:
     branches: [ '*' ]
-
+  pull_request:
+    branches: [ '*' ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   mingw:
-    if: github.repository == 'aws/aws-lc'
+    if: github.repository_owner == 'aws'
     runs-on: windows-latest
     steps:
       - name: Install NASM
@@ -41,7 +40,7 @@ jobs:
       - name: Run tests
         run: cmake --build ./build --target run_tests
   clang:
-    if: github.repository == 'aws/aws-lc'
+    if: github.repository_owner == 'aws'
     runs-on: windows-latest
     steps:
       - name: Install NASM


### PR DESCRIPTION
### Description of changes: 
* Align our GitHub workflows/jobs so that they all run on the same conditions.
* Avoid costly CI runs when on non-"aws" repos.
  * The "General CI Tests sanity-test-run" and "Code Coverage codecov-ci" jobs will still run on any repo that has GitHub actions enabled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
