### PR TITLE
Link porting guide table to header documentation

### DIFF
--- a/docs/porting/configuration-differences.md
+++ b/docs/porting/configuration-differences.md
@@ -318,12 +318,18 @@ The following table contains the differences in libssl configuration options AWS
       <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L3089-L3096l">
         SSL_set_hostflags<br>
       </a>
-      <br>
-      <a href="https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_get0_peername.html">
+      <!-- TODO: Update the links below once we pull in google/boringssl@5bed5b9 and other documentation commits. -->
+      <a href="https://github.com/aws/aws-lc/blob/311ca381c01957c654575cd378926ffd26a19093/include/openssl/x509.h#L3463-L3464">
         X509_STORE_CTX_set_flags<br>
+      </a>
+      <a href="https://github.com/aws/aws-lc/blob/311ca381c01957c654575cd378926ffd26a19093/include/openssl/x509.h#L3340">
         X509_STORE_set_flags<br>
+      </a>
+      <a href="https://github.com/aws/aws-lc/blob/311ca381c01957c654575cd378926ffd26a19093/include/openssl/x509.h#L3541-L3542">
         X509_VERIFY_PARAM_set_flags<br>
-        X509_VERIFY_PARAM_set_hostflags
+      </a>
+      <a href="https://github.com/aws/aws-lc/blob/311ca381c01957c654575cd378926ffd26a19093/include/openssl/x509.h#L3603-L3606">
+        X509_VERIFY_PARAM_set_hostflags<br>
       </a>
     </span>
   </p>

--- a/docs/porting/configuration-differences.md
+++ b/docs/porting/configuration-differences.md
@@ -55,12 +55,12 @@ The following table contains the differences in libssl configuration options AWS
   <td rowspan=5>
   <p>
     <span>
-      <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html">
+      <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L889-L892">
         SSL_CTX_set_mode<br>
         SSL_set_mode
       </a>
       <br><br>
-      <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_mode.html">
+      <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L894-L897">
         SSL_CTX_clear_mode<br>
         SSL_clear_mode
       </a>
@@ -85,7 +85,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_MODE_AUTO_RETRY</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5534-L5538">
+      SSL_MODE_AUTO_RETRY
+    </a>  
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -96,7 +100,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_MODE_RELEASE_BUFFERS</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5540-L5543">
+      SSL_MODE_RELEASE_BUFFERS
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -107,7 +115,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_MODE_SEND_CLIENTHELLO_TIME</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5545-L5548">
+      SSL_MODE_SEND_CLIENTHELLO_TIME
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -118,7 +130,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_MODE_SEND_SERVERHELLO_TIME</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5550-L5552">
+      SSL_MODE_SEND_SERVERHELLO_TIME
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -131,12 +147,12 @@ The following table contains the differences in libssl configuration options AWS
   <td rowspan=10>
   <p>
     <span>
-      <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">
+      <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L794-L797">
         SSL_CTX_set_options<br>
         SSL_set_options
       </a>
       <br><br>
-      <a href="https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html">
+      <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L799-L802">
         SSL_CTX_clear_options<br>
         SSL_clear_options
       </a>
@@ -144,7 +160,11 @@ The following table contains the differences in libssl configuration options AWS
     </p>
   </td>
   <td>
-  <p><span>SSL_OP_ALL</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5554-L5559">
+      SSL_OP_ALL
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -155,7 +175,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5561-L5564">
+      SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -166,7 +190,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5566-L5570">
+      SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -177,7 +205,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_OP_LEGACY_SERVER_CONNECT</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5572-L5575">
+      SSL_OP_LEGACY_SERVER_CONNECT
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -188,7 +220,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_OP_NO_COMPRESSION</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5577-L5579">
+      SSL_OP_NO_COMPRESSION
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -199,7 +235,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_OP_NO_RENEGOTIATION</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5581-L5584">
+      SSL_OP_NO_RENEGOTIATION
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -213,7 +253,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5586-L5591">
+      SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -224,7 +268,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_OP_NO_SSLv3</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5597-L5599">
+      SSL_OP_NO_SSLv3
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -235,7 +283,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_OP_TLS_ROLLBACK_BUG</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5601-L5604">
+      SSL_OP_TLS_ROLLBACK_BUG
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -246,7 +298,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>SSL_VERIFY_CLIENT_ONCE</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5606-L5609">
+      SSL_VERIFY_CLIENT_ONCE
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -259,8 +315,11 @@ The following table contains the differences in libssl configuration options AWS
   <td rowspan=2>
   <p>
     <span>
