### PR TITLE
ppc64le: EVP_has_aes_hardware is false w/ no-asm

### DIFF
--- a/crypto/fipsmodule/cipher/e_aes.c
+++ b/crypto/fipsmodule/cipher/e_aes.c
@@ -1738,7 +1738,7 @@ int EVP_has_aes_hardware(void) {
 #elif defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
   return hwaes_capable() && CRYPTO_is_ARMv8_PMULL_capable();
 #elif defined(OPENSSL_PPC64LE)
-  return CRYPTO_is_PPC64LE_vcrypto_capable();
+  return hwaes_capable() && CRYPTO_is_PPC64LE_vcrypto_capable();
 #else
   return 0;
 #endif


### PR DESCRIPTION
### Issues:
* CryptoAlg-2425

### Description of changes: 
* On ppc64le, `EVP_has_aes_hardware` should return false when `OPENSSL_NO_ASM` flag is set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
