### PR TITLE
Only emit deprecation warnings for no-ops in debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -730,6 +730,10 @@ if(CONSTANT_TIME_VALIDATION)
   add_definitions(-DNDEBUG)
 endif()
 
+if(CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
+  add_definitions(-DAWSLC_DEBUG_BUILD)
+endif()
+
 # CMake's iOS support uses Apple's multiple-architecture toolchain. It takes an
 # architecture list from CMAKE_OSX_ARCHITECTURES, leaves CMAKE_SYSTEM_PROCESSOR
 # alone, and expects all architecture-specific logic to be conditioned within

--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -184,9 +184,28 @@ TEST(Crypto, OnDemandIntegrityTest) {
 
 OPENSSL_DEPRECATED static void DeprecatedFunction() {}
 
-OPENSSL_BEGIN_ALLOW_DEPRECATED
 TEST(CryptoTest, DeprecatedFunction) {
   // This is deprecated, but should not trigger any warnings.
   DeprecatedFunction();
 }
+
+AWSLC_NOOP static void NOOPFunction() {}
+
+#if defined(AWSLC_DEBUG_BUILD)
+
+OPENSSL_BEGIN_ALLOW_DEPRECATED
+TEST(CryptoTest, NOOPFunction) {
+  // This is deprecated and should trigger a warning without
+  // |OPENSSL_BEGIN/END_ALLOW_DEPRECATED|.
+  NOOPFunction();
+}
 OPENSSL_END_ALLOW_DEPRECATED
+
+#else
+
+TEST(CryptoTest, NOOPFunction) {
+  // This is a no-op function, warnings should only trigger in debug builds.
+  NOOPFunction();
+}
+
+#endif

--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -2045,20 +2045,17 @@ OPENSSL_EXPORT long ASN1_ENUMERATED_get(const ASN1_ENUMERATED *a);
 // General No-op Functions [Deprecated].
 
 // ASN1_STRING_set_default_mask does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void ASN1_STRING_set_default_mask(
-    unsigned long mask);
+OPENSSL_EXPORT AWSLC_NOOP void ASN1_STRING_set_default_mask(unsigned long mask);
 
 // ASN1_STRING_set_default_mask_asc returns one.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int ASN1_STRING_set_default_mask_asc(
-    const char *p);
+OPENSSL_EXPORT AWSLC_NOOP int ASN1_STRING_set_default_mask_asc(const char *p);
 
 // ASN1_STRING_get_default_mask returns |B_ASN1_UTF8STRING|. This is
 // the value AWS-LC uses by default and is not configurable.
-OPENSSL_EXPORT OPENSSL_DEPRECATED unsigned long ASN1_STRING_get_default_mask(
-    void);
+OPENSSL_EXPORT AWSLC_NOOP unsigned long ASN1_STRING_get_default_mask(void);
 
 // ASN1_STRING_TABLE_cleanup does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void ASN1_STRING_TABLE_cleanup(void);
