### PR TITLE
Require newer assembler for _CET_ENDBR

### DIFF
--- a/include/openssl/asm_base.h
+++ b/include/openssl/asm_base.h
@@ -47,7 +47,8 @@
 .popsection
 #endif
 
-#if defined(__CET__) && defined(OPENSSL_X86_64)
+#if defined(__CET__) && defined(OPENSSL_X86_64) && \
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
 // Clang and GCC define __CET__ and provide <cet.h> when they support Intel's
 // Indirect Branch Tracking.
 // https://lpc.events/event/7/contributions/729/attachments/496/903/CET-LPC-2020.pdf


### PR DESCRIPTION
### Issues:
Resolves: P135542828

### Description of changes: 
* No use of `_CET_ENDBR` with old compilers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
