### PR TITLE
Add SHA3-256 KAT to FIPS self-test

### DIFF
--- a/crypto/fipsmodule/self_check/fips.c
+++ b/crypto/fipsmodule/self_check/fips.c
@@ -65,6 +65,8 @@ int FIPS_query_algorithm_status(const char *algorithm) {
     "SHA3-256",
     "SHA3-384",
     "SHA3-512",
+    "SHAKE128",
+    "SHAKE256",
   };
   for (size_t i = 0; i < OPENSSL_ARRAY_SIZE(kApprovedAlgorithms); i++) {
     if (strcmp(algorithm, kApprovedAlgorithms[i]) == 0) {

--- a/crypto/fipsmodule/self_check/fips.c
+++ b/crypto/fipsmodule/self_check/fips.c
@@ -62,6 +62,9 @@ int FIPS_query_algorithm_status(const char *algorithm) {
     "SHA2-384",
     "SHA2-512",
     "SHA2-512/256",
+    "SHA3-256",
+    "SHA3-384",
+    "SHA3-512",
   };
   for (size_t i = 0; i < OPENSSL_ARRAY_SIZE(kApprovedAlgorithms); i++) {
     if (strcmp(algorithm, kApprovedAlgorithms[i]) == 0) {

--- a/crypto/fipsmodule/self_check/self_check.c
+++ b/crypto/fipsmodule/self_check/self_check.c
@@ -924,6 +924,28 @@ static int boringssl_self_test_hkdf_sha256(void) {
                     "HKDF-SHA-256 KAT");
 }
 
+static int boringssl_self_test_sha3_256(void) {
+  // From: SHA3_256ShortMsg.txt
+  // Len = 128
+  // Msg = d83c721ee51b060c5a41438a8221e040
+  // MD  = b87d9e4722edd3918729ded9a6d03af8256998ee088a1ae662ef4bcaff142a96
+  static const uint8_t kInput[16] = {
+    0xd8, 0x3c, 0x72, 0x1e, 0xe5, 0x1b, 0x06, 0x0c,
+    0x5a, 0x41, 0x43, 0x8a, 0x82, 0x21, 0xe0, 0x40,
+};
+  static const uint8_t kPlaintextSHA3_256[SHA3_256_DIGEST_LENGTH] = {
+    0xb8, 0x7d, 0x9e, 0x47, 0x22, 0xed, 0xd3, 0x91, 0x87, 0x29, 0xde,
+    0xd9, 0xa6, 0xd0, 0x3a, 0xf8, 0x25, 0x69, 0x98, 0xee, 0x08, 0x8a,
+    0x1a, 0xe6, 0x62, 0xef, 0x4b, 0xca, 0xff, 0x14, 0x2a, 0x96,
+};
+  uint8_t output[SHA3_256_DIGEST_LENGTH];
+
+  // SHA3-256 KAT
+  SHA3_256(kInput, sizeof(kInput), output);
+  return check_test(kPlaintextSHA3_256, output, sizeof(kPlaintextSHA3_256),
+                    "SHA3-256 KAT");
+}
+
 static int boringssl_self_test_fast(void) {
   static const uint8_t kAESKey[16] = "BoringCrypto Key";
   // Older versions of the gcc release build on ARM will optimize out the
@@ -1063,6 +1085,7 @@ static int boringssl_self_test_fast(void) {
   }
 
   if (!boringssl_self_test_sha512() ||
+      !boringssl_self_test_sha3_256() ||
       !boringssl_self_test_hkdf_sha256()) {
     goto err;
   }


### PR DESCRIPTION
### Description of changes: 
* Add SHA3-256 KAT to FIPS self-test

### Call-outs:
* The KAT was taken from here: https://github.com/aws/aws-lc/blob/52834938a5d709bcd8b838b249ee8e5a3954c5d0/crypto/fipsmodule/sha/testvectors/SHA3_256ShortMsg.txt#L65

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