+OPENSSL_EXPORT AWSLC_NOOP void ASN1_STRING_TABLE_cleanup(void);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -182,6 +182,22 @@ extern "C" {
 
 #endif
 
+#if defined(AWSLC_DEBUG_BUILD)
+
+// AWSLC_NOOP is used to mark a no-op symbol in AWS-LC as deprecated
+// in debug builds. This allows potential reliance on these no-ops symbols
+// to be more discoverable when migrating to AWS-LC, but does not block
+// release builds that may define "-Werror".
+// Refer to "docs/porting/functionality-differences.md" for more details
+// on no-op symbols in AWS-LC.
+#define AWSLC_NOOP __attribute__((__deprecated__))
+
+#else
+
+#define AWSLC_NOOP
+
+#endif
+
 
 #if defined(__GNUC__) || defined(__clang__)
 // MinGW has two different printf implementations. Ensure the format macro

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -889,20 +889,19 @@ OPENSSL_EXPORT int BIO_meth_set_puts(BIO_METHOD *method,
                                      int (*puts)(BIO *, const char *));
 
 // BIO_meth_get_puts returns |puts| function of |method|.
-OPENSSL_EXPORT int (*BIO_meth_get_puts(const BIO_METHOD *method)) (BIO *, const char *);
+OPENSSL_EXPORT int (*BIO_meth_get_puts(const BIO_METHOD *method))(BIO *,
+                                                                  const char *);
 
-// BIO_s_secmem returns the normal BIO_METHOD |BIO_s_mem|. Deprecated since AWS-LC
-// does not support secure heaps.
-OPENSSL_EXPORT OPENSSL_DEPRECATED const BIO_METHOD *BIO_s_secmem(void);
+// BIO_s_secmem returns the normal BIO_METHOD |BIO_s_mem|. This is a no-op since
+// AWS-LC does not support secure heaps.
+OPENSSL_EXPORT AWSLC_NOOP const BIO_METHOD *BIO_s_secmem(void);
 
 
 // General No-op Functions [Deprecated].
 
 // BIO_set_write_buffer_size returns zero.
-//
-// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. nginx defines -Werror and
-// depends on this.
-OPENSSL_EXPORT int BIO_set_write_buffer_size(BIO *bio, int buffer_size);
+OPENSSL_EXPORT AWSLC_NOOP int BIO_set_write_buffer_size(BIO *bio,
+                                                        int buffer_size);
 
 
 // Private functions

--- a/include/openssl/cipher.h
+++ b/include/openssl/cipher.h
@@ -563,7 +563,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED const EVP_CIPHER *EVP_cast5_cbc(void);
 
 // EVP_CIPHER_CTX_set_flags does nothing. We strongly discourage doing
 // any additional configurations when consuming |EVP_CIPHER_CTX|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_CIPHER_CTX_set_flags(
+OPENSSL_EXPORT AWSLC_NOOP void EVP_CIPHER_CTX_set_flags(
     const EVP_CIPHER_CTX *ctx, uint32_t flags);
 
 // The following flags are related to |EVP_CIPHER_CTX_set_flags|. They
@@ -572,8 +572,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_CIPHER_CTX_set_flags(
 #define EVP_CIPHER_CTX_FLAG_WRAP_ALLOW 0
 
 // EVP_add_cipher_alias does nothing and returns one.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_add_cipher_alias(const char *a,
-                                                           const char *b);
+OPENSSL_EXPORT AWSLC_NOOP int EVP_add_cipher_alias(const char *a,
+                                                   const char *b);
 
 
 // Private functions.

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -136,17 +136,18 @@ OPENSSL_EXPORT const char *NCONF_get_string(const CONF *conf,
 
 // CONF_modules_load_file returns one. AWS-LC is defined to have no config
 // file options, thus loading from |filename| always succeeds by doing nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int CONF_modules_load_file(
-    const char *filename, const char *appname, unsigned long flags);
+OPENSSL_EXPORT AWSLC_NOOP int CONF_modules_load_file(const char *filename,
+                                                     const char *appname,
+                                                     unsigned long flags);
 
 // CONF_modules_free does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_free(void);
+OPENSSL_EXPORT AWSLC_NOOP void CONF_modules_free(void);
 
 // CONF_modules_unload does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_unload(int all);
+OPENSSL_EXPORT AWSLC_NOOP void CONF_modules_unload(int all);
 
 // CONF_modules_finish does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void CONF_modules_finish(void);
+OPENSSL_EXPORT AWSLC_NOOP void CONF_modules_finish(void);
 
 // OPENSSL_config does nothing. This has been deprecated since OpenSSL 1.1.0.
 //

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -353,7 +353,7 @@ OPENSSL_EXPORT DH *DH_get_2048_256(void);
 
 // DH_clear_flags does nothing and is included to simplify compiling code that
 // expects it.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void DH_clear_flags(DH *dh, int flags);
+OPENSSL_EXPORT AWSLC_NOOP void DH_clear_flags(DH *dh, int flags);
 
 // DH_FLAG_CACHE_MONT_P is not supported by AWS-LC and is included to simplify
 // compiling code that expects it. This flag controls if the DH APIs should

--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -355,8 +355,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED bool EVP_MD_unstable_sha3_is_enabled(void);
 
 // EVP_MD_CTX_set_flags does nothing. We strongly discourage doing any
 // additional configurations when consuming |EVP_MD_CTX|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx,
-                                                            int flags);
+OPENSSL_EXPORT AWSLC_NOOP void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx,
+                                                    int flags);
 
 // EVP_MD_CTX_FLAG_NON_FIPS_ALLOW is meaningless. In OpenSSL it permits non-FIPS
 // algorithms in FIPS mode. But BoringSSL FIPS mode doesn't prohibit algorithms
@@ -367,7 +367,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx,
 // EVP_add_digest does nothing and returns one. It exists only for
 // compatibility with OpenSSL, which requires manually loading supported digests
 // when certain options are turned on.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_add_digest(const EVP_MD *digest);
+OPENSSL_EXPORT AWSLC_NOOP int EVP_add_digest(const EVP_MD *digest);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -432,19 +432,19 @@ OPENSSL_EXPORT void EC_POINT_clear_free(EC_POINT *point);
 
 // EC_GROUP_set_asn1_flag does nothing. AWS-LC only supports
 // |OPENSSL_EC_NAMED_CURVE|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_asn1_flag(EC_GROUP *group,
