### PR TITLE
add support for X509_CRL_http_nbio

### DIFF
--- a/crypto/ocsp/internal.h
+++ b/crypto/ocsp/internal.h
@@ -258,7 +258,7 @@ DECLARE_ASN1_FUNCTIONS(OCSP_SIGNATURE)
 // Try exchanging request and response via HTTP on (non-)blocking BIO in rctx.
 OPENSSL_EXPORT int OCSP_REQ_CTX_nbio(OCSP_REQ_CTX *rctx);
 
-// Tries to exchange the request and response with OCSP_REQ_CTX_nbio(), but on
+// Tries to exchange the request and response with |OCSP_REQ_CTX_nbio|, but on
 // success, it additionally parses the response, which must be a
 // DER-encoded ASN.1 structure.
 int OCSP_REQ_CTX_nbio_d2i(OCSP_REQ_CTX *rctx, ASN1_VALUE **pval,

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -67,6 +67,7 @@
 #include <openssl/stack.h>
 
 #include "../asn1/internal.h"
+#include "../ocsp/internal.h"
 #include "internal.h"
 
 
@@ -118,6 +119,11 @@ int X509_CRL_sign_ctx(X509_CRL *x, EVP_MD_CTX *ctx) {
   asn1_encoding_clear(&x->crl->enc);
   return ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_CRL_INFO), x->crl->sig_alg,
                             x->sig_alg, x->signature, x->crl, ctx);
+}
+
+int X509_CRL_http_nbio(OCSP_REQ_CTX *rctx, X509_CRL **pcrl) {
+  return OCSP_REQ_CTX_nbio_d2i(rctx, (ASN1_VALUE **)pcrl,
+                               ASN1_ITEM_rptr(X509_CRL));
 }
 
 int NETSCAPE_SPKI_sign(NETSCAPE_SPKI *x, EVP_PKEY *pkey, const EVP_MD *md) {

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -347,6 +347,7 @@ typedef struct evp_pkey_st EVP_PKEY;
 typedef struct hmac_ctx_st HMAC_CTX;
 typedef struct md4_state_st MD4_CTX;
 typedef struct md5_state_st MD5_CTX;
+typedef struct ocsp_req_ctx_st OCSP_REQ_CTX;
 typedef struct ossl_init_settings_st OPENSSL_INIT_SETTINGS;
 typedef struct pkcs12_st PKCS12;
 typedef struct pkcs8_priv_key_info_st PKCS8_PRIV_KEY_INFO;

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -50,7 +50,6 @@ extern "C" {
 typedef struct ocsp_cert_id_st OCSP_CERTID;
 typedef struct ocsp_one_request_st OCSP_ONEREQ;
 typedef struct ocsp_req_info_st OCSP_REQINFO;
-typedef struct ocsp_req_ctx_st OCSP_REQ_CTX;
 typedef struct ocsp_signature_st OCSP_SIGNATURE;
 typedef struct ocsp_request_st OCSP_REQUEST;
 typedef struct ocsp_resp_bytes_st OCSP_RESPBYTES;

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -79,7 +79,6 @@
 #include <openssl/evp.h>
 #include <openssl/lhash.h>
 #include <openssl/obj.h>
-#include <openssl/ocsp.h>
 #include <openssl/pkcs7.h>
 #include <openssl/pool.h>
 #include <openssl/rsa.h>

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -79,6 +79,7 @@
 #include <openssl/evp.h>
 #include <openssl/lhash.h>
 #include <openssl/obj.h>
+#include <openssl/ocsp.h>
 #include <openssl/pkcs7.h>
 #include <openssl/pool.h>
 #include <openssl/rsa.h>
@@ -965,6 +966,11 @@ OPENSSL_EXPORT int X509_CRL_set1_signature_algo(X509_CRL *crl,
 OPENSSL_EXPORT int X509_CRL_set1_signature_value(X509_CRL *crl,
                                                  const uint8_t *sig,
                                                  size_t sig_len);
+
+// X509_CRL_http_nbio calls |OCSP_REQ_CTX_nbio_d2i| to exchange the request
+// via http. On success, it parses the response as a DER-encoded |X509_CRL|
+// ASN.1 structure.
+OPENSSL_EXPORT int X509_CRL_http_nbio(OCSP_REQ_CTX *rctx, X509_CRL **pcrl);
 
 
 // CRL entries.


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1648`

### Description of changes: 
`X509_CRL_http_nbio` is the last API needed to support the AzureSDK after implementation of https://github.com/aws/aws-lc/commit/7ef93cb8b9305405f619ab7639e1e7d0d3d4614c. It's a simple wrapper around an existing API, so might as well add support so we can resolve the ticket.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
