### PR TITLE
Fix mariadb ssl_crl patch

### DIFF
--- a/tests/ci/integration/mariadb_patch/ssl_crl_expect.patch
+++ b/tests/ci/integration/mariadb_patch/ssl_crl_expect.patch
@@ -1,12 +1,12 @@
 diff --git a/mysql-test/main/ssl_crl.test b/mysql-test/main/ssl_crl.test
-index 9b475857..58d23087 100644
+index a09490f2..2e71138b 100644
 --- a/mysql-test/main/ssl_crl.test
 +++ b/mysql-test/main/ssl_crl.test
 @@ -8,6 +8,6 @@
  
  --echo # try logging in with a certificate in the server's --ssl-crl : should fail
- # OpenSSL 1.1.1a correctly rejects the certificate, but the error message is different
----replace_regex /ERROR 2013 \(HY000\): Lost connection to server at '.*', system error: [0-9]+/ERROR 2026 (HY000): TLS\/SSL error: sslv3 alert certificate revoked/
-+--replace_regex /ERROR 2013 \(HY000\): Lost connection to server at '.*', system error: [0-9]+/ERROR 2026 (HY000): TLS\/SSL error: sslv3 alert certificate revoked/ /SSLV3_ALERT_CERTIFICATE_REVOKED/sslv3 alert certificate revoked/
+ # OpenSSL 1.1.1a and later releases correctly rejects the certificate, but the error message is different
+---replace_regex /(ERROR 2013 \(HY000\): Lost connection to server at '.*', system error: [0-9]+|ERROR 2026 \(HY000\): TLS\/SSL error: sslv3 alert certificate revoked)/ERROR 2026 (HY000): TLS\/SSL error: ssl\/tls alert certificate revoked/
++--replace_regex /(ERROR 2013 \(HY000\): Lost connection to server at '.*', system error: [0-9]+|ERROR 2026 \(HY000\): TLS\/SSL error: sslv3 alert certificate revoked)/ERROR 2026 (HY000): TLS\/SSL error: ssl\/tls alert certificate revoked/ /SSLV3_ALERT_CERTIFICATE_REVOKED/ssl\/tls alert certificate revoked/
  --error 1
  --exec $MYSQL --ssl-ca=$MYSQL_TEST_DIR/std_data/cacert.pem --ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem --ssl-cert=$MYSQL_TEST_DIR/std_data/client-cert.pem test -e "SHOW STATUS LIKE 'Ssl_version'" 2>&1


### PR DESCRIPTION
### Description of changes: 
MariaDB updated their patch with this commit: https://github.com/MariaDB/server/commit/d8368ae289c2d704e9df1fcb465208e925f1aba4. This updates our patch to be applicable with the new changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