+OPENSSL_EXPORT AWSLC_NOOP void EC_GROUP_set_asn1_flag(EC_GROUP *group,
                                                               int flag);
 
 // EC_GROUP_get_asn1_flag returns |OPENSSL_EC_NAMED_CURVE|. This is the only
 // type AWS-LC supports.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int EC_GROUP_get_asn1_flag(
+OPENSSL_EXPORT AWSLC_NOOP int EC_GROUP_get_asn1_flag(
     const EC_GROUP *group);
 
 // EC_GROUP_set_point_conversion_form aborts the process if |form| is not
 // |POINT_CONVERSION_UNCOMPRESSED| or |POINT_CONVERSION_COMPRESSED|, and
 // otherwise does nothing.
 // AWS-LC always uses |POINT_CONVERSION_UNCOMPRESSED|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_point_conversion_form(
+OPENSSL_EXPORT AWSLC_NOOP void EC_GROUP_set_point_conversion_form(
     EC_GROUP *group, point_conversion_form_t form);
 
 

--- a/include/openssl/ec_key.h
+++ b/include/openssl/ec_key.h
@@ -359,8 +359,8 @@ OPENSSL_EXPORT int i2o_ECPublicKey(const EC_KEY *key, unsigned char **outp);
 
 // EC_KEY_set_asn1_flag does nothing. AWS-LC only supports
 // |OPENSSL_EC_NAMED_CURVE|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_KEY_set_asn1_flag(EC_KEY *key,
-                                                            int flag);
+OPENSSL_EXPORT AWSLC_NOOP void EC_KEY_set_asn1_flag(EC_KEY *key,
+                                                    int flag);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1149,9 +1149,9 @@ OPENSSL_EXPORT EVP_PKEY *EVP_PKEY_new_mac_key(int type, ENGINE *engine,
 // functions instead.
 //
 // Note: In OpenSSL, the returned type will be different depending on the type
-//       of |EVP_PKEY| consumed. This leads to misuage very easily and has been
+//       of |EVP_PKEY| consumed. This leads to misusage very easily and has been
 //       deprecated as a no-op to avoid so.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void *EVP_PKEY_get0(const EVP_PKEY *pkey);
+OPENSSL_EXPORT AWSLC_NOOP void *EVP_PKEY_get0(const EVP_PKEY *pkey);
 
 // OpenSSL_add_all_algorithms does nothing. This has been deprecated since
 // OpenSSL 1.1.0.
@@ -1188,11 +1188,11 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_cleanup(void);
 #define EVP_PKEY_DSA NID_dsa
 
 // EVP_PKEY_CTX_set_dsa_paramgen_bits returns zero.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_PKEY_CTX_set_dsa_paramgen_bits(
+OPENSSL_EXPORT AWSLC_NOOP int EVP_PKEY_CTX_set_dsa_paramgen_bits(
     EVP_PKEY_CTX *ctx, int nbits);
 
 // EVP_PKEY_CTX_set_dsa_paramgen_q_bits returns zero.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
+OPENSSL_EXPORT AWSLC_NOOP int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
     EVP_PKEY_CTX *ctx, int qbits);
 
 
@@ -1206,13 +1206,10 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
 #define EVP_PKEY_DH NID_dhKeyAgreement
 
 // EVP_PKEY_get0_DH returns NULL.
-//
-// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. curl defines -Werror and
-// depends on this.
-OPENSSL_EXPORT DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
+OPENSSL_EXPORT AWSLC_NOOP DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
 
 // EVP_PKEY_get1_DH returns NULL.
-OPENSSL_EXPORT OPENSSL_DEPRECATED DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
+OPENSSL_EXPORT AWSLC_NOOP DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
 
 
 // Preprocessor compatibility section (hidden).

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -87,31 +87,29 @@ OPENSSL_EXPORT void RAND_seed(const void *buf, int num);
 // curl and tpm2-tss defines -Wnerror and depend on them.
 
 // RAND_load_file returns a nonnegative number.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_load_file(const char *path,
-                                                     long num);
+OPENSSL_EXPORT AWSLC_NOOP int RAND_load_file(const char *path, long num);
 
 // RAND_write_file does nothing and returns negative 1.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_write_file(const char *file);
+OPENSSL_EXPORT AWSLC_NOOP int RAND_write_file(const char *file);
 
 // RAND_file_name returns NULL.
-OPENSSL_EXPORT OPENSSL_DEPRECATED const char *RAND_file_name(char *buf,
-                                                             size_t num);
+OPENSSL_EXPORT AWSLC_NOOP const char *RAND_file_name(char *buf, size_t num);
 
 // RAND_add does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void RAND_add(const void *buf, int num,
