### PR TITLE
Move SSL_CIPHER_get_version test to SSLVersionTest.Version

### DIFF
--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -5003,6 +5003,20 @@ TEST_P(SSLVersionTest, Version) {
       SSL_SESSION_get_version(SSL_get_session(server_.get()));
   EXPECT_EQ(strcmp(version_name, client_name), 0);
   EXPECT_EQ(strcmp(version_name, server_name), 0);
+
+  // Client/server version equality asserted above, assert equality for cipher here.
+  ASSERT_TRUE(SSL_get_current_cipher(client_.get()));
+  ASSERT_TRUE(SSL_get_current_cipher(server_.get()));
+  EXPECT_EQ(SSL_get_current_cipher(client_.get())->id, SSL_get_current_cipher(server_.get())->id);
+  const uint16_t version = SSL_version(client_.get());
+  if (version == TLS1_2_VERSION || version == TLS1_3_VERSION) {
+    const char *version_str = SSL_get_version(client_.get());
+    EXPECT_STREQ(version_str, SSL_CIPHER_get_version(SSL_get_current_cipher(client_.get())));
+  } else if (version == DTLS1_2_VERSION) {    // ciphers don't differentiate D/TLS
+    EXPECT_STREQ("TLSv1.2", SSL_CIPHER_get_version(SSL_get_current_cipher(client_.get())));
+  } else {
+    EXPECT_STREQ("TLSv1/SSLv3", SSL_CIPHER_get_version(SSL_get_current_cipher(client_.get())));
+  }
 }
 
 // Tests that that |SSL_get_pending_cipher| is available during the ALPN
@@ -7828,15 +7842,6 @@ TEST_P(SSLVersionTest, SessionPropertiesThreads) {
     EXPECT_FALSE(verified_chain);
     EXPECT_TRUE(SSL_get_current_cipher(ssl));
     EXPECT_TRUE(SSL_get_group_id(ssl));
-    const uint16_t version = SSL_version(ssl);
-    if (version == TLS1_2_VERSION || version == TLS1_3_VERSION) {
-      const char *version_str = SSL_get_version(ssl);
-      EXPECT_STREQ(version_str, SSL_CIPHER_get_version(SSL_get_current_cipher(ssl)));
-    } else if (version == DTLS1_2_VERSION) {    // ciphers don't differentiate D/TLS
-      EXPECT_STREQ("TLSv1.2", SSL_CIPHER_get_version(SSL_get_current_cipher(ssl)));
-    } else {
-      EXPECT_STREQ("TLSv1/SSLv3", SSL_CIPHER_get_version(SSL_get_current_cipher(ssl)));
-    }
   };
 
   std::vector<std::thread> threads;


### PR DESCRIPTION
### Issues:
Resolves n/a (not needed for v1.29.0 release)
Addresses n/a

### Description of changes: 

@andrewhop noticed that this test didn't cover TLSv1.3 although we'd expected it to. This is because the previous test case [guards against TLSv1.3][1] for unrelated reasons. So, we move the test to another case that does cover TLSv1.3.

[1]: https://github.com/aws/aws-lc/blob/main/ssl/ssl_test.cc#L7786-L7789

### Call-outs:
- n/a

### Testing:

- CI
- verified TLSv1.3 parameterized tests pass

```
$ cmake-build.sh && ./build/ssl/ssl_test --gtest_filter='WithVersion/SSLVersionTest.Version*' | grep TLS1_3
...
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_0
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_0 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_128
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_128 (0 ms)
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_512
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_512 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_8192
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_8192 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_65535
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_BufferSize_65535 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_0
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_0 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_128
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_128 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_512
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_512 (1 ms)
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_8192
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_8192 (0 ms)
[ RUN      ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_65535
[       OK ] WithVersion/SSLVersionTest.Version/TLS1_3_SSL_TRANSFER_BufferSize_65535 (1 ms)
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
