### PR TITLE
Implement SSL_CIPHER_get_version for recent TLS versions

### DIFF
--- a/ssl/ssl_cipher.cc
+++ b/ssl/ssl_cipher.cc
@@ -1834,7 +1834,15 @@ bool tls_print_all_supported_cipher_suites(bool use_openssl_name) {
 }
 
 const char *SSL_CIPHER_get_version(const SSL_CIPHER *cipher) {
-  return "TLSv1/SSLv3";
+  switch (SSL_CIPHER_get_min_version(cipher)) {
+    case TLS1_2_VERSION:
+    case DTLS1_2_VERSION:
+      return "TLSv1.2";
+    case TLS1_3_VERSION:
+      return "TLSv1.3";
+    default:
+      return "TLSv1/SSLv3";
+  }
 }
 
 STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void) { return NULL; }

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -7828,6 +7828,15 @@ TEST_P(SSLVersionTest, SessionPropertiesThreads) {
     EXPECT_FALSE(verified_chain);
     EXPECT_TRUE(SSL_get_current_cipher(ssl));
     EXPECT_TRUE(SSL_get_group_id(ssl));
+    const uint16_t version = SSL_version(ssl);
+    if (version == TLS1_2_VERSION || version == TLS1_3_VERSION) {
+      const char *version_str = SSL_get_version(ssl);
+      EXPECT_STREQ(version_str, SSL_CIPHER_get_version(SSL_get_current_cipher(ssl)));
+    } else if (version == DTLS1_2_VERSION) {    // ciphers don't differentiate D/TLS
+      EXPECT_STREQ("TLSv1.2", SSL_CIPHER_get_version(SSL_get_current_cipher(ssl)));
+    } else {
+      EXPECT_STREQ("TLSv1/SSLv3", SSL_CIPHER_get_version(SSL_get_current_cipher(ssl)));
+    }
   };
 
   std::vector<std::thread> threads;


### PR DESCRIPTION
### Issues:
Resolves t-V1408365647
Addresses n/a

### Description of changes: 

This change modifies `SSL_CIPHER_get_version` to return the relevant version for non-deprecated TLS versions, namely TLSv1.2 and TLSv1.3 (preferred). For older TLS versions, the previous behavior (return constant cstring `TLSv1/SSLv3`) is preserved.

### Call-outs:
- n/a

### Testing:
- CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
