### PR TITLE
Implement DEPRECATED RSA_pkey_ctx_ctrl

### DIFF
--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -836,6 +836,15 @@ void RSA_blinding_off_temp_for_accp_compatibility(RSA *rsa) {
   }
 }
 
+int RSA_pkey_ctx_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *p2) {
+    if (ctx != NULL && ctx->pmeth != NULL
+        && ctx->pmeth->pkey_id != EVP_PKEY_RSA
+        && ctx->pmeth->pkey_id != EVP_PKEY_RSA_PSS) {
+        return -1;
+    }
+     return EVP_PKEY_CTX_ctrl(ctx, -1, optype, cmd, p1, p2);
+}
+
 // ------------- KEY CHECKING FUNCTIONS ----------------
 //
 // Performs several checks on the public component of the given RSA key.

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -837,12 +837,12 @@ void RSA_blinding_off_temp_for_accp_compatibility(RSA *rsa) {
 }
 
 int RSA_pkey_ctx_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *p2) {
-    if (ctx != NULL && ctx->pmeth != NULL
-        && ctx->pmeth->pkey_id != EVP_PKEY_RSA
-        && ctx->pmeth->pkey_id != EVP_PKEY_RSA_PSS) {
-        return -1;
-    }
-     return EVP_PKEY_CTX_ctrl(ctx, -1, optype, cmd, p1, p2);
+  if (ctx != NULL && ctx->pmeth != NULL
+      && ctx->pmeth->pkey_id != EVP_PKEY_RSA
+      && ctx->pmeth->pkey_id != EVP_PKEY_RSA_PSS) {
+    return -1;
+  }
+  return EVP_PKEY_CTX_ctrl(ctx, -1, optype, cmd, p1, p2);
 }
 
 // ------------- KEY CHECKING FUNCTIONS ----------------

--- a/crypto/fipsmodule/rsa/rsa.c
+++ b/crypto/fipsmodule/rsa/rsa.c
@@ -837,12 +837,14 @@ void RSA_blinding_off_temp_for_accp_compatibility(RSA *rsa) {
 }
 
 int RSA_pkey_ctx_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *p2) {
-  if (ctx != NULL && ctx->pmeth != NULL
-      && ctx->pmeth->pkey_id != EVP_PKEY_RSA
-      && ctx->pmeth->pkey_id != EVP_PKEY_RSA_PSS) {
+  if (ctx != NULL && ctx->pmeth != NULL) {
+    if (ctx->pmeth->pkey_id == EVP_PKEY_RSA ||
+        ctx->pmeth->pkey_id == EVP_PKEY_RSA_PSS) {
+      return EVP_PKEY_CTX_ctrl(ctx, -1, optype, cmd, p1, p2);
+    }
     return -1;
   }
-  return EVP_PKEY_CTX_ctrl(ctx, -1, optype, cmd, p1, p2);
+  return 0;
 }
 
 // ------------- KEY CHECKING FUNCTIONS ----------------

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -739,12 +739,15 @@ OPENSSL_EXPORT int RSA_blinding_on(RSA *rsa, BN_CTX *ctx);
 // a private exponent having blinding disabled.
 OPENSSL_EXPORT OPENSSL_DEPRECATED void RSA_blinding_off_temp_for_accp_compatibility(RSA *rsa);
 
-// RSA_pkey_ctx_ctrl is a vestigial function that has been obsoleted by the EVP
-// interface. Use |EVP_PKEY_CTX_ctrl| instead.
+// RSA_pkey_ctx_ctrl is a vestigial OpenSSL function that has been obsoleted by
+// the EVP interface. External callers should not use this. Internal callers
+// should use |EVP_PKEY_CTX_ctrl| instead.
 //
 // This function directly calls |EVP_PKEY_CTX_ctrl| with some guards around the
-// key's "type". If key type is not RSA or RSA-PSS, -1 is returned.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int RSA_pkey_ctx_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *p2);
+// key's type. The key type must either be RSA or RSA-PSS, otherwise -1 is
+// returned.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int RSA_pkey_ctx_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd,
+                                                        int p1, void *p2);
 
 // RSA_generate_key behaves like |RSA_generate_key_ex|, which is what you
 // should use instead. It returns NULL on error, or a newly-allocated |RSA| on

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -739,6 +739,13 @@ OPENSSL_EXPORT int RSA_blinding_on(RSA *rsa, BN_CTX *ctx);
 // a private exponent having blinding disabled.
 OPENSSL_EXPORT OPENSSL_DEPRECATED void RSA_blinding_off_temp_for_accp_compatibility(RSA *rsa);
 
+// RSA_pkey_ctx_ctrl is a vestigial function that has been obsoleted by the EVP
+// interface. Use |EVP_PKEY_CTX_ctrl| instead.
+//
+// This function directly calls |EVP_PKEY_CTX_ctrl| with some guards around the
+// key's "type". If key type is not RSA or RSA-PSS, -1 is returned.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int RSA_pkey_ctx_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *p2);
+
 // RSA_generate_key behaves like |RSA_generate_key_ex|, which is what you
 // should use instead. It returns NULL on error, or a newly-allocated |RSA| on
 // success. This function is provided for compatibility only. The |callback|


### PR DESCRIPTION
# Notes

[AWS-LC][3] and [OpenSSL 3][4] implement various RSA control functions
as concrete functions, but OpenSSL 1.1.1 [implements][1] them as macros
calling `RSA_pkey_ctx_ctrl`. This commit provides an implementation of
`RSA_pkey_ctx_ctrl` [directly cribbed][1] from OpenSSL 1.1.1, and
identical to OpenSSL 3's implementation [today][2].

[1]: https://github.com/openssl/openssl/commit/e5e04ee3983dcf5283c99ce63f3fe37093921747
[2]: https://github.com/openssl/openssl/blob/067fbc01b9e867b31c71091d62f0f9012dc9e41a/crypto/rsa/rsa_lib.c#L734
[3]: https://github.com/aws/aws-lc/blob/2c03113451b5f84f61c8ed283b289a6db87b3397/include/openssl/evp.h#L796
[4]: https://github.com/openssl/openssl/blob/067fbc01b9e867b31c71091d62f0f9012dc9e41a/include/openssl/rsa.h#L125

# Tests

- CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
