### PR TITLE
Fix build with -Wmissing-field-initializers

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -492,44 +492,27 @@ int X509_VERIFY_PARAM_get_depth(const X509_VERIFY_PARAM *param) {
 #define vpm_empty_id NULL, 0U, NULL, 0, NULL, 0, 0
 
 static const X509_VERIFY_PARAM kDefaultParam = {
-    /*check_time=*/0,
-    /*inh_flags=*/0,
-    /*flags=*/X509_V_FLAG_TRUSTED_FIRST,
-    /*purpose=*/0,
-    /*trust=*/0,
-    /*depth=*/100,
-    /*policies=*/NULL,
-    vpm_empty_id};
+    .flags = X509_V_FLAG_TRUSTED_FIRST,
+    .depth = 100,
+};
 
 static const X509_VERIFY_PARAM kSMIMESignParam = {
-    /*check_time=*/0,
-    /*inh_flags=*/0,
-    /*flags=*/0,
-    /*purpose=*/X509_PURPOSE_SMIME_SIGN,
-    /*trust=*/X509_TRUST_EMAIL,
-    /*depth=*/-1,
-    /*policies=*/NULL,
-    vpm_empty_id};
+    .purpose = X509_PURPOSE_SMIME_SIGN,
+    .trust = X509_TRUST_EMAIL,
+    .depth = -1,
+};
 
 static const X509_VERIFY_PARAM kSSLClientParam = {
-    /*check_time=*/0,
-    /*inh_flags=*/0,
-    /*flags=*/0,
-    /*purpose=*/X509_PURPOSE_SSL_CLIENT,
-    /*trust=*/X509_TRUST_SSL_CLIENT,
-    /*depth=*/-1,
-    /*policies=*/NULL,
-    vpm_empty_id};
+    .purpose = X509_PURPOSE_SSL_CLIENT,
+    .trust = X509_TRUST_SSL_CLIENT,
+    .depth = -1,
+};
 
 static const X509_VERIFY_PARAM kSSLServerParam = {
-    /*check_time=*/0,
-    /*inh_flags=*/0,
-    /*flags=*/0,
-    /*purpose=*/X509_PURPOSE_SSL_SERVER,
-    /*trust=*/X509_TRUST_SSL_SERVER,
-    /*depth=*/-1,
-    /*policies=*/NULL,
-    vpm_empty_id};
+    .purpose = X509_PURPOSE_SSL_SERVER,
+    .trust = X509_TRUST_SSL_SERVER,
+    .depth = -1,
+};
 
 const X509_VERIFY_PARAM *X509_VERIFY_PARAM_lookup(const char *name) {
   if (strcmp(name, "default") == 0) {


### PR DESCRIPTION
Since it's otherwise pretty tedious, let's try this with C99 designated initializers. From testing, I remember they worked pretty reliably in C. (In C++, it's a little trickier because MSVC won't accept them outside C++20. Although I think all our supported MSVCs have a C++20 mode now...)

AWS-LC:
Changes to CMakeLists were not taken as that flag exists there already.

Fixed: 671
Change-Id: Ia29ade8721ecfe2140a2d183ad60c8a730c631f0 Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/64447
Auto-Submit: David Benjamin <davidben@google.com>
Reviewed-by: Bob Beck <bbe@google.com>
Commit-Queue: David Benjamin <davidben@google.com>
(cherry picked from commit a9a4c6dc89aff96f64c6ed93c1c3fc4d0c8e6e74)

### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
