### PR TITLE
Migrate from __FreeBSD__ to __FreeBSD_version

### DIFF
--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -71,7 +71,8 @@
 
 #if defined(OPENSSL_FREEBSD)
 #define URANDOM_BLOCKS_FOR_ENTROPY
-#if __FreeBSD__ >= 12
+#include <sys/param.h>
+#if __FreeBSD_version >= 1200000
 // getrandom is supported in FreeBSD 12 and up.
 #define FREEBSD_GETRANDOM
 #include <sys/random.h>


### PR DESCRIPTION
### Issues:
Resolves https://github.com/aws/aws-lc/issues/1557

### Description of changes: 
[`__FreeBSD__`](https://docs.freebsd.org/en/books/porters-handbook/porting-dads/#porting-versions) doesn't seem to be as well supported (or as accurate) as `__FreeBSD_version`. This change migrates to [`__FreeBSD_version`](https://docs.freebsd.org/en/books/porters-handbook/versions/#versions) which appears to be the recommended way to check for versions. 

### Call-outs:
`__FreeBSD_version` is defined in [`sys/param.h`](https://cgit.freebsd.org/src/tree/sys/sys/param.h#n76)

### Testing:
We don't have FreeBSD in our CI, a similar but not exactly the same change was tested by the requester in https://github.com/aws/aws-lc/issues/1557.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
