### PR TITLE
Enforce minimum go version when runnign cmake if go is not disabled

### DIFF
--- a/cmake/go.cmake
+++ b/cmake/go.cmake
@@ -12,6 +12,22 @@ endif()
 
 if(NOT GO_EXECUTABLE AND NOT DISABLE_GO)
   message(FATAL_ERROR "Could not find Go")
+elseif(NOT DISABLE_GO)
+  execute_process(
+          COMMAND ${GO_EXECUTABLE} version
+          OUTPUT_VARIABLE go_version_output
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  # Example: 'go version go1.21.3 darwin/arm64' match any number of '#.' and one '#'
+  string(REGEX MATCH "([0-9]+\\.)*[0-9]+" go_version ${go_version_output})
+
+  # This should track /go.mod and /BUILDING.md
+  set(minimum_go_version "1.18")
+  if(go_version VERSION_LESS minimum_go_version)
+    message(FATAL_ERROR "Go compiler version must be at least ${minimum_go_version}. Found version ${go_version}")
+  else()
+    message(STATUS "Go compiler ${go_version} found")
+  endif()
 endif()
 
 function(go_executable dest package)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module boringssl.googlesource.com/boringssl
 
+// When this changes update /cmake/go.cmake minimum_go_version and /BUILDING.md
 go 1.18
 
 require (


### PR DESCRIPTION
### Description of changes: 
The version specified in go.mod isn't enforced and users can hit weird issues when building AWS-LC with old versions of go:
```
long build output
 util/embed_test_data.go:81:16: undefined: os.ReadFile
more build output
...
 make: *** [Makefile:117: all] Error 2
BUILD FAILED 
```

This is confusing because the go error can be easily overlooked.

### Call-outs:
This change isn't changing what version of Go builders need, just making the requirement more clear. 

### Testing:
Built locally and verified output `-- Go compiler 1.21.3 found` I also tried raising the minimum version to 1.180 and verified it failed: 
```
CMake Error at cmake/go.cmake:28 (message):
  Go compiler version must be at least 1.180.  Found version 1.21.3
Call Stack (most recent call first):
  CMakeLists.txt:26 (include)
```
And if you disable go the configure passes and checks nothing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
