### PR TITLE
Make DH_check consistent with OpenSSL

### DIFF
--- a/crypto/dh_extra/dh_test.cc
+++ b/crypto/dh_extra/dh_test.cc
@@ -1036,8 +1036,8 @@ TEST(DHTest, PrivateKeyLength) {
 // from RFC 3526 and RFC 7919.
 TEST(DHTest, DHCheckForStandardParams) {
   int flags;
-
-  ASSERT_TRUE(DH_check(DH_get_rfc7919_2048(), &flags));
+  bssl::UniquePtr<DH> dh1(DH_get_rfc7919_2048());
+  ASSERT_TRUE(DH_check(dh1.get(), &flags));
   EXPECT_EQ(flags, 0);
 
   bssl::UniquePtr<BIGNUM> p(BN_get_rfc3526_prime_2048(nullptr));
@@ -1046,8 +1046,8 @@ TEST(DHTest, DHCheckForStandardParams) {
   ASSERT_TRUE(g);
   ASSERT_TRUE(BN_set_word(g.get(), 2));
 
-  bssl::UniquePtr<DH> dh = NewDHGroup(p.get(), /*q=*/nullptr, g.get());
-  ASSERT_TRUE(dh);
-  ASSERT_TRUE(DH_check(dh.get(), &flags));
+  bssl::UniquePtr<DH> dh2 = NewDHGroup(p.get(), /*q=*/nullptr, g.get());
+  ASSERT_TRUE(dh2);
+  ASSERT_TRUE(DH_check(dh2.get(), &flags));
   EXPECT_EQ(flags, 0);
 }

--- a/crypto/fipsmodule/dh/check.c
+++ b/crypto/fipsmodule/dh/check.c
@@ -150,7 +150,6 @@ int DH_check(const DH *dh, int *out_flags) {
   // should hold.
   int ok = 0, r, q_good = 0;
   BN_CTX *ctx = NULL;
-  BN_ULONG l;
   BIGNUM *t1 = NULL, *t2 = NULL;
 
   ctx = BN_CTX_new();
@@ -203,24 +202,6 @@ int DH_check(const DH *dh, int *out_flags) {
     if (!BN_is_one(t2)) {
       *out_flags |= DH_CHECK_INVALID_Q_VALUE;
     }
-  } else if (BN_is_word(dh->g, DH_GENERATOR_2)) {
-    l = BN_mod_word(dh->p, 24);
-    if (l == (BN_ULONG)-1) {
-      goto err;
-    }
-    if (l != 11) {
-      *out_flags |= DH_CHECK_NOT_SUITABLE_GENERATOR;
-    }
-  } else if (BN_is_word(dh->g, DH_GENERATOR_5)) {
-    l = BN_mod_word(dh->p, 10);
-    if (l == (BN_ULONG)-1) {
-      goto err;
-    }
-    if (l != 3 && l != 7) {
-      *out_flags |= DH_CHECK_NOT_SUITABLE_GENERATOR;
-    }
-  } else {
-    *out_flags |= DH_CHECK_UNABLE_TO_CHECK_GENERATOR;
   }
 
   r = BN_is_prime_ex(dh->p, BN_prime_checks_for_validation, ctx, NULL);

--- a/crypto/fipsmodule/dh/check.c
+++ b/crypto/fipsmodule/dh/check.c
@@ -136,18 +136,14 @@ err:
 }
 
 
+// DH_check confirms that the Diffie-Hellman parameters dh are valid.
 int DH_check(const DH *dh, int *out_flags) {
   *out_flags = 0;
   if (!dh_check_params_fast(dh)) {
     return 0;
   }
 
-  // Check that p is a safe prime and if g is 2, 3 or 5, check that it is a
-  // suitable generator where:
-  //   for 2, p mod 24 == 11
-  //   for 3, p mod 12 == 5
-  //   for 5, p mod 10 == 3 or 7
-  // should hold.
+  // Check that p is a safe prime.
   int ok = 0, r, q_good = 0;
   BN_CTX *ctx = NULL;
   BIGNUM *t1 = NULL, *t2 = NULL;


### PR DESCRIPTION
### Issues:
CryptoAlg-2490

### Description of changes: 
Previously, `DH_check` allowed only primes with certain
properties when the generator was equal to 2 or 5. We remove
this requirement to:
  - be more consistent with OpenSSL that doesn't have these
    checks. As a consequence, it was possible to generate DH
    parameters with OpenSSL that wouldn't pass AWS-LC `DH_check`.
  - not break customers who use one of the standard DH groups
    from RFC's 3526 and 7919 and call `DH_check` on it (like s2n-tls).

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
