### PR TITLE
align gcc version with curl's CI

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -147,7 +147,7 @@ batch:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_MEDIUM
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-11x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_curl_integration.sh"
 
@@ -157,7 +157,7 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:ubuntu-22.04_gcc-12x_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:ubuntu-22.04_gcc-11x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_curl_integration.sh"
 


### PR DESCRIPTION
### Description of changes: 
Curl's tip of main is failing against a compiler warning specific to gcc-12 at the moment with `-Werror` enabled. This is causing errors in our integration CI. We enable the flag since Curl's CI enables it, but they run against [gcc-11 for their CI](https://github.com/curl/curl/actions/runs/9484140318/job/26132948154).

I've submitted an issue to curl to fix it (https://github.com/curl/curl/issues/13932), but we should use gcc-11 for our Curl CI to avoid with curl's main branch that are out of our control.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
