### PR TITLE
Give X509_STORE an ex_data

### DIFF
--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -789,15 +789,6 @@ TEST(BIOTest, Gets) {
   EXPECT_EQ(c, 'a');
 }
 
-typedef struct {
-  int custom_data;
-} CustomData;
-
-static void CustomDataFree(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
-                           int index, long argl, void *argp) {
-  free(ptr);
-}
-
 TEST(BIOTest, ExternalData) {
   // Create a |BIO| object
   bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));

--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -25,6 +25,7 @@
 #include <openssl/service_indicator.h>
 
 #include <gtest/gtest.h>
+#include "test/test_util.h"
 
 // Test that OPENSSL_VERSION_NUMBER and OPENSSL_VERSION_TEXT are consistent.
 // Node.js parses the version out of OPENSSL_VERSION_TEXT instead of using

--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -126,3 +126,9 @@ FILE* createRawTempFILE() {
 TempFILE createTempFILE() {
   return TempFILE(createRawTempFILE());
 }
+
+void CustomDataFree(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                           int index, long argl, void *argp) {
+  free(ptr);
+}
+

--- a/crypto/test/test_util.h
+++ b/crypto/test/test_util.h
@@ -95,4 +95,12 @@ size_t createTempFILEpath(char buffer[PATH_MAX]);
 FILE* createRawTempFILE();
 TempFILE createTempFILE();
 
+// CustomData is for testing new structs that we add support for |ex_data|.
+typedef struct {
+  int custom_data;
+} CustomData;
+
+void CustomDataFree(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                           int index, long argl, void *argp);
+
 #endif  // OPENSSL_HEADER_CRYPTO_TEST_TEST_UTIL_H

--- a/crypto/x509/internal.h
+++ b/crypto/x509/internal.h
@@ -305,6 +305,7 @@ struct x509_store_st {
   X509_STORE_CTX_check_crl_fn check_crl;    // Check CRL validity
 
   CRYPTO_refcount_t references;
+  CRYPTO_EX_DATA ex_data;
 } /* X509_STORE */;
 
 

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -674,10 +674,9 @@ X509_STORE_CTX_check_crl_fn X509_STORE_get_check_crl(X509_STORE *ctx) {
 
 X509_STORE *X509_STORE_CTX_get0_store(X509_STORE_CTX *ctx) { return ctx->ctx; }
 
-int X509_STORE_get_ex_new_index(long argl, void *argp,
-                                    CRYPTO_EX_unused *unused,
-                                    CRYPTO_EX_dup *dup_unused,
-                                    CRYPTO_EX_free *free_func) {
+int X509_STORE_get_ex_new_index(long argl, void *argp, CRYPTO_EX_unused *unused,
+                                CRYPTO_EX_dup *dup_unused,
+                                CRYPTO_EX_free *free_func) {
   int index;
   if (!CRYPTO_get_ex_new_index(&g_ex_data_class, &index, argl, argp,
                                free_func)) {
@@ -693,4 +692,3 @@ int X509_STORE_set_ex_data(X509_STORE *ctx, int idx, void *data) {
 void *X509_STORE_get_ex_data(X509_STORE *ctx, int idx) {
   return CRYPTO_get_ex_data(&ctx->ex_data, idx);
 }
-

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -149,6 +149,9 @@ static int x509_object_cmp_sk(const X509_OBJECT *const *a,
   return x509_object_cmp(*a, *b);
 }
 
+static CRYPTO_EX_DATA_CLASS g_ex_data_class =
+    CRYPTO_EX_DATA_CLASS_INIT_WITH_APP_DATA;
+
 X509_STORE *X509_STORE_new(void) {
   X509_STORE *ret = OPENSSL_zalloc(sizeof(X509_STORE));
   if (ret == NULL) {
@@ -157,6 +160,7 @@ X509_STORE *X509_STORE_new(void) {
 
   ret->references = 1;
   CRYPTO_MUTEX_init(&ret->objs_lock);
+  CRYPTO_new_ex_data(&ret->ex_data);
   ret->objs = sk_X509_OBJECT_new(x509_object_cmp_sk);
   ret->get_cert_methods = sk_X509_LOOKUP_new_null();
   ret->param = X509_VERIFY_PARAM_new();
@@ -201,6 +205,7 @@ void X509_STORE_free(X509_STORE *vfy) {
   }
 
   CRYPTO_MUTEX_cleanup(&vfy->objs_lock);
+  CRYPTO_free_ex_data(&g_ex_data_class, vfy, &vfy->ex_data);
   sk_X509_LOOKUP_pop_free(vfy->get_cert_methods, X509_LOOKUP_free);
   sk_X509_OBJECT_pop_free(vfy->objs, X509_OBJECT_free);
   X509_VERIFY_PARAM_free(vfy->param);
@@ -668,3 +673,24 @@ X509_STORE_CTX_check_crl_fn X509_STORE_get_check_crl(X509_STORE *ctx) {
 }
 
 X509_STORE *X509_STORE_CTX_get0_store(X509_STORE_CTX *ctx) { return ctx->ctx; }
+
+int X509_STORE_get_ex_new_index(long argl, void *argp,
+                                    CRYPTO_EX_unused *unused,
+                                    CRYPTO_EX_dup *dup_unused,
+                                    CRYPTO_EX_free *free_func) {
+  int index;
+  if (!CRYPTO_get_ex_new_index(&g_ex_data_class, &index, argl, argp,
+                               free_func)) {
+    return -1;
+  }
+  return index;
+}
+
+int X509_STORE_set_ex_data(X509_STORE *ctx, int idx, void *data) {
+  return CRYPTO_set_ex_data(&ctx->ex_data, idx, data);
+}
+
+void *X509_STORE_get_ex_data(X509_STORE *ctx, int idx) {
+  return CRYPTO_get_ex_data(&ctx->ex_data, idx);
+}
+

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -7091,3 +7091,25 @@ TEST(X509Test, GetSigInfo) {
   EXPECT_EQ(sec_bits, -1);
   EXPECT_TRUE(flags & X509_SIG_INFO_VALID);
 }
+
+TEST(X509Test, ExternalData) {
+  // Create a |X509_STORE| object
+  bssl::UniquePtr<X509_STORE> store(X509_STORE_new());
+  int store_index =
+      X509_STORE_get_ex_new_index(0, nullptr, nullptr, nullptr, CustomDataFree);
+  ASSERT_GT(store_index, 0);
+
+  // Associate custom data with the |X509_STORE| using |X509_STORE_set_ex_data|
+  // and set an arbitrary number.
+  auto *custom_data = static_cast<CustomData *>(malloc(sizeof(CustomData)));
+  ASSERT_TRUE(custom_data);
+  custom_data->custom_data = 123;
+  ASSERT_TRUE(X509_STORE_set_ex_data(store.get(), store_index, custom_data));
+
+  // Retrieve the custom data using |X509_STORE_get_ex_data|.
+  auto *retrieved_data = static_cast<CustomData *>(
+      X509_STORE_get_ex_data(store.get(), store_index));
+  ASSERT_TRUE(retrieved_data);
+  EXPECT_EQ(retrieved_data->custom_data, 123);
+}
+

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -870,7 +870,7 @@ OPENSSL_EXPORT int X509_REVOKED_set_revocationDate(X509_REVOKED *revoked,
 OPENSSL_EXPORT const STACK_OF(X509_EXTENSION) *X509_REVOKED_get0_extensions(
     const X509_REVOKED *r);
 
-    // X509_REVOKED_get_ext_count returns the number of extensions in |x|.
+// X509_REVOKED_get_ext_count returns the number of extensions in |x|.
 OPENSSL_EXPORT int X509_REVOKED_get_ext_count(const X509_REVOKED *x);
 
 // X509_REVOKED_get_ext_by_NID behaves like |X509v3_get_ext_by_NID| but searches
@@ -2601,11 +2601,10 @@ OPENSSL_EXPORT int X509_STORE_CTX_set_ex_data(X509_STORE_CTX *ctx, int idx,
 OPENSSL_EXPORT void *X509_STORE_CTX_get_ex_data(X509_STORE_CTX *ctx, int idx);
 
 OPENSSL_EXPORT int X509_STORE_get_ex_new_index(long argl, void *argp,
-                                                   CRYPTO_EX_unused *unused,
-                                                   CRYPTO_EX_dup *dup_unused,
-                                                   CRYPTO_EX_free *free_func);
-OPENSSL_EXPORT int X509_STORE_set_ex_data(X509_STORE *ctx, int idx,
-                                              void *data);
+                                               CRYPTO_EX_unused *unused,
+                                               CRYPTO_EX_dup *dup_unused,
+                                               CRYPTO_EX_free *free_func);
+OPENSSL_EXPORT int X509_STORE_set_ex_data(X509_STORE *ctx, int idx, void *data);
 OPENSSL_EXPORT void *X509_STORE_get_ex_data(X509_STORE *ctx, int idx);
 
 // Hashing and signing ASN.1 structures.
@@ -4087,8 +4086,9 @@ DECLARE_ASN1_ITEM(POLICY_CONSTRAINTS)
 
 OPENSSL_EXPORT GENERAL_NAME *a2i_GENERAL_NAME(GENERAL_NAME *out,
                                               const X509V3_EXT_METHOD *method,
-                                              const X509V3_CTX *ctx, int gen_type,
-                                              const char *value, int is_nc);
+                                              const X509V3_CTX *ctx,
+                                              int gen_type, const char *value,
+                                              int is_nc);
 
 OPENSSL_EXPORT GENERAL_NAME *v2i_GENERAL_NAME(const X509V3_EXT_METHOD *method,
                                               const X509V3_CTX *ctx,
@@ -4239,8 +4239,8 @@ OPENSSL_EXPORT X509_EXTENSION *X509V3_EXT_i2d(int ext_nid, int crit,
 // append if it is not present.
 #define X509V3_ADD_REPLACE 2L
 
-// X509V3_ADD_REPLACE_EXISTING causes the function to replace the existing extension and
-// fail if it is not present.
+// X509V3_ADD_REPLACE_EXISTING causes the function to replace the existing
+// extension and fail if it is not present.
 #define X509V3_ADD_REPLACE_EXISTING 3L
 
 // X509V3_ADD_KEEP_EXISTING causes the function to succeed without replacing the

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2600,6 +2600,13 @@ OPENSSL_EXPORT int X509_STORE_CTX_set_ex_data(X509_STORE_CTX *ctx, int idx,
                                               void *data);
 OPENSSL_EXPORT void *X509_STORE_CTX_get_ex_data(X509_STORE_CTX *ctx, int idx);
 
+OPENSSL_EXPORT int X509_STORE_get_ex_new_index(long argl, void *argp,
+                                                   CRYPTO_EX_unused *unused,
+                                                   CRYPTO_EX_dup *dup_unused,
+                                                   CRYPTO_EX_free *free_func);
+OPENSSL_EXPORT int X509_STORE_set_ex_data(X509_STORE *ctx, int idx,
+                                              void *data);
+OPENSSL_EXPORT void *X509_STORE_get_ex_data(X509_STORE *ctx, int idx);
 
 // Hashing and signing ASN.1 structures.
 


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1648`

### Description of changes: 
X509_STORE has an ex_data upstream and Ruby happens to consume this. This is mostly following the work done in https://github.com/aws/aws-lc/pull/1328

### Call-outs:
N/A

### Testing:
New test for ex_data

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
