### PR TITLE
More minor symbols for Ruby support

### DIFF
--- a/crypto/conf/conf.c
+++ b/crypto/conf/conf.c
@@ -642,6 +642,18 @@ int CONF_modules_load_file(const char *filename, const char *appname,
   return 1;
 }
 
+char *CONF_get1_default_config_file(void) {
+  const char *temp = "No support for Config files in AWS-LC.";
+  size_t temp_len = strlen(temp);
+
+  char *ret = (char *)OPENSSL_malloc(temp_len);
+  if(ret == NULL) {
+    OPENSSL_PUT_ERROR(CONF, ERR_R_MALLOC_FAILURE);
+  }
+  OPENSSL_memcpy(ret, temp, temp_len);
+  return ret;
+}
+
 void CONF_modules_free(void) {}
 
 void CONF_modules_unload(int all) {}

--- a/crypto/conf/conf.c
+++ b/crypto/conf/conf.c
@@ -649,6 +649,7 @@ char *CONF_get1_default_config_file(void) {
   char *ret = (char *)OPENSSL_malloc(temp_len);
   if(ret == NULL) {
     OPENSSL_PUT_ERROR(CONF, ERR_R_MALLOC_FAILURE);
+    return NULL;
   }
   OPENSSL_memcpy(ret, temp, temp_len);
   return ret;

--- a/crypto/conf/conf.c
+++ b/crypto/conf/conf.c
@@ -643,15 +643,7 @@ int CONF_modules_load_file(const char *filename, const char *appname,
 }
 
 char *CONF_get1_default_config_file(void) {
-  const char *temp = "No support for Config files in AWS-LC.";
-  size_t temp_len = strlen(temp) + 1;
-
-  char *ret = (char *)OPENSSL_malloc(temp_len);
-  if(ret == NULL) {
-    return NULL;
-  }
-  OPENSSL_memcpy(ret, temp, temp_len);
-  return ret;
+  return OPENSSL_strdup("No support for Config files in AWS-LC.");
 }
 
 void CONF_modules_free(void) {}

--- a/crypto/conf/conf.c
+++ b/crypto/conf/conf.c
@@ -644,7 +644,7 @@ int CONF_modules_load_file(const char *filename, const char *appname,
 
 char *CONF_get1_default_config_file(void) {
   const char *temp = "No support for Config files in AWS-LC.";
-  size_t temp_len = strlen(temp);
+  size_t temp_len = strlen(temp) + 1;
 
   char *ret = (char *)OPENSSL_malloc(temp_len);
   if(ret == NULL) {

--- a/crypto/conf/conf.c
+++ b/crypto/conf/conf.c
@@ -648,7 +648,6 @@ char *CONF_get1_default_config_file(void) {
 
   char *ret = (char *)OPENSSL_malloc(temp_len);
   if(ret == NULL) {
-    OPENSSL_PUT_ERROR(CONF, ERR_R_MALLOC_FAILURE);
     return NULL;
   }
   OPENSSL_memcpy(ret, temp, temp_len);

--- a/crypto/conf/conf_test.cc
+++ b/crypto/conf/conf_test.cc
@@ -401,3 +401,8 @@ TEST(ConfTest, ParseList) {
     EXPECT_EQ(result, t.expected);
   }
 }
+
+TEST(ConfTest, NoopString) {
+  bssl::UniquePtr<char> string(CONF_get1_default_config_file());
+  EXPECT_STREQ("No support for Config files in AWS-LC.", string.get());
+}

--- a/crypto/pkcs8/pkcs12_test.cc
+++ b/crypto/pkcs8/pkcs12_test.cc
@@ -674,3 +674,9 @@ TEST(PKCS12Test, CreateWithAlias) {
   ASSERT_EQ(alias, std::string(reinterpret_cast<const char *>(parsed_alias),
                                static_cast<size_t>(alias_len)));
 }
+
+TEST(PKCS12Test, BasicAlloc) {
+  // Test direct allocation of |PKCS12_new| and |PKCS12_free|.
+  bssl::UniquePtr<PKCS12> p12(PKCS12_new());
+  ASSERT_TRUE(p12);
+}

--- a/crypto/pkcs8/pkcs8_x509.c
+++ b/crypto/pkcs8/pkcs8_x509.c
@@ -741,7 +741,7 @@ struct pkcs12_st {
 
 PKCS12 *d2i_PKCS12(PKCS12 **out_p12, const uint8_t **ber_bytes,
                    size_t ber_len) {
-  PKCS12 *p12 = OPENSSL_malloc(sizeof(PKCS12));
+  PKCS12 *p12 = PKCS12_new();
   if (!p12) {
     return NULL;
   }
@@ -1328,7 +1328,7 @@ PKCS12 *PKCS12_create(const char *password, const char *name,
     goto err;
   }
 
-  ret = OPENSSL_malloc(sizeof(PKCS12));
+  ret = PKCS12_new();
   if (ret == NULL ||
       !CBB_finish(&cbb, &ret->ber_bytes, &ret->ber_len)) {
     OPENSSL_free(ret);
@@ -1340,6 +1340,10 @@ err:
   OPENSSL_cleanse(mac_key, sizeof(mac_key));
   CBB_cleanup(&cbb);
   return ret;
+}
+
+PKCS12 *PKCS12_new(void) {
+  return OPENSSL_zalloc(sizeof(PKCS12));
 }
 
 void PKCS12_free(PKCS12 *p12) {

--- a/docs/porting/configuration-differences.md
+++ b/docs/porting/configuration-differences.md
@@ -144,7 +144,7 @@ The following table contains the differences in libssl configuration options AWS
   </td>
  </tr>
  <tr>
-  <td rowspan=10>
+  <td rowspan=13>
   <p>
     <span>
       <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L794-L797">
@@ -178,6 +178,21 @@ The following table contains the differences in libssl configuration options AWS
   <p><span>
     <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5561-L5564">
       SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION
+    </a>
+  </span></p>
+  </td>
+  <td>
+  <p><span>OFF</span></p>
+  </td>
+  <td>
+  <p><span>NO-OP</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td>
+  <p><span>
+    <a href="">
+      SSL_OP_CRYPTOPRO_TLSEXT_BUG
     </a>
   </span></p>
   </td>
@@ -271,6 +286,36 @@ The following table contains the differences in libssl configuration options AWS
   <p><span>
     <a href="https://github.com/aws/aws-lc/blob/e91524c10ad698fd56f77289ba3430baf3c7af64/include/openssl/ssl.h#L5597-L5599">
       SSL_OP_NO_SSLv3
+    </a>
+  </span></p>
+  </td>
+  <td>
+  <p><span>ON</span></p>
+  </td>
+  <td>
+  <p><span>NO-OP</span></p>
+  </td>
+ </tr>
+  <tr>
+  <td>
+  <p><span>
+    <a href="">
+      SSL_OP_SAFARI_ECDHE_ECDSA_BUG
+    </a>
+  </span></p>
+  </td>
+  <td>
+  <p><span>ON</span></p>
+  </td>
+  <td>
+  <p><span>NO-OP</span></p>
+  </td>
+ </tr>
+  <tr>
+  <td>
+  <p><span>
+    <a href="">
+      SSL_OP_TLSEXT_PADDING
     </a>
   </span></p>
   </td>

--- a/docs/porting/functionality-differences.md
+++ b/docs/porting/functionality-differences.md
@@ -480,10 +480,10 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   </td>
  </tr>
  <tr>
-  <td rowspan=4>
+  <td rowspan=5>
   <p><span>CONF modules</span></p>
   </td>
-  <td rowspan=4>
+  <td rowspan=5>
   <p>
     <span>
         <a href="https://github.com/aws/aws-lc/blob/746d06505b3a3827cf61959ca0c3d87c3f21accc/include/openssl/conf.h#L127-L149">
@@ -497,6 +497,14 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   </td>
   <td>
   <p><span>Returns one.</span></p>
+  </td>
+ </tr>
+  <tr>
+  <td>
+  <p><span>CONF_get1_default_config_file</span></p>
+  </td>
+  <td>
+  <p><span>Returns a fixed dummy string(&quot;</span>No support for Config files in AWS-LC.&quot;)</p>
   </td>
  </tr>
  <tr>

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -142,6 +142,10 @@ OPENSSL_EXPORT const char *NCONF_get_string(const CONF *conf,
 OPENSSL_EXPORT OPENSSL_DEPRECATED int CONF_modules_load_file(
     const char *filename, const char *appname, unsigned long flags);
 
+// CONF_get1_default_config_file returns a fixed dummy string. AWS-LC is defined
+// to have no config file options.
+OPENSSL_EXPORT OPENSSL_DEPRECATED char *CONF_get1_default_config_file(void);
+
 // CONF_modules_free does nothing.
 OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_free(void);
 

--- a/include/openssl/pkcs8.h
+++ b/include/openssl/pkcs8.h
@@ -232,6 +232,9 @@ OPENSSL_EXPORT PKCS12 *PKCS12_create(const char *password, const char *name,
                                      int cert_nid, int iterations,
                                      int mac_iterations, int key_type);
 
+// PKCS12_new returns a newly-allocated |PKCS12| object.
+OPENSSL_EXPORT PKCS12 *PKCS12_new(void);
+
 // PKCS12_free frees |p12| and its contents.
 OPENSSL_EXPORT void PKCS12_free(PKCS12 *p12);
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5618,6 +5618,14 @@ OPENSSL_EXPORT int SSL_set1_curves_list(SSL *ssl, const char *curves);
 // unpatched clients and servers and is intentionally not supported in AWS-LC.
 #define SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION 0
 
+// SSL_OP_CRYPTOPRO_TLSEXT_BUG is OFF by default in AWS-LC. Turning this ON in
+// OpenSSL lets the server add a server-hello extension from early version of
+// the cryptopro draft, when the GOST ciphersuite is negotiated. Required for
+// interoperability with CryptoPro CSP 3.x.
+//
+// Note: AWS-LC does not support GOST ciphersuites.
+#define SSL_OP_CRYPTOPRO_TLSEXT_BUG 0
+
 // SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS is ON by default in AWS-LC. This
 // disables a countermeasure against a SSL 3.0/TLS 1.0 protocol vulnerability
 // affecting CBC ciphers, which cannot be handled by some broken SSL
@@ -5642,7 +5650,7 @@ OPENSSL_EXPORT int SSL_set1_curves_list(SSL *ssl, const char *curves);
 // This always starts a new session when performing renegotiation as a server
 // (i.e., session resumption requests are only accepted in the initial
 // handshake).
-// There is no support for renegototiation for a server in AWS-LC
+// There is no support for renegototiation for a server in AWS-LC.
 #define SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION 0
 
 // SSL_OP_NO_SSLv2 is ON by default in AWS-LC. There is no support for SSLv2 in
@@ -5652,6 +5660,18 @@ OPENSSL_EXPORT int SSL_set1_curves_list(SSL *ssl, const char *curves);
 // SSL_OP_NO_SSLv3 is ON by default in AWS-LC. There is no support for SSLv3 in
 // AWS-LC
 #define SSL_OP_NO_SSLv3 0
+
+// SSL_OP_SAFARI_ECDHE_ECDSA_BUG is OFF by default in AWS-LC. Turning this ON in
+// OpenSSL lets the application not prefer ECDHE-ECDSA ciphers when the client
+// appears to be Safari on OSX.
+//
+// Note: OS X 10.8..10.8.3 broke support for ECDHE-ECDSA ciphers.
+#define SSL_OP_SAFARI_ECDHE_ECDSA_BUG 0
+
+// SSL_OP_TLSEXT_PADDING is OFF by default in AWS-LC. Turning this ON in OpenSSL
+// adds a padding extension to ensure the ClientHello size is never between 256
+// and 511 bytes in length. This is needed as a workaround for F5 terminators.
+#define SSL_OP_TLSEXT_PADDING 0
 
 // SSL_OP_TLS_ROLLBACK_BUG is OFF by default in AWS-LC. Turning this ON in
 // OpenSSL disables version rollback attack detection and is intentionally not


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1717`

### Description of changes: 
This implements two minor symbols and a few no-op flags for Ruby support.

New symbols:
* PKCS12_new
* CONF_get1_default_config_file

No-op flags:
* SSL_OP_CRYPTOPRO_TLSEXT_BUG
* SSL_OP_SAFARI_ECDHE_ECDSA_BUG
* SSL_OP_TLSEXT_PADDING

### Call-outs:
All of these no-ops are following a precedent in AWS-LC. We may have to have a discussion on whether to support CONF modules further down the line, but exposing this as a no-op for now.

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
