### PR TITLE
Release build for MinGW CI; Fix GCC 12/13 warnings

### DIFF
--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -35,6 +35,7 @@ jobs:
             CMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
             CMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
             CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+            CMAKE_BUILD_TYPE=Release \
       - name: Build Project
         run: cmake --build ./build --target all
       - name: Run tests
@@ -63,6 +64,7 @@ jobs:
             CMAKE_SYSTEM_NAME=Windows \
             CMAKE_SYSTEM_PROCESSOR=x86_64 \
             CMAKE_BUILD_TOOL=ninja.exe \
+            CMAKE_BUILD_TYPE=Release \
       - name: Build Project
         run: cmake --build ./build --target all
       - name: Run tests

--- a/crypto/bytestring/cbs.c
+++ b/crypto/bytestring/cbs.c
@@ -520,7 +520,9 @@ int CBS_get_asn1_int64(CBS *cbs, int64_t *out) {
   }
   uint8_t sign_extend[sizeof(int64_t)];
   memset(sign_extend, is_negative ? 0xff : 0, sizeof(sign_extend));
-  for (size_t i = 0; i < len; i++) {
+  // GCC 12/13 report `stringop-overflow` on the following line
+  // without additional condition: `i < sizeof(int64_t)`
+  for (size_t i = 0; i < len && i < sizeof(int64_t); i++) {
 // `data` is big-endian.
 // Values are always shifted toward the "little" end.
 #ifdef OPENSSL_BIG_ENDIAN

--- a/crypto/fipsmodule/ecdsa/ecdsa.c
+++ b/crypto/fipsmodule/ecdsa/ecdsa.c
@@ -442,7 +442,7 @@ ECDSA_SIG *ecdsa_digestsign_no_self_test(const EVP_MD *md, const uint8_t *input,
                                          const uint8_t *nonce,
                                          size_t nonce_len) {
   uint8_t digest[EVP_MAX_MD_SIZE];
-  unsigned int digest_len;
+  unsigned int digest_len = EVP_MAX_MD_SIZE;
   if (!EVP_Digest(input, in_len, digest, &digest_len, md, NULL)) {
     return 0;
   }
@@ -455,7 +455,7 @@ int ecdsa_digestverify_no_self_test(const EVP_MD *md, const uint8_t *input,
                                     size_t in_len, const ECDSA_SIG *sig,
                                     const EC_KEY *eckey){
   uint8_t digest[EVP_MAX_MD_SIZE];
-  unsigned int digest_len;
+  unsigned int digest_len = EVP_MAX_MD_SIZE;
   if (!EVP_Digest(input, in_len, digest, &digest_len, md, NULL)) {
     return 0;
   }

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -692,7 +692,7 @@ int rsa_digestsign_no_self_test(const EVP_MD *md, const uint8_t *input,
                                 size_t in_len, uint8_t *out, unsigned *out_len,
                                 RSA *rsa) {
   uint8_t digest[EVP_MAX_MD_SIZE];
-  unsigned int digest_len;
+  unsigned int digest_len = EVP_MAX_MD_SIZE;
   if (!EVP_Digest(input, in_len, digest, &digest_len, md, NULL)) {
     return 0;
   }
@@ -760,7 +760,7 @@ int rsa_digestverify_no_self_test(const EVP_MD *md, const uint8_t *input,
                                   size_t in_len, const uint8_t *sig,
                                   size_t sig_len, RSA *rsa) {
   uint8_t digest[EVP_MAX_MD_SIZE];
-  unsigned int digest_len;
+  unsigned int digest_len = EVP_MAX_MD_SIZE;
   if (!EVP_Digest(input, in_len, digest, &digest_len, md, NULL)) {
     return 0;
   }


### PR DESCRIPTION
### Issues:
Resolves: 
* https://github.com/aws/aws-lc-rs/issues/397

### Description of changes: 
* Perform "release" build for MinGW in the CI.
* Address several GCC 12/13 warnings


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
