### PR TITLE
Update ec2-test-framework to use gv2

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
@@ -6,8 +6,8 @@ version: 0.2
 # Doc for batch https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html#build-spec.batch.build-list
 batch:
   build-list:
-    # Actual tests are ran on an Graviton3 ec2 instance via SSM Commands.
-    - identifier: graviton3_tests
+    # Actual tests are ran on an Graviton2 ec2 instance via SSM Commands.
+    - identifier: graviton2_tests
       buildspec: ./tests/ci/codebuild/common/run_ec2_target.yml
       env:
         type: LINUX_CONTAINER
@@ -15,6 +15,6 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
         variables:
-          EC2_AMI: "ami-0a24e6e101933d294"
-          EC2_INSTANCE_TYPE: "c7g.2xlarge"
+          EC2_AMI: "ami-0c29a2c5cf69b5a9c"
+          EC2_INSTANCE_TYPE: "c6g.2xlarge"
           ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"


### PR DESCRIPTION
### Description of changes: 
Codebuild has upgraded their ARM containers to use gv3. This means we have to update our ec2 testing framework to test on gv2 instead.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