-                                                double entropy);
+OPENSSL_EXPORT AWSLC_NOOP void RAND_add(const void *buf, int num,
+                                        double entropy);
 
 // RAND_egd returns 255.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_egd(const char *);
+OPENSSL_EXPORT AWSLC_NOOP int RAND_egd(const char *);
 
 // RAND_poll returns one.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int RAND_poll(void);
+OPENSSL_EXPORT AWSLC_NOOP int RAND_poll(void);
 
 // RAND_status returns one.
-OPENSSL_EXPORT int RAND_status(void);
+OPENSSL_EXPORT AWSLC_NOOP int RAND_status(void);
 
 // RAND_cleanup does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void RAND_cleanup(void);
+OPENSSL_EXPORT AWSLC_NOOP void RAND_cleanup(void);
 
 // rand_meth_st is typedefed to |RAND_METHOD| in base.h. It isn't used; it
 // exists only to be the return type of |RAND_SSLeay|. It's
@@ -138,7 +136,7 @@ OPENSSL_EXPORT const RAND_METHOD *RAND_get_rand_method(void);
 OPENSSL_EXPORT int RAND_set_rand_method(const RAND_METHOD *);
 
 // RAND_keep_random_devices_open does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void RAND_keep_random_devices_open(int a);
+OPENSSL_EXPORT AWSLC_NOOP void RAND_keep_random_devices_open(int a);
 
 
 #if defined(__cplusplus)

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5688,33 +5688,32 @@ typedef void COMP_METHOD;
 typedef struct ssl_comp_st SSL_COMP;
 
 // SSL_COMP_get_compression_methods returns NULL.
-OPENSSL_EXPORT OPENSSL_DEPRECATED STACK_OF(SSL_COMP) *
-SSL_COMP_get_compression_methods(void);
+OPENSSL_EXPORT AWSLC_NOOP STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(
+    void);
 
 // SSL_COMP_add_compression_method returns one.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_COMP_add_compression_method(
-    int id, COMP_METHOD *cm);
+OPENSSL_EXPORT AWSLC_NOOP int SSL_COMP_add_compression_method(int id,
+                                                              COMP_METHOD *cm);
 
 // SSL_COMP_get_name returns NULL.
-OPENSSL_EXPORT OPENSSL_DEPRECATED const char *SSL_COMP_get_name(
+OPENSSL_EXPORT AWSLC_NOOP const char *SSL_COMP_get_name(
     const COMP_METHOD *comp);
 
 // SSL_COMP_get0_name returns the |name| member of |comp|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED const char *SSL_COMP_get0_name(
-    const SSL_COMP *comp);
+OPENSSL_EXPORT AWSLC_NOOP const char *SSL_COMP_get0_name(const SSL_COMP *comp);
 
 // SSL_COMP_get_id returns the |id| member of |comp|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_COMP_get_id(const SSL_COMP *comp);
+OPENSSL_EXPORT AWSLC_NOOP int SSL_COMP_get_id(const SSL_COMP *comp);
 
 // SSL_COMP_free_compression_methods does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_COMP_free_compression_methods(void);
+OPENSSL_EXPORT AWSLC_NOOP void SSL_COMP_free_compression_methods(void);
 
 // SSL_get_current_compression returns NULL.
-OPENSSL_EXPORT OPENSSL_DEPRECATED const COMP_METHOD *
-SSL_get_current_compression(SSL *ssl);
+OPENSSL_EXPORT AWSLC_NOOP const COMP_METHOD *SSL_get_current_compression(
+    SSL *ssl);
 
 // SSL_get_current_expansion returns NULL.
