### PR TITLE
(FIPS Backport) Close FD in Snapsafe test function (#1649)

### DIFF
--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -133,23 +133,27 @@ const char* CRYPTO_get_sysgenid_path(void) {
 
 #if defined(OPENSSL_LINUX) && defined(AWSLC_SNAPSAFE_TESTING)
 int HAZMAT_init_sysgenid_file(void) {
-  int fd_sgn = open(CRYPTO_get_sysgenid_path(), O_CREAT | O_RDWR, S_IRWXU | S_IRGRP | S_IROTH);
+  int fd_sgn = open(CRYPTO_get_sysgenid_path(), O_CREAT | O_RDWR,
+                    S_IRWXU | S_IRGRP | S_IROTH);
   if (fd_sgn == -1) {
     return 0;
   }
-  if (0 != lseek(fd_sgn, 0, SEEK_SET)) {
-    close(fd_sgn);
-    return 0;
-  }
-  uint32_t value = 0;
-  if(0 >= write(fd_sgn, &value, sizeof(uint32_t))) {
-    close(fd_sgn);
-    return 0;
-  }
+  // If the file is empty, populate it. Otherwise, no change.
+  if (0 == lseek(fd_sgn, 0, SEEK_END)) {
+    if (0 != lseek(fd_sgn, 0, SEEK_SET)) {
+      close(fd_sgn);
+      return 0;
+    }
+    uint32_t value = 0;
+    if (0 >= write(fd_sgn, &value, sizeof(uint32_t))) {
+      close(fd_sgn);
+      return 0;
+    }
 
-  if (0 != fsync(fd_sgn)) {
-    close(fd_sgn);
-    return 0;
+    if (0 != fsync(fd_sgn)) {
+      close(fd_sgn);
+      return 0;
+    }
   }
 
   close(fd_sgn);


### PR DESCRIPTION
Backport of commit from main: https://github.com/aws/aws-lc/pull/1649

--------
* Close file-descriptor if `HAZMAT_init_sysgenid_file` fails to sync sysgenid test file.
--------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.