### PR TITLE
Support vpinsrq in delocater

### DIFF
--- a/util/fipstools/delocate/delocate_test.go
+++ b/util/fipstools/delocate/delocate_test.go
@@ -55,6 +55,7 @@ var delocateTests = []delocateTest{
 	{"x86_64-LabelRewrite", nil, []string{"in1.s", "in2.s"}, "out.s", true},
 	{"x86_64-Sections", nil, []string{"in.s"}, "out.s", true},
 	{"x86_64-ThreeArg", nil, []string{"in.s"}, "out.s", true},
+	{"x86_64-FourArg", nil, []string{"in.s"}, "out.s", true},
 	{"aarch64-Basic", nil, []string{"in.s"}, "out.s", true},
 }
 

--- a/util/fipstools/delocate/testdata/x86_64-FourArg/in.s
+++ b/util/fipstools/delocate/testdata/x86_64-FourArg/in.s
@@ -1,0 +1,13 @@
+	.type foo, @function
+	.globl foo
+foo:
+	movq  %rbx, %rbx # instruction allowing delocator to detect architecture
+	vpinsrq $0x08, kBoringSSLRSASqrtTwo@GOTPCREL(%rip), %xmm1, %xmm0
+	vpinsrq $1, fooExternal@GOTPCREL(%rip), %xmm14, %xmm15
+
+	.type kBoringSSLRSASqrtTwo,@object # @kBoringSSLRSASqrtTwo
+	.section  .rodata,"a",@progbits,unique,760
+	.globl  kBoringSSLRSASqrtTwo
+	.p2align  4
+kBoringSSLRSASqrtTwo:
+	.quad -2404814165548301886    # 0xdea06241f7aa81c2

--- a/util/fipstools/delocate/testdata/x86_64-FourArg/out.s
+++ b/util/fipstools/delocate/testdata/x86_64-FourArg/out.s
@@ -1,0 +1,85 @@
+.text
+.file 1 "inserted_by_delocate.c"
+.loc 1 1 0
+BORINGSSL_bcm_text_start:
+	.type foo, @function
+	.globl foo
+.Lfoo_local_target:
+foo:
+	movq  %rbx, %rbx # instruction allowing delocator to detect architecture
+# WAS vpinsrq $0x08, kBoringSSLRSASqrtTwo@GOTPCREL(%rip), %xmm1, %xmm0
+	leaq -128(%rsp), %rsp
+	pushq %rax
+	leaq	.LkBoringSSLRSASqrtTwo_local_target(%rip), %rax
+	vpinsrq $0x08, %rax, %xmm1, %xmm0
+	popq %rax
+	leaq 128(%rsp), %rsp
+# WAS vpinsrq $1, fooExternal@GOTPCREL(%rip), %xmm14, %xmm15
+	leaq -128(%rsp), %rsp
+	pushq %rax
+	pushf
+	leaq fooExternal_GOTPCREL_external(%rip), %rax
+	addq (%rax), %rax
+	movq (%rax), %rax
+	popf
+	vpinsrq $1, %rax, %xmm14, %xmm15
+	popq %rax
+	leaq 128(%rsp), %rsp
+
+	.type kBoringSSLRSASqrtTwo,@object # @kBoringSSLRSASqrtTwo
+# WAS .section  .rodata,"a",@progbits,unique,760
+.text
+	.globl  kBoringSSLRSASqrtTwo
+	.p2align  4
+.LkBoringSSLRSASqrtTwo_local_target:
+kBoringSSLRSASqrtTwo:
+	.quad -2404814165548301886    # 0xdea06241f7aa81c2
+.text
+.loc 1 2 0
+BORINGSSL_bcm_text_end:
+.type fooExternal_GOTPCREL_external, @object
+.size fooExternal_GOTPCREL_external, 8
+fooExternal_GOTPCREL_external:
+	.long fooExternal@GOTPCREL
+	.long 0
+.type OPENSSL_ia32cap_get, @function
+.globl OPENSSL_ia32cap_get
+.LOPENSSL_ia32cap_get_local_target:
+OPENSSL_ia32cap_get:
+	leaq OPENSSL_ia32cap_P(%rip), %rax
+	ret
+.type BORINGSSL_bcm_text_hash, @object
+.size BORINGSSL_bcm_text_hash, 32
+BORINGSSL_bcm_text_hash:
+.byte 0xae
+.byte 0x2c
+.byte 0xea
+.byte 0x2a
+.byte 0xbd
+.byte 0xa6
+.byte 0xf3
+.byte 0xec
+.byte 0x97
+.byte 0x7f
+.byte 0x9b
+.byte 0xf6
+.byte 0x94
+.byte 0x9a
+.byte 0xfc
+.byte 0x83
+.byte 0x68
+.byte 0x27
+.byte 0xcb
+.byte 0xa0
+.byte 0xa0
+.byte 0x9f
+.byte 0x6b
+.byte 0x6f
+.byte 0xde
+.byte 0x52
+.byte 0xcd
+.byte 0xe2
+.byte 0xcd
+.byte 0xff
+.byte 0x31
+.byte 0x80


### PR DESCRIPTION
### Issues:

P125414272

### Description of changes: 

Instead of generating portable code, gcc can be configured with e.g. `march=cpu-type` that allows it to generate code using instructions from instruction sets supported on up-to `cpu-type`.

In one of these cases, we for example saw:
```
[ 62%] Generating bcm-delocated.S
error while processing "\tvpinsrq\t$1, EVP_PKEY_CTX_dup@GOTPCREL(%rip), %xmm1, %xmm0\n" on line 27676: "GOT access must be source operand, instrOther"
```
In this case, the compiler tries to be smart and get the necessary memory addresses for `EVP_PKEY_CTX_free` and `EVP_PKEY_CTX_dup` to populate `EVP_MD_pctx_ops ` e.g.:
```
    vmovq   EVP_PKEY_CTX_free@GOTPCREL(%rip), %xmm1
    vpinsrq $1, EVP_PKEY_CTX_dup@GOTPCREL(%rip), %xmm1, %xmm0
    vmovdqa %xmm0, -16(%rbp)
```
This fails because `vpinsrq` is not supported in the delocater.

This PR adds support for `vpinsrq` an instruction from the set `AVX512DQ`. I don't think there are other 4-argument instructions, for where a GOT reloc can be emitted, that we need to support right now. This also makes the implementation a tad easier, because we do not need to cater for the relocation being either the first or second argument - it can only be the second.

Otherwise, the implementation follows the one for the type `instrThreeArg`.

### Testing:

Tested this in an environment with conditions that triggers the missing support for `vpinsrq`. Before it failed, after this PR is applied, build and tests succeeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
