### PR TITLE
add back ASN1_dup with tests

### DIFF
--- a/crypto/asn1/a_dup.c
+++ b/crypto/asn1/a_dup.c
@@ -59,6 +59,26 @@
 #include <openssl/err.h>
 #include <openssl/mem.h>
 
+void *ASN1_dup(i2d_of_void *i2d, d2i_of_void *d2i, void *input) {
+  if (i2d == NULL || d2i == NULL || input == NULL) {
+    OPENSSL_PUT_ERROR(ASN1, ERR_R_PASSED_NULL_PARAMETER);
+    return NULL;
+  }
+
+  // Size and allocate |buf|.
+  unsigned char *buf = NULL;
+  int buf_len = i2d(input, &buf);
+  if (buf == NULL) {
+    return NULL;
+  }
+
+  // |buf| needs to be converted to |const| to be passed in.
+  const unsigned char *temp_input = buf;
+  char *ret = d2i(NULL, &temp_input, buf_len);
+  OPENSSL_free(buf);
+  return ret;
+}
+
 // ASN1_ITEM version of dup: this follows the model above except we don't
 // need to allocate the buffer. At some point this could be rewritten to
 // directly dup the underlying structure instead of doing and encode and

--- a/crypto/asn1/a_dup.c
+++ b/crypto/asn1/a_dup.c
@@ -68,7 +68,7 @@ void *ASN1_dup(i2d_of_void *i2d, d2i_of_void *d2i, void *input) {
   // Size and allocate |buf|.
   unsigned char *buf = NULL;
   int buf_len = i2d(input, &buf);
-  if (buf == NULL) {
+  if (buf == NULL || buf_len < 0) {
     return NULL;
   }
 

--- a/crypto/asn1/asn1_test.cc
+++ b/crypto/asn1/asn1_test.cc
@@ -2412,27 +2412,6 @@ TEST(ASN1Test, LargeString) {
 #endif
 }
 
-
-// Wrapper functions are needed to get around Control Flow Integrity Sanitizers.
-static int i2d_ASN1_TYPE_void(const void *a, unsigned char **out) {
-  return i2d_ASN1_TYPE((ASN1_TYPE *)a, out);
-}
-static void *d2i_ASN1_TYPE_void(void **a, const unsigned char **in, long len) {
-  return d2i_ASN1_TYPE((ASN1_TYPE **)a, in, len);
-}
-static int i2d_ECPrivateKey_void(const void *a, unsigned char **out) {
-  return i2d_ECPrivateKey((EC_KEY *)a, out);
-}
-static void *d2i_ECPrivateKey_void(void **a, const unsigned char **in, long len) {
-  return d2i_ECPrivateKey((EC_KEY **)a, in, len);
-}
-static int i2d_X509_PUBKEY_void(const void *a, unsigned char **out) {
-  return i2d_X509_PUBKEY((X509_PUBKEY *)a, out);
-}
-static void *d2i_X509_PUBKEY_void(void **a, const unsigned char **in, long len) {
-  return d2i_X509_PUBKEY((X509_PUBKEY **)a, in, len);
-}
-
 TEST(ASN1Test, ASN1Dup) {
   const uint8_t *tag = kTag128;
   bssl::UniquePtr<ASN1_TYPE> asn1(
@@ -2440,7 +2419,7 @@ TEST(ASN1Test, ASN1Dup) {
   ASSERT_TRUE(asn1);
   EXPECT_EQ(128, asn1->type);
   bssl::UniquePtr<ASN1_TYPE> asn1_copy((ASN1_TYPE *)ASN1_dup(
-      i2d_ASN1_TYPE_void, d2i_ASN1_TYPE_void, asn1.get()));
+      CHECKED_I2D_OF(ASN1_TYPE, i2d_ASN1_TYPE), CHECKED_D2I_OF(ASN1_TYPE, d2i_ASN1_TYPE), asn1.get()));
   ASSERT_TRUE(asn1_copy);
   EXPECT_EQ(ASN1_TYPE_cmp(asn1.get(), asn1_copy.get()), 0);
 
@@ -2448,7 +2427,7 @@ TEST(ASN1Test, ASN1Dup) {
   ASSERT_TRUE(key);
   ASSERT_TRUE(EC_KEY_generate_key(key.get()));
   bssl::UniquePtr<EC_KEY> key_copy((EC_KEY *)ASN1_dup(
-      i2d_ECPrivateKey_void, d2i_ECPrivateKey_void, key.get()));
+      CHECKED_I2D_OF(EC_KEY, i2d_ECPrivateKey), CHECKED_D2I_OF(EC_KEY, d2i_ECPrivateKey), key.get()));
   ASSERT_TRUE(key_copy);
   EXPECT_EQ(BN_cmp(EC_KEY_get0_private_key(key.get()),
                    EC_KEY_get0_private_key(key_copy.get())),
@@ -2468,7 +2447,7 @@ TEST(ASN1Test, ASN1Dup) {
   ASSERT_TRUE(X509_PUBKEY_set(&tmp_key, evp_pkey.get()));
   bssl::UniquePtr<X509_PUBKEY> x509_pubkey(tmp_key);
   bssl::UniquePtr<X509_PUBKEY> x509_pubkey_copy((X509_PUBKEY *)ASN1_dup(
-      i2d_X509_PUBKEY_void, d2i_X509_PUBKEY_void, x509_pubkey.get()));
+      CHECKED_I2D_OF(X509_PUBKEY, i2d_X509_PUBKEY), CHECKED_D2I_OF(X509_PUBKEY, d2i_X509_PUBKEY), x509_pubkey.get()));
   ASSERT_TRUE(x509_pubkey_copy);
   EXPECT_EQ(
       ASN1_STRING_cmp(X509_PUBKEY_get0_public_key(x509_pubkey.get()),

--- a/crypto/asn1/asn1_test.cc
+++ b/crypto/asn1/asn1_test.cc
@@ -2412,9 +2412,6 @@ TEST(ASN1Test, LargeString) {
 #endif
 }
 
-#define CHECKED_I2D_OF_const(type, i2d) \
-    ((i2d_of_void*) (1 ? i2d : ((I2D_OF_const(type))0)))
-
 TEST(ASN1Test, ASN1Dup) {
   const uint8_t *tag = kTag128;
   bssl::UniquePtr<ASN1_TYPE> asn1(
@@ -2422,17 +2419,15 @@ TEST(ASN1Test, ASN1Dup) {
   ASSERT_TRUE(asn1);
   EXPECT_EQ(128, asn1->type);
   bssl::UniquePtr<ASN1_TYPE> asn1_copy((ASN1_TYPE *)ASN1_dup(
-      CHECKED_I2D_OF_const(ASN1_TYPE, i2d_ASN1_TYPE),
-      CHECKED_D2I_OF(ASN1_TYPE, d2i_ASN1_TYPE), asn1.get()));
+      CHECKED_I2D_OF(ASN1_TYPE, i2d_ASN1_TYPE), CHECKED_D2I_OF(ASN1_TYPE, d2i_ASN1_TYPE), asn1.get()));
   ASSERT_TRUE(asn1_copy);
   EXPECT_EQ(ASN1_TYPE_cmp(asn1.get(), asn1_copy.get()), 0);
 
   bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
   ASSERT_TRUE(key);
   ASSERT_TRUE(EC_KEY_generate_key(key.get()));
-  bssl::UniquePtr<EC_KEY> key_copy(
-      (EC_KEY *)ASN1_dup(CHECKED_I2D_OF_const(EC_KEY, i2d_ECPrivateKey),
-                         CHECKED_D2I_OF(EC_KEY, d2i_ECPrivateKey), key.get()));
+  bssl::UniquePtr<EC_KEY> key_copy((EC_KEY *)ASN1_dup(
+      CHECKED_I2D_OF(EC_KEY, i2d_ECPrivateKey), CHECKED_D2I_OF(EC_KEY, d2i_ECPrivateKey), key.get()));
   ASSERT_TRUE(key_copy);
   EXPECT_EQ(BN_cmp(EC_KEY_get0_private_key(key.get()),
                    EC_KEY_get0_private_key(key_copy.get())),
@@ -2452,8 +2447,7 @@ TEST(ASN1Test, ASN1Dup) {
   ASSERT_TRUE(X509_PUBKEY_set(&tmp_key, evp_pkey.get()));
   bssl::UniquePtr<X509_PUBKEY> x509_pubkey(tmp_key);
   bssl::UniquePtr<X509_PUBKEY> x509_pubkey_copy((X509_PUBKEY *)ASN1_dup(
-      CHECKED_I2D_OF_const(X509_PUBKEY, i2d_X509_PUBKEY),
-      CHECKED_D2I_OF(X509_PUBKEY, d2i_X509_PUBKEY), x509_pubkey.get()));
+      CHECKED_I2D_OF(X509_PUBKEY, i2d_X509_PUBKEY), CHECKED_D2I_OF(X509_PUBKEY, d2i_X509_PUBKEY), x509_pubkey.get()));
   ASSERT_TRUE(x509_pubkey_copy);
   EXPECT_EQ(
       ASN1_STRING_cmp(X509_PUBKEY_get0_public_key(x509_pubkey.get()),
@@ -2470,13 +2464,13 @@ typedef struct asn1_linked_list_st {
 } ASN1_LINKED_LIST;
 
 DECLARE_ASN1_ITEM(ASN1_LINKED_LIST)
-DECLARE_ASN1_FUNCTIONS_const(ASN1_LINKED_LIST)
+DECLARE_ASN1_FUNCTIONS(ASN1_LINKED_LIST)
 
 ASN1_SEQUENCE(ASN1_LINKED_LIST) = {
     ASN1_OPT(ASN1_LINKED_LIST, next, ASN1_LINKED_LIST),
 } ASN1_SEQUENCE_END(ASN1_LINKED_LIST)
 
-IMPLEMENT_ASN1_FUNCTIONS_const(ASN1_LINKED_LIST)
+IMPLEMENT_ASN1_FUNCTIONS(ASN1_LINKED_LIST)
 
 static bool MakeLinkedList(bssl::UniquePtr<uint8_t> *out, size_t *out_len,
                            size_t count) {
@@ -2520,6 +2514,10 @@ TEST(ASN1Test, Recursive) {
   ASN1_LINKED_LIST_free(list);
 }
 
+static int i2d_ASN1_LINKED_LIST_void(const void *a, unsigned char **out) {
+  return i2d_ASN1_LINKED_LIST((ASN1_LINKED_LIST *)a, out);
+}
+
 TEST(ASN1Test, BIO) {
   bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
   bssl::UniquePtr<uint8_t> data;
@@ -2536,9 +2534,7 @@ TEST(ASN1Test, BIO) {
 
   const uint8_t *out;
   size_t out_len;
-  EXPECT_TRUE(
-      ASN1_i2d_bio(CHECKED_I2D_OF_const(ASN1_LINKED_LIST, i2d_ASN1_LINKED_LIST),
-                   bio.get(), list));
+  EXPECT_TRUE(ASN1_i2d_bio(i2d_ASN1_LINKED_LIST_void, bio.get(), list));
   ASSERT_TRUE(BIO_mem_contents(bio.get(), &out, &out_len));
 
   EXPECT_EQ(Bytes(out, out_len), Bytes(expected, expected_len));

--- a/crypto/asn1/asn1_test.cc
+++ b/crypto/asn1/asn1_test.cc
@@ -2412,6 +2412,27 @@ TEST(ASN1Test, LargeString) {
 #endif
 }
 
+
+// Wrapper functions are needed to get around Control Flow Integrity Sanitizers.
+static int i2d_ASN1_TYPE_void(const void *a, unsigned char **out) {
+  return i2d_ASN1_TYPE((ASN1_TYPE *)a, out);
+}
+static void *d2i_ASN1_TYPE_void(void **a, const unsigned char **in, long len) {
+  return d2i_ASN1_TYPE((ASN1_TYPE **)a, in, len);
+}
+static int i2d_ECPrivateKey_void(const void *a, unsigned char **out) {
+  return i2d_ECPrivateKey((EC_KEY *)a, out);
+}
+static void *d2i_ECPrivateKey_void(void **a, const unsigned char **in, long len) {
+  return d2i_ECPrivateKey((EC_KEY **)a, in, len);
+}
+static int i2d_X509_PUBKEY_void(const void *a, unsigned char **out) {
+  return i2d_X509_PUBKEY((X509_PUBKEY *)a, out);
+}
+static void *d2i_X509_PUBKEY_void(void **a, const unsigned char **in, long len) {
+  return d2i_X509_PUBKEY((X509_PUBKEY **)a, in, len);
+}
+
 TEST(ASN1Test, ASN1Dup) {
   const uint8_t *tag = kTag128;
   bssl::UniquePtr<ASN1_TYPE> asn1(
@@ -2419,7 +2440,7 @@ TEST(ASN1Test, ASN1Dup) {
   ASSERT_TRUE(asn1);
   EXPECT_EQ(128, asn1->type);
   bssl::UniquePtr<ASN1_TYPE> asn1_copy((ASN1_TYPE *)ASN1_dup(
-      CHECKED_I2D_OF(ASN1_TYPE, i2d_ASN1_TYPE), CHECKED_D2I_OF(ASN1_TYPE, d2i_ASN1_TYPE), asn1.get()));
+      i2d_ASN1_TYPE_void, d2i_ASN1_TYPE_void, asn1.get()));
   ASSERT_TRUE(asn1_copy);
   EXPECT_EQ(ASN1_TYPE_cmp(asn1.get(), asn1_copy.get()), 0);
 
@@ -2427,7 +2448,7 @@ TEST(ASN1Test, ASN1Dup) {
   ASSERT_TRUE(key);
   ASSERT_TRUE(EC_KEY_generate_key(key.get()));
   bssl::UniquePtr<EC_KEY> key_copy((EC_KEY *)ASN1_dup(
-      CHECKED_I2D_OF(EC_KEY, i2d_ECPrivateKey), CHECKED_D2I_OF(EC_KEY, d2i_ECPrivateKey), key.get()));
+      i2d_ECPrivateKey_void, d2i_ECPrivateKey_void, key.get()));
   ASSERT_TRUE(key_copy);
   EXPECT_EQ(BN_cmp(EC_KEY_get0_private_key(key.get()),
                    EC_KEY_get0_private_key(key_copy.get())),
@@ -2447,7 +2468,7 @@ TEST(ASN1Test, ASN1Dup) {
   ASSERT_TRUE(X509_PUBKEY_set(&tmp_key, evp_pkey.get()));
   bssl::UniquePtr<X509_PUBKEY> x509_pubkey(tmp_key);
   bssl::UniquePtr<X509_PUBKEY> x509_pubkey_copy((X509_PUBKEY *)ASN1_dup(
-      CHECKED_I2D_OF(X509_PUBKEY, i2d_X509_PUBKEY), CHECKED_D2I_OF(X509_PUBKEY, d2i_X509_PUBKEY), x509_pubkey.get()));
+      i2d_X509_PUBKEY_void, d2i_X509_PUBKEY_void, x509_pubkey.get()));
   ASSERT_TRUE(x509_pubkey_copy);
   EXPECT_EQ(
       ASN1_STRING_cmp(X509_PUBKEY_get0_public_key(x509_pubkey.get()),

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -269,13 +269,17 @@ int i2d_SAMPLE(const SAMPLE *in, uint8_t **outp);
 
 // The following macros are used to retrieve the function pointer of the
 // |d2i| or |i2d| ASN1 functions of |type|.
-//
-// NOTE: |D2I_OF| and |I2D_OF_const| are not implemented.
 #define I2D_OF(type) int (*)(type *, unsigned char **)
+#define I2D_OF_const(type) int (*)(const type *, unsigned char **)
+#define D2I_OF(type) type* (*)(type **, const unsigned char **, long)
 
 // CHECKED_I2D_OF casts a given pointer to i2d_of_void* and statically checks
 // that it was a pointer to |type|'s |i2d| function.
-#define CHECKED_I2D_OF(type, i2d) ((i2d_of_void *)(1 ? i2d : ((I2D_OF(type))0)))
+#define CHECKED_I2D_OF(type, i2d) ((i2d_of_void *)(1 ? i2d : ((I2D_OF_const(type))0)))
+
+// CHECKED_D2I_OF casts a given pointer to d2i_of_void* and statically checks
+// that it was a pointer to |type|'s |d2i| function.
+#define CHECKED_D2I_OF(type, d2i) ((d2i_of_void *)(1 ? d2i : ((D2I_OF(type))0)))
 
 // The following typedefs are sometimes used for pointers to functions like
 // |d2i_SAMPLE| and |i2d_SAMPLE|. Note, however, that these act on |void*|.

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -275,8 +275,7 @@ int i2d_SAMPLE(const SAMPLE *in, uint8_t **outp);
 
 // CHECKED_I2D_OF casts a given pointer to i2d_of_void* and statically checks
 // that it was a pointer to |type|'s |i2d| function.
-#define CHECKED_I2D_OF(type, i2d) \
-    ((i2d_of_void*) (1 ? i2d : ((I2D_OF(type))0)))
+#define CHECKED_I2D_OF(type, i2d) ((i2d_of_void *)(1 ? i2d : ((I2D_OF(type))0)))
 
 // The following typedefs are sometimes used for pointers to functions like
 // |d2i_SAMPLE| and |i2d_SAMPLE|. Note, however, that these act on |void*|.
@@ -391,6 +390,16 @@ OPENSSL_EXPORT ASN1_VALUE *ASN1_item_d2i(ASN1_VALUE **out,
 OPENSSL_EXPORT int ASN1_item_i2d(ASN1_VALUE *val, unsigned char **outp,
                                  const ASN1_ITEM *it);
 
+// ASN1_dup returns a newly-allocated copy of |x| by re-encoding with |i2d| and
+// |d2i|. |i2d| and |d2i| must be the corresponding type functions of |x|. NULL
+// is returned on error.
+//
+// WARNING: DO NOT USE. Casting the result of this function to the wrong type,
+// or passing a pointer of the wrong type into this function, are potentially
+// exploitable memory errors. Prefer directly calling |i2d| and |d2i| or other
+// type-specific functions.
+OPENSSL_EXPORT void *ASN1_dup(i2d_of_void *i2d, d2i_of_void *d2i, void *x);
+
 // ASN1_item_dup returns a newly-allocated copy of |x|, or NULL on error. |x|
 // must be an object of |it|'s C type.
 //
@@ -443,7 +452,7 @@ OPENSSL_EXPORT int ASN1_i2d_bio(i2d_of_void *i2d, BIO *out, void *in);
 // forces the user to use undefined C behavior and will cause failures when
 // running against undefined behavior sanitizers in clang.
 #define ASN1_i2d_bio_of(type, i2d, out, in) \
-    (ASN1_i2d_bio(CHECKED_I2D_OF(type, i2d), out, CHECKED_PTR_OF(type, in)))
+  (ASN1_i2d_bio(CHECKED_I2D_OF(type, i2d), out, CHECKED_PTR_OF(type, in)))
 
 // ASN1_item_unpack parses |oct|'s contents as |it|'s ASN.1 type. It returns a
 // newly-allocated instance of |it|'s C type on success, or NULL on error.

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -269,17 +269,17 @@ int i2d_SAMPLE(const SAMPLE *in, uint8_t **outp);
 
 // The following macros are used to retrieve the function pointer of the
 // |d2i| or |i2d| ASN1 functions of |type|.
-#define D2I_OF(type) type *(*)(type **, const unsigned char **, long)
 #define I2D_OF(type) int (*)(type *, unsigned char **)
 #define I2D_OF_const(type) int (*)(const type *, unsigned char **)
+#define D2I_OF(type) type* (*)(type **, const unsigned char **, long)
+
+// CHECKED_I2D_OF casts a given pointer to i2d_of_void* and statically checks
+// that it was a pointer to |type|'s |i2d| function.
+#define CHECKED_I2D_OF(type, i2d) ((i2d_of_void *)(1 ? i2d : ((I2D_OF_const(type))0)))
 
 // CHECKED_D2I_OF casts a given pointer to d2i_of_void* and statically checks
 // that it was a pointer to |type|'s |d2i| function.
 #define CHECKED_D2I_OF(type, d2i) ((d2i_of_void *)(1 ? d2i : ((D2I_OF(type))0)))
-
-// CHECKED_I2D_OF casts a given pointer to i2d_of_void* and statically checks
-// that it was a pointer to |type|'s |i2d| function.
-#define CHECKED_I2D_OF(type, i2d) ((i2d_of_void *)(1 ? i2d : ((I2D_OF(type))0)))
 
 // The following typedefs are sometimes used for pointers to functions like
 // |d2i_SAMPLE| and |i2d_SAMPLE|. Note, however, that these act on |void*|.

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -269,17 +269,17 @@ int i2d_SAMPLE(const SAMPLE *in, uint8_t **outp);
 
 // The following macros are used to retrieve the function pointer of the
 // |d2i| or |i2d| ASN1 functions of |type|.
+#define D2I_OF(type) type *(*)(type **, const unsigned char **, long)
 #define I2D_OF(type) int (*)(type *, unsigned char **)
 #define I2D_OF_const(type) int (*)(const type *, unsigned char **)
-#define D2I_OF(type) type* (*)(type **, const unsigned char **, long)
-
-// CHECKED_I2D_OF casts a given pointer to i2d_of_void* and statically checks
-// that it was a pointer to |type|'s |i2d| function.
-#define CHECKED_I2D_OF(type, i2d) ((i2d_of_void *)(1 ? i2d : ((I2D_OF_const(type))0)))
 
 // CHECKED_D2I_OF casts a given pointer to d2i_of_void* and statically checks
 // that it was a pointer to |type|'s |d2i| function.
 #define CHECKED_D2I_OF(type, d2i) ((d2i_of_void *)(1 ? d2i : ((D2I_OF(type))0)))
+
+// CHECKED_I2D_OF casts a given pointer to i2d_of_void* and statically checks
+// that it was a pointer to |type|'s |i2d| function.
+#define CHECKED_I2D_OF(type, i2d) ((i2d_of_void *)(1 ? i2d : ((I2D_OF(type))0)))
 
 // The following typedefs are sometimes used for pointers to functions like
 // |d2i_SAMPLE| and |i2d_SAMPLE|. Note, however, that these act on |void*|.

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -269,17 +269,13 @@ int i2d_SAMPLE(const SAMPLE *in, uint8_t **outp);
 
 // The following macros are used to retrieve the function pointer of the
 // |d2i| or |i2d| ASN1 functions of |type|.
+//
+// NOTE: |D2I_OF| and |I2D_OF_const| are not implemented.
 #define I2D_OF(type) int (*)(type *, unsigned char **)
-#define I2D_OF_const(type) int (*)(const type *, unsigned char **)
-#define D2I_OF(type) type* (*)(type **, const unsigned char **, long)
 
 // CHECKED_I2D_OF casts a given pointer to i2d_of_void* and statically checks
 // that it was a pointer to |type|'s |i2d| function.
-#define CHECKED_I2D_OF(type, i2d) ((i2d_of_void *)(1 ? i2d : ((I2D_OF_const(type))0)))
-
-// CHECKED_D2I_OF casts a given pointer to d2i_of_void* and statically checks
-// that it was a pointer to |type|'s |d2i| function.
-#define CHECKED_D2I_OF(type, d2i) ((d2i_of_void *)(1 ? d2i : ((D2I_OF(type))0)))
+#define CHECKED_I2D_OF(type, i2d) ((i2d_of_void *)(1 ? i2d : ((I2D_OF(type))0)))
 
 // The following typedefs are sometimes used for pointers to functions like
 // |d2i_SAMPLE| and |i2d_SAMPLE|. Note, however, that these act on |void*|.


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1717`

### Description of changes: 
`ASN1_dup` was removed in https://github.com/aws/aws-lc/commit/419144adce049b5341bd94d355c52d099eac56e3 in favor of `ASN1_Item_dup`. This shouldn't normally be called directly, but Ruby happens to consume the API[ in several instances](https://github.com/search?q=repo%3Aruby%2Fruby%20ASN1_dup&type=code).
I've optimized the function to allocate memory with `i2d` directly, instead of the [ancient OpenSSL allocate](https://github.com/aws/aws-lc/commit/419144adce049b5341bd94d355c52d099eac56e3#diff-46888fde23260e66fc474ee241cefde06f5af3ec79856c2c45a491103e91739eL72-L78) and pass into behavior.
Also added some tests for verification along with a do-not-use warning.

### Call-outs:
N/A

### Testing:
New tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
