### PR TITLE
Cleanup remaing duplicate symbol definitions and turn Wredundant-decls on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,10 +290,13 @@ if(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
   message(STATUS "MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX selected, removing AVX512 optimisations")
 endif()
 
-# Detect if memcmp is wrongly stripped like strcmp.
-# If exists, let CMake generate a warning.
-# memcmp bug link https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
 if (GCC)
+  # All versions of GCC that AWS-LC supports has this warning
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wredundant-decls")
+
+  # Detect if memcmp is wrongly stripped like strcmp.
+  # If exists, let CMake generate a warning.
+  # memcmp bug link https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
   # CMake try_run requires these variables must be preset.
   # https://cmake.org/cmake/help/latest/command/try_run.html
   set(MEMCMP_INVALID_STRIPPED "")

--- a/crypto/evp_extra/internal.h
+++ b/crypto/evp_extra/internal.h
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+#ifndef AWS_LC_EVP_EXTRA_INTERNAL_H
+#define AWS_LC_EVP_EXTRA_INTERNAL_H
+
 #include <openssl/base.h>
 #include "../fipsmodule/evp/internal.h"
 
@@ -60,3 +63,5 @@ const EVP_PKEY_METHOD *const *AWSLC_non_fips_pkey_evp_methods(void);
 // Returns a reference to the list |asn1_evp_pkey_methods|. The list has
 // size |ASN1_EVP_PKEY_METHODS|.
 const EVP_PKEY_ASN1_METHOD *const *AWSLC_non_fips_pkey_evp_asn1_methods(void);
+
+#endif

--- a/crypto/fipsmodule/cpucap/cpu_intel.c
+++ b/crypto/fipsmodule/cpucap/cpu_intel.c
@@ -158,7 +158,6 @@ static void handle_cpu_env(uint32_t *out, const char *in) {
   }
 }
 
-extern uint32_t OPENSSL_ia32cap_P[4];
 extern uint8_t OPENSSL_cpucap_initialized;
 
 void OPENSSL_cpuid_setup(void) {

--- a/crypto/fipsmodule/evp/evp.c
+++ b/crypto/fipsmodule/evp/evp.c
@@ -68,8 +68,9 @@
 #include <openssl/rsa.h>
 #include <openssl/thread.h>
 
-#include "internal.h"
+#include "../../evp_extra/internal.h"
 #include "../../internal.h"
+#include "internal.h"
 
 
 // Node depends on |EVP_R_NOT_XOF_OR_INVALID_LENGTH|.
@@ -233,8 +234,6 @@ const char *EVP_MD_get0_name(const EVP_MD *md) {
 const char *EVP_MD_name(const EVP_MD *md) {
   return EVP_MD_get0_name(md);
 }
-
-extern const EVP_PKEY_ASN1_METHOD *const *AWSLC_non_fips_pkey_evp_asn1_methods(void);
 
 // evp_pkey_asn1_find returns the ASN.1 method table for the given |nid|, which
 // should be one of the |EVP_PKEY_*| values. It returns NULL if |nid| is

--- a/crypto/fipsmodule/evp/evp_ctx.c
+++ b/crypto/fipsmodule/evp/evp_ctx.c
@@ -64,9 +64,7 @@
 
 #include "../../internal.h"
 #include "internal.h"
-
-// Forward declaration of |AWSLC_non_fips_pkey_evp_methods| to learn return type.
-extern const EVP_PKEY_METHOD *const *AWSLC_non_fips_pkey_evp_methods(void);
+#include "../../evp_extra/internal.h"
 
 DEFINE_LOCAL_DATA(struct fips_evp_pkey_methods, AWSLC_fips_evp_pkey_methods) {
   out->methods[0] = EVP_PKEY_rsa_pkey_meth();

--- a/crypto/fipsmodule/sha/sha1-altivec.c
+++ b/crypto/fipsmodule/sha/sha1-altivec.c
@@ -69,8 +69,6 @@
 
 #include <altivec.h>
 
-void sha1_block_data_order(uint32_t *state, const uint8_t *data, size_t num);
-
 static uint32_t rotate(uint32_t a, int n) { return (a << n) | (a >> (32 - n)); }
 
 typedef vector unsigned int vec_uint32_t;

--- a/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
+++ b/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h
@@ -12,6 +12,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+#ifndef S2N_BIGNUM_AWS_LC_H
+#define S2N_BIGNUM_AWS_LC_H
 
 // ----------------------------------------------------------------------------
 // C prototypes for s2n-bignum functions used in AWS-LC
@@ -322,3 +324,4 @@ extern void edwards25519_scalarmuldouble(uint64_t res[static 8], uint64_t scalar
         uint64_t point[static 8], uint64_t bscalar[static 4]);
 extern void edwards25519_scalarmuldouble_alt(uint64_t res[static 8], uint64_t scalar[static 4],
         uint64_t point[static 8], uint64_t bscalar[static 4]);
+#endif


### PR DESCRIPTION
### Issues:

Addresses https://github.com/aws/aws-lc/issues/1556

### Description of changes: 
Fix a few other cases of duplicate definitions and turn this on so the CI can catch this in the future. 

### Call-outs:
We own this s2n-bignum header file.

### Testing:
We have GCC CI for x86/ARM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