-      <a href="https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_get0_peername.html">
+      <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L3089-L3096l">
         SSL_set_hostflags<br>
+      </a>
+      <br>
+      <a href="https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_get0_peername.html">
         X509_STORE_CTX_set_flags<br>
         X509_STORE_set_flags<br>
         X509_VERIFY_PARAM_set_flags<br>
@@ -270,7 +329,11 @@ The following table contains the differences in libssl configuration options AWS
   </p>
   </td>
   <td>
-  <p><span>X509_V_FLAG_X509_STRICT</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L3015-L3018">
+      X509_V_FLAG_X509_STRICT
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -281,7 +344,11 @@ The following table contains the differences in libssl configuration options AWS
  </tr>
  <tr>
   <td>
-  <p><span>X509_V_FLAG_ALLOW_PROXY_CERTS</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L3019-L3021">
+      X509_V_FLAG_ALLOW_PROXY_CERTS
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -319,9 +386,13 @@ The following table contains the differences in libcrypto configuration options 
   <td rowspan=6>
   <p>
     <span>
-      <a href="https://www.openssl.org/docs/manmaster/man3/X509_check_host.html">
+      <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L4343-L4351">
         X509_check_host<br>
+      </a>
+      <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L4353-L4360">
         X509_check_email<br>
+      </a>
+      <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L4362-L4369">
         X509_check_ip<br>
         X509_check_ip_asc
       </a>
@@ -329,7 +400,11 @@ The following table contains the differences in libcrypto configuration options 
   </p>
   </td>
   <td>
-  <p><span>X509_CHECK_FLAG_NO_WILDCARDS</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L4310-L4312">
+      X509_CHECK_FLAG_NO_WILDCARDS
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -340,7 +415,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>X509_CHECK_FLAG_NEVER_CHECK_SUBJECT</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L4314-L4316">
+      X509_CHECK_FLAG_NEVER_CHECK_SUBJECT
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -351,7 +430,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L4323-L4328">
+      X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -362,7 +445,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L4318-L4321">
+      X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>ON</span></p>
@@ -373,7 +460,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L4330-L4334">
+      X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -384,7 +475,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/x509.h#L4336-L4341">
+      X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -397,14 +492,18 @@ The following table contains the differences in libcrypto configuration options 
   <td rowspan=8>
   <p>
     <span>
-      <a href="https://www.openssl.org/docs/manmaster/man3/PKCS7_sign.html">
+      <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/pkcs7.h#L231-L250">
         PKCS7_sign
       </a>
     </span>
   </p>
   </td>
   <td>
-  <p><span>PKCS7_DETACHED</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/pkcs7.h#L192-L193">
+      PKCS7_DETACHED
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -415,7 +514,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>PKCS7_BINARY</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/pkcs7.h#L195-L198">
+      PKCS7_BINARY
+    </a>
+  </span></p>
   </td>
   <td rowspan=3>
   <p>
@@ -435,17 +538,29 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>PKCS7_NOATTR</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/pkcs7.h#L200-L202">
+      PKCS7_NOATTR
+    </a>
+  </span></p>
   </td>
  </tr>
  <tr>
   <td>
-  <p><span>PKCS7_PARTIAL</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/pkcs7.h#L204-L207">
+      PKCS7_PARTIAL
+    </a>
+  </span></p>
   </td>
  </tr>
  <tr>
   <td>
-  <p><span>PKCS7_TEXT</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/pkcs7.h#L209-L211">
+      PKCS7_TEXT
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -456,7 +571,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>PKCS7_NOCERTS</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/pkcs7.h#L213-L215">
+      PKCS7_NOCERTS
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -467,7 +586,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>PKCS7_STREAM</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/pkcs7.h#L220-L223">
+      PKCS7_STREAM
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -478,7 +601,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>PKCS7_NOSMIMECAP</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/pkcs7.h#L217-L218">
+      PKCS7_NOSMIMECAP
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>OFF</span></p>
@@ -489,21 +616,18 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td rowspan=4>
-  <p><span>EVP_PKEY_assign</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/evp.h#L1123-L1129">
+      EVP_PKEY_assign
+    </a>
+  </span></p>
   </td>
   <td>
