### PR TITLE
Use params to build_compilation_database.sh

### DIFF
--- a/util/build_compilation_database.sh
+++ b/util/build_compilation_database.sh
@@ -12,7 +12,7 @@ MY_CMAKE_FLAGS=("-GNinja" "-DCMAKE_BUILD_TYPE=Debug" "-DCMAKE_EXPORT_COMPILE_COM
 
 mkdir -p "${AWS_LC_BUILD}"
 
-cmake "${BASE_DIR}" -B "${AWS_LC_BUILD}" ${MY_CMAKE_FLAGS[@]}
+cmake "${BASE_DIR}" -B "${AWS_LC_BUILD}" ${MY_CMAKE_FLAGS[@]} "${@}"
 
 cmake --build "${AWS_LC_BUILD}" --target all
 


### PR DESCRIPTION
### Description of changes: 
Propogates script parameters to cmake command

### Testing:
```
❯ ./util/build_compilation_database.sh -DFIPS=1 -DBUILD_SHARED_LIBS=1
...
+ mkdir -p /var/folders/bd/5rrlftjx2098f44h7jbj3n400000gr/T/tmp.69gTlsxzTf/AWS-LC-BUILD
+ cmake /Users/justsmth/repos/aws-lc -B /var/folders/bd/5rrlftjx2098f44h7jbj3n400000gr/T/tmp.69gTlsxzTf/AWS-LC-BUILD -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DFIPS=1 -DBUILD_SHARED_LIBS=1
...
...


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