-OPENSSL_EXPORT OPENSSL_DEPRECATED const COMP_METHOD *SSL_get_current_expansion(
+OPENSSL_EXPORT AWSLC_NOOP const COMP_METHOD *SSL_get_current_expansion(
     SSL *ssl);
 
 struct ssl_comp_st {
@@ -5733,29 +5732,25 @@ DEFINE_STACK_OF(SSL_COMP)
 
 // SSL_get_server_tmp_key returns zero. This was deprecated as part of the
 // removal of |EVP_PKEY_DH|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_get_server_tmp_key(
-    SSL *ssl, EVP_PKEY **out_key);
+OPENSSL_EXPORT AWSLC_NOOP int SSL_get_server_tmp_key(SSL *ssl,
+                                                     EVP_PKEY **out_key);
 
 // SSL_CTX_set_tmp_dh returns 1.
-//
-// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. nginx defines -Werror and
-// depends on this.
-OPENSSL_EXPORT int SSL_CTX_set_tmp_dh(SSL_CTX *ctx, const DH *dh);
+OPENSSL_EXPORT AWSLC_NOOP int SSL_CTX_set_tmp_dh(SSL_CTX *ctx, const DH *dh);
 
 // SSL_set_tmp_dh returns 1.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_dh(SSL *ssl, const DH *dh);
+OPENSSL_EXPORT AWSLC_NOOP int SSL_set_tmp_dh(SSL *ssl, const DH *dh);
 
 // SSL_CTX_set_tmp_dh_callback does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_CTX_set_tmp_dh_callback(
+OPENSSL_EXPORT AWSLC_NOOP void SSL_CTX_set_tmp_dh_callback(
     SSL_CTX *ctx, DH *(*cb)(SSL *ssl, int is_export, int keylength));
 
 // SSL_set_tmp_dh_callback does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_tmp_dh_callback(
+OPENSSL_EXPORT AWSLC_NOOP void SSL_set_tmp_dh_callback(
     SSL *ssl, DH *(*cb)(SSL *ssl, int is_export, int keylength));
 
 // SSL_CTX_set_dh_auto does nothing and returns 0 for error.
-OPENSSL_EXPORT OPENSSL_DEPRECATED long SSL_CTX_set_dh_auto(SSL_CTX *ctx,
-                                                           int onoff);
+OPENSSL_EXPORT AWSLC_NOOP long SSL_CTX_set_dh_auto(SSL_CTX *ctx, int onoff);
 
 
 // Security Levels No-ops [Deprecated].
@@ -5794,13 +5789,12 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED long SSL_CTX_set_dh_auto(SSL_CTX *ctx,
 // or RC4 related cipher suites. However, we don't directly prohibit 512 bit RSA
 // keys like Level 1 in OpenSSL states. Since this function is only retained for
 // OpenSSL compatibility, we set the returned value to 0.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_CTX_get_security_level(
-    const SSL_CTX *ctx);
+OPENSSL_EXPORT AWSLC_NOOP int SSL_CTX_get_security_level(const SSL_CTX *ctx);
 
 // SSL_CTX_set_security_level does nothing. See documentation in
 // |SSL_CTX_get_security_level| about implied security levels for AWS-LC.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_CTX_set_security_level(
-    const SSL_CTX *ctx, int level);
+OPENSSL_EXPORT AWSLC_NOOP void SSL_CTX_set_security_level(const SSL_CTX *ctx,
+                                                          int level);
 
 
 // General No-op Functions [Deprecated].
@@ -5810,15 +5804,15 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_state(SSL *ssl, int state);
 
 // SSL_get_shared_ciphers writes an empty string to |buf| and returns a
 // pointer to |buf|, or NULL if |len| is less than or equal to zero.
-//
-// TODO (CryptoAlg-2398): Add |OPENSSL_DEPRECATED|. nginx defines -Werror and
-// depends on this.
-OPENSSL_EXPORT char *SSL_get_shared_ciphers(const SSL *ssl, char *buf, int len);
+OPENSSL_EXPORT AWSLC_NOOP char *SSL_get_shared_ciphers(const SSL *ssl,
+                                                       char *buf, int len);
 
 // SSL_get_shared_sigalgs returns zero.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_get_shared_sigalgs(
-    SSL *ssl, int idx, int *psign, int *phash, int *psignandhash, uint8_t *rsig,
-    uint8_t *rhash);
+OPENSSL_EXPORT AWSLC_NOOP int SSL_get_shared_sigalgs(SSL *ssl, int idx,
+                                                     int *psign, int *phash,
+                                                     int *psignandhash,
+                                                     uint8_t *rsig,
+                                                     uint8_t *rhash);
 
 // SSL_CTX_set_ecdh_auto returns one. This is also a no-op in OpenSSL.
 #define SSL_CTX_set_ecdh_auto(ctx, onoff) 1


### PR DESCRIPTION
### Description of changes: 
More consumers than anticipated define `-Werror` and the no-op symbols we've marked as deprecated are breaking builds that define so. The original concept was great for finding integrations that consume no-op symbols and debugging them, so we'd like to keep that.
This change only marks no-op symbols as deprecated in debug builds. This unblocks our release build to work with projects that define `-Werror` and lets us keep the behavior that was great for debugging.

### Call-outs:
I didn't go the route of using `NDEBUG` since it's not always defined for downstream release builds. If it's not defined in the environment, the deprecation warnings will be emitted for no-op builds and break `-Werror` consuming applications that don't have `NDEBUG` defined.

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
