### PR TITLE
Add dependency to python3-six in github action grpc

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -35,6 +35,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          brew install ninja golang
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           ./tests/ci/run_posix_tests.sh
@@ -45,6 +48,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          brew install ninja golang
       - name: Build ${{ env.PACKAGE_NAME }} with FIPS mode
         run: |
           ./tests/ci/run_fips_tests.sh

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -32,7 +32,7 @@ jobs:
   macOS-x86:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
   macOS-x86-FIPS:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install OS Dependencies
         run: |
           apt-get update
-          apt-get -y --no-install-recommends install cmake gcc g++ ninja-build golang make python3 python3-sphinx autoconf libtool pkg-config git libc++-dev
+          apt-get -y --no-install-recommends install cmake gcc g++ ninja-build golang make python3 python3-sphinx autoconf libtool pkg-config git libc++-dev python3-six
       - uses: actions/checkout@v3
       - name: Run integration build
         run: |


### PR DESCRIPTION
### Description of changes: 

Fix Github actions to work with Ubuntu 24.04

Ubuntu 24.04 does not provide the Python package six by default, contrary to previous Ubuntu versions. This causes issues with the integrations:grpc action.

### Call-outs:

N/A

### Testing:

N/A (just a change in dependencies in integrations tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