-  <p><span>EVP_PKEY_DH</span></p>
-  </td>
-  <td>
-  <p><span>Not Supported</span></p>
-  </td>
-  <td>
-  <p><span>NO-OP</span></p>
-  </td>
- </tr>
- <tr>
-  <td>
-  <p><span>EVP_PKEY_X448</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/evp.h#L1197-L1200">
+      EVP_PKEY_DH
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>Not Supported</span></p>
@@ -514,7 +638,11 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>EVP_PKEY_ED448</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/evp.h#L935-L937">
+      EVP_PKEY_X448
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>Not Supported</span></p>
@@ -525,7 +653,26 @@ The following table contains the differences in libcrypto configuration options 
  </tr>
  <tr>
   <td>
-  <p><span>EVP_PKEY_RSA2</span></p>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/evp.h#L939-L941">
+      EVP_PKEY_ED448
+    </a>
+  </span></p>
+  </td>
+  <td>
+  <p><span>Not Supported</span></p>
+  </td>
+  <td>
+  <p><span>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td>
+  <p><span>
+    <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/evp.h#L931-L933">
+      EVP_PKEY_RSA2
+    </a>
+  </span></p>
   </td>
   <td>
   <p><span>Not Supported</span></p>
@@ -563,7 +710,7 @@ The following table contains configuration options AWS-LC has intentionally omit
   <td>
   <p>
     <span>
-      <a href="https://github.com/aws/aws-lc/blob/f61870199f1bdfe3182e493231e60ea7243edbcb/include/openssl/bn.h#L1053-L1062">
+      <a href="https://github.com/aws/aws-lc/blob/10a389e1adda37889b4ef9186901df15c48846b5/include/openssl/bn.h#L1053-L1062">
         BN_FLG_CONSTTIME
       </a>
     </span>

--- a/docs/porting/functionality-differences.md
+++ b/docs/porting/functionality-differences.md
@@ -918,7 +918,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=2>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/digest.h#L347-L370">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/digest.h#L356-L370">
             digest.h
         </a>
     </span>
@@ -931,7 +931,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p>
     Does nothing.<br><br>
     This functions sets flags for EVP_MD_CTX, so any related flags are also no-ops. Related no-op flags can be found in 
-    <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/digest.h#L356-L365">
+    <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/digest.h#L361-L365">
       the surrounding documentation
     </a>
     .
@@ -999,7 +999,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/bio.h#L865-L866">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/bio.h#L880-L886">
             bio.h
         </a>
     </span>

--- a/docs/porting/functionality-differences.md
+++ b/docs/porting/functionality-differences.md
@@ -40,9 +40,8 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <td rowspan=2>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5211-L5240">
-            ssl.h<br>
-            Security Levels
+        <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5709-L5751">
+            Security Levels No-ops
         </a>
     </span></p>
   </td>
@@ -68,9 +67,8 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <td rowspan=4>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5148-L5161">
-            ssl.h<br>
-            Deprecated DH functions
+        <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5677-L5706">
+            FFDH Ciphersuite No-ops
         </a>
     </span></p>
   </td>
@@ -114,9 +112,8 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <td rowspan=6>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4938-L4957">
-            ssl.h<br>
-            Deprecated COMP functions
+        <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5630-L5674">
+            SSL_COMP and COMP_METHOD No-ops
         </a>
     </span></p>
   </td>
@@ -174,8 +171,7 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <td>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L4542-L4609">
-            ssl.h<br>
+        <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L4573-L4648">
             TLS Renegotiation
         </a>
     </span></p>
@@ -200,8 +196,7 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <td>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5085-L5087">
-            ssl.h<br>
+        <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5759-L5764">
             SSL_get_shared_ciphers
         </a>
     </span></p>
@@ -217,8 +212,7 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <td>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5089-L5092">
-            ssl.h<br>
+        <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5766-L5769">
             SSL_get_shared_sigalgs
         </a>
     </span></p>
