### PR TITLE
Fix MySQL version tag alarm

### DIFF
--- a/tests/ci/integration/run_mysql_integration.sh
+++ b/tests/ci/integration/run_mysql_integration.sh
@@ -39,7 +39,7 @@ cd ${SCRATCH_FOLDER}
 
 function mysql_patch_reminder() {
   # Check latest MySQL version. MySQL often updates with large changes depending on OpenSSL all at once, so we pin to a specific version.
-  LATEST_MYSQL_VERSION_TAG=`git tag --sort=-taggerdate | head -n 1`
+  LATEST_MYSQL_VERSION_TAG=`git tag --sort=-taggerdate | tail -1`
   if [[ "${LATEST_MYSQL_VERSION_TAG}" != "${MYSQL_VERSION_TAG}" ]]; then
     aws cloudwatch put-metric-data --namespace AWS-LC --metric-name MySQLVersionMismatch --value 1
   else


### PR DESCRIPTION
### Issues:
Resolves `V1379971621`

### Description of changes: 
We got a false alarm when we updated the mysql version tag strategy. Apparently my ubuntu box and the docker image had different versions of git and this caused a behavioral difference when running `git tag --sort=-taggerdate`.

The docker image has a newer version (`2.34.1`) and gives the tag date in ascending order. This caused us to compare against the oldest version of mysql instead and triggers the alarm. This PR fixes that.

More data: https://gist.github.com/rponte/fdc0724dd984088606b0?permalink_comment_id=3169553

### Call-outs:
N/A

### Testing:
In docker image:
```
/home/ubuntu/workplace/MYSQL_BUILD_ROOT/mysql-server /home/ubuntu/workplace/MYSQL_BUILD_ROOT
+ mysql_patch_reminder
++ git tag --sort=-taggerdate
++ tail -1
+ LATEST_MYSQL_VERSION_TAG=mysql-cluster-8.4.0
+ [[ mysql-cluster-8.4.0 != \m\y\s\q\l\-\c\l\u\s\t\e\r\-\8\.\4\.\0 ]]
+ aws cloudwatch put-metric-data --namespace AWS-LC --metric-name MySQLVersionMismatch --value 0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
