### PR TITLE
Cleanse the right amount of bytes in HMAC.

### DIFF
--- a/crypto/fipsmodule/digest/internal.h
+++ b/crypto/fipsmodule/digest/internal.h
@@ -63,7 +63,6 @@
 extern "C" {
 #endif
 
-#define EVP_MAX_MD_BLOCK_SIZE_BYTES  (EVP_MAX_MD_BLOCK_SIZE / 8)
 
 struct env_md_st {
   // type contains a NID identifing the digest function. (For example,

--- a/crypto/fipsmodule/hmac/hmac.c
+++ b/crypto/fipsmodule/hmac/hmac.c
@@ -289,8 +289,8 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, size_t key_len,
   FIPS_service_indicator_lock_state();
   int result = 0;
 
-  uint64_t pad[EVP_MAX_MD_BLOCK_SIZE / 8] = {0};
-  uint64_t key_block[EVP_MAX_MD_BLOCK_SIZE / 8] = {0};
+  uint64_t pad[EVP_MAX_MD_BLOCK_SIZE / sizeof(uint64_t)] = {0};
+  uint64_t key_block[EVP_MAX_MD_BLOCK_SIZE / sizeof(uint64_t)] = {0};
   if (block_size < key_len) {
     // Long keys are hashed.
     if (!methods->init(&ctx->md_ctx) ||

--- a/crypto/fipsmodule/hmac/hmac.c
+++ b/crypto/fipsmodule/hmac/hmac.c
@@ -289,8 +289,8 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, size_t key_len,
   FIPS_service_indicator_lock_state();
   int result = 0;
 
-  uint64_t pad[EVP_MAX_MD_BLOCK_SIZE_BYTES] = {0};
-  uint64_t key_block[EVP_MAX_MD_BLOCK_SIZE_BYTES] = {0};
+  uint64_t pad[EVP_MAX_MD_BLOCK_SIZE / 8] = {0};
+  uint64_t key_block[EVP_MAX_MD_BLOCK_SIZE / 8] = {0};
   if (block_size < key_len) {
     // Long keys are hashed.
     if (!methods->init(&ctx->md_ctx) ||
@@ -322,8 +322,8 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, size_t key_len,
 
   result = 1;
 end:
-  OPENSSL_cleanse(pad, EVP_MAX_MD_BLOCK_SIZE_BYTES);
-  OPENSSL_cleanse(key_block, EVP_MAX_MD_BLOCK_SIZE_BYTES);
+  OPENSSL_cleanse(pad, EVP_MAX_MD_BLOCK_SIZE);
+  OPENSSL_cleanse(key_block, EVP_MAX_MD_BLOCK_SIZE);
   FIPS_service_indicator_unlock_state();
   if (result != 1) {
     // We're in some error state, so return our context to a known and well defined zero state.


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
EVP_MAX_MD_BLOCK_SIZE is the block size in bytes. It is divided by 8 in a 64-bit word array initialisation in hmac.c

This partially reverts "Zeroize data immediately after use for FIPS (#911)", commit c7a9fd0dd20c0e35a5b7b98f22b78f16c8c34567, while keeping and correcting the cleansing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