@@ -234,8 +228,7 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <td>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/ssl.h#L5145-L5146C20">
-            ssl.h<br>
+        <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5682-L5685">
             SSL_get_server_tmp_key
         </a>
     </span></p>
@@ -332,11 +325,12 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=2>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L182">
-            evp.h
-        </a><br>
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/evp.h#L1180-L1194">
+            EVP_PKEY_DSA No-ops
+        </a>
+        <br><br>
         <a href="https://github.com/aws/aws-lc/blob/main/PORTING.md#dsa-evp_pkeys">
-            EVP_PKEY_DSA
+            Porting Guide
         </a>
     </span>
   </p>
@@ -360,8 +354,8 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=2>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L932-L934">
-            evp.h
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/evp.h#L1197-L1213">
+            EVP_PKEY_DH No-ops
         </a>
     </span>
   </p>
@@ -385,7 +379,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/0aaec70548c91e755918452713e0419eadb032bb/include/openssl/evp.h#L948-L951">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/evp.h#L1145-L1152">
             evp.h
         </a>
     </span>
@@ -407,11 +401,12 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=3>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec_key.h#L314-L315">
-            ec_key.h
-        </a><br><br>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L413-L417">
-            ec.h
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/ec_key.h#L360-L363">
+            EC_KEY
+        </a>
+        <br><br>
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/ec.h#L433-L441">
+            EC_GROUP
         </a>
     </span>
   </p>
@@ -443,8 +438,8 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=2>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L419-L425">
-            ec.h
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/ec.h#L451-L468">
+            EC_METHOD
         </a>
     </span>
   </p>
@@ -468,8 +463,8 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ec.h#L427-L431">
-            ec.h
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/ec.h#L443-L448">
+            Compressed Forms
         </a>
     </span>
   </p>
@@ -480,7 +475,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td>
   <p>
     Returns nothing as a void function. Aborts if a form other than
-    POINT_CONVERSION_UNCOMPRESSED is requested.
+    POINT_CONVERSION_UNCOMPRESSED or POINT_CONVERSION_COMPRESSED is requested.
   </p>
   </td>
  </tr>
@@ -491,7 +486,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=4>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/conf.h#L134-L147">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/conf.h#L127-L149">
             conf.h
         </a>
     </span>
@@ -535,6 +530,10 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=13>
   <p>
     <span>
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/rand.h#L79-L141">
+            rand.h
+        </a>
+        <br><br>
         <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/crypto/fipsmodule/FIPS.md#entropy-sources">
             Entropy Sources
         </a>
@@ -653,7 +652,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=4>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/asn1.h#L1894-L1904">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/asn1.h#L2045-L2061">
             asn1.h
         </a>
     </span>
@@ -697,7 +696,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=16>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/f31f7091ec6b13163c7764519a6d95daefacd6e5/include/openssl/thread.h#L119-L199">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/thread.h#L119-L204">
             thread.h
         </a>
     </span>
@@ -838,7 +837,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=5>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/evp.h#L961-L975">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/evp.h#L1154-L1178">
             evp.h
         </a>
     </span>
@@ -887,7 +886,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=2>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L561-L566">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/cipher.h#L559-L573">
             cipher.h
         </a>
     </span>
@@ -900,7 +899,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>Does nothing.</span><br>
   <br>
   This functions sets flags for EVP_CIPHER_CTX, so any related flags are also no-ops. Related no-op flags can be found in 
-    <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/cipher.h#L560-L566">
+    <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/cipher.h#L559-L569">
       the surrounding documentation
     </a>
     .
@@ -919,7 +918,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=2>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/digest.h#L303-L310">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/digest.h#L347-L370">
             digest.h
         </a>
     </span>
@@ -932,7 +931,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p>
     Does nothing.<br><br>
     This functions sets flags for EVP_MD_CTX, so any related flags are also no-ops. Related no-op flags can be found in 
-    <a href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/digest.h#L303-L310">
+    <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/digest.h#L356-L365">
       the surrounding documentation
     </a>
     .
@@ -951,7 +950,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/dh.h#L351-L360">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/dh.h#L352-L365">
             dh.h
         </a>
     </span>
@@ -964,7 +963,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p>
     Does nothing.<br><br>
     This functions clears flags for DH, so any related flags are also no-ops. Related no-op flags can be found in 
