### PR TITLE
fix X509V3_EXT_METHODs for ocsp nonce extension

### DIFF
--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -170,7 +170,7 @@ static int asn1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in,
   ASN1_VALUE **pchptr;
   int combine = aclass & ASN1_TFLG_COMBINE;
   aclass &= ~ASN1_TFLG_COMBINE;
-  if (!pval) {
+  if (pval == NULL || it == NULL) {
     return 0;
   }
 

--- a/crypto/asn1/tasn_fre.c
+++ b/crypto/asn1/tasn_fre.c
@@ -78,7 +78,7 @@ void asn1_item_combine_free(ASN1_VALUE **pval, const ASN1_ITEM *it,
   const ASN1_TEMPLATE *tt = NULL, *seqtt;
   const ASN1_EXTERN_FUNCS *ef;
   int i;
-  if (!pval) {
+  if (pval == NULL || it == NULL) {
     return;
   }
   if ((it->itype != ASN1_ITYPE_PRIMITIVE) && !*pval) {

--- a/crypto/x509/internal.h
+++ b/crypto/x509/internal.h
@@ -480,6 +480,10 @@ typedef struct {
 int x509V3_add_value_asn1_string(const char *name, const ASN1_STRING *value,
                                  STACK_OF(CONF_VALUE) **extlist);
 
+// x509v3_ext_free_with_method frees |ext_data| with |ext_method|.
+int x509v3_ext_free_with_method(const X509V3_EXT_METHOD *ext_method,
+                                void *ext_data);
+
 // X509V3_NAME_from_section adds attributes to |nm| by interpreting the
 // key/value pairs in |dn_sk|. It returns one on success and zero on error.
 // |chtype|, which should be one of |MBSTRING_*| constants, determines the

--- a/crypto/x509/v3_conf.c
+++ b/crypto/x509/v3_conf.c
@@ -205,7 +205,7 @@ static X509_EXTENSION *do_ext_i2d(const X509V3_EXT_METHOD *method, int ext_nid,
     if (ext_len < 0) {
       return NULL;
     }
-  } else {
+  } else if (method->ext_nid == NID_id_pkix_OCSP_Nonce && method->i2d != NULL) {
     // |NID_id_pkix_OCSP_Nonce| is the only extension using the "old-style"
     // ASN.1 callbacks for backwards compatibility reasons.
     // Note: See |v3_ext_method| under "include/openssl/x509.h".
@@ -215,6 +215,9 @@ static X509_EXTENSION *do_ext_i2d(const X509V3_EXT_METHOD *method, int ext_nid,
     }
     unsigned char *p = ext_der;
     method->i2d(ext_struc, &p);
+  } else {
+    OPENSSL_PUT_ERROR(X509, X509V3_R_OPERATION_NOT_DEFINED);
+    return NULL;
   }
 
   ASN1_OCTET_STRING *ext_oct = ASN1_OCTET_STRING_new();

--- a/crypto/x509/v3_conf.c
+++ b/crypto/x509/v3_conf.c
@@ -206,13 +206,9 @@ static X509_EXTENSION *do_ext_i2d(const X509V3_EXT_METHOD *method, int ext_nid,
       return NULL;
     }
   } else {
-    // This is using the "old-style" ASN.1 callbacks. The only X509v3 extension
-    // that's still dependent on this code internally are OCSP nonce extensions.
-    // We can't easily migrate OCSP nonce extensions to use the "new" callbacks
-    // either, since OCSP nonces are handled differently in the code (according
-    // to OpenSSL and us having to maintain backwards compatibility with them).
-    // Every other |X509V3_EXT_METHOD|, both inside and outside the library, has
-    // and should have an |ASN1_ITEM|.
+    // |NID_id_pkix_OCSP_Nonce| is the only extension using the "old-style"
+    // ASN.1 callbacks for backwards compatibility reasons.
+    // Note: See |v3_ext_method| under "include/openssl/x509.h".
     ext_len = method->i2d(ext_struc, NULL);
     if (!(ext_der = OPENSSL_malloc(ext_len))) {
       return NULL;

--- a/crypto/x509/v3_lib.c
+++ b/crypto/x509/v3_lib.c
@@ -198,13 +198,15 @@ void *X509V3_EXT_d2i(const X509_EXTENSION *ext) {
   if (method->it) {
     ret =
         ASN1_item_d2i(NULL, &p, ext->value->length, ASN1_ITEM_ptr(method->it));
-  } else {
+  } else if (method->ext_nid == NID_id_pkix_OCSP_Nonce && method->d2i != NULL) {
     // |NID_id_pkix_OCSP_Nonce| is the only extension using the "old-style"
     // ASN.1 callbacks for backwards compatibility reasons.
     // Note: See |v3_ext_method| under "include/openssl/x509.h".
-    assert(method->ext_nid == NID_id_pkix_OCSP_Nonce);
     ret = method->d2i(NULL, &p, ext->value->length);
+  } else {
+    assert(0);
   }
+
   if (ret == NULL) {
     return NULL;
   }

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -42,6 +42,23 @@
 #include <thread>
 #endif
 
+static const char kX509ExtensionsCert[] = R"(
+-----BEGIN CERTIFICATE-----
+MIICwDCCAimgAwIBAgIEAJNOazANBgkqhkiG9w0BAQEFADAQMQ4wDAYDVQQKEwVjYXNzYTAeFw0xMTAz
+MzAxMTEwMzZaFw0xNDAzMzAxNTQwMzZaMC0xDjAMBgNVBAoMBWNhc9ijMRswGQYDVQQDExJlbXMuZ3J1
+cG9jYXNzYdeckJIwgZ8wDQYJKoZIhvcNAQEJBQADgY0AMIGJAoGBAFUEB/i0583rnah0hLRk1hleI5T0
+xw+naVIxs/h4ZHu19xva671kvXfN97PZBmzAwFAWXmfs5MUrviy6RjZjhc0Ad2510cmqWy9FUx4D7kjy
+iuZZIaA0xL0AAfvJbDkXrGpHZWz8BkANFZ/RHl961BRB3fTGvPWiZK6C4mCwPgIDaQABjwGjggEIMIIB
+BDALBgNVHRAEBAMCBaAwKwYDVR0VBCQKCf8O1s/Ozk3MzM8xNTo7MzZaMIIBBDALBgNVHRAEBAMCBaAw
+KwYDVR0VBCQKCf8O1s/OKoUDBwExNTo7MzZagQ8BBDALBgNVHRAEBAMCBaAwKwYDVR0VBCQKAYPxKTDO
+zs3MzM8xNTo7MzZagQ8yMDEzMDAxMzAxKjUwNlowEQYJKwYBBQUHMAECBAQDAgEHMBEGCWCGSAGG+EJZ
+AQQEAwIGQDAbBgNVHQ0EFDASMBAGCSqGSIb2fQcQBAQDAgWgMCsGA1UdFQQkCiFD8Skwzs7NzMzPMTU6
+OzM2WoEPAQQwCwYDVR0QBAQDAgWgMA0GCSsGAQUFBzABBQUAA4GBAKTNw5fTOnPCcOFMARmAD1RtaAN8
+0TBKIy2A0hG/2dlNeI6s0dqZe6juverYmC5sOResakdlbPwGQA0Vn9EeX8Yr67/d9Ma89aJkroLiXbA+
+j2kCAwG+LLpGNmNwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBw5lmgITTEvXIj+8ls
+-----END CERTIFICATE-----
+)";
+
 
 std::string GetTestData(const char *path);
 
@@ -1548,6 +1565,20 @@ static int Verify(
   }
 
   return X509_V_OK;
+}
+
+TEST(X509Test, X509Extensions) {
+  bssl::UniquePtr<X509> cert(CertFromPEM(kX509ExtensionsCert));
+  ASSERT_TRUE(cert);
+
+  for (int i = 0; i < X509_get_ext_count(cert.get()); i++) {
+    const X509_EXTENSION *ext = X509_get_ext(cert.get(), i);
+    void *parsed = X509V3_EXT_d2i(ext);
+    if (parsed != nullptr) {
+      int nid = OBJ_obj2nid(X509_EXTENSION_get_object(ext));
+      ASSERT_TRUE(X509V3_EXT_free(nid, parsed));
+    }
+  }
 }
 
 TEST(X509Test, TestVerify) {


### PR DESCRIPTION
### Issues:
Resolves `V1391929042`

### Description of changes: 
This backports more of the changes done in https://github.com/aws/aws-lc/commit/736a28388873faa25d892197e5777d32356c5084 to reintroduce the "old-style" `X509V3_EXT_METHOD`s.
Although we're reintroducing the methods we discourage using, I've added checks to ensure that these are only used with `NID_id_pkix_OCSP_Nonce`. The assertion in `X509V3_EXT_add` is kept so that we continue to only allow |ASN1_ITEM|-based extensions for consumers that add their own.

### Call-outs:
I've abstracted out the freeing logic to `x509v3_ext_free_with_method`. This used to be all over the place.

### Testing:
New test case added 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
