### PR TITLE
Cross-compile w/ MinGW; set `_WIN32_WINNT`

### DIFF
--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -69,3 +69,30 @@ jobs:
         run: cmake --build ./build --target all
       - name: Run tests
         run: cmake --build ./build --target run_tests
+  cross-mingw:
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install Tools
+        run: |
+          set -ex
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends  software-properties-common
+          sudo add-apt-repository --yes ppa:longsleep/golang-backports
+          sudo dpkg --add-architecture i386
+          sudo mkdir -pm755 /etc/apt/keyrings
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends build-essential cmake golang-go nasm clang wget mingw-w64
+          sudo apt-get install --assume-yes --install-recommends winehq-stable wine-binfmt
+          sudo update-binfmts --display
+          sudo update-binfmts --disable
+          sudo update-binfmts --enable wine
+          sudo update-binfmts --display
+          sudo rm -rf /tmp/*
+      - uses: actions/checkout@v4
+      - name: x86_64-w64-mingw32 Build/Test
+        run:
+          ./tests/ci/run_cross_mingw_tests.sh x86_64 w64-mingw32 "-DCMAKE_BUILD_TYPE=Release"
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,13 @@ if(GCC OR CLANG)
     set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wall -fvisibility=hidden -fno-common")
   endif()
 
+  if(MINGW)
+    # Some MinGW compilers set _WIN32_WINNT to an older version (Windows Server 2003)
+    # See: https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
+    # Support Windows 7 and later.
+    add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN7)
+  endif()
+
   if(CLANG)
     set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wnewline-eof -fcolor-diagnostics")
   elseif(CMAKE_C_COMPILER_VERSION VERSION_GREATER "4.1.3")

--- a/tests/ci/run_cross_mingw_tests.sh
+++ b/tests/ci/run_cross_mingw_tests.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -ex
+
+TARGET_CPU="${1}"
+TARGET_PLATFORM="${2}"
+BUILD_OPTIONS=("${@:3:5}")
+GCC_VERSION="10"
+THREAD_MODEL="posix"
+
+if [ "${#BUILD_OPTIONS[@]}" -lt 1 ]; then
+    echo "Must pass build parameters"
+    exit 1
+fi
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$(readlink -f "${SCRIPT_DIR}")"
+
+source "${SCRIPT_DIR}/common_posix_setup.sh"
+source "${SCRIPT_DIR}/gtest_util.sh"
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER="${SYS_ROOT}/SCRATCH_${TARGET_CPU}"
+
+if [ -e "${SCRATCH_FOLDER}" ]; then
+    # Some directories in the archive lack write permission, preventing deletion of files
+    chmod +w -R "${SCRATCH_FOLDER}"
+    rm -rf "${SCRATCH_FOLDER:?}"
+fi
+mkdir -p "${SCRATCH_FOLDER}"
+
+pushd "${SCRATCH_FOLDER}"
+
+cat <<EOF > ${TARGET_CPU}-${TARGET_PLATFORM}.cmake
+# Specify the target system
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR ${TARGET_CPU})
+
+# Specify the cross-compiler
+# Specify the cross-compiler
+set(CMAKE_C_COMPILER /usr/bin/${TARGET_CPU}-${TARGET_PLATFORM}-gcc-${THREAD_MODEL})
+set(CMAKE_CXX_COMPILER /usr/bin/${TARGET_CPU}-${TARGET_PLATFORM}-g++-${THREAD_MODEL})
+
+# Specify the sysroot for the target system
+set(CMAKE_SYSROOT /usr/lib/gcc/${TARGET_CPU}-${TARGET_PLATFORM}/${GCC_VERSION}-${THREAD_MODEL}/)
+set(CMAKE_SYSTEM_INCLUDE_PATH /usr/lib/gcc/${TARGET_CPU}-${TARGET_PLATFORM}/${GCC_VERSION}-${THREAD_MODEL}/include)
+
+set(CMAKE_FIND_ROOT_PATH /usr/lib/gcc/${TARGET_CPU}-${TARGET_PLATFORM}/${GCC_VERSION}-${THREAD_MODEL}/)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Static to minimize runtime linking requirements
+set(CMAKE_C_FLAGS --static)
+set(CMAKE_CXX_FLAGS --static)
+
+set(CMAKE_GENERATOR Ninja)
+EOF
+
+cat ${TARGET_CPU}-${TARGET_PLATFORM}.cmake
+
+echo "Testing AWS-LC static library for ${TARGET_CPU}."
+
+for BO in "${BUILD_OPTIONS[@]}"; do
+  run_build -DCMAKE_TOOLCHAIN_FILE="${SCRATCH_FOLDER}/${TARGET_CPU}-${TARGET_PLATFORM}.cmake" ${BO}
+
+  shard_gtest "${BUILD_ROOT}/crypto/crypto_test.exe --gtest_also_run_disabled_tests"
+  shard_gtest ${BUILD_ROOT}/crypto/urandom_test.exe
+  shard_gtest ${BUILD_ROOT}/crypto/mem_test.exe
+  shard_gtest ${BUILD_ROOT}/crypto/mem_set_test.exe
+
+  shard_gtest ${BUILD_ROOT}/ssl/ssl_test.exe
+  shard_gtest ${BUILD_ROOT}/ssl/integration_test.exe
+
+  # Due to its special linkage, this does not use GoogleTest
+  ${BUILD_ROOT}/crypto/dynamic_loading_test.exe
+done
+popd

--- a/tests/ci/run_cross_mingw_tests.sh
+++ b/tests/ci/run_cross_mingw_tests.sh
@@ -39,7 +39,6 @@ set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_SYSTEM_PROCESSOR ${TARGET_CPU})
 
 # Specify the cross-compiler
-# Specify the cross-compiler
 set(CMAKE_C_COMPILER /usr/bin/${TARGET_CPU}-${TARGET_PLATFORM}-gcc-${THREAD_MODEL})
 set(CMAKE_CXX_COMPILER /usr/bin/${TARGET_CPU}-${TARGET_PLATFORM}-g++-${THREAD_MODEL})
 
@@ -53,8 +52,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
 # Static to minimize runtime linking requirements
-set(CMAKE_C_FLAGS --static)
-set(CMAKE_CXX_FLAGS --static)
+set(CMAKE_EXE_LINKER_FLAGS --static)
 
 set(CMAKE_GENERATOR Ninja)
 EOF
@@ -70,6 +68,7 @@ for BO in "${BUILD_OPTIONS[@]}"; do
   shard_gtest ${BUILD_ROOT}/crypto/urandom_test.exe
   shard_gtest ${BUILD_ROOT}/crypto/mem_test.exe
   shard_gtest ${BUILD_ROOT}/crypto/mem_set_test.exe
+  shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init.exe
 
   shard_gtest ${BUILD_ROOT}/ssl/ssl_test.exe
   shard_gtest ${BUILD_ROOT}/ssl/integration_test.exe

--- a/tests/ci/run_cross_tests.sh
+++ b/tests/ci/run_cross_tests.sh
@@ -64,6 +64,7 @@ for BO in "${BUILD_OPTIONS[@]}"; do
   shard_gtest ${BUILD_ROOT}/crypto/urandom_test
   shard_gtest ${BUILD_ROOT}/crypto/mem_test
   shard_gtest ${BUILD_ROOT}/crypto/mem_set_test
+  shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init
 
   shard_gtest ${BUILD_ROOT}/ssl/ssl_test
   shard_gtest ${BUILD_ROOT}/ssl/integration_test


### PR DESCRIPTION
### Description of changes:
* Cross-compile and test MinGW on Ubuntu.
* Some versions of MinGW set `_WIN32_WINNT` for [compatibility with Windows Server 2003](https://stackoverflow.com/questions/75873115/min-gw-gcc-cant-link-winsock2-h).
* Set compatibility to "Windows 7" when building with MinGW.

### Callout
* The following build failure occurs when building w/o setting `_WIN32_WINNT`:
```
/home/justsmth/repos/aws-lc/crypto/bio/bio_test.cc:147:7: error: ‘inet_pton’ was not declared in this scope; did you mean ‘inet_ntoa’?
  147 |   if (inet_pton(AF_INET6, "::1", &sin6.sin6_addr) != 1) {
      |       ^~~~~~~~~
      |       inet_ntoa
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
