### PR TITLE
Minor functions to build with Ruby's cipher module

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -524,6 +524,7 @@ add_library(
   decrepit/cfb/cfb.c
   decrepit/dh/dh_decrepit.c
   decrepit/evp/evp_do_all.c
+  decrepit/obj/obj_decrepit.c
   decrepit/ripemd/ripemd.c
   decrepit/rsa/rsa_decrepit.c
   decrepit/x509/x509_decrepit.c

--- a/crypto/cipher_extra/derive_key.c
+++ b/crypto/cipher_extra/derive_key.c
@@ -60,9 +60,8 @@
 
 #include <openssl/digest.h>
 #include <openssl/mem.h>
+#include <openssl/evp.h>
 
-
-#define PKCS5_SALT_LEN 8
 
 int EVP_BytesToKey(const EVP_CIPHER *type, const EVP_MD *md,
                    const uint8_t *salt, const uint8_t *data, size_t data_len,

--- a/crypto/decrepit/obj/obj_decrepit.c
+++ b/crypto/decrepit/obj/obj_decrepit.c
@@ -1,0 +1,70 @@
+/* Copyright (c) 2016, Google Inc.	
+ *	
+ * Permission to use, copy, modify, and/or distribute this software for any	
+ * purpose with or without fee is hereby granted, provided that the above	
+ * copyright notice and this permission notice appear in all copies.	
+ *	
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES	
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF	
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY	
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES	
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION	
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN	
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */	
+
+#include <openssl/obj.h>
+
+#include <assert.h>
+#include <string.h>
+
+#include <openssl/evp.h>
+
+#include "../../internal.h"
+
+
+struct wrapped_callback {
+  void (*callback)(const OBJ_NAME *, void *arg);
+  void *arg;
+};
+
+static void cipher_callback(const EVP_CIPHER *cipher, const char *name,
+                            const char *unused, void *arg) {
+  const struct wrapped_callback *wrapped = (struct wrapped_callback *)arg;
+  OBJ_NAME obj_name;
+
+  OPENSSL_memset(&obj_name, 0, sizeof(obj_name));
+  obj_name.type = OBJ_NAME_TYPE_CIPHER_METH;
+  obj_name.name = name;
+  obj_name.data = (const char *)cipher;
+
+  wrapped->callback(&obj_name, wrapped->arg);
+}
+
+static void md_callback(const EVP_MD *md, const char *name, const char *unused,
+                        void *arg) {
+  const struct wrapped_callback *wrapped = (struct wrapped_callback*) arg;
+  OBJ_NAME obj_name;
+
+  OPENSSL_memset(&obj_name, 0, sizeof(obj_name));
+  obj_name.type = OBJ_NAME_TYPE_MD_METH;
+  obj_name.name = name;
+  obj_name.data = (const char *)md;
+
+  wrapped->callback(&obj_name, wrapped->arg);
+}	
+
+void OBJ_NAME_do_all_sorted(int type,
+                            void (*callback)(const OBJ_NAME *, void *arg),
+                            void *arg) {
+  struct wrapped_callback wrapped;
+  wrapped.callback = callback;
+  wrapped.arg = arg;
+
+  if (type == OBJ_NAME_TYPE_CIPHER_METH) {
+    EVP_CIPHER_do_all_sorted(cipher_callback, &wrapped);
+  } else if (type == OBJ_NAME_TYPE_MD_METH) {
+    EVP_MD_do_all_sorted(md_callback, &wrapped);
+  } else {
+    assert(0);
+  }
+}

--- a/crypto/fipsmodule/bn/bn.c
+++ b/crypto/fipsmodule/bn/bn.c
@@ -441,3 +441,7 @@ void bn_set_minimal_width(BIGNUM *bn) {
     bn->neg = 0;
   }
 }
+
+int BN_get_flags(const BIGNUM *bn, int flags) {
+  return bn->flags & flags;
+}

--- a/crypto/fipsmodule/cipher/cipher.c
+++ b/crypto/fipsmodule/cipher/cipher.c
@@ -63,6 +63,7 @@
 #include <openssl/err.h>
 #include <openssl/mem.h>
 #include <openssl/nid.h>
+#include <openssl/obj.h>
 
 #include "internal.h"
 #include "../../internal.h"
@@ -701,6 +702,13 @@ uint32_t EVP_CIPHER_flags(const EVP_CIPHER *cipher) {
 
 uint32_t EVP_CIPHER_mode(const EVP_CIPHER *cipher) {
   return cipher->flags & EVP_CIPH_MODE_MASK;
+}
+
+const char *EVP_CIPHER_name(const EVP_CIPHER *cipher) {
+  if (cipher != NULL) {
+    return OBJ_nid2sn(cipher->nid);
+  }
+  return NULL;
 }
 
 int EVP_CipherInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,

--- a/crypto/pkcs8/internal.h
+++ b/crypto/pkcs8/internal.h
@@ -112,8 +112,6 @@ struct pbe_suite {
                       const char *pass, size_t pass_len, CBS *param);
 };
 
-#define PKCS5_SALT_LEN 8
-
 int PKCS5_pbe2_decrypt_init(const struct pbe_suite *suite, EVP_CIPHER_CTX *ctx,
                             const char *pass, size_t pass_len, CBS *param);
 

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -336,6 +336,11 @@ OPENSSL_EXPORT BN_ULONG BN_get_word(const BIGNUM *bn);
 // returns zero.
 OPENSSL_EXPORT int BN_get_u64(const BIGNUM *bn, uint64_t *out);
 
+// BN_get_flags interprets |flags| as a bitmask and returns the flags for |bn|.
+// The returned value is a set of bitmask of |BN_FLG_*| values, ORed together,
+// or 0 if none of the given flags are set.
+OPENSSL_EXPORT int BN_get_flags(const BIGNUM *bn, int flags);
+
 
 // ASN.1 functions.
 

--- a/include/openssl/cipher.h
+++ b/include/openssl/cipher.h
@@ -309,6 +309,9 @@ OPENSSL_EXPORT int EVP_CIPHER_CTX_set_key_length(EVP_CIPHER_CTX *ctx,
 // |NID_aes_128_gcm|.)
 OPENSSL_EXPORT int EVP_CIPHER_nid(const EVP_CIPHER *cipher);
 
+// EVP_CIPHER_name returns the short name of |cipher|.
+OPENSSL_EXPORT const char *EVP_CIPHER_name(const EVP_CIPHER *cipher);
+
 // EVP_CIPHER_block_size returns the block size, in bytes, for |cipher|, or one
 // if |cipher| is a stream cipher.
 OPENSSL_EXPORT unsigned EVP_CIPHER_block_size(const EVP_CIPHER *cipher);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -489,6 +489,8 @@ OPENSSL_EXPORT int EVP_PKEY_print_params(BIO *out, const EVP_PKEY *pkey,
 // function that results in a key suitable for use in symmetric
 // cryptography.
 
+#define PKCS5_SALT_LEN 8
+
 // PKCS5_PBKDF2_HMAC computes |iterations| iterations of PBKDF2 of |password|
 // and |salt|, using |digest|, and outputs |key_len| bytes to |out_key|. It
 // returns one on success and zero on allocation failure or if |iterations| is

--- a/include/openssl/obj.h
+++ b/include/openssl/obj.h
@@ -238,6 +238,17 @@ typedef struct obj_name_st {
 #define OBJ_NAME_TYPE_MD_METH 1
 #define OBJ_NAME_TYPE_CIPHER_METH 2
 
+// OBJ_NAME_do_all_sorted calls |callback| zero or more times, each time with
+// the name of a different primitive. If |type| is |OBJ_NAME_TYPE_MD_METH| then
+// the primitives will be hash functions, alternatively if |type| is
+// |OBJ_NAME_TYPE_CIPHER_METH| then the primitives will be ciphers or cipher
+// modes.
+//
+// This function is ill-specified and should never be used.
+OPENSSL_EXPORT void OBJ_NAME_do_all_sorted(
+    int type, void (*callback)(const OBJ_NAME *, void *arg), void *arg);
+
+
 // OBJ_cleanup does nothing.
 OPENSSL_EXPORT void OBJ_cleanup(void);
 


### PR DESCRIPTION
### Description of changes: 
First round of minor APIs for Ruby support. These encapsulate the APIs needed to build Ruby's cipher module.
* https://github.com/ruby/ruby/blob/ruby_3_1/ext/openssl/ossl_cipher.c
* https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/Cipher.html

1. `PKCS5_SALT_LEN` was exposed from our existing internal definitions.
2. `OBJ_NAME_do_all_sorted` already existed in AWS-LC prior to our decrepit removal: https://github.com/aws/aws-lc/commit/abbbd0045c9dc3a6f7de0fa29efaf298f44b7852. This directly adds back the original implementation.
3. `EVP_CIPHER_name` follows an identical pattern to the existing `EVP_MD_name`: 
https://github.com/aws/aws-lc/blob/0541314f0c8ab0e6e4955e70cb31747732797a9c/crypto/fipsmodule/evp/evp.c#L227-L236

### Call-outs:
N/A

### Testing:
Ruby script in draft PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