-    <a href="https://github.com/aws/aws-lc/blob/c8d82c7599449609d3540eefb7972f137fc1b872/include/openssl/dh.h#L351-L360">
+    <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/dh.h#L354-L365">
       the surrounding documentation
     </a>
     .
@@ -975,7 +974,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td rowspan=2>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/ex_data.h#L180-L185">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/ex_data.h#L178-L185">
             ex_data.h
         </a>
     </span>
@@ -1000,7 +999,7 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <td>
   <p>
     <span>
-        <a href="https://github.com/aws/aws-lc/blob/5c358103c5df836b9343bf995717b5bc13d5e82f/include/openssl/bio.h#L865-L866">
+        <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/bio.h#L865-L866">
             bio.h
         </a>
     </span>

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5594,7 +5594,7 @@ OPENSSL_EXPORT int SSL_set1_curves_list(SSL *ssl, const char *curves);
 // AWS-LC
 #define SSL_OP_NO_SSLv2 0
 
-// SSL_OP_NO_SSLv2 is ON by default in AWS-LC. There is no support for SSLv3 in
+// SSL_OP_NO_SSLv3 is ON by default in AWS-LC. There is no support for SSLv3 in
 // AWS-LC
 #define SSL_OP_NO_SSLv3 0
 

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -3127,7 +3127,15 @@ OPENSSL_EXPORT STACK_OF(X509) *X509_STORE_get1_certs(X509_STORE_CTX *st,
                                                      X509_NAME *nm);
 OPENSSL_EXPORT STACK_OF(X509_CRL) *X509_STORE_get1_crls(X509_STORE_CTX *st,
                                                         X509_NAME *nm);
-OPENSSL_EXPORT int X509_STORE_set_flags(X509_STORE *ctx, unsigned long flags);
+
+// X509_STORE_set_flags enables all values in |flags| in |store|'s verification
+// flags. |flags| should be a combination of |X509_V_FLAG_*| constants.
+//
+// WARNING: These flags will be combined with default flags when copied to an
+// |X509_STORE_CTX|. This means it is impossible to unset those defaults from
+// the |X509_STORE|. See discussion in |X509_STORE_get0_param|.
+OPENSSL_EXPORT int X509_STORE_set_flags(X509_STORE *store, unsigned long flags);
+
 OPENSSL_EXPORT int X509_STORE_set_purpose(X509_STORE *ctx, int purpose);
 OPENSSL_EXPORT int X509_STORE_set_trust(X509_STORE *ctx, int trust);
 OPENSSL_EXPORT int X509_STORE_set1_param(X509_STORE *ctx,
@@ -3248,6 +3256,10 @@ OPENSSL_EXPORT int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust);
 OPENSSL_EXPORT int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx,
                                                   int def_purpose, int purpose,
                                                   int trust);
+
+// X509_STORE_CTX_set_flags enables all values in |flags| in |ctx|'s
+// verification flags. |flags| should be a combination of |X509_V_FLAG_*|
+// constants.
 OPENSSL_EXPORT void X509_STORE_CTX_set_flags(X509_STORE_CTX *ctx,
                                              unsigned long flags);
 
@@ -3326,8 +3338,13 @@ OPENSSL_EXPORT int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *to,
                                              const X509_VERIFY_PARAM *from);
 OPENSSL_EXPORT int X509_VERIFY_PARAM_set1(X509_VERIFY_PARAM *to,
                                           const X509_VERIFY_PARAM *from);
+
+// X509_VERIFY_PARAM_set_flags enables all values in |flags| in |param|'s
+// verification flags and returns one. |flags| should be a combination of
+// |X509_V_FLAG_*| constants.
 OPENSSL_EXPORT int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param,
                                                unsigned long flags);
+
 OPENSSL_EXPORT int X509_VERIFY_PARAM_clear_flags(X509_VERIFY_PARAM *param,
                                                  unsigned long flags);
 OPENSSL_EXPORT unsigned long X509_VERIFY_PARAM_get_flags(


### PR DESCRIPTION
### Description of changes: 
This finalizes the changes for the previous two documentation PRS: https://github.com/aws/aws-lc/pull/1463 and https://github.com/aws/aws-lc/pull/1473. Now that these two PRs are in, we have a commit to link the header documentation from the table.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
