### PR TITLE
Update x25519_test.cc array initialization to avoid a bug with a GCC 13 warning

### DIFF
--- a/crypto/curve25519/x25519_test.cc
+++ b/crypto/curve25519/x25519_test.cc
@@ -157,7 +157,9 @@ TEST(X25519Test, SmallOrder) {
 
 TEST(X25519Test, Iterated) {
   // Taken from https://tools.ietf.org/html/rfc7748#section-5.2.
-  uint8_t scalar[32] = {9}, point[32] = {9}, out[32];
+  uint8_t scalar[32] = {}, point[32] = {}, out[32];
+  scalar[0] = 9;
+  point[0] = 9;
 
   for (unsigned i = 0; i < 1000; i++) {
     EXPECT_TRUE(ctwrapX25519(out, scalar, point));
@@ -176,7 +178,9 @@ TEST(X25519Test, Iterated) {
 
 TEST(X25519Test, DISABLED_IteratedLarge) {
   // Taken from https://tools.ietf.org/html/rfc7748#section-5.2.
-  uint8_t scalar[32] = {9}, point[32] = {9}, out[32];
+  uint8_t scalar[32] = {}, point[32] = {}, out[32];
+  scalar[0] = 9;
+  point[0] = 9;
 
   for (unsigned i = 0; i < 1000000; i++) {
     EXPECT_TRUE(ctwrapX25519(out, scalar, point));


### PR DESCRIPTION
### Issues:
Resolves V1360237371

### Description of changes: 
Avoid a [GCC 13 bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114826) by initializing the test vector separately.  This test still needs the `= {}` to zero initialize the entire array. 

### Call-outs:
This isn't tested in the CI because we don't want to test all march/compiler combinations at this time, this support is best effort for now. 

### Testing:
```
docker run -v `pwd`:`pwd` -w `pwd` -it gcc:13
apt update && apt install cmake ninja less -y
export CFLAGS='-march=haswell -mcrc32'
export CXXFLAGS='-march=haswell -mcrc32'
cmake -GNinja ../
ninja run_tests
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
