### PR TITLE
Always close file descriptor in test

### DIFF
--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -133,26 +133,31 @@ const char* CRYPTO_get_sysgenid_path(void) {
 
 #if defined(OPENSSL_LINUX) && defined(AWSLC_SNAPSAFE_TESTING)
 int HAZMAT_init_sysgenid_file(void) {
+
+  int ret = 0;
+
   int fd_sgn = open(CRYPTO_get_sysgenid_path(), O_CREAT | O_RDWR, S_IRWXU | S_IRGRP | S_IROTH);
   if (fd_sgn == -1) {
     return 0;
   }
+
   if (0 != lseek(fd_sgn, 0, SEEK_SET)) {
-    close(fd_sgn);
-    return 0;
+    goto out;
   }
+
   uint32_t value = 0;
   if(0 >= write(fd_sgn, &value, sizeof(uint32_t))) {
-    close(fd_sgn);
-    return 0;
+    goto out;
   }
 
   if (0 != fsync(fd_sgn)) {
-    return 0;
+    goto out;
   }
 
-  close(fd_sgn);
+  ret = 1;
 
-  return 1;
+out:
+  close(fd_sgn);
+  return ret;
 }
 #endif


### PR DESCRIPTION
### Description of changes: 


Insignificant fd leak in a test. Reordered function to always pass through a close when appropriate.

### Testing:

```
$ ./crypto/crypto_test --gtest_also_run_disabled_tests --gtest_filter=SnapsafeGenerationTest.DISABLED_SysGenIDretrievalTesting
Note: Google Test filter = SnapsafeGenerationTest.DISABLED_SysGenIDretrievalTesting
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SnapsafeGenerationTest
[ RUN      ] SnapsafeGenerationTest.DISABLED_SysGenIDretrievalTesting
[       OK ] SnapsafeGenerationTest.DISABLED_SysGenIDretrievalTesting (4 ms)
[----------] 1 test from SnapsafeGenerationTest (4 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
