### PR TITLE
v1.26.0 Release Preparation

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4280,7 +4280,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.25.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.26.0");
 }
 
 #else
@@ -4323,6 +4323,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.25.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.26.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.25.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.26.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
d52018b0f Minor functions to build with Ruby's cipher module (#1564)
364d28bb3 Changed SSL_client_hello_get0_ciphers to align with OpenSSL behavior (#1542)
e8eb7de79 ppc64le: EVP_has_aes_hardware is false w/ no-asm (#1566)
d726d0616 OpenBSD 7.4 and 7.5 Support (#1437)
a66c66efb Remove comments about overread for entropy generation (#1551)
f8a575feb Migrate from __FreeBSD__ to __FreeBSD_version (#1562)
c31d1ce42 Centralize handling of s2n-bignum alt/non-alt function selection (#1547)
00f3c4583 CI for other MacOS versions (#1558)
0541314f0 Cleanup remaing duplicate symbol definitions and turn Wredundant-decls on (#1561)
4d280eb7b Fix ec2 CI testing framework (#1541)
9a4b43ec3 Update x25519_test.cc array initialization to avoid a bug with a GCC 13 warning (#1555)
388cbe7f3 Remove duplicate X509_OBJECT_new and X509_OBJECT_free declarations (#1560)
2ea670683 Avoid 'z' format with MSVCRT (#1559)
c25dc2afd Add dependency to python3-six in github action grpc (#1554)
2bdcba36f Link porting guide table to header documentation (#1540)
311ca381c Basic GH CI build/test with full range of gcc/clang (#1546)
1f19717d7 Add SHA3-256 KAT to FIPS self-test (#1549)
0f3548ace Add EC point add/dbl to speed.cc (#1545)
d7ddfc415 Fix the NTP integration test (NTP website changed) (#1548)
8ccd85b1b Fix skipped tests in Mariadb integration CI (#1533)
d9401623b Support vpinsrq in delocater (#1543)
4cd6d216e Remove redundant test exec libraries (#1544)
56f356950 [ML-KEM] Add experimental support for ML-KEM-512-IPD (#1516)
c295aef74 Upstream merge 2024 04 16 (#1535)
2e516292d Re-add function
0aebf17b6 Define OPENSSL_NO_TLS_PHA, typedef PSK callback signatures (#1526)
46056cf30 Pull the string-based extensions APIs into their own section
960ea4291 Unexport X509_VERIFY_PARAM_lookup
3c597b144 Remove X509_VERIFY_PARAM_get0_peername
9c399e5bc Document some key usage accessors
2fe70b576 Simplify and document X509_supported_extension
2e0489705 Const-correct X509_LOOKUP_METHOD
9826568c0 Replace X509_LOOKUP_ctrl with real functions
e47c05633 Tidy up x509_lu.c functions a little
62e019f14 Clean up the by_file_ctrl x509 code to be slightly less obtuse
45c46c2a1 Use relative links in markdown files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
