### PR TITLE
Initial design for export of Merkle-Damgard hash state

### DIFF
--- a/crypto/fipsmodule/sha/internal.h
+++ b/crypto/fipsmodule/sha/internal.h
@@ -19,6 +19,17 @@
 extern "C" {
 #endif
 
+// Internal SHA2 constants
+
+// SHA224_CHAINING_LENGTH is the chaining length in bytes of SHA-224
+// It corresponds to the length in bytes of the h part of the state
+#define SHA224_CHAINING_LENGTH 32
+
+// SHA256_CHAINING_LENGTH is the chaining length in bytes of SHA-256
+// It corresponds to the length in bytes of the h part of the state
+#define SHA256_CHAINING_LENGTH 32
+
+
 // SHA3 constants, from NIST FIPS202.
 // https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
 #define SHA3_ROWS 5
@@ -91,6 +102,26 @@ void sha512_block_data_order(uint64_t *state, const uint8_t *in,
 #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_AARCH64)
 #define KECCAK1600_ASM
 #endif
+
+// SHA256_Init_from_state is a low-level function that initializes |sha| with a
+// custom state. |h| is the hash state in big endian. |n| is the number of bits
+// processed at this point. It must be a multiple of |SHA256_CBLOCK*8|.
+// It returns one on success and zero on programmer error.
+// External users should never use directly this function.
+OPENSSL_EXPORT int SHA256_Init_from_state(
+    SHA256_CTX *sha, const uint8_t h[SHA256_CHAINING_LENGTH], uint64_t n);
+
+// SHA256_get_state is a low-level function that exports the hash state in big
+// endian into |out_n| and the number of bits processed at this point in
+// |out_n|. SHA256_Final must not have been called before (otherwise results
+// are not guaranteed). Furthermore, the number of bytes processed by
+// SHA256_Update must be a multiple of the block length |SHA256_CBLOCK|
+// (otherwise it fails). It returns one on success and zero on programmer
+// error.
+// External users should never use directly this function.
+OPENSSL_EXPORT int SHA256_get_state(SHA256_CTX *ctx,
+                                    uint8_t out_h[SHA256_CHAINING_LENGTH],
+                                    uint64_t *out_n);
 
 // SHA3_224 writes the digest of |len| bytes from |data| to |out| and returns |out|. 
 // There must be at least |SHA3_224_DIGEST_LENGTH| bytes of space in |out|.

--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -171,6 +171,12 @@ OPENSSL_EXPORT int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data,
 // at least this much space.
 #define EVP_MAX_MD_SIZE 64  // SHA-512 is the longest so far.
 
+// EVP_MAX_MD_CHAINING_LENGTH is the largest chaining length supported, in
+// bytes. This constant is only for Merkle-Damgard-based hashed functions
+// like SHA-1, SHA-2, and MD5.
+// This constant is only used internally by HMAC.
+#define EVP_MAX_MD_CHAINING_LENGTH 64  // SHA-512 has the longest chaining length so far
+
 // EVP_MAX_MD_BLOCK_SIZE is the largest digest block size supported, in
 // bytes.
 #define EVP_MAX_MD_BLOCK_SIZE 128  // SHA-512 is the longest so far.


### PR DESCRIPTION
### Description of changes: 

This PR provides a building block to implement HMAC with precomputed keys from https://github.com/aws/aws-lc/pull/1574.

It adds internal functions to export the state of SHA-256 and use such exported state to initialize a SHA-256 context.

Once the design is reviewed and approved, we will similar functions to the other Merkle-Damgard hash functions (MD4, MD5, SHA-1, SHA-2).

### Call-outs:

N/A

### Testing:

Unit tests added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
