### PR TITLE
Fix for loading JCA stripped private keys

### DIFF
--- a/crypto/rsa_extra/rsa_asn1.c
+++ b/crypto/rsa_extra/rsa_asn1.c
@@ -174,6 +174,7 @@ static void detect_stripped_jca_private_key(RSA *key) {
     key->dmp1 = NULL;
     key->dmq1 = NULL;
     key->iqmp = NULL;
+    key->flags |= RSA_FLAG_NO_PUBLIC_EXPONENT;
   }
 }
 

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -4088,6 +4088,21 @@ AHTJ6cWWjCNrZhqiWWVI3jdK+h5xpRG8jGMXxR4JnjtoYRRusJLOXhmapwCB6fA0
 -----END CERTIFICATE-----
 )";
 
+static const char kRSAStrippedJCAKey[] = R"(
+-----BEGIN PRIVATE KEY-----
+MIGyAgEAMA0GCSqGSIb3DQEBAQUABIGdMIGaAgEAAkEAzVnSq89o3KlYlMWcB/3UFpD5isq2aGsYcnmr
+P4iGyFmlOvYR+DdkmiuxcKTZu/16uUi9BbQLtXyzhV3qX24YOwIBAAJAAfe+YQ8XviWRR7utBxaTlbPF
+8GKI5O9ByLcJwQ4Z3Ima9xdb14zqcXjA+Ox93ePHC0ruax1n+TptsoDhd+RoAQIBAAIBAAIBAAIBAAIB
+AA==
+-----END PRIVATE KEY-----
+)";
+
+// Make sure we can load stripped private RSA keys that JCA uses.
+TEST(X509Test, RSAStrippedJCAKey) {
+  bssl::UniquePtr<EVP_PKEY> key = PrivateKeyFromPEM(kRSAStrippedJCAKey);
+  ASSERT_TRUE(key);
+}
+
 TEST(X509Test, AlgorithmParameters) {
   // P-256 parameters should be omitted, but we accept NULL ones.
   bssl::UniquePtr<EVP_PKEY> key = PrivateKeyFromPEM(kP256Key);


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Set an appropriate RSA flag when stripped private keys are loaded.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
