### PR TITLE
Fix aws-lc-rs  GH CI for FIPS-2.x branch

### DIFF
--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -5,25 +5,27 @@ on:
   pull_request:
     branches: [ '*' ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org,direct
+  AWS_LC_SYS_CMAKE_BUILDER: 1
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-05-22
 jobs:
   standard:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v3
         with:
           repository: aws/aws-lc-rs
           path: ./aws-lc-rs
           submodules: false
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           # Our aws-lc-fips-sys generation scripts require nightly.
-          toolchain: nightly
-          override: true
+          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+      - run: rustup override set $RUST_NIGHTLY_TOOLCHAIN
       - uses: actions-rs/cargo@v1
         with:
           command: install


### PR DESCRIPTION
### Description of changes: 
* Update the aws-lc-rs GH CI test for the FIPS-2.x branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
