### PR TITLE
Script for creating compilation database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ symbols.txt
 .fleet/
 .cache/
 /CMakePresets.json
+/compile_commands.json

--- a/util/build_compilation_database.sh
+++ b/util/build_compilation_database.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+BASE_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}/" )/.." &> /dev/null && pwd )
+
+TMP_DIR=`mktemp -d`
+echo ${TMP_DIR}
+AWS_LC_BUILD="${TMP_DIR}/AWS-LC-BUILD"
+
+MY_CMAKE_FLAGS=("-GNinja" "-DCMAKE_BUILD_TYPE=Debug" "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
+
+mkdir -p "${AWS_LC_BUILD}"
+
+cmake "${BASE_DIR}" -B "${AWS_LC_BUILD}" ${MY_CMAKE_FLAGS[@]}
+
+cmake --build "${AWS_LC_BUILD}" --target all
+
+cp "${AWS_LC_BUILD}"/compile_commands.json "${BASE_DIR}"/


### PR DESCRIPTION
### Description of changes: 
* A [compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) is a JSON file that helps facilitate code assistance within a code/text editor.  This is typically via the editor's integration with [Clangd/LSP](https://clangd.llvm.org/).  It is supported by a variety of editors: [VSCode](https://code.visualstudio.com/docs/cpp/faq-cpp#_how-do-i-get-intellisense-to-work-correctly), [CLion](https://www.jetbrains.com/help/clion/compilation-database.html), [Neovim](https://neovim.io/), [Helix](https://helix-editor.com/) among others.
* This script simplifies the creation of this database for AWS-LC: `compile_commands.json`
* This adds the `compile_commands.json` file to `.gitignore`.

### Testing
* I tested the script on both Linux and macOS.
```
❯ ls -lh *.json
-rw-rw-r-- 1 justsmth justsmth 456K Jun  3 14:04 compile_commands.json
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
