### PR TITLE
Fix NTP integration test in the case of multiple occurrences of the package

### DIFF
--- a/tests/ci/integration/run_ntp_integration.sh
+++ b/tests/ci/integration/run_ntp_integration.sh
@@ -22,9 +22,9 @@ NTP_WEBSITE_URL="https://downloads.nwtime.org/ntp/"
 # - curl fetches the HTML content of the website,
 # - the first grep searches for all occurrences of href attributes in anchor tags and outputs only the URLs,
 # - sed removes the href=" and trailing " from the URLs,
-# - the second grep filters only the links ending with .tar.gz,
+# - the second grep filters only the links ending with .tar.gz, keeping only the first occurrence,
 # - cut strips "/ntp/" from the link and retains only the tar name.
-NTP_TAR=$(curl -s ${NTP_WEBSITE_URL} | grep -o 'href="[^"]*"' | sed 's/href="//;s/"$//' | grep '.tar.gz$' | cut -d '/' -f3)
+NTP_TAR=$(curl -s ${NTP_WEBSITE_URL} | grep -o 'href="[^"]*"' | sed 's/href="//;s/"$//' | grep -m1 '.tar.gz$' | cut -d '/' -f3)
 NTP_DOWNLOAD_URL="${NTP_WEBSITE_URL}/${NTP_TAR}"
 NTP_SRC_FOLDER="${SCRATCH_FOLDER}/ntp-src"
 NTP_PATCH_FOLDER="${SRC_ROOT}/tests/ci/integration/ntp_patch"


### PR DESCRIPTION
Fix the NTP integration test, a continuation of the fix in https://github.com/aws/aws-lc/pull/1548.

When there were multiple `.tar.gz` packages, the test was trying `wget` with
```
wget -q https://downloads.nwtime.org/ntp//ntp-4.2.8p17.tar.gz ntp-4.2.8p18-RC1.tar.gz
```
and was failing.
