### PR TITLE
Minor GitHub Action cleanup

### DIFF
--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org,direct
@@ -34,6 +34,7 @@ jobs:
     needs: [sanity-test-run]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - "macos-14-large"
@@ -53,6 +54,7 @@ jobs:
     needs: [sanity-test-run]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - "macos-14-large"
@@ -72,6 +74,7 @@ jobs:
     needs: [sanity-test-run]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - "macos-14-xlarge"
@@ -90,6 +93,7 @@ jobs:
     needs: [sanity-test-run]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - "macos-14-xlarge"
@@ -168,6 +172,7 @@ jobs:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     strategy:
+      fail-fast: false
       matrix:
         gccversion:
           - "9"
@@ -202,6 +207,7 @@ jobs:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     strategy:
+      fail-fast: false
       matrix:
         gccversion:
           - "13"
@@ -234,6 +240,7 @@ jobs:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     strategy:
+      fail-fast: false
       matrix:
         gccversion:
           - "10"

--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org,direct

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 env:
   DOCKER_BUILDKIT: 1
@@ -15,6 +15,7 @@ jobs:
     if: github.repository_owner == 'aws'
     name: CMake ${{ matrix.cmake.version}} build with ${{ matrix.generator}} FIPS=${{ matrix.fips }}
     strategy:
+      fail-fast: false
       matrix:
         cmake:
           - { version: "3.2", url: "https://cmake.org/files/v3.2/cmake-3.2.3.tar.gz", hash: "a1ebcaf6d288eb4c966714ea457e3b9677cdfde78820d0f088712d7320850297" }

--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
   codecov-ci:

--- a/.github/workflows/cross-test.yml
+++ b/.github/workflows/cross-test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
   ppc64-build-test:

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 env:
   CC: gcc

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
   mingw:


### PR DESCRIPTION
### Description of changes: 
* Group actions by `github.ref_name` which is applicable to both pushes and pulls. See [docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).
* Don't fail entire "matrix" when one job fails.  See [docs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
