### PR TITLE
Upstream: Add Intel Indirect Branch Tracking support

### DIFF
--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -235,6 +235,7 @@ $code.=<<___;
 .align	64
 ChaCha20_ctr32:
 .cfi_startproc
+	_CET_ENDBR
 	cmp	\$0,$len
 	je	.Lno_data
 	mov	OPENSSL_ia32cap_P+4(%rip),%r10

--- a/crypto/cipher_extra/asm/aes128gcmsiv-x86_64.pl
+++ b/crypto/cipher_extra/asm/aes128gcmsiv-x86_64.pl
@@ -140,6 +140,7 @@ $code.=<<___;
 .align 16
 aesgcmsiv_htable_init:
 .cfi_startproc
+    _CET_ENDBR
     vmovdqa ($H), $T
     vmovdqa $T, $TMP0
     vmovdqa $T, ($Htbl)      # H
@@ -180,6 +181,7 @@ sub aesgcmsiv_htable6_init {
 .align 16
 aesgcmsiv_htable6_init:
 .cfi_startproc
+    _CET_ENDBR
     vmovdqa ($H), $T
     vmovdqa $T, $TMP0
     vmovdqa $T, ($Htbl)      # H
@@ -241,6 +243,7 @@ ___
 .align 16
 aesgcmsiv_htable_polyval:
 .cfi_startproc
+    _CET_ENDBR
     test  $len, $len
     jnz   .Lhtable_polyval_start
     ret
@@ -426,6 +429,7 @@ sub aesgcmsiv_polyval_horner {
 .align 16
 aesgcmsiv_polyval_horner:
 .cfi_startproc
+    _CET_ENDBR
     test $L, $L
     jnz .Lpolyval_horner_start
     ret
@@ -466,6 +470,7 @@ $code.=<<___;
 .align 16
 aes128gcmsiv_aes_ks:
 .cfi_startproc
+    _CET_ENDBR
     vmovdqu (%rdi), %xmm1           # xmm1 = user key
     vmovdqa %xmm1, (%rsi)           # rsi points to output
 
@@ -527,6 +532,7 @@ $code.=<<___;
 .align 16
 aes256gcmsiv_aes_ks:
 .cfi_startproc
+    _CET_ENDBR
     vmovdqu (%rdi), %xmm1
     vmovdqu 16(%rdi), %xmm3
     vmovdqa %xmm1, (%rsi)
@@ -620,6 +626,7 @@ ___
 .align 16
 aes128gcmsiv_aes_ks_enc_x1:
 .cfi_startproc
+    _CET_ENDBR
     vmovdqa (%rcx), %xmm1                 # xmm1 = first 16 bytes of random key
     vmovdqa 0*16(%rdi), $BLOCK1
 
@@ -693,6 +700,7 @@ ___
 .align 16
 aes128gcmsiv_kdf:
 .cfi_startproc
+    _CET_ENDBR
 # parameter 1: %rdi                         Pointer to NONCE
 # parameter 2: %rsi                         Pointer to CT
 # parameter 4: %rdx                         Pointer to keys
@@ -793,6 +801,7 @@ ___
 .align 16
 aes128gcmsiv_enc_msg_x4:
 .cfi_startproc
+    _CET_ENDBR
     test $LEN, $LEN
     jnz .L128_enc_msg_x4_start
     ret
@@ -990,6 +999,7 @@ ___
 .align 16
 aes128gcmsiv_enc_msg_x8:
 .cfi_startproc
+    _CET_ENDBR
     test $LEN, $LEN
     jnz .L128_enc_msg_x8_start
     ret
@@ -1245,6 +1255,7 @@ ___
 
   $code.=<<___;
 .cfi_startproc
+    _CET_ENDBR
     test \$~15, $LEN
     jnz .L${labelPrefix}_dec_start
     ret
@@ -1584,6 +1595,7 @@ sub aes128gcmsiv_ecb_enc_block {
 .align 16
 aes128gcmsiv_ecb_enc_block:
 .cfi_startproc
+    _CET_ENDBR
     vmovdqa (%rdi), $STATE_1
 
     vpxor       ($KSp), $STATE_1, $STATE_1
@@ -1676,6 +1688,7 @@ ___
 .align 16
 aes256gcmsiv_aes_ks_enc_x1:
 .cfi_startproc
+    _CET_ENDBR
     vmovdqa con1(%rip), $CON_MASK    # CON_MASK  = 1,1,1,1
     vmovdqa mask(%rip), $MASK_256    # MASK_256
     vmovdqa ($PT), $BLOCK1
@@ -1717,6 +1730,7 @@ sub aes256gcmsiv_ecb_enc_block {
 .align 16
 aes256gcmsiv_ecb_enc_block:
 .cfi_startproc
+    _CET_ENDBR
     vmovdqa (%rdi), $STATE_1
     vpxor ($KSp), $STATE_1, $STATE_1
     vaesenc 1*16($KSp), $STATE_1, $STATE_1
@@ -1800,6 +1814,7 @@ ___
 .align 16
 aes256gcmsiv_enc_msg_x4:
 .cfi_startproc
+    _CET_ENDBR
     test $LEN, $LEN
     jnz .L256_enc_msg_x4_start
     ret
@@ -2000,6 +2015,7 @@ ___
 .align 16
 aes256gcmsiv_enc_msg_x8:
 .cfi_startproc
+    _CET_ENDBR
     test $LEN, $LEN
     jnz .L256_enc_msg_x8_start
     ret
@@ -2206,6 +2222,7 @@ ___
 .align 16
 aes256gcmsiv_kdf:
 .cfi_startproc
+    _CET_ENDBR
 # parameter 1: %rdi                         Pointer to NONCE
 # parameter 2: %rsi                         Pointer to CT
 # parameter 4: %rdx                         Pointer to keys

--- a/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl
+++ b/crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl
@@ -453,6 +453,7 @@ $code.="
 .align 64
 chacha20_poly1305_open:
 .cfi_startproc
+    _CET_ENDBR
     push %rbp
 .cfi_push %rbp
     push %rbx
@@ -875,6 +876,7 @@ $code.="
 .align 64
 chacha20_poly1305_seal:
 .cfi_startproc
+    _CET_ENDBR
     push %rbp
 .cfi_push %rbp
     push %rbx

--- a/crypto/fipsmodule/aes/asm/aesni-x86_64.pl
+++ b/crypto/fipsmodule/aes/asm/aesni-x86_64.pl
@@ -278,6 +278,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_encrypt:
 .cfi_startproc
+	_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern	BORINGSSL_function_hit
 	movb \$1,BORINGSSL_function_hit+1(%rip)
@@ -300,6 +301,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_decrypt:
 .cfi_startproc
+	_CET_ENDBR
 	movups	($inp),$inout0		# load input
 	mov	240($key),$rounds	# key->rounds
 ___
@@ -620,6 +622,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_ecb_encrypt:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___ if ($win64);
 	lea	-0x58(%rsp),%rsp
@@ -1206,6 +1209,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_ctr32_encrypt_blocks:
 .cfi_startproc
+	_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 	movb \$1,BORINGSSL_function_hit(%rip)
 #endif
@@ -1784,6 +1788,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_xts_encrypt:
 .cfi_startproc
+	_CET_ENDBR
 	lea	(%rsp),%r11			# frame pointer
 .cfi_def_cfa_register	%r11
 	push	%rbp
@@ -2267,6 +2272,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_xts_decrypt:
 .cfi_startproc
+	_CET_ENDBR
 	lea	(%rsp),%r11			# frame pointer
 .cfi_def_cfa_register	%r11
 	push	%rbp
@@ -2785,6 +2791,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_cbc_encrypt:
 .cfi_startproc
+	_CET_ENDBR
 	test	$len,$len		# check length
 	jz	.Lcbc_ret
 
@@ -3334,6 +3341,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_set_decrypt_key:
 .cfi_startproc
+	_CET_ENDBR
 	.byte	0x48,0x83,0xEC,0x08	# sub rsp,8
 .cfi_adjust_cfa_offset	8
 	call	__aesni_set_encrypt_key
@@ -3406,6 +3414,7 @@ $code.=<<___;
 ${PREFIX}_set_encrypt_key:
 __aesni_set_encrypt_key:
 .cfi_startproc
+	_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 	movb \$1,BORINGSSL_function_hit+3(%rip)
 #endif

--- a/crypto/fipsmodule/aes/asm/vpaes-x86_64.pl
+++ b/crypto/fipsmodule/aes/asm/vpaes-x86_64.pl
@@ -874,6 +874,7 @@ _vpaes_schedule_mangle:
 .align	16
 ${PREFIX}_set_encrypt_key:
 .cfi_startproc
+	_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
        movb \$1, BORINGSSL_function_hit+5(%rip)
@@ -929,6 +930,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_set_decrypt_key:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___ if ($win64);
 	lea	-0xb8(%rsp),%rsp
@@ -984,6 +986,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_encrypt:
 .cfi_startproc
+	_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern        BORINGSSL_function_hit
        movb \$1, BORINGSSL_function_hit+4(%rip)
@@ -1033,6 +1036,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_decrypt:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___ if ($win64);
 	lea	-0xb8(%rsp),%rsp
@@ -1084,6 +1088,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_cbc_encrypt:
 .cfi_startproc
+	_CET_ENDBR
 	xchg	$key,$len
 ___
 ($len,$key)=($key,$len);
@@ -1169,6 +1174,7 @@ $code.=<<___;
 .align	16
 ${PREFIX}_ctr32_encrypt_blocks:
 .cfi_startproc
+	_CET_ENDBR
 	# _vpaes_encrypt_core and _vpaes_encrypt_core_2x expect the key in %rdx.
 	xchg	$key, $blocks
 ___

--- a/crypto/fipsmodule/bn/asm/rsaz-avx2.pl
+++ b/crypto/fipsmodule/bn/asm/rsaz-avx2.pl
@@ -116,6 +116,7 @@ $code.=<<___;
 .align	64
 rsaz_1024_sqr_avx2:		# 702 cycles, 14% faster than rsaz_1024_mul_avx2
 .cfi_startproc
+	_CET_ENDBR
 	lea	(%rsp), %rax
 .cfi_def_cfa_register	%rax
 	push	%rbx
@@ -867,6 +868,7 @@ $code.=<<___;
 .align	64
 rsaz_1024_mul_avx2:
 .cfi_startproc
+	_CET_ENDBR
 	lea	(%rsp), %rax
 .cfi_def_cfa_register	%rax
 	push	%rbx
@@ -1478,6 +1480,7 @@ $code.=<<___;
 .align	32
 rsaz_1024_red2norm_avx2:
 .cfi_startproc
+	_CET_ENDBR
 	sub	\$-128,$inp	# size optimization
 	xor	%rax,%rax
 ___
@@ -1519,6 +1522,7 @@ $code.=<<___;
 .align	32
 rsaz_1024_norm2red_avx2:
 .cfi_startproc
+	_CET_ENDBR
 	sub	\$-128,$out	# size optimization
 	mov	($inp),@T[0]
 	mov	\$0x1fffffff,%eax
@@ -1563,6 +1567,7 @@ $code.=<<___;
 .align	32
 rsaz_1024_scatter5_avx2:
 .cfi_startproc
+	_CET_ENDBR
 	vzeroupper
 	vmovdqu	.Lscatter_permd(%rip),%ymm5
 	shl	\$4,$power
@@ -1590,6 +1595,7 @@ rsaz_1024_scatter5_avx2:
 .align	32
 rsaz_1024_gather5_avx2:
 .cfi_startproc
+	_CET_ENDBR
 	vzeroupper
 	mov	%rsp,%r11
 .cfi_def_cfa_register	%r11

--- a/crypto/fipsmodule/bn/asm/x86_64-mont.pl
+++ b/crypto/fipsmodule/bn/asm/x86_64-mont.pl
@@ -96,6 +96,7 @@ $code=<<___;
 .align	16
 bn_mul_mont:
 .cfi_startproc
+	_CET_ENDBR
 	mov	${num}d,${num}d
 	mov	%rsp,%rax
 .cfi_def_cfa_register	%rax

--- a/crypto/fipsmodule/bn/asm/x86_64-mont5.pl
+++ b/crypto/fipsmodule/bn/asm/x86_64-mont5.pl
@@ -83,6 +83,7 @@ $code=<<___;
 .align	64
 bn_mul_mont_gather5:
 .cfi_startproc
+	_CET_ENDBR
 	mov	${num}d,${num}d
 	mov	%rsp,%rax
 .cfi_def_cfa_register	%rax
@@ -1106,6 +1107,7 @@ $code.=<<___;
 .align	32
 bn_power5:
 .cfi_startproc
+	_CET_ENDBR
 	mov	%rsp,%rax
 .cfi_def_cfa_register	%rax
 ___
@@ -1250,6 +1252,7 @@ $code.=<<___;
 bn_sqr8x_internal:
 __bn_sqr8x_internal:
 .cfi_startproc
+	_CET_ENDBR
 	##############################################################
 	# Squaring part:
 	#
@@ -2748,6 +2751,7 @@ bn_powerx5:
 bn_sqrx8x_internal:
 __bn_sqrx8x_internal:
 .cfi_startproc
+	_CET_ENDBR
 	##################################################################
 	# Squaring part:
 	#
@@ -3460,6 +3464,7 @@ $code.=<<___;
 .align	16
 bn_scatter5:
 .cfi_startproc
+	_CET_ENDBR
 	cmp	\$0, $num
 	jz	.Lscatter_epilogue
 
@@ -3490,6 +3495,7 @@ bn_scatter5:
 bn_gather5:
 .cfi_startproc
 .LSEH_begin_bn_gather5:			# Win64 thing, but harmless in other cases
+	_CET_ENDBR
 	# I can't trust assembler to use specific encoding:-(
 	.byte	0x4c,0x8d,0x14,0x24			#lea    (%rsp),%r10
 .cfi_def_cfa_register	%r10

--- a/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl
@@ -102,6 +102,7 @@ $code.=<<___;
 .align	32
 ecp_nistz256_neg:
 .cfi_startproc
+	_CET_ENDBR
 	push	%r12
 .cfi_push	%r12
 	push	%r13
@@ -170,6 +171,7 @@ $code.=<<___;
 .align	32
 ecp_nistz256_ord_mul_mont:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___	if ($addx);
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -503,6 +505,7 @@ $code.=<<___;
 .align	32
 ecp_nistz256_ord_sqr_mont:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___	if ($addx);
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -1257,6 +1260,7 @@ $code.=<<___;
 .align	32
 ecp_nistz256_mul_mont:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___	if ($addx);
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -1565,6 +1569,7 @@ __ecp_nistz256_mul_montq:
 .align	32
 ecp_nistz256_sqr_mont:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___	if ($addx);
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -2122,6 +2127,7 @@ $code.=<<___;
 .align	32
 ecp_nistz256_select_w5:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___	if ($avx>1);
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -2224,6 +2230,7 @@ $code.=<<___;
 .align	32
 ecp_nistz256_select_w7:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___	if ($avx>1);
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -2433,6 +2440,7 @@ $code.=<<___;
 ecp_nistz256_avx2_select_w7:
 .cfi_startproc
 .Lavx2_select_w7:
+	_CET_ENDBR
 	vzeroupper
 ___
 $code.=<<___	if ($win64);
@@ -2545,6 +2553,7 @@ $code.=<<___;
 .type	ecp_nistz256_avx2_select_w7,\@function,3
 .align	32
 ecp_nistz256_avx2_select_w7:
+	_CET_ENDBR
 	.byte	0x0f,0x0b	# ud2
 	ret
 .size	ecp_nistz256_avx2_select_w7,.-ecp_nistz256_avx2_select_w7
@@ -2749,6 +2758,7 @@ $code.=<<___;
 .align	32
 ecp_nistz256_point_double:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___	if ($addx);
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -3003,6 +3013,7 @@ $code.=<<___;
 .align	32
 ecp_nistz256_point_add:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___	if ($addx);
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -3403,6 +3414,7 @@ $code.=<<___;
 .align	32
 ecp_nistz256_point_add_affine:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___	if ($addx);
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX

--- a/crypto/fipsmodule/ec/asm/p256_beeu-x86_64-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256_beeu-x86_64-asm.pl
@@ -160,6 +160,7 @@ $code.=<<___  if($avx);
 .align 32
 beeu_mod_inverse_vartime:
 .cfi_startproc
+    _CET_ENDBR
     push %rbp
 .cfi_push rbp
     push %r12

--- a/crypto/fipsmodule/md5/asm/md5-x86_64.pl
+++ b/crypto/fipsmodule/md5/asm/md5-x86_64.pl
@@ -135,6 +135,7 @@ $code .= <<EOF;
 .type md5_block_asm_data_order,\@function,3
 md5_block_asm_data_order:
 .cfi_startproc
+	_CET_ENDBR
 	push	%rbp
 .cfi_push	rbp
 	push	%rbx

--- a/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl
+++ b/crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl
@@ -446,6 +446,7 @@ $code.=<<___;
 aesni_gcm_decrypt:
 .cfi_startproc
 .seh_startproc
+	_CET_ENDBR
 	xor	%rax,%rax
 
 	# We call |_aesni_ctr32_ghash_6x|, which requires at least 96 (0x60)
@@ -719,6 +720,7 @@ _aesni_ctr32_6x:
 aesni_gcm_encrypt:
 .cfi_startproc
 .seh_startproc
+	_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern	BORINGSSL_function_hit
 	movb \$1,BORINGSSL_function_hit+2(%rip)
@@ -1093,6 +1095,7 @@ $code=<<___;	# assembler is too old
 .globl	aesni_gcm_encrypt
 .type	aesni_gcm_encrypt,\@abi-omnipotent
 aesni_gcm_encrypt:
+	_CET_ENDBR
 	xor	%eax,%eax
 	ret
 .size	aesni_gcm_encrypt,.-aesni_gcm_encrypt
@@ -1100,6 +1103,7 @@ aesni_gcm_encrypt:
 .globl	aesni_gcm_decrypt
 .type	aesni_gcm_decrypt,\@abi-omnipotent
 aesni_gcm_decrypt:
+	_CET_ENDBR
 	xor	%eax,%eax
 	ret
 .size	aesni_gcm_decrypt,.-aesni_gcm_decrypt

--- a/crypto/fipsmodule/modes/asm/ghash-ssse3-x86_64.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-ssse3-x86_64.pl
@@ -107,6 +107,7 @@ my $code = <<____;
 gcm_gmult_ssse3:
 .cfi_startproc
 .seh_startproc
+	_CET_ENDBR
 ____
 $code .= <<____ if ($win64);
 	subq	\$40, %rsp
@@ -249,6 +250,7 @@ $code .= <<____;
 gcm_ghash_ssse3:
 .cfi_startproc
 .seh_startproc
+	_CET_ENDBR
 ____
 $code .= <<____ if ($win64);
 	subq	\$56, %rsp

--- a/crypto/fipsmodule/modes/asm/ghash-x86_64.pl
+++ b/crypto/fipsmodule/modes/asm/ghash-x86_64.pl
@@ -210,6 +210,7 @@ $code.=<<___;
 gcm_init_clmul:
 .cfi_startproc
 .seh_startproc
+	_CET_ENDBR
 .L_init_clmul:
 ___
 $code.=<<___ if ($win64);
@@ -292,6 +293,7 @@ $code.=<<___;
 .align	16
 gcm_gmult_clmul:
 .cfi_startproc
+	_CET_ENDBR
 .L_gmult_clmul:
 	movdqu		($Xip),$Xi
 	movdqa		.Lbswap_mask(%rip),$T3
@@ -344,6 +346,7 @@ $code.=<<___;
 gcm_ghash_clmul:
 .cfi_startproc
 .seh_startproc
+	_CET_ENDBR
 .L_ghash_clmul:
 ___
 $code.=<<___ if ($win64);
@@ -712,6 +715,7 @@ $code.=<<___;
 .align	32
 gcm_init_avx:
 .cfi_startproc
+	_CET_ENDBR
 ___
 if ($avx) {
 my ($Htbl,$Xip)=@_4args;
@@ -858,6 +862,7 @@ $code.=<<___;
 .align	32
 gcm_gmult_avx:
 .cfi_startproc
+	_CET_ENDBR
 	jmp	.L_gmult_clmul
 .cfi_endproc
 .size	gcm_gmult_avx,.-gcm_gmult_avx
@@ -869,6 +874,7 @@ $code.=<<___;
 .align	32
 gcm_ghash_avx:
 .cfi_startproc
+	_CET_ENDBR
 ___
 if ($avx) {
 my ($Xip,$Htbl,$inp,$len)=@_4args;

--- a/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
+++ b/crypto/fipsmodule/rand/asm/rdrand-x86_64.pl
@@ -49,6 +49,7 @@ print<<___;
 .align	16
 CRYPTO_rdrand:
 .cfi_startproc
+	_CET_ENDBR
 	xorq %rax, %rax
 	rdrand $tmp1
 	test $tmp1, $tmp1 # OLD cpu's: can use all 0s in output as error signal
@@ -74,6 +75,7 @@ CRYPTO_rdrand:
 .align 16
 CRYPTO_rdrand_multiple8_buf:
 .cfi_startproc
+	_CET_ENDBR
 	test $len, $len
 	jz .Lout
 	movq \$8, $tmp1

--- a/crypto/fipsmodule/sha/asm/sha1-x86_64.pl
+++ b/crypto/fipsmodule/sha/asm/sha1-x86_64.pl
@@ -248,6 +248,7 @@ $code.=<<___;
 .align	16
 sha1_block_data_order:
 .cfi_startproc
+	_CET_ENDBR
 	leaq	OPENSSL_ia32cap_P(%rip),%r10
 	mov	0(%r10),%r9d
 	mov	4(%r10),%r8d

--- a/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
+++ b/crypto/fipsmodule/sha/asm/sha512-x86_64.pl
@@ -267,6 +267,7 @@ $code=<<___;
 .align	16
 $func:
 .cfi_startproc
+	_CET_ENDBR
 ___
 $code.=<<___ if ($SZ==4 || $avx);
 	leaq	OPENSSL_ia32cap_P(%rip),%r11

--- a/crypto/hrss/asm/poly_rq_mul.S
+++ b/crypto/hrss/asm/poly_rq_mul.S
@@ -302,6 +302,7 @@ mask_mod8192:
 .att_syntax prefix
 poly_Rq_mul:
 .cfi_startproc
+_CET_ENDBR
 push %rbp
 .cfi_adjust_cfa_offset 8
 .cfi_offset rbp, -16

--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -1499,6 +1499,7 @@ default	rel
 \%define XMMWORD
 \%define YMMWORD
 \%define ZMMWORD
+\%define _CET_ENDBR
 
 \%include "openssl/boringssl_prefix_symbols_nasm.inc"
 ___

--- a/crypto/test/asm/trampoline-x86_64.pl
+++ b/crypto/test/asm/trampoline-x86_64.pl
@@ -140,6 +140,7 @@ my $code = <<____;
 abi_test_trampoline:
 .cfi_startproc
 .seh_startproc
+	_CET_ENDBR
 	# Stack layout:
 	#   8 bytes - align
 	#   $caller_state_size bytes - saved caller registers
@@ -306,6 +307,7 @@ foreach ("ax", "bx", "cx", "dx", "di", "si", "bp", 8..15) {
 .globl	abi_test_clobber_r$_
 .align	16
 abi_test_clobber_r$_:
+	_CET_ENDBR
 	xorq	%r$_, %r$_
 	ret
 .size	abi_test_clobber_r$_,.-abi_test_clobber_r$_
@@ -318,6 +320,7 @@ foreach (0..15) {
 .globl	abi_test_clobber_xmm$_
 .align	16
 abi_test_clobber_xmm$_:
+	_CET_ENDBR
 	pxor	%xmm$_, %xmm$_
 	ret
 .size	abi_test_clobber_xmm$_,.-abi_test_clobber_xmm$_
@@ -334,6 +337,7 @@ $code .= <<____;
 abi_test_bad_unwind_wrong_register:
 .cfi_startproc
 .seh_startproc
+	_CET_ENDBR
 	pushq	%r12
 .cfi_push	%r13	# This should be %r13
 .seh_pushreg	%r13	# This should be %r13
@@ -357,6 +361,7 @@ abi_test_bad_unwind_wrong_register:
 abi_test_bad_unwind_temporary:
 .cfi_startproc
 .seh_startproc
+	_CET_ENDBR
 	pushq	%r12
 .cfi_push	%r12
 .seh_pushreg	%r12
@@ -383,6 +388,7 @@ abi_test_bad_unwind_temporary:
 .type	abi_test_set_direction_flag, \@abi-omnipotent
 .globl	abi_test_get_and_clear_direction_flag
 abi_test_get_and_clear_direction_flag:
+	_CET_ENDBR
 	pushfq
 	popq	%rax
 	andq	\$0x400, %rax
@@ -396,6 +402,7 @@ abi_test_get_and_clear_direction_flag:
 .type	abi_test_set_direction_flag, \@abi-omnipotent
 .globl	abi_test_set_direction_flag
 abi_test_set_direction_flag:
+	_CET_ENDBR
 	std
 	ret
 .size abi_test_set_direction_flag,.-abi_test_set_direction_flag

--- a/generated-src/linux-x86_64/crypto/chacha/chacha-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/chacha/chacha-x86_64.S
@@ -46,6 +46,7 @@
 .align	64
 ChaCha20_ctr32:
 .cfi_startproc	
+_CET_ENDBR
 	cmpq	$0,%rdx
 	je	.Lno_data
 	movq	OPENSSL_ia32cap_P+4(%rip),%r10

--- a/generated-src/linux-x86_64/crypto/cipher_extra/aes128gcmsiv-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/cipher_extra/aes128gcmsiv-x86_64.S
@@ -71,6 +71,7 @@ GFMUL:
 .align	16
 aesgcmsiv_htable_init:
 .cfi_startproc	
+_CET_ENDBR
 	vmovdqa	(%rsi),%xmm0
 	vmovdqa	%xmm0,%xmm1
 	vmovdqa	%xmm0,(%rdi)
@@ -97,6 +98,7 @@ aesgcmsiv_htable_init:
 .align	16
 aesgcmsiv_htable6_init:
 .cfi_startproc	
+_CET_ENDBR
 	vmovdqa	(%rsi),%xmm0
 	vmovdqa	%xmm0,%xmm1
 	vmovdqa	%xmm0,(%rdi)
@@ -119,6 +121,7 @@ aesgcmsiv_htable6_init:
 .align	16
 aesgcmsiv_htable_polyval:
 .cfi_startproc	
+_CET_ENDBR
 	testq	%rdx,%rdx
 	jnz	.Lhtable_polyval_start
 	.byte	0xf3,0xc3
@@ -336,6 +339,7 @@ aesgcmsiv_htable_polyval:
 .align	16
 aesgcmsiv_polyval_horner:
 .cfi_startproc	
+_CET_ENDBR
 	testq	%rcx,%rcx
 	jnz	.Lpolyval_horner_start
 	.byte	0xf3,0xc3
@@ -369,6 +373,7 @@ aesgcmsiv_polyval_horner:
 .align	16
 aes128gcmsiv_aes_ks:
 .cfi_startproc	
+_CET_ENDBR
 	vmovdqu	(%rdi),%xmm1
 	vmovdqa	%xmm1,(%rsi)
 
@@ -425,6 +430,7 @@ aes128gcmsiv_aes_ks:
 .align	16
 aes256gcmsiv_aes_ks:
 .cfi_startproc	
+_CET_ENDBR
 	vmovdqu	(%rdi),%xmm1
 	vmovdqu	16(%rdi),%xmm3
 	vmovdqa	%xmm1,(%rsi)
@@ -472,6 +478,7 @@ aes256gcmsiv_aes_ks:
 .align	16
 aes128gcmsiv_aes_ks_enc_x1:
 .cfi_startproc	
+_CET_ENDBR
 	vmovdqa	(%rcx),%xmm1
 	vmovdqa	0(%rdi),%xmm4
 
@@ -614,6 +621,7 @@ aes128gcmsiv_aes_ks_enc_x1:
 .align	16
 aes128gcmsiv_kdf:
 .cfi_startproc	
+_CET_ENDBR
 
 
 
@@ -707,6 +715,7 @@ aes128gcmsiv_kdf:
 .align	16
 aes128gcmsiv_enc_msg_x4:
 .cfi_startproc	
+_CET_ENDBR
 	testq	%r8,%r8
 	jnz	.L128_enc_msg_x4_start
 	.byte	0xf3,0xc3
@@ -886,6 +895,7 @@ aes128gcmsiv_enc_msg_x4:
 .align	16
 aes128gcmsiv_enc_msg_x8:
 .cfi_startproc	
+_CET_ENDBR
 	testq	%r8,%r8
 	jnz	.L128_enc_msg_x8_start
 	.byte	0xf3,0xc3
@@ -1147,6 +1157,7 @@ aes128gcmsiv_enc_msg_x8:
 .align	16
 aes128gcmsiv_dec:
 .cfi_startproc	
+_CET_ENDBR
 	testq	$~15,%r9
 	jnz	.L128_dec_start
 	.byte	0xf3,0xc3
@@ -1639,6 +1650,7 @@ aes128gcmsiv_dec:
 .align	16
 aes128gcmsiv_ecb_enc_block:
 .cfi_startproc	
+_CET_ENDBR
 	vmovdqa	(%rdi),%xmm1
 
 	vpxor	(%rdx),%xmm1,%xmm1
@@ -1664,6 +1676,7 @@ aes128gcmsiv_ecb_enc_block:
 .align	16
 aes256gcmsiv_aes_ks_enc_x1:
 .cfi_startproc	
+_CET_ENDBR
 	vmovdqa	con1(%rip),%xmm0
 	vmovdqa	mask(%rip),%xmm15
 	vmovdqa	(%rdi),%xmm8
@@ -1847,6 +1860,7 @@ aes256gcmsiv_aes_ks_enc_x1:
 .align	16
 aes256gcmsiv_ecb_enc_block:
 .cfi_startproc	
+_CET_ENDBR
 	vmovdqa	(%rdi),%xmm1
 	vpxor	(%rdx),%xmm1,%xmm1
 	vaesenc	16(%rdx),%xmm1,%xmm1
@@ -1873,6 +1887,7 @@ aes256gcmsiv_ecb_enc_block:
 .align	16
 aes256gcmsiv_enc_msg_x4:
 .cfi_startproc	
+_CET_ENDBR
 	testq	%r8,%r8
 	jnz	.L256_enc_msg_x4_start
 	.byte	0xf3,0xc3
@@ -2074,6 +2089,7 @@ aes256gcmsiv_enc_msg_x4:
 .align	16
 aes256gcmsiv_enc_msg_x8:
 .cfi_startproc	
+_CET_ENDBR
 	testq	%r8,%r8
 	jnz	.L256_enc_msg_x8_start
 	.byte	0xf3,0xc3
@@ -2363,6 +2379,7 @@ aes256gcmsiv_enc_msg_x8:
 .align	16
 aes256gcmsiv_dec:
 .cfi_startproc	
+_CET_ENDBR
 	testq	$~15,%r9
 	jnz	.L256_dec_start
 	.byte	0xf3,0xc3
@@ -2923,6 +2940,7 @@ aes256gcmsiv_dec:
 .align	16
 aes256gcmsiv_kdf:
 .cfi_startproc	
+_CET_ENDBR
 
 
 

--- a/generated-src/linux-x86_64/crypto/cipher_extra/chacha20_poly1305_x86_64.S
+++ b/generated-src/linux-x86_64/crypto/cipher_extra/chacha20_poly1305_x86_64.S
@@ -223,6 +223,7 @@ poly_hash_ad_internal:
 .align	64
 chacha20_poly1305_open:
 .cfi_startproc	
+_CET_ENDBR
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%rbp,-16
@@ -2108,6 +2109,7 @@ chacha20_poly1305_open:
 .align	64
 chacha20_poly1305_seal:
 .cfi_startproc	
+_CET_ENDBR
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%rbp,-16

--- a/generated-src/linux-x86_64/crypto/fipsmodule/aesni-gcm-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/aesni-gcm-x86_64.S
@@ -346,6 +346,7 @@ _aesni_ctr32_ghash_6x:
 aesni_gcm_decrypt:
 .cfi_startproc	
 
+_CET_ENDBR
 	xorq	%rax,%rax
 
 
@@ -569,6 +570,7 @@ _aesni_ctr32_6x:
 aesni_gcm_encrypt:
 .cfi_startproc	
 
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern	BORINGSSL_function_hit
 .hidden BORINGSSL_function_hit

--- a/generated-src/linux-x86_64/crypto/fipsmodule/aesni-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/aesni-x86_64.S
@@ -13,6 +13,7 @@
 .align	16
 aes_hw_encrypt:
 .cfi_startproc	
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern	BORINGSSL_function_hit
 .hidden BORINGSSL_function_hit
@@ -45,6 +46,7 @@ aes_hw_encrypt:
 .align	16
 aes_hw_decrypt:
 .cfi_startproc	
+_CET_ENDBR
 	movups	(%rdi),%xmm2
 	movl	240(%rdx),%eax
 	movups	(%rdx),%xmm0
@@ -533,6 +535,7 @@ _aesni_decrypt8:
 .align	16
 aes_hw_ecb_encrypt:
 .cfi_startproc	
+_CET_ENDBR
 	andq	$-16,%rdx
 	jz	.Lecb_ret
 
@@ -878,6 +881,7 @@ aes_hw_ecb_encrypt:
 .align	16
 aes_hw_ctr32_encrypt_blocks:
 .cfi_startproc	
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 	movb	$1,BORINGSSL_function_hit(%rip)
 #endif
@@ -1463,6 +1467,7 @@ aes_hw_ctr32_encrypt_blocks:
 .align	16
 aes_hw_xts_encrypt:
 .cfi_startproc	
+_CET_ENDBR
 	leaq	(%rsp),%r11
 .cfi_def_cfa_register	%r11
 	pushq	%rbp
@@ -1934,6 +1939,7 @@ aes_hw_xts_encrypt:
 .align	16
 aes_hw_xts_decrypt:
 .cfi_startproc	
+_CET_ENDBR
 	leaq	(%rsp),%r11
 .cfi_def_cfa_register	%r11
 	pushq	%rbp
@@ -2442,6 +2448,7 @@ aes_hw_xts_decrypt:
 .align	16
 aes_hw_cbc_encrypt:
 .cfi_startproc	
+_CET_ENDBR
 	testq	%rdx,%rdx
 	jz	.Lcbc_ret
 
@@ -3035,6 +3042,7 @@ aes_hw_cbc_encrypt:
 .align	16
 aes_hw_set_decrypt_key:
 .cfi_startproc	
+_CET_ENDBR
 .byte	0x48,0x83,0xEC,0x08
 .cfi_adjust_cfa_offset	8
 	call	__aesni_set_encrypt_key
@@ -3081,6 +3089,7 @@ aes_hw_set_decrypt_key:
 aes_hw_set_encrypt_key:
 __aesni_set_encrypt_key:
 .cfi_startproc	
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 	movb	$1,BORINGSSL_function_hit+3(%rip)
 #endif

--- a/generated-src/linux-x86_64/crypto/fipsmodule/ghash-ssse3-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/ghash-ssse3-x86_64.S
@@ -17,6 +17,7 @@
 gcm_gmult_ssse3:
 .cfi_startproc	
 
+_CET_ENDBR
 	movdqu	(%rdi),%xmm0
 	movdqa	.Lreverse_bytes(%rip),%xmm10
 	movdqa	.Llow4_mask(%rip),%xmm2
@@ -207,6 +208,7 @@ gcm_gmult_ssse3:
 gcm_ghash_ssse3:
 .cfi_startproc	
 
+_CET_ENDBR
 	movdqu	(%rdi),%xmm0
 	movdqa	.Lreverse_bytes(%rip),%xmm10
 	movdqa	.Llow4_mask(%rip),%xmm11

--- a/generated-src/linux-x86_64/crypto/fipsmodule/ghash-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/ghash-x86_64.S
@@ -14,6 +14,7 @@
 gcm_init_clmul:
 .cfi_startproc	
 
+_CET_ENDBR
 .L_init_clmul:
 	movdqu	(%rsi),%xmm2
 	pshufd	$78,%xmm2,%xmm2
@@ -174,6 +175,7 @@ gcm_init_clmul:
 .align	16
 gcm_gmult_clmul:
 .cfi_startproc	
+_CET_ENDBR
 .L_gmult_clmul:
 	movdqu	(%rdi),%xmm0
 	movdqa	.Lbswap_mask(%rip),%xmm5
@@ -229,6 +231,7 @@ gcm_gmult_clmul:
 gcm_ghash_clmul:
 .cfi_startproc	
 
+_CET_ENDBR
 .L_ghash_clmul:
 	movdqa	.Lbswap_mask(%rip),%xmm10
 
@@ -617,6 +620,7 @@ gcm_ghash_clmul:
 .align	32
 gcm_init_avx:
 .cfi_startproc	
+_CET_ENDBR
 	vzeroupper
 
 	vmovdqu	(%rsi),%xmm2
@@ -728,6 +732,7 @@ gcm_init_avx:
 .align	32
 gcm_gmult_avx:
 .cfi_startproc	
+_CET_ENDBR
 	jmp	.L_gmult_clmul
 .cfi_endproc	
 .size	gcm_gmult_avx,.-gcm_gmult_avx
@@ -737,6 +742,7 @@ gcm_gmult_avx:
 .align	32
 gcm_ghash_avx:
 .cfi_startproc	
+_CET_ENDBR
 	vzeroupper
 
 	vmovdqu	(%rdi),%xmm10

--- a/generated-src/linux-x86_64/crypto/fipsmodule/md5-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/md5-x86_64.S
@@ -12,6 +12,7 @@
 .type	md5_block_asm_data_order,@function
 md5_block_asm_data_order:
 .cfi_startproc	
+_CET_ENDBR
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	rbp,-16

--- a/generated-src/linux-x86_64/crypto/fipsmodule/p256-x86_64-asm.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/p256-x86_64-asm.S
@@ -38,6 +38,7 @@
 .align	32
 ecp_nistz256_neg:
 .cfi_startproc	
+_CET_ENDBR
 	pushq	%r12
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%r12,-16
@@ -100,6 +101,7 @@ ecp_nistz256_neg:
 .align	32
 ecp_nistz256_ord_mul_mont:
 .cfi_startproc	
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -436,6 +438,7 @@ ecp_nistz256_ord_mul_mont:
 .align	32
 ecp_nistz256_ord_sqr_mont:
 .cfi_startproc	
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -1199,6 +1202,7 @@ ecp_nistz256_ord_sqr_montx:
 .align	32
 ecp_nistz256_mul_mont:
 .cfi_startproc	
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -1502,6 +1506,7 @@ __ecp_nistz256_mul_montq:
 .align	32
 ecp_nistz256_sqr_mont:
 .cfi_startproc	
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -2040,6 +2045,7 @@ __ecp_nistz256_sqr_montx:
 .align	32
 ecp_nistz256_select_w5:
 .cfi_startproc	
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rax
 	movq	8(%rax),%rax
@@ -2109,6 +2115,7 @@ ecp_nistz256_select_w5:
 .align	32
 ecp_nistz256_select_w7:
 .cfi_startproc	
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rax
 	movq	8(%rax),%rax
@@ -2233,6 +2240,7 @@ ecp_nistz256_avx2_select_w5:
 ecp_nistz256_avx2_select_w7:
 .cfi_startproc	
 .Lavx2_select_w7:
+_CET_ENDBR
 	vzeroupper
 	vmovdqa	.LThree(%rip),%ymm0
 
@@ -2440,6 +2448,7 @@ __ecp_nistz256_mul_by_2q:
 .align	32
 ecp_nistz256_point_double:
 .cfi_startproc	
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -2676,6 +2685,7 @@ ecp_nistz256_point_double:
 .align	32
 ecp_nistz256_point_add:
 .cfi_startproc	
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -3115,6 +3125,7 @@ ecp_nistz256_point_add:
 .align	32
 ecp_nistz256_point_add_affine:
 .cfi_startproc	
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx

--- a/generated-src/linux-x86_64/crypto/fipsmodule/p256_beeu-x86_64-asm.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/p256_beeu-x86_64-asm.S
@@ -13,6 +13,7 @@
 .align	32
 beeu_mod_inverse_vartime:
 .cfi_startproc	
+_CET_ENDBR
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	rbp,-16

--- a/generated-src/linux-x86_64/crypto/fipsmodule/rdrand-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/rdrand-x86_64.S
@@ -15,6 +15,7 @@
 .align	16
 CRYPTO_rdrand:
 .cfi_startproc	
+_CET_ENDBR
 	xorq	%rax,%rax
 .byte	72,15,199,242
 	testq	%rdx,%rdx
@@ -41,6 +42,7 @@ CRYPTO_rdrand:
 .align	16
 CRYPTO_rdrand_multiple8_buf:
 .cfi_startproc	
+_CET_ENDBR
 	testq	%rsi,%rsi
 	jz	.Lout
 	movq	$8,%rdx

--- a/generated-src/linux-x86_64/crypto/fipsmodule/rsaz-avx2.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/rsaz-avx2.S
@@ -12,6 +12,7 @@
 .align	64
 rsaz_1024_sqr_avx2:
 .cfi_startproc	
+_CET_ENDBR
 	leaq	(%rsp),%rax
 .cfi_def_cfa_register	%rax
 	pushq	%rbx
@@ -666,6 +667,7 @@ rsaz_1024_sqr_avx2:
 .align	64
 rsaz_1024_mul_avx2:
 .cfi_startproc	
+_CET_ENDBR
 	leaq	(%rsp),%rax
 .cfi_def_cfa_register	%rax
 	pushq	%rbx
@@ -1222,6 +1224,7 @@ rsaz_1024_mul_avx2:
 .align	32
 rsaz_1024_red2norm_avx2:
 .cfi_startproc	
+_CET_ENDBR
 	subq	$-128,%rsi
 	xorq	%rax,%rax
 	movq	-128(%rsi),%r8
@@ -1422,6 +1425,7 @@ rsaz_1024_red2norm_avx2:
 .align	32
 rsaz_1024_norm2red_avx2:
 .cfi_startproc	
+_CET_ENDBR
 	subq	$-128,%rdi
 	movq	(%rsi),%r8
 	movl	$0x1fffffff,%eax
@@ -1582,6 +1586,7 @@ rsaz_1024_norm2red_avx2:
 .align	32
 rsaz_1024_scatter5_avx2:
 .cfi_startproc	
+_CET_ENDBR
 	vzeroupper
 	vmovdqu	.Lscatter_permd(%rip),%ymm5
 	shll	$4,%edx
@@ -1610,6 +1615,7 @@ rsaz_1024_scatter5_avx2:
 .align	32
 rsaz_1024_gather5_avx2:
 .cfi_startproc	
+_CET_ENDBR
 	vzeroupper
 	movq	%rsp,%r11
 .cfi_def_cfa_register	%r11

--- a/generated-src/linux-x86_64/crypto/fipsmodule/sha1-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/sha1-x86_64.S
@@ -14,6 +14,7 @@
 .align	16
 sha1_block_data_order:
 .cfi_startproc	
+_CET_ENDBR
 	leaq	OPENSSL_ia32cap_P(%rip),%r10
 	movl	0(%r10),%r9d
 	movl	4(%r10),%r8d

--- a/generated-src/linux-x86_64/crypto/fipsmodule/sha256-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/sha256-x86_64.S
@@ -14,6 +14,7 @@
 .align	16
 sha256_block_data_order:
 .cfi_startproc	
+_CET_ENDBR
 	leaq	OPENSSL_ia32cap_P(%rip),%r11
 	movl	0(%r11),%r9d
 	movl	4(%r11),%r10d

--- a/generated-src/linux-x86_64/crypto/fipsmodule/sha512-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/sha512-x86_64.S
@@ -14,6 +14,7 @@
 .align	16
 sha512_block_data_order:
 .cfi_startproc	
+_CET_ENDBR
 	leaq	OPENSSL_ia32cap_P(%rip),%r11
 	movl	0(%r11),%r9d
 	movl	4(%r11),%r10d

--- a/generated-src/linux-x86_64/crypto/fipsmodule/vpaes-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/vpaes-x86_64.S
@@ -805,6 +805,7 @@ _vpaes_schedule_mangle:
 .align	16
 vpaes_set_encrypt_key:
 .cfi_startproc	
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern	BORINGSSL_function_hit
 .hidden BORINGSSL_function_hit
@@ -830,6 +831,7 @@ vpaes_set_encrypt_key:
 .align	16
 vpaes_set_decrypt_key:
 .cfi_startproc	
+_CET_ENDBR
 	movl	%esi,%eax
 	shrl	$5,%eax
 	addl	$5,%eax
@@ -854,6 +856,7 @@ vpaes_set_decrypt_key:
 .align	16
 vpaes_encrypt:
 .cfi_startproc	
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 .extern	BORINGSSL_function_hit
 .hidden BORINGSSL_function_hit
@@ -873,6 +876,7 @@ vpaes_encrypt:
 .align	16
 vpaes_decrypt:
 .cfi_startproc	
+_CET_ENDBR
 	movdqu	(%rdi),%xmm0
 	call	_vpaes_preheat
 	call	_vpaes_decrypt_core
@@ -886,6 +890,7 @@ vpaes_decrypt:
 .align	16
 vpaes_cbc_encrypt:
 .cfi_startproc	
+_CET_ENDBR
 	xchgq	%rcx,%rdx
 	subq	$16,%rcx
 	jc	.Lcbc_abort
@@ -929,6 +934,7 @@ vpaes_cbc_encrypt:
 .align	16
 vpaes_ctr32_encrypt_blocks:
 .cfi_startproc	
+_CET_ENDBR
 
 	xchgq	%rcx,%rdx
 	testq	%rcx,%rcx

--- a/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont.S
@@ -15,6 +15,7 @@
 .align	16
 bn_mul_mont:
 .cfi_startproc	
+_CET_ENDBR
 	movl	%r9d,%r9d
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax

--- a/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont5.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont5.S
@@ -15,6 +15,7 @@
 .align	64
 bn_mul_mont_gather5:
 .cfi_startproc	
+_CET_ENDBR
 	movl	%r9d,%r9d
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
@@ -1097,6 +1098,7 @@ mul4x_internal:
 .align	32
 bn_power5:
 .cfi_startproc	
+_CET_ENDBR
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -1238,6 +1240,7 @@ bn_power5:
 bn_sqr8x_internal:
 __bn_sqr8x_internal:
 .cfi_startproc	
+_CET_ENDBR
 
 
 
@@ -2751,6 +2754,7 @@ bn_powerx5:
 bn_sqrx8x_internal:
 __bn_sqrx8x_internal:
 .cfi_startproc	
+_CET_ENDBR
 
 
 
@@ -3424,6 +3428,7 @@ __bn_postx4x_internal:
 .align	16
 bn_scatter5:
 .cfi_startproc	
+_CET_ENDBR
 	cmpl	$0,%esi
 	jz	.Lscatter_epilogue
 
@@ -3455,6 +3460,7 @@ bn_scatter5:
 bn_gather5:
 .cfi_startproc	
 .LSEH_begin_bn_gather5:
+_CET_ENDBR
 
 .byte	0x4c,0x8d,0x14,0x24
 .cfi_def_cfa_register	%r10

--- a/generated-src/linux-x86_64/crypto/test/trampoline-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/test/trampoline-x86_64.S
@@ -20,6 +20,7 @@
 abi_test_trampoline:
 .cfi_startproc	
 
+_CET_ENDBR
 
 
 
@@ -181,6 +182,7 @@ abi_test_unwind_stop:
 .hidden abi_test_clobber_rax
 .align	16
 abi_test_clobber_rax:
+_CET_ENDBR
 	xorq	%rax,%rax
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_rax,.-abi_test_clobber_rax
@@ -189,6 +191,7 @@ abi_test_clobber_rax:
 .hidden abi_test_clobber_rbx
 .align	16
 abi_test_clobber_rbx:
+_CET_ENDBR
 	xorq	%rbx,%rbx
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_rbx,.-abi_test_clobber_rbx
@@ -197,6 +200,7 @@ abi_test_clobber_rbx:
 .hidden abi_test_clobber_rcx
 .align	16
 abi_test_clobber_rcx:
+_CET_ENDBR
 	xorq	%rcx,%rcx
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_rcx,.-abi_test_clobber_rcx
@@ -205,6 +209,7 @@ abi_test_clobber_rcx:
 .hidden abi_test_clobber_rdx
 .align	16
 abi_test_clobber_rdx:
+_CET_ENDBR
 	xorq	%rdx,%rdx
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_rdx,.-abi_test_clobber_rdx
@@ -213,6 +218,7 @@ abi_test_clobber_rdx:
 .hidden abi_test_clobber_rdi
 .align	16
 abi_test_clobber_rdi:
+_CET_ENDBR
 	xorq	%rdi,%rdi
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_rdi,.-abi_test_clobber_rdi
@@ -221,6 +227,7 @@ abi_test_clobber_rdi:
 .hidden abi_test_clobber_rsi
 .align	16
 abi_test_clobber_rsi:
+_CET_ENDBR
 	xorq	%rsi,%rsi
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_rsi,.-abi_test_clobber_rsi
@@ -229,6 +236,7 @@ abi_test_clobber_rsi:
 .hidden abi_test_clobber_rbp
 .align	16
 abi_test_clobber_rbp:
+_CET_ENDBR
 	xorq	%rbp,%rbp
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_rbp,.-abi_test_clobber_rbp
@@ -237,6 +245,7 @@ abi_test_clobber_rbp:
 .hidden abi_test_clobber_r8
 .align	16
 abi_test_clobber_r8:
+_CET_ENDBR
 	xorq	%r8,%r8
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_r8,.-abi_test_clobber_r8
@@ -245,6 +254,7 @@ abi_test_clobber_r8:
 .hidden abi_test_clobber_r9
 .align	16
 abi_test_clobber_r9:
+_CET_ENDBR
 	xorq	%r9,%r9
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_r9,.-abi_test_clobber_r9
@@ -253,6 +263,7 @@ abi_test_clobber_r9:
 .hidden abi_test_clobber_r10
 .align	16
 abi_test_clobber_r10:
+_CET_ENDBR
 	xorq	%r10,%r10
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_r10,.-abi_test_clobber_r10
@@ -261,6 +272,7 @@ abi_test_clobber_r10:
 .hidden abi_test_clobber_r11
 .align	16
 abi_test_clobber_r11:
+_CET_ENDBR
 	xorq	%r11,%r11
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_r11,.-abi_test_clobber_r11
@@ -269,6 +281,7 @@ abi_test_clobber_r11:
 .hidden abi_test_clobber_r12
 .align	16
 abi_test_clobber_r12:
+_CET_ENDBR
 	xorq	%r12,%r12
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_r12,.-abi_test_clobber_r12
@@ -277,6 +290,7 @@ abi_test_clobber_r12:
 .hidden abi_test_clobber_r13
 .align	16
 abi_test_clobber_r13:
+_CET_ENDBR
 	xorq	%r13,%r13
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_r13,.-abi_test_clobber_r13
@@ -285,6 +299,7 @@ abi_test_clobber_r13:
 .hidden abi_test_clobber_r14
 .align	16
 abi_test_clobber_r14:
+_CET_ENDBR
 	xorq	%r14,%r14
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_r14,.-abi_test_clobber_r14
@@ -293,6 +308,7 @@ abi_test_clobber_r14:
 .hidden abi_test_clobber_r15
 .align	16
 abi_test_clobber_r15:
+_CET_ENDBR
 	xorq	%r15,%r15
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_r15,.-abi_test_clobber_r15
@@ -301,6 +317,7 @@ abi_test_clobber_r15:
 .hidden abi_test_clobber_xmm0
 .align	16
 abi_test_clobber_xmm0:
+_CET_ENDBR
 	pxor	%xmm0,%xmm0
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm0,.-abi_test_clobber_xmm0
@@ -309,6 +326,7 @@ abi_test_clobber_xmm0:
 .hidden abi_test_clobber_xmm1
 .align	16
 abi_test_clobber_xmm1:
+_CET_ENDBR
 	pxor	%xmm1,%xmm1
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm1,.-abi_test_clobber_xmm1
@@ -317,6 +335,7 @@ abi_test_clobber_xmm1:
 .hidden abi_test_clobber_xmm2
 .align	16
 abi_test_clobber_xmm2:
+_CET_ENDBR
 	pxor	%xmm2,%xmm2
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm2,.-abi_test_clobber_xmm2
@@ -325,6 +344,7 @@ abi_test_clobber_xmm2:
 .hidden abi_test_clobber_xmm3
 .align	16
 abi_test_clobber_xmm3:
+_CET_ENDBR
 	pxor	%xmm3,%xmm3
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm3,.-abi_test_clobber_xmm3
@@ -333,6 +353,7 @@ abi_test_clobber_xmm3:
 .hidden abi_test_clobber_xmm4
 .align	16
 abi_test_clobber_xmm4:
+_CET_ENDBR
 	pxor	%xmm4,%xmm4
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm4,.-abi_test_clobber_xmm4
@@ -341,6 +362,7 @@ abi_test_clobber_xmm4:
 .hidden abi_test_clobber_xmm5
 .align	16
 abi_test_clobber_xmm5:
+_CET_ENDBR
 	pxor	%xmm5,%xmm5
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm5,.-abi_test_clobber_xmm5
@@ -349,6 +371,7 @@ abi_test_clobber_xmm5:
 .hidden abi_test_clobber_xmm6
 .align	16
 abi_test_clobber_xmm6:
+_CET_ENDBR
 	pxor	%xmm6,%xmm6
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm6,.-abi_test_clobber_xmm6
@@ -357,6 +380,7 @@ abi_test_clobber_xmm6:
 .hidden abi_test_clobber_xmm7
 .align	16
 abi_test_clobber_xmm7:
+_CET_ENDBR
 	pxor	%xmm7,%xmm7
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm7,.-abi_test_clobber_xmm7
@@ -365,6 +389,7 @@ abi_test_clobber_xmm7:
 .hidden abi_test_clobber_xmm8
 .align	16
 abi_test_clobber_xmm8:
+_CET_ENDBR
 	pxor	%xmm8,%xmm8
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm8,.-abi_test_clobber_xmm8
@@ -373,6 +398,7 @@ abi_test_clobber_xmm8:
 .hidden abi_test_clobber_xmm9
 .align	16
 abi_test_clobber_xmm9:
+_CET_ENDBR
 	pxor	%xmm9,%xmm9
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm9,.-abi_test_clobber_xmm9
@@ -381,6 +407,7 @@ abi_test_clobber_xmm9:
 .hidden abi_test_clobber_xmm10
 .align	16
 abi_test_clobber_xmm10:
+_CET_ENDBR
 	pxor	%xmm10,%xmm10
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm10,.-abi_test_clobber_xmm10
@@ -389,6 +416,7 @@ abi_test_clobber_xmm10:
 .hidden abi_test_clobber_xmm11
 .align	16
 abi_test_clobber_xmm11:
+_CET_ENDBR
 	pxor	%xmm11,%xmm11
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm11,.-abi_test_clobber_xmm11
@@ -397,6 +425,7 @@ abi_test_clobber_xmm11:
 .hidden abi_test_clobber_xmm12
 .align	16
 abi_test_clobber_xmm12:
+_CET_ENDBR
 	pxor	%xmm12,%xmm12
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm12,.-abi_test_clobber_xmm12
@@ -405,6 +434,7 @@ abi_test_clobber_xmm12:
 .hidden abi_test_clobber_xmm13
 .align	16
 abi_test_clobber_xmm13:
+_CET_ENDBR
 	pxor	%xmm13,%xmm13
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm13,.-abi_test_clobber_xmm13
@@ -413,6 +443,7 @@ abi_test_clobber_xmm13:
 .hidden abi_test_clobber_xmm14
 .align	16
 abi_test_clobber_xmm14:
+_CET_ENDBR
 	pxor	%xmm14,%xmm14
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm14,.-abi_test_clobber_xmm14
@@ -421,6 +452,7 @@ abi_test_clobber_xmm14:
 .hidden abi_test_clobber_xmm15
 .align	16
 abi_test_clobber_xmm15:
+_CET_ENDBR
 	pxor	%xmm15,%xmm15
 	.byte	0xf3,0xc3
 .size	abi_test_clobber_xmm15,.-abi_test_clobber_xmm15
@@ -434,6 +466,7 @@ abi_test_clobber_xmm15:
 abi_test_bad_unwind_wrong_register:
 .cfi_startproc	
 
+_CET_ENDBR
 	pushq	%r12
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%r13,-16
@@ -460,6 +493,7 @@ abi_test_bad_unwind_wrong_register:
 abi_test_bad_unwind_temporary:
 .cfi_startproc	
 
+_CET_ENDBR
 	pushq	%r12
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%r12,-16
@@ -489,6 +523,7 @@ abi_test_bad_unwind_temporary:
 .globl	abi_test_get_and_clear_direction_flag
 .hidden abi_test_get_and_clear_direction_flag
 abi_test_get_and_clear_direction_flag:
+_CET_ENDBR
 	pushfq
 	popq	%rax
 	andq	$0x400,%rax
@@ -503,6 +538,7 @@ abi_test_get_and_clear_direction_flag:
 .globl	abi_test_set_direction_flag
 .hidden abi_test_set_direction_flag
 abi_test_set_direction_flag:
+_CET_ENDBR
 	std
 	.byte	0xf3,0xc3
 .size	abi_test_set_direction_flag,.-abi_test_set_direction_flag

--- a/generated-src/mac-x86_64/crypto/chacha/chacha-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/chacha/chacha-x86_64.S
@@ -45,6 +45,7 @@ L$sixteen:
 .p2align	6
 _ChaCha20_ctr32:
 
+_CET_ENDBR
 	cmpq	$0,%rdx
 	je	L$no_data
 	movq	_OPENSSL_ia32cap_P+4(%rip),%r10

--- a/generated-src/mac-x86_64/crypto/cipher_extra/aes128gcmsiv-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/cipher_extra/aes128gcmsiv-x86_64.S
@@ -71,6 +71,7 @@ GFMUL:
 .p2align	4
 _aesgcmsiv_htable_init:
 
+_CET_ENDBR
 	vmovdqa	(%rsi),%xmm0
 	vmovdqa	%xmm0,%xmm1
 	vmovdqa	%xmm0,(%rdi)
@@ -97,6 +98,7 @@ _aesgcmsiv_htable_init:
 .p2align	4
 _aesgcmsiv_htable6_init:
 
+_CET_ENDBR
 	vmovdqa	(%rsi),%xmm0
 	vmovdqa	%xmm0,%xmm1
 	vmovdqa	%xmm0,(%rdi)
@@ -119,6 +121,7 @@ _aesgcmsiv_htable6_init:
 .p2align	4
 _aesgcmsiv_htable_polyval:
 
+_CET_ENDBR
 	testq	%rdx,%rdx
 	jnz	L$htable_polyval_start
 	.byte	0xf3,0xc3
@@ -336,6 +339,7 @@ L$htable_polyval_out:
 .p2align	4
 _aesgcmsiv_polyval_horner:
 
+_CET_ENDBR
 	testq	%rcx,%rcx
 	jnz	L$polyval_horner_start
 	.byte	0xf3,0xc3
@@ -369,6 +373,7 @@ L$polyval_horner_loop:
 .p2align	4
 _aes128gcmsiv_aes_ks:
 
+_CET_ENDBR
 	vmovdqu	(%rdi),%xmm1
 	vmovdqa	%xmm1,(%rsi)
 
@@ -425,6 +430,7 @@ L$ks128_loop:
 .p2align	4
 _aes256gcmsiv_aes_ks:
 
+_CET_ENDBR
 	vmovdqu	(%rdi),%xmm1
 	vmovdqu	16(%rdi),%xmm3
 	vmovdqa	%xmm1,(%rsi)
@@ -472,6 +478,7 @@ L$ks256_loop:
 .p2align	4
 _aes128gcmsiv_aes_ks_enc_x1:
 
+_CET_ENDBR
 	vmovdqa	(%rcx),%xmm1
 	vmovdqa	0(%rdi),%xmm4
 
@@ -614,6 +621,7 @@ _aes128gcmsiv_aes_ks_enc_x1:
 .p2align	4
 _aes128gcmsiv_kdf:
 
+_CET_ENDBR
 
 
 
@@ -707,6 +715,7 @@ _aes128gcmsiv_kdf:
 .p2align	4
 _aes128gcmsiv_enc_msg_x4:
 
+_CET_ENDBR
 	testq	%r8,%r8
 	jnz	L$128_enc_msg_x4_start
 	.byte	0xf3,0xc3
@@ -882,6 +891,7 @@ L$128_enc_msg_x4_out:
 .p2align	4
 _aes128gcmsiv_enc_msg_x8:
 
+_CET_ENDBR
 	testq	%r8,%r8
 	jnz	L$128_enc_msg_x8_start
 	.byte	0xf3,0xc3
@@ -1137,6 +1147,7 @@ L$128_enc_msg_x8_out:
 .p2align	4
 _aes128gcmsiv_dec:
 
+_CET_ENDBR
 	testq	$~15,%r9
 	jnz	L$128_dec_start
 	.byte	0xf3,0xc3
@@ -1629,6 +1640,7 @@ L$128_dec_out:
 .p2align	4
 _aes128gcmsiv_ecb_enc_block:
 
+_CET_ENDBR
 	vmovdqa	(%rdi),%xmm1
 
 	vpxor	(%rdx),%xmm1,%xmm1
@@ -1654,6 +1666,7 @@ _aes128gcmsiv_ecb_enc_block:
 .p2align	4
 _aes256gcmsiv_aes_ks_enc_x1:
 
+_CET_ENDBR
 	vmovdqa	con1(%rip),%xmm0
 	vmovdqa	mask(%rip),%xmm15
 	vmovdqa	(%rdi),%xmm8
@@ -1837,6 +1850,7 @@ _aes256gcmsiv_aes_ks_enc_x1:
 .p2align	4
 _aes256gcmsiv_ecb_enc_block:
 
+_CET_ENDBR
 	vmovdqa	(%rdi),%xmm1
 	vpxor	(%rdx),%xmm1,%xmm1
 	vaesenc	16(%rdx),%xmm1,%xmm1
@@ -1863,6 +1877,7 @@ _aes256gcmsiv_ecb_enc_block:
 .p2align	4
 _aes256gcmsiv_enc_msg_x4:
 
+_CET_ENDBR
 	testq	%r8,%r8
 	jnz	L$256_enc_msg_x4_start
 	.byte	0xf3,0xc3
@@ -2064,6 +2079,7 @@ L$256_enc_msg_x4_out:
 .p2align	4
 _aes256gcmsiv_enc_msg_x8:
 
+_CET_ENDBR
 	testq	%r8,%r8
 	jnz	L$256_enc_msg_x8_start
 	.byte	0xf3,0xc3
@@ -2353,6 +2369,7 @@ L$256_enc_msg_x8_out:
 .p2align	4
 _aes256gcmsiv_dec:
 
+_CET_ENDBR
 	testq	$~15,%r9
 	jnz	L$256_dec_start
 	.byte	0xf3,0xc3
@@ -2913,6 +2930,7 @@ L$256_dec_out:
 .p2align	4
 _aes256gcmsiv_kdf:
 
+_CET_ENDBR
 
 
 

--- a/generated-src/mac-x86_64/crypto/cipher_extra/chacha20_poly1305_x86_64.S
+++ b/generated-src/mac-x86_64/crypto/cipher_extra/chacha20_poly1305_x86_64.S
@@ -222,6 +222,7 @@ L$hash_ad_done:
 .p2align	6
 _chacha20_poly1305_open:
 
+_CET_ENDBR
 	pushq	%rbp
 
 	pushq	%rbx
@@ -2093,6 +2094,7 @@ L$open_sse_128_xor_hash:
 .p2align	6
 _chacha20_poly1305_seal:
 
+_CET_ENDBR
 	pushq	%rbp
 
 	pushq	%rbx

--- a/generated-src/mac-x86_64/crypto/fipsmodule/aesni-gcm-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/aesni-gcm-x86_64.S
@@ -346,6 +346,7 @@ L$6x_done:
 _aesni_gcm_decrypt:
 
 
+_CET_ENDBR
 	xorq	%rax,%rax
 
 
@@ -562,6 +563,7 @@ L$handle_ctr32_2:
 _aesni_gcm_encrypt:
 
 
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 
 	movb	$1,_BORINGSSL_function_hit+2(%rip)

--- a/generated-src/mac-x86_64/crypto/fipsmodule/aesni-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/aesni-x86_64.S
@@ -12,6 +12,7 @@
 .p2align	4
 _aes_hw_encrypt:
 
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 
 	movb	$1,_BORINGSSL_function_hit+1(%rip)
@@ -43,6 +44,7 @@ L$oop_enc1_1:
 .p2align	4
 _aes_hw_decrypt:
 
+_CET_ENDBR
 	movups	(%rdi),%xmm2
 	movl	240(%rdx),%eax
 	movups	(%rdx),%xmm0
@@ -531,6 +533,7 @@ L$dec_loop8_enter:
 .p2align	4
 _aes_hw_ecb_encrypt:
 
+_CET_ENDBR
 	andq	$-16,%rdx
 	jz	L$ecb_ret
 
@@ -876,6 +879,7 @@ L$ecb_ret:
 .p2align	4
 _aes_hw_ctr32_encrypt_blocks:
 
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 	movb	$1,_BORINGSSL_function_hit(%rip)
 #endif
@@ -1461,6 +1465,7 @@ L$ctr32_epilogue:
 .p2align	4
 _aes_hw_xts_encrypt:
 
+_CET_ENDBR
 	leaq	(%rsp),%r11
 
 	pushq	%rbp
@@ -1932,6 +1937,7 @@ L$xts_enc_epilogue:
 .p2align	4
 _aes_hw_xts_decrypt:
 
+_CET_ENDBR
 	leaq	(%rsp),%r11
 
 	pushq	%rbp
@@ -2440,6 +2446,7 @@ L$xts_dec_epilogue:
 .p2align	4
 _aes_hw_cbc_encrypt:
 
+_CET_ENDBR
 	testq	%rdx,%rdx
 	jz	L$cbc_ret
 
@@ -3033,6 +3040,7 @@ L$cbc_ret:
 .p2align	4
 _aes_hw_set_decrypt_key:
 
+_CET_ENDBR
 .byte	0x48,0x83,0xEC,0x08
 
 	call	__aesni_set_encrypt_key
@@ -3079,6 +3087,7 @@ L$SEH_end_set_decrypt_key:
 _aes_hw_set_encrypt_key:
 __aesni_set_encrypt_key:
 
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 	movb	$1,_BORINGSSL_function_hit+3(%rip)
 #endif

--- a/generated-src/mac-x86_64/crypto/fipsmodule/ghash-ssse3-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/ghash-ssse3-x86_64.S
@@ -17,6 +17,7 @@
 _gcm_gmult_ssse3:
 
 
+_CET_ENDBR
 	movdqu	(%rdi),%xmm0
 	movdqa	L$reverse_bytes(%rip),%xmm10
 	movdqa	L$low4_mask(%rip),%xmm2
@@ -207,6 +208,7 @@ L$oop_row_3:
 _gcm_ghash_ssse3:
 
 
+_CET_ENDBR
 	movdqu	(%rdi),%xmm0
 	movdqa	L$reverse_bytes(%rip),%xmm10
 	movdqa	L$low4_mask(%rip),%xmm11

--- a/generated-src/mac-x86_64/crypto/fipsmodule/ghash-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/ghash-x86_64.S
@@ -13,6 +13,7 @@
 _gcm_init_clmul:
 
 
+_CET_ENDBR
 L$_init_clmul:
 	movdqu	(%rsi),%xmm2
 	pshufd	$78,%xmm2,%xmm2
@@ -173,6 +174,7 @@ L$_init_clmul:
 .p2align	4
 _gcm_gmult_clmul:
 
+_CET_ENDBR
 L$_gmult_clmul:
 	movdqu	(%rdi),%xmm0
 	movdqa	L$bswap_mask(%rip),%xmm5
@@ -228,6 +230,7 @@ L$_gmult_clmul:
 _gcm_ghash_clmul:
 
 
+_CET_ENDBR
 L$_ghash_clmul:
 	movdqa	L$bswap_mask(%rip),%xmm10
 
@@ -616,6 +619,7 @@ L$done:
 .p2align	5
 _gcm_init_avx:
 
+_CET_ENDBR
 	vzeroupper
 
 	vmovdqu	(%rsi),%xmm2
@@ -727,6 +731,7 @@ L$init_start_avx:
 .p2align	5
 _gcm_gmult_avx:
 
+_CET_ENDBR
 	jmp	L$_gmult_clmul
 
 
@@ -736,6 +741,7 @@ _gcm_gmult_avx:
 .p2align	5
 _gcm_ghash_avx:
 
+_CET_ENDBR
 	vzeroupper
 
 	vmovdqu	(%rdi),%xmm10

--- a/generated-src/mac-x86_64/crypto/fipsmodule/md5-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/md5-x86_64.S
@@ -12,6 +12,7 @@
 
 _md5_block_asm_data_order:
 
+_CET_ENDBR
 	pushq	%rbp
 
 	pushq	%rbx

--- a/generated-src/mac-x86_64/crypto/fipsmodule/p256-x86_64-asm.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/p256-x86_64-asm.S
@@ -37,6 +37,7 @@ L$ordK:
 .p2align	5
 _ecp_nistz256_neg:
 
+_CET_ENDBR
 	pushq	%r12
 
 	pushq	%r13
@@ -97,6 +98,7 @@ L$neg_epilogue:
 .p2align	5
 _ecp_nistz256_ord_mul_mont:
 
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -427,6 +429,7 @@ L$ord_mul_epilogue:
 .p2align	5
 _ecp_nistz256_ord_sqr_mont:
 
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -1172,6 +1175,7 @@ L$ord_sqrx_epilogue:
 .p2align	5
 _ecp_nistz256_mul_mont:
 
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -1469,6 +1473,7 @@ __ecp_nistz256_mul_montq:
 .p2align	5
 _ecp_nistz256_sqr_mont:
 
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -2001,6 +2006,7 @@ __ecp_nistz256_sqr_montx:
 .p2align	5
 _ecp_nistz256_select_w5:
 
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rax
 	movq	8(%rax),%rax
@@ -2070,6 +2076,7 @@ L$SEH_end_ecp_nistz256_select_w5:
 .p2align	5
 _ecp_nistz256_select_w7:
 
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rax
 	movq	8(%rax),%rax
@@ -2194,6 +2201,7 @@ L$SEH_end_ecp_nistz256_avx2_select_w5:
 _ecp_nistz256_avx2_select_w7:
 
 L$avx2_select_w7:
+_CET_ENDBR
 	vzeroupper
 	vmovdqa	L$Three(%rip),%ymm0
 
@@ -2401,6 +2409,7 @@ __ecp_nistz256_mul_by_2q:
 .p2align	5
 _ecp_nistz256_point_double:
 
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -2631,6 +2640,7 @@ L$point_doubleq_epilogue:
 .p2align	5
 _ecp_nistz256_point_add:
 
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
@@ -3064,6 +3074,7 @@ L$point_addq_epilogue:
 .p2align	5
 _ecp_nistz256_point_add_affine:
 
+_CET_ENDBR
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx

--- a/generated-src/mac-x86_64/crypto/fipsmodule/p256_beeu-x86_64-asm.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/p256_beeu-x86_64-asm.S
@@ -13,6 +13,7 @@
 .p2align	5
 _beeu_mod_inverse_vartime:
 
+_CET_ENDBR
 	pushq	%rbp
 
 	pushq	%r12

--- a/generated-src/mac-x86_64/crypto/fipsmodule/rdrand-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/rdrand-x86_64.S
@@ -15,6 +15,7 @@
 .p2align	4
 _CRYPTO_rdrand:
 
+_CET_ENDBR
 	xorq	%rax,%rax
 .byte	72,15,199,242
 	testq	%rdx,%rdx
@@ -41,6 +42,7 @@ L$err:
 .p2align	4
 _CRYPTO_rdrand_multiple8_buf:
 
+_CET_ENDBR
 	testq	%rsi,%rsi
 	jz	L$out
 	movq	$8,%rdx

--- a/generated-src/mac-x86_64/crypto/fipsmodule/rsaz-avx2.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/rsaz-avx2.S
@@ -12,6 +12,7 @@
 .p2align	6
 _rsaz_1024_sqr_avx2:
 
+_CET_ENDBR
 	leaq	(%rsp),%rax
 
 	pushq	%rbx
@@ -666,6 +667,7 @@ L$sqr_1024_epilogue:
 .p2align	6
 _rsaz_1024_mul_avx2:
 
+_CET_ENDBR
 	leaq	(%rsp),%rax
 
 	pushq	%rbx
@@ -1222,6 +1224,7 @@ L$mul_1024_epilogue:
 .p2align	5
 _rsaz_1024_red2norm_avx2:
 
+_CET_ENDBR
 	subq	$-128,%rsi
 	xorq	%rax,%rax
 	movq	-128(%rsi),%r8
@@ -1422,6 +1425,7 @@ _rsaz_1024_red2norm_avx2:
 .p2align	5
 _rsaz_1024_norm2red_avx2:
 
+_CET_ENDBR
 	subq	$-128,%rdi
 	movq	(%rsi),%r8
 	movl	$0x1fffffff,%eax
@@ -1582,6 +1586,7 @@ _rsaz_1024_norm2red_avx2:
 .p2align	5
 _rsaz_1024_scatter5_avx2:
 
+_CET_ENDBR
 	vzeroupper
 	vmovdqu	L$scatter_permd(%rip),%ymm5
 	shll	$4,%edx
@@ -1610,6 +1615,7 @@ L$oop_scatter_1024:
 .p2align	5
 _rsaz_1024_gather5_avx2:
 
+_CET_ENDBR
 	vzeroupper
 	movq	%rsp,%r11
 

--- a/generated-src/mac-x86_64/crypto/fipsmodule/sha1-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/sha1-x86_64.S
@@ -13,6 +13,7 @@
 .p2align	4
 _sha1_block_data_order:
 
+_CET_ENDBR
 	leaq	_OPENSSL_ia32cap_P(%rip),%r10
 	movl	0(%r10),%r9d
 	movl	4(%r10),%r8d

--- a/generated-src/mac-x86_64/crypto/fipsmodule/sha256-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/sha256-x86_64.S
@@ -13,6 +13,7 @@
 .p2align	4
 _sha256_block_data_order:
 
+_CET_ENDBR
 	leaq	_OPENSSL_ia32cap_P(%rip),%r11
 	movl	0(%r11),%r9d
 	movl	4(%r11),%r10d

--- a/generated-src/mac-x86_64/crypto/fipsmodule/sha512-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/sha512-x86_64.S
@@ -13,6 +13,7 @@
 .p2align	4
 _sha512_block_data_order:
 
+_CET_ENDBR
 	leaq	_OPENSSL_ia32cap_P(%rip),%r11
 	movl	0(%r11),%r9d
 	movl	4(%r11),%r10d

--- a/generated-src/mac-x86_64/crypto/fipsmodule/vpaes-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/vpaes-x86_64.S
@@ -805,6 +805,7 @@ L$schedule_mangle_both:
 .p2align	4
 _vpaes_set_encrypt_key:
 
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 
 	movb	$1,_BORINGSSL_function_hit+5(%rip)
@@ -829,6 +830,7 @@ _vpaes_set_encrypt_key:
 .p2align	4
 _vpaes_set_decrypt_key:
 
+_CET_ENDBR
 	movl	%esi,%eax
 	shrl	$5,%eax
 	addl	$5,%eax
@@ -853,6 +855,7 @@ _vpaes_set_decrypt_key:
 .p2align	4
 _vpaes_encrypt:
 
+_CET_ENDBR
 #ifdef BORINGSSL_DISPATCH_TEST
 
 	movb	$1,_BORINGSSL_function_hit+4(%rip)
@@ -871,6 +874,7 @@ _vpaes_encrypt:
 .p2align	4
 _vpaes_decrypt:
 
+_CET_ENDBR
 	movdqu	(%rdi),%xmm0
 	call	_vpaes_preheat
 	call	_vpaes_decrypt_core
@@ -884,6 +888,7 @@ _vpaes_decrypt:
 .p2align	4
 _vpaes_cbc_encrypt:
 
+_CET_ENDBR
 	xchgq	%rcx,%rdx
 	subq	$16,%rcx
 	jc	L$cbc_abort
@@ -927,6 +932,7 @@ L$cbc_abort:
 .p2align	4
 _vpaes_ctr32_encrypt_blocks:
 
+_CET_ENDBR
 
 	xchgq	%rcx,%rdx
 	testq	%rcx,%rcx

--- a/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont.S
@@ -14,6 +14,7 @@
 .p2align	4
 _bn_mul_mont:
 
+_CET_ENDBR
 	movl	%r9d,%r9d
 	movq	%rsp,%rax
 

--- a/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont5.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont5.S
@@ -14,6 +14,7 @@
 .p2align	6
 _bn_mul_mont_gather5:
 
+_CET_ENDBR
 	movl	%r9d,%r9d
 	movq	%rsp,%rax
 
@@ -1096,6 +1097,7 @@ L$inner4x:
 .p2align	5
 _bn_power5:
 
+_CET_ENDBR
 	movq	%rsp,%rax
 
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -1237,6 +1239,7 @@ L$power5_epilogue:
 _bn_sqr8x_internal:
 __bn_sqr8x_internal:
 
+_CET_ENDBR
 
 
 
@@ -2750,6 +2753,7 @@ L$powerx5_epilogue:
 _bn_sqrx8x_internal:
 __bn_sqrx8x_internal:
 
+_CET_ENDBR
 
 
 
@@ -3423,6 +3427,7 @@ L$sqrx4x_sub_entry:
 .p2align	4
 _bn_scatter5:
 
+_CET_ENDBR
 	cmpl	$0,%esi
 	jz	L$scatter_epilogue
 
@@ -3454,6 +3459,7 @@ L$scatter_epilogue:
 _bn_gather5:
 
 L$SEH_begin_bn_gather5:
+_CET_ENDBR
 
 .byte	0x4c,0x8d,0x14,0x24
 

--- a/generated-src/mac-x86_64/crypto/test/trampoline-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/test/trampoline-x86_64.S
@@ -20,6 +20,7 @@
 _abi_test_trampoline:
 
 
+_CET_ENDBR
 
 
 
@@ -181,6 +182,7 @@ L$call_done:
 .private_extern _abi_test_clobber_rax
 .p2align	4
 _abi_test_clobber_rax:
+_CET_ENDBR
 	xorq	%rax,%rax
 	.byte	0xf3,0xc3
 
@@ -189,6 +191,7 @@ _abi_test_clobber_rax:
 .private_extern _abi_test_clobber_rbx
 .p2align	4
 _abi_test_clobber_rbx:
+_CET_ENDBR
 	xorq	%rbx,%rbx
 	.byte	0xf3,0xc3
 
@@ -197,6 +200,7 @@ _abi_test_clobber_rbx:
 .private_extern _abi_test_clobber_rcx
 .p2align	4
 _abi_test_clobber_rcx:
+_CET_ENDBR
 	xorq	%rcx,%rcx
 	.byte	0xf3,0xc3
 
@@ -205,6 +209,7 @@ _abi_test_clobber_rcx:
 .private_extern _abi_test_clobber_rdx
 .p2align	4
 _abi_test_clobber_rdx:
+_CET_ENDBR
 	xorq	%rdx,%rdx
 	.byte	0xf3,0xc3
 
@@ -213,6 +218,7 @@ _abi_test_clobber_rdx:
 .private_extern _abi_test_clobber_rdi
 .p2align	4
 _abi_test_clobber_rdi:
+_CET_ENDBR
 	xorq	%rdi,%rdi
 	.byte	0xf3,0xc3
 
@@ -221,6 +227,7 @@ _abi_test_clobber_rdi:
 .private_extern _abi_test_clobber_rsi
 .p2align	4
 _abi_test_clobber_rsi:
+_CET_ENDBR
 	xorq	%rsi,%rsi
 	.byte	0xf3,0xc3
 
@@ -229,6 +236,7 @@ _abi_test_clobber_rsi:
 .private_extern _abi_test_clobber_rbp
 .p2align	4
 _abi_test_clobber_rbp:
+_CET_ENDBR
 	xorq	%rbp,%rbp
 	.byte	0xf3,0xc3
 
@@ -237,6 +245,7 @@ _abi_test_clobber_rbp:
 .private_extern _abi_test_clobber_r8
 .p2align	4
 _abi_test_clobber_r8:
+_CET_ENDBR
 	xorq	%r8,%r8
 	.byte	0xf3,0xc3
 
@@ -245,6 +254,7 @@ _abi_test_clobber_r8:
 .private_extern _abi_test_clobber_r9
 .p2align	4
 _abi_test_clobber_r9:
+_CET_ENDBR
 	xorq	%r9,%r9
 	.byte	0xf3,0xc3
 
@@ -253,6 +263,7 @@ _abi_test_clobber_r9:
 .private_extern _abi_test_clobber_r10
 .p2align	4
 _abi_test_clobber_r10:
+_CET_ENDBR
 	xorq	%r10,%r10
 	.byte	0xf3,0xc3
 
@@ -261,6 +272,7 @@ _abi_test_clobber_r10:
 .private_extern _abi_test_clobber_r11
 .p2align	4
 _abi_test_clobber_r11:
+_CET_ENDBR
 	xorq	%r11,%r11
 	.byte	0xf3,0xc3
 
@@ -269,6 +281,7 @@ _abi_test_clobber_r11:
 .private_extern _abi_test_clobber_r12
 .p2align	4
 _abi_test_clobber_r12:
+_CET_ENDBR
 	xorq	%r12,%r12
 	.byte	0xf3,0xc3
 
@@ -277,6 +290,7 @@ _abi_test_clobber_r12:
 .private_extern _abi_test_clobber_r13
 .p2align	4
 _abi_test_clobber_r13:
+_CET_ENDBR
 	xorq	%r13,%r13
 	.byte	0xf3,0xc3
 
@@ -285,6 +299,7 @@ _abi_test_clobber_r13:
 .private_extern _abi_test_clobber_r14
 .p2align	4
 _abi_test_clobber_r14:
+_CET_ENDBR
 	xorq	%r14,%r14
 	.byte	0xf3,0xc3
 
@@ -293,6 +308,7 @@ _abi_test_clobber_r14:
 .private_extern _abi_test_clobber_r15
 .p2align	4
 _abi_test_clobber_r15:
+_CET_ENDBR
 	xorq	%r15,%r15
 	.byte	0xf3,0xc3
 
@@ -301,6 +317,7 @@ _abi_test_clobber_r15:
 .private_extern _abi_test_clobber_xmm0
 .p2align	4
 _abi_test_clobber_xmm0:
+_CET_ENDBR
 	pxor	%xmm0,%xmm0
 	.byte	0xf3,0xc3
 
@@ -309,6 +326,7 @@ _abi_test_clobber_xmm0:
 .private_extern _abi_test_clobber_xmm1
 .p2align	4
 _abi_test_clobber_xmm1:
+_CET_ENDBR
 	pxor	%xmm1,%xmm1
 	.byte	0xf3,0xc3
 
@@ -317,6 +335,7 @@ _abi_test_clobber_xmm1:
 .private_extern _abi_test_clobber_xmm2
 .p2align	4
 _abi_test_clobber_xmm2:
+_CET_ENDBR
 	pxor	%xmm2,%xmm2
 	.byte	0xf3,0xc3
 
@@ -325,6 +344,7 @@ _abi_test_clobber_xmm2:
 .private_extern _abi_test_clobber_xmm3
 .p2align	4
 _abi_test_clobber_xmm3:
+_CET_ENDBR
 	pxor	%xmm3,%xmm3
 	.byte	0xf3,0xc3
 
@@ -333,6 +353,7 @@ _abi_test_clobber_xmm3:
 .private_extern _abi_test_clobber_xmm4
 .p2align	4
 _abi_test_clobber_xmm4:
+_CET_ENDBR
 	pxor	%xmm4,%xmm4
 	.byte	0xf3,0xc3
 
@@ -341,6 +362,7 @@ _abi_test_clobber_xmm4:
 .private_extern _abi_test_clobber_xmm5
 .p2align	4
 _abi_test_clobber_xmm5:
+_CET_ENDBR
 	pxor	%xmm5,%xmm5
 	.byte	0xf3,0xc3
 
@@ -349,6 +371,7 @@ _abi_test_clobber_xmm5:
 .private_extern _abi_test_clobber_xmm6
 .p2align	4
 _abi_test_clobber_xmm6:
+_CET_ENDBR
 	pxor	%xmm6,%xmm6
 	.byte	0xf3,0xc3
 
@@ -357,6 +380,7 @@ _abi_test_clobber_xmm6:
 .private_extern _abi_test_clobber_xmm7
 .p2align	4
 _abi_test_clobber_xmm7:
+_CET_ENDBR
 	pxor	%xmm7,%xmm7
 	.byte	0xf3,0xc3
 
@@ -365,6 +389,7 @@ _abi_test_clobber_xmm7:
 .private_extern _abi_test_clobber_xmm8
 .p2align	4
 _abi_test_clobber_xmm8:
+_CET_ENDBR
 	pxor	%xmm8,%xmm8
 	.byte	0xf3,0xc3
 
@@ -373,6 +398,7 @@ _abi_test_clobber_xmm8:
 .private_extern _abi_test_clobber_xmm9
 .p2align	4
 _abi_test_clobber_xmm9:
+_CET_ENDBR
 	pxor	%xmm9,%xmm9
 	.byte	0xf3,0xc3
 
@@ -381,6 +407,7 @@ _abi_test_clobber_xmm9:
 .private_extern _abi_test_clobber_xmm10
 .p2align	4
 _abi_test_clobber_xmm10:
+_CET_ENDBR
 	pxor	%xmm10,%xmm10
 	.byte	0xf3,0xc3
 
@@ -389,6 +416,7 @@ _abi_test_clobber_xmm10:
 .private_extern _abi_test_clobber_xmm11
 .p2align	4
 _abi_test_clobber_xmm11:
+_CET_ENDBR
 	pxor	%xmm11,%xmm11
 	.byte	0xf3,0xc3
 
@@ -397,6 +425,7 @@ _abi_test_clobber_xmm11:
 .private_extern _abi_test_clobber_xmm12
 .p2align	4
 _abi_test_clobber_xmm12:
+_CET_ENDBR
 	pxor	%xmm12,%xmm12
 	.byte	0xf3,0xc3
 
@@ -405,6 +434,7 @@ _abi_test_clobber_xmm12:
 .private_extern _abi_test_clobber_xmm13
 .p2align	4
 _abi_test_clobber_xmm13:
+_CET_ENDBR
 	pxor	%xmm13,%xmm13
 	.byte	0xf3,0xc3
 
@@ -413,6 +443,7 @@ _abi_test_clobber_xmm13:
 .private_extern _abi_test_clobber_xmm14
 .p2align	4
 _abi_test_clobber_xmm14:
+_CET_ENDBR
 	pxor	%xmm14,%xmm14
 	.byte	0xf3,0xc3
 
@@ -421,6 +452,7 @@ _abi_test_clobber_xmm14:
 .private_extern _abi_test_clobber_xmm15
 .p2align	4
 _abi_test_clobber_xmm15:
+_CET_ENDBR
 	pxor	%xmm15,%xmm15
 	.byte	0xf3,0xc3
 
@@ -434,6 +466,7 @@ _abi_test_clobber_xmm15:
 _abi_test_bad_unwind_wrong_register:
 
 
+_CET_ENDBR
 	pushq	%r12
 
 
@@ -458,6 +491,7 @@ _abi_test_bad_unwind_wrong_register:
 _abi_test_bad_unwind_temporary:
 
 
+_CET_ENDBR
 	pushq	%r12
 
 
@@ -485,6 +519,7 @@ _abi_test_bad_unwind_temporary:
 .globl	_abi_test_get_and_clear_direction_flag
 .private_extern _abi_test_get_and_clear_direction_flag
 _abi_test_get_and_clear_direction_flag:
+_CET_ENDBR
 	pushfq
 	popq	%rax
 	andq	$0x400,%rax
@@ -499,6 +534,7 @@ _abi_test_get_and_clear_direction_flag:
 .globl	_abi_test_set_direction_flag
 .private_extern _abi_test_set_direction_flag
 _abi_test_set_direction_flag:
+_CET_ENDBR
 	std
 	.byte	0xf3,0xc3
 

--- a/generated-src/win-x86_64/crypto/chacha/chacha-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/chacha/chacha-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -65,6 +66,7 @@ $L$SEH_begin_ChaCha20_ctr32:
 
 
 
+_CET_ENDBR
 	cmp	rdx,0
 	je	NEAR $L$no_data
 	mov	r10,QWORD[((OPENSSL_ia32cap_P+4))]

--- a/generated-src/win-x86_64/crypto/cipher_extra/aes128gcmsiv-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/cipher_extra/aes128gcmsiv-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.rdata rdata align=8
@@ -83,6 +84,7 @@ $L$SEH_begin_aesgcmsiv_htable_init:
 
 
 
+_CET_ENDBR
 	vmovdqa	xmm0,XMMWORD[rsi]
 	vmovdqa	xmm1,xmm0
 	vmovdqa	XMMWORD[rdi],xmm0
@@ -118,6 +120,7 @@ $L$SEH_begin_aesgcmsiv_htable6_init:
 
 
 
+_CET_ENDBR
 	vmovdqa	xmm0,XMMWORD[rsi]
 	vmovdqa	xmm1,xmm0
 	vmovdqa	XMMWORD[rdi],xmm0
@@ -151,6 +154,7 @@ $L$SEH_begin_aesgcmsiv_htable_polyval:
 
 
 
+_CET_ENDBR
 	test	rdx,rdx
 	jnz	NEAR $L$htable_polyval_start
 	mov	rdi,QWORD[8+rsp]	;WIN64 epilogue
@@ -381,6 +385,7 @@ $L$SEH_begin_aesgcmsiv_polyval_horner:
 
 
 
+_CET_ENDBR
 	test	rcx,rcx
 	jnz	NEAR $L$polyval_horner_start
 	mov	rdi,QWORD[8+rsp]	;WIN64 epilogue
@@ -425,6 +430,7 @@ $L$SEH_begin_aes128gcmsiv_aes_ks:
 
 
 
+_CET_ENDBR
 	vmovdqu	xmm1,XMMWORD[rdi]
 	vmovdqa	XMMWORD[rsi],xmm1
 
@@ -490,6 +496,7 @@ $L$SEH_begin_aes256gcmsiv_aes_ks:
 
 
 
+_CET_ENDBR
 	vmovdqu	xmm1,XMMWORD[rdi]
 	vmovdqu	xmm3,XMMWORD[16+rdi]
 	vmovdqa	XMMWORD[rsi],xmm1
@@ -548,6 +555,7 @@ $L$SEH_begin_aes128gcmsiv_aes_ks_enc_x1:
 
 
 
+_CET_ENDBR
 	vmovdqa	xmm1,XMMWORD[rcx]
 	vmovdqa	xmm4,XMMWORD[rdi]
 
@@ -700,6 +708,7 @@ $L$SEH_begin_aes128gcmsiv_kdf:
 
 
 
+_CET_ENDBR
 
 
 
@@ -805,6 +814,7 @@ $L$SEH_begin_aes128gcmsiv_enc_msg_x4:
 
 
 
+_CET_ENDBR
 	test	r8,r8
 	jnz	NEAR $L$128_enc_msg_x4_start
 	mov	rdi,QWORD[8+rsp]	;WIN64 epilogue
@@ -994,6 +1004,7 @@ $L$SEH_begin_aes128gcmsiv_enc_msg_x8:
 
 
 
+_CET_ENDBR
 	test	r8,r8
 	jnz	NEAR $L$128_enc_msg_x8_start
 	mov	rdi,QWORD[8+rsp]	;WIN64 epilogue
@@ -1264,6 +1275,7 @@ $L$SEH_begin_aes128gcmsiv_dec:
 
 
 
+_CET_ENDBR
 	test	r9,~15
 	jnz	NEAR $L$128_dec_start
 	mov	rdi,QWORD[8+rsp]	;WIN64 epilogue
@@ -1768,6 +1780,7 @@ $L$SEH_begin_aes128gcmsiv_ecb_enc_block:
 
 
 
+_CET_ENDBR
 	vmovdqa	xmm1,XMMWORD[rdi]
 
 	vpxor	xmm1,xmm1,XMMWORD[rdx]
@@ -1804,6 +1817,7 @@ $L$SEH_begin_aes256gcmsiv_aes_ks_enc_x1:
 
 
 
+_CET_ENDBR
 	vmovdqa	xmm0,XMMWORD[con1]
 	vmovdqa	xmm15,XMMWORD[mask]
 	vmovdqa	xmm8,XMMWORD[rdi]
@@ -1997,6 +2011,7 @@ $L$SEH_begin_aes256gcmsiv_ecb_enc_block:
 
 
 
+_CET_ENDBR
 	vmovdqa	xmm1,XMMWORD[rdi]
 	vpxor	xmm1,xmm1,XMMWORD[rdx]
 	vaesenc	xmm1,xmm1,XMMWORD[16+rdx]
@@ -2035,6 +2050,7 @@ $L$SEH_begin_aes256gcmsiv_enc_msg_x4:
 
 
 
+_CET_ENDBR
 	test	r8,r8
 	jnz	NEAR $L$256_enc_msg_x4_start
 	mov	rdi,QWORD[8+rsp]	;WIN64 epilogue
@@ -2250,6 +2266,7 @@ $L$SEH_begin_aes256gcmsiv_enc_msg_x8:
 
 
 
+_CET_ENDBR
 	test	r8,r8
 	jnz	NEAR $L$256_enc_msg_x8_start
 	mov	rdi,QWORD[8+rsp]	;WIN64 epilogue
@@ -2554,6 +2571,7 @@ $L$SEH_begin_aes256gcmsiv_dec:
 
 
 
+_CET_ENDBR
 	test	r9,~15
 	jnz	NEAR $L$256_dec_start
 	mov	rdi,QWORD[8+rsp]	;WIN64 epilogue
@@ -3126,6 +3144,7 @@ $L$SEH_begin_aes256gcmsiv_kdf:
 
 
 
+_CET_ENDBR
 
 
 

--- a/generated-src/win-x86_64/crypto/cipher_extra/aesni-sha1-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/cipher_extra/aesni-sha1-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64

--- a/generated-src/win-x86_64/crypto/cipher_extra/aesni-sha256-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/cipher_extra/aesni-sha256-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64

--- a/generated-src/win-x86_64/crypto/cipher_extra/chacha20_poly1305_x86_64.asm
+++ b/generated-src/win-x86_64/crypto/cipher_extra/chacha20_poly1305_x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -239,6 +240,7 @@ $L$SEH_begin_chacha20_poly1305_open:
 
 
 
+_CET_ENDBR
 	push	rbp
 
 	push	rbx
@@ -2145,6 +2147,7 @@ $L$SEH_begin_chacha20_poly1305_seal:
 
 
 
+_CET_ENDBR
 	push	rbp
 
 	push	rbx

--- a/generated-src/win-x86_64/crypto/fipsmodule/aesni-gcm-avx512.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/aesni-gcm-avx512.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64

--- a/generated-src/win-x86_64/crypto/fipsmodule/aesni-gcm-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/aesni-gcm-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -350,6 +351,7 @@ ALIGN	32
 aesni_gcm_decrypt:
 
 $L$SEH_begin_aesni_gcm_decrypt_1:
+_CET_ENDBR
 	xor	rax,rax
 
 
@@ -610,6 +612,7 @@ ALIGN	32
 aesni_gcm_encrypt:
 
 $L$SEH_begin_aesni_gcm_encrypt_1:
+_CET_ENDBR
 %ifdef BORINGSSL_DISPATCH_TEST
 EXTERN	BORINGSSL_function_hit
 	mov	BYTE[((BORINGSSL_function_hit+2))],1

--- a/generated-src/win-x86_64/crypto/fipsmodule/aesni-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/aesni-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -16,6 +17,7 @@ global	aes_hw_encrypt
 ALIGN	16
 aes_hw_encrypt:
 
+_CET_ENDBR
 %ifdef BORINGSSL_DISPATCH_TEST
 EXTERN	BORINGSSL_function_hit
 	mov	BYTE[((BORINGSSL_function_hit+1))],1
@@ -46,6 +48,7 @@ global	aes_hw_decrypt
 ALIGN	16
 aes_hw_decrypt:
 
+_CET_ENDBR
 	movups	xmm2,XMMWORD[rcx]
 	mov	eax,DWORD[240+r8]
 	movups	xmm0,XMMWORD[r8]
@@ -544,6 +547,7 @@ $L$SEH_begin_aes_hw_ecb_encrypt:
 
 
 
+_CET_ENDBR
 	lea	rsp,[((-88))+rsp]
 	movaps	XMMWORD[rsp],xmm6
 	movaps	XMMWORD[16+rsp],xmm7
@@ -917,6 +921,7 @@ $L$SEH_begin_aes_hw_ctr32_encrypt_blocks:
 
 
 
+_CET_ENDBR
 %ifdef BORINGSSL_DISPATCH_TEST
 	mov	BYTE[BORINGSSL_function_hit],1
 %endif
@@ -1536,6 +1541,7 @@ $L$SEH_begin_aes_hw_xts_encrypt:
 
 
 
+_CET_ENDBR
 	lea	r11,[rsp]
 
 	push	rbp
@@ -2041,6 +2047,7 @@ $L$SEH_begin_aes_hw_xts_decrypt:
 
 
 
+_CET_ENDBR
 	lea	r11,[rsp]
 
 	push	rbp
@@ -2583,6 +2590,7 @@ $L$SEH_begin_aes_hw_cbc_encrypt:
 
 
 
+_CET_ENDBR
 	test	rdx,rdx
 	jz	NEAR $L$cbc_ret
 
@@ -3204,6 +3212,7 @@ global	aes_hw_set_decrypt_key
 ALIGN	16
 aes_hw_set_decrypt_key:
 
+_CET_ENDBR
 	DB	0x48,0x83,0xEC,0x08
 
 	call	__aesni_set_encrypt_key
@@ -3249,6 +3258,7 @@ ALIGN	16
 aes_hw_set_encrypt_key:
 __aesni_set_encrypt_key:
 
+_CET_ENDBR
 %ifdef BORINGSSL_DISPATCH_TEST
 	mov	BYTE[((BORINGSSL_function_hit+3))],1
 %endif

--- a/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX

--- a/generated-src/win-x86_64/crypto/fipsmodule/ghash-ssse3-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/ghash-ssse3-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -21,6 +22,7 @@ ALIGN	16
 gcm_gmult_ssse3:
 
 $L$SEH_begin_gcm_gmult_ssse3_1:
+_CET_ENDBR
 	sub	rsp,40
 $L$SEH_prolog_gcm_gmult_ssse3_2:
 	movdqa	XMMWORD[rsp],xmm6
@@ -219,6 +221,7 @@ ALIGN	16
 gcm_ghash_ssse3:
 
 $L$SEH_begin_gcm_ghash_ssse3_1:
+_CET_ENDBR
 	sub	rsp,56
 $L$SEH_prolog_gcm_ghash_ssse3_2:
 	movdqa	XMMWORD[rsp],xmm6

--- a/generated-src/win-x86_64/crypto/fipsmodule/ghash-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/ghash-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -17,6 +18,7 @@ ALIGN	16
 gcm_init_clmul:
 
 $L$SEH_begin_gcm_init_clmul_1:
+_CET_ENDBR
 $L$_init_clmul:
 	sub	rsp,0x18
 $L$SEH_prolog_gcm_init_clmul_2:
@@ -182,6 +184,7 @@ global	gcm_gmult_clmul
 ALIGN	16
 gcm_gmult_clmul:
 
+_CET_ENDBR
 $L$_gmult_clmul:
 	movdqu	xmm0,XMMWORD[rcx]
 	movdqa	xmm5,XMMWORD[$L$bswap_mask]
@@ -236,6 +239,7 @@ ALIGN	32
 gcm_ghash_clmul:
 
 $L$SEH_begin_gcm_ghash_clmul_1:
+_CET_ENDBR
 $L$_ghash_clmul:
 	lea	rax,[((-136))+rsp]
 	lea	rsp,[((-32))+rax]
@@ -657,6 +661,7 @@ global	gcm_init_avx
 ALIGN	32
 gcm_init_avx:
 
+_CET_ENDBR
 $L$SEH_begin_gcm_init_avx_1:
 	sub	rsp,0x18
 $L$SEH_prolog_gcm_init_avx_2:
@@ -774,6 +779,7 @@ global	gcm_gmult_avx
 ALIGN	32
 gcm_gmult_avx:
 
+_CET_ENDBR
 	jmp	NEAR $L$_gmult_clmul
 
 
@@ -782,6 +788,7 @@ global	gcm_ghash_avx
 ALIGN	32
 gcm_ghash_avx:
 
+_CET_ENDBR
 $L$SEH_begin_gcm_ghash_avx_1:
 	lea	rax,[((-136))+rsp]
 	lea	rsp,[((-32))+rax]

--- a/generated-src/win-x86_64/crypto/fipsmodule/md5-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/md5-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -25,6 +26,7 @@ $L$SEH_begin_md5_block_asm_data_order:
 
 
 
+_CET_ENDBR
 	push	rbp
 
 	push	rbx

--- a/generated-src/win-x86_64/crypto/fipsmodule/p256-x86_64-asm.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/p256-x86_64-asm.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -50,6 +51,7 @@ $L$SEH_begin_ecp_nistz256_neg:
 
 
 
+_CET_ENDBR
 	push	r12
 
 	push	r13
@@ -120,6 +122,7 @@ $L$SEH_begin_ecp_nistz256_ord_mul_mont:
 
 
 
+_CET_ENDBR
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
@@ -460,6 +463,7 @@ $L$SEH_begin_ecp_nistz256_ord_sqr_mont:
 
 
 
+_CET_ENDBR
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
@@ -1237,6 +1241,7 @@ $L$SEH_begin_ecp_nistz256_mul_mont:
 
 
 
+_CET_ENDBR
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
@@ -1543,6 +1548,7 @@ $L$SEH_begin_ecp_nistz256_sqr_mont:
 
 
 
+_CET_ENDBR
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
@@ -2076,6 +2082,7 @@ global	ecp_nistz256_select_w5
 ALIGN	32
 ecp_nistz256_select_w5:
 
+_CET_ENDBR
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rax,[OPENSSL_ia32cap_P]
 	mov	rax,QWORD[8+rax]
@@ -2168,6 +2175,7 @@ global	ecp_nistz256_select_w7
 ALIGN	32
 ecp_nistz256_select_w7:
 
+_CET_ENDBR
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rax,[OPENSSL_ia32cap_P]
 	mov	rax,QWORD[8+rax]
@@ -2340,6 +2348,7 @@ ALIGN	32
 ecp_nistz256_avx2_select_w7:
 
 $L$avx2_select_w7:
+_CET_ENDBR
 	vzeroupper
 	mov	r11,rsp
 	lea	rax,[((-136))+rsp]
@@ -2579,6 +2588,7 @@ $L$SEH_begin_ecp_nistz256_point_double:
 
 
 
+_CET_ENDBR
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
@@ -2819,6 +2829,7 @@ $L$SEH_begin_ecp_nistz256_point_add:
 
 
 
+_CET_ENDBR
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
@@ -3262,6 +3273,7 @@ $L$SEH_begin_ecp_nistz256_point_add_affine:
 
 
 
+_CET_ENDBR
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]

--- a/generated-src/win-x86_64/crypto/fipsmodule/p256_beeu-x86_64-asm.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/p256_beeu-x86_64-asm.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -29,6 +30,7 @@ $L$SEH_begin_beeu_mod_inverse_vartime:
 
 
 
+_CET_ENDBR
 	push	rbp
 
 	push	r12

--- a/generated-src/win-x86_64/crypto/fipsmodule/rdrand-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/rdrand-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -19,6 +20,7 @@ global	CRYPTO_rdrand
 ALIGN	16
 CRYPTO_rdrand:
 
+_CET_ENDBR
 	xor	rax,rax
 DB	73,15,199,240
 	test	r8,r8
@@ -44,6 +46,7 @@ global	CRYPTO_rdrand_multiple8_buf
 ALIGN	16
 CRYPTO_rdrand_multiple8_buf:
 
+_CET_ENDBR
 	test	rdx,rdx
 	jz	NEAR $L$out
 	mov	r8,8

--- a/generated-src/win-x86_64/crypto/fipsmodule/rsaz-avx2.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/rsaz-avx2.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -27,6 +28,7 @@ $L$SEH_begin_rsaz_1024_sqr_avx2:
 
 
 
+_CET_ENDBR
 	lea	rax,[rsp]
 
 	push	rbx
@@ -716,6 +718,7 @@ $L$SEH_begin_rsaz_1024_mul_avx2:
 
 
 
+_CET_ENDBR
 	lea	rax,[rsp]
 
 	push	rbx
@@ -1297,6 +1300,7 @@ global	rsaz_1024_red2norm_avx2
 ALIGN	32
 rsaz_1024_red2norm_avx2:
 
+_CET_ENDBR
 	sub	rdx,-128
 	xor	rax,rax
 	mov	r8,QWORD[((-128))+rdx]
@@ -1496,6 +1500,7 @@ global	rsaz_1024_norm2red_avx2
 ALIGN	32
 rsaz_1024_norm2red_avx2:
 
+_CET_ENDBR
 	sub	rcx,-128
 	mov	r8,QWORD[rdx]
 	mov	eax,0x1fffffff
@@ -1655,6 +1660,7 @@ global	rsaz_1024_scatter5_avx2
 ALIGN	32
 rsaz_1024_scatter5_avx2:
 
+_CET_ENDBR
 	vzeroupper
 	vmovdqu	ymm5,YMMWORD[$L$scatter_permd]
 	shl	r8d,4
@@ -1682,6 +1688,7 @@ global	rsaz_1024_gather5_avx2
 ALIGN	32
 rsaz_1024_gather5_avx2:
 
+_CET_ENDBR
 	vzeroupper
 	mov	r11,rsp
 

--- a/generated-src/win-x86_64/crypto/fipsmodule/sha1-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/sha1-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -26,6 +27,7 @@ $L$SEH_begin_sha1_block_data_order:
 
 
 
+_CET_ENDBR
 	lea	r10,[OPENSSL_ia32cap_P]
 	mov	r9d,DWORD[r10]
 	mov	r8d,DWORD[4+r10]

--- a/generated-src/win-x86_64/crypto/fipsmodule/sha256-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/sha256-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -26,6 +27,7 @@ $L$SEH_begin_sha256_block_data_order:
 
 
 
+_CET_ENDBR
 	lea	r11,[OPENSSL_ia32cap_P]
 	mov	r9d,DWORD[r11]
 	mov	r10d,DWORD[4+r11]

--- a/generated-src/win-x86_64/crypto/fipsmodule/sha512-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/sha512-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -26,6 +27,7 @@ $L$SEH_begin_sha512_block_data_order:
 
 
 
+_CET_ENDBR
 	lea	r11,[OPENSSL_ia32cap_P]
 	mov	r9d,DWORD[r11]
 	mov	r10d,DWORD[4+r11]

--- a/generated-src/win-x86_64/crypto/fipsmodule/vpaes-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/vpaes-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -818,6 +819,7 @@ $L$SEH_begin_vpaes_set_encrypt_key:
 
 
 
+_CET_ENDBR
 %ifdef BORINGSSL_DISPATCH_TEST
 EXTERN	BORINGSSL_function_hit
 	mov	BYTE[((BORINGSSL_function_hit+5))],1
@@ -876,6 +878,7 @@ $L$SEH_begin_vpaes_set_decrypt_key:
 
 
 
+_CET_ENDBR
 	lea	rsp,[((-184))+rsp]
 	movaps	XMMWORD[16+rsp],xmm6
 	movaps	XMMWORD[32+rsp],xmm7
@@ -934,6 +937,7 @@ $L$SEH_begin_vpaes_encrypt:
 
 
 
+_CET_ENDBR
 %ifdef BORINGSSL_DISPATCH_TEST
 EXTERN	BORINGSSL_function_hit
 	mov	BYTE[((BORINGSSL_function_hit+4))],1
@@ -986,6 +990,7 @@ $L$SEH_begin_vpaes_decrypt:
 
 
 
+_CET_ENDBR
 	lea	rsp,[((-184))+rsp]
 	movaps	XMMWORD[16+rsp],xmm6
 	movaps	XMMWORD[32+rsp],xmm7
@@ -1036,6 +1041,7 @@ $L$SEH_begin_vpaes_cbc_encrypt:
 
 
 
+_CET_ENDBR
 	xchg	rdx,rcx
 	sub	rcx,16
 	jc	NEAR $L$cbc_abort
@@ -1115,6 +1121,7 @@ $L$SEH_begin_vpaes_ctr32_encrypt_blocks:
 
 
 
+_CET_ENDBR
 
 	xchg	rdx,rcx
 	test	rcx,rcx

--- a/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -30,6 +31,7 @@ $L$SEH_begin_bn_mul_mont:
 
 
 
+_CET_ENDBR
 	mov	r9d,r9d
 	mov	rax,rsp
 

--- a/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont5.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont5.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -30,6 +31,7 @@ $L$SEH_begin_bn_mul_mont_gather5:
 
 
 
+_CET_ENDBR
 	mov	r9d,r9d
 	mov	rax,rsp
 
@@ -1139,6 +1141,7 @@ $L$SEH_begin_bn_power5:
 
 
 
+_CET_ENDBR
 	mov	rax,rsp
 
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -1281,6 +1284,7 @@ ALIGN	32
 bn_sqr8x_internal:
 __bn_sqr8x_internal:
 
+_CET_ENDBR
 
 
 
@@ -2821,6 +2825,7 @@ ALIGN	32
 bn_sqrx8x_internal:
 __bn_sqrx8x_internal:
 
+_CET_ENDBR
 
 
 
@@ -3493,6 +3498,7 @@ global	bn_scatter5
 ALIGN	16
 bn_scatter5:
 
+_CET_ENDBR
 	cmp	edx,0
 	jz	NEAR $L$scatter_epilogue
 
@@ -3523,6 +3529,7 @@ ALIGN	32
 bn_gather5:
 
 $L$SEH_begin_bn_gather5:
+_CET_ENDBR
 
 	DB	0x4c,0x8d,0x14,0x24
 

--- a/generated-src/win-x86_64/crypto/test/trampoline-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/test/trampoline-x86_64.asm
@@ -6,6 +6,7 @@ default	rel
 %define XMMWORD
 %define YMMWORD
 %define ZMMWORD
+%define _CET_ENDBR
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
 section	.text code align=64
@@ -24,6 +25,7 @@ ALIGN	16
 abi_test_trampoline:
 
 $L$SEH_begin_abi_test_trampoline_1:
+_CET_ENDBR
 
 
 
@@ -256,6 +258,7 @@ $L$SEH_end_abi_test_trampoline_21:
 global	abi_test_clobber_rax
 ALIGN	16
 abi_test_clobber_rax:
+_CET_ENDBR
 	xor	rax,rax
 	DB	0F3h,0C3h		;repret
 
@@ -263,6 +266,7 @@ abi_test_clobber_rax:
 global	abi_test_clobber_rbx
 ALIGN	16
 abi_test_clobber_rbx:
+_CET_ENDBR
 	xor	rbx,rbx
 	DB	0F3h,0C3h		;repret
 
@@ -270,6 +274,7 @@ abi_test_clobber_rbx:
 global	abi_test_clobber_rcx
 ALIGN	16
 abi_test_clobber_rcx:
+_CET_ENDBR
 	xor	rcx,rcx
 	DB	0F3h,0C3h		;repret
 
@@ -277,6 +282,7 @@ abi_test_clobber_rcx:
 global	abi_test_clobber_rdx
 ALIGN	16
 abi_test_clobber_rdx:
+_CET_ENDBR
 	xor	rdx,rdx
 	DB	0F3h,0C3h		;repret
 
@@ -284,6 +290,7 @@ abi_test_clobber_rdx:
 global	abi_test_clobber_rdi
 ALIGN	16
 abi_test_clobber_rdi:
+_CET_ENDBR
 	xor	rdi,rdi
 	DB	0F3h,0C3h		;repret
 
@@ -291,6 +298,7 @@ abi_test_clobber_rdi:
 global	abi_test_clobber_rsi
 ALIGN	16
 abi_test_clobber_rsi:
+_CET_ENDBR
 	xor	rsi,rsi
 	DB	0F3h,0C3h		;repret
 
@@ -298,6 +306,7 @@ abi_test_clobber_rsi:
 global	abi_test_clobber_rbp
 ALIGN	16
 abi_test_clobber_rbp:
+_CET_ENDBR
 	xor	rbp,rbp
 	DB	0F3h,0C3h		;repret
 
@@ -305,6 +314,7 @@ abi_test_clobber_rbp:
 global	abi_test_clobber_r8
 ALIGN	16
 abi_test_clobber_r8:
+_CET_ENDBR
 	xor	r8,r8
 	DB	0F3h,0C3h		;repret
 
@@ -312,6 +322,7 @@ abi_test_clobber_r8:
 global	abi_test_clobber_r9
 ALIGN	16
 abi_test_clobber_r9:
+_CET_ENDBR
 	xor	r9,r9
 	DB	0F3h,0C3h		;repret
 
@@ -319,6 +330,7 @@ abi_test_clobber_r9:
 global	abi_test_clobber_r10
 ALIGN	16
 abi_test_clobber_r10:
+_CET_ENDBR
 	xor	r10,r10
 	DB	0F3h,0C3h		;repret
 
@@ -326,6 +338,7 @@ abi_test_clobber_r10:
 global	abi_test_clobber_r11
 ALIGN	16
 abi_test_clobber_r11:
+_CET_ENDBR
 	xor	r11,r11
 	DB	0F3h,0C3h		;repret
 
@@ -333,6 +346,7 @@ abi_test_clobber_r11:
 global	abi_test_clobber_r12
 ALIGN	16
 abi_test_clobber_r12:
+_CET_ENDBR
 	xor	r12,r12
 	DB	0F3h,0C3h		;repret
 
@@ -340,6 +354,7 @@ abi_test_clobber_r12:
 global	abi_test_clobber_r13
 ALIGN	16
 abi_test_clobber_r13:
+_CET_ENDBR
 	xor	r13,r13
 	DB	0F3h,0C3h		;repret
 
@@ -347,6 +362,7 @@ abi_test_clobber_r13:
 global	abi_test_clobber_r14
 ALIGN	16
 abi_test_clobber_r14:
+_CET_ENDBR
 	xor	r14,r14
 	DB	0F3h,0C3h		;repret
 
@@ -354,6 +370,7 @@ abi_test_clobber_r14:
 global	abi_test_clobber_r15
 ALIGN	16
 abi_test_clobber_r15:
+_CET_ENDBR
 	xor	r15,r15
 	DB	0F3h,0C3h		;repret
 
@@ -361,6 +378,7 @@ abi_test_clobber_r15:
 global	abi_test_clobber_xmm0
 ALIGN	16
 abi_test_clobber_xmm0:
+_CET_ENDBR
 	pxor	xmm0,xmm0
 	DB	0F3h,0C3h		;repret
 
@@ -368,6 +386,7 @@ abi_test_clobber_xmm0:
 global	abi_test_clobber_xmm1
 ALIGN	16
 abi_test_clobber_xmm1:
+_CET_ENDBR
 	pxor	xmm1,xmm1
 	DB	0F3h,0C3h		;repret
 
@@ -375,6 +394,7 @@ abi_test_clobber_xmm1:
 global	abi_test_clobber_xmm2
 ALIGN	16
 abi_test_clobber_xmm2:
+_CET_ENDBR
 	pxor	xmm2,xmm2
 	DB	0F3h,0C3h		;repret
 
@@ -382,6 +402,7 @@ abi_test_clobber_xmm2:
 global	abi_test_clobber_xmm3
 ALIGN	16
 abi_test_clobber_xmm3:
+_CET_ENDBR
 	pxor	xmm3,xmm3
 	DB	0F3h,0C3h		;repret
 
@@ -389,6 +410,7 @@ abi_test_clobber_xmm3:
 global	abi_test_clobber_xmm4
 ALIGN	16
 abi_test_clobber_xmm4:
+_CET_ENDBR
 	pxor	xmm4,xmm4
 	DB	0F3h,0C3h		;repret
 
@@ -396,6 +418,7 @@ abi_test_clobber_xmm4:
 global	abi_test_clobber_xmm5
 ALIGN	16
 abi_test_clobber_xmm5:
+_CET_ENDBR
 	pxor	xmm5,xmm5
 	DB	0F3h,0C3h		;repret
 
@@ -403,6 +426,7 @@ abi_test_clobber_xmm5:
 global	abi_test_clobber_xmm6
 ALIGN	16
 abi_test_clobber_xmm6:
+_CET_ENDBR
 	pxor	xmm6,xmm6
 	DB	0F3h,0C3h		;repret
 
@@ -410,6 +434,7 @@ abi_test_clobber_xmm6:
 global	abi_test_clobber_xmm7
 ALIGN	16
 abi_test_clobber_xmm7:
+_CET_ENDBR
 	pxor	xmm7,xmm7
 	DB	0F3h,0C3h		;repret
 
@@ -417,6 +442,7 @@ abi_test_clobber_xmm7:
 global	abi_test_clobber_xmm8
 ALIGN	16
 abi_test_clobber_xmm8:
+_CET_ENDBR
 	pxor	xmm8,xmm8
 	DB	0F3h,0C3h		;repret
 
@@ -424,6 +450,7 @@ abi_test_clobber_xmm8:
 global	abi_test_clobber_xmm9
 ALIGN	16
 abi_test_clobber_xmm9:
+_CET_ENDBR
 	pxor	xmm9,xmm9
 	DB	0F3h,0C3h		;repret
 
@@ -431,6 +458,7 @@ abi_test_clobber_xmm9:
 global	abi_test_clobber_xmm10
 ALIGN	16
 abi_test_clobber_xmm10:
+_CET_ENDBR
 	pxor	xmm10,xmm10
 	DB	0F3h,0C3h		;repret
 
@@ -438,6 +466,7 @@ abi_test_clobber_xmm10:
 global	abi_test_clobber_xmm11
 ALIGN	16
 abi_test_clobber_xmm11:
+_CET_ENDBR
 	pxor	xmm11,xmm11
 	DB	0F3h,0C3h		;repret
 
@@ -445,6 +474,7 @@ abi_test_clobber_xmm11:
 global	abi_test_clobber_xmm12
 ALIGN	16
 abi_test_clobber_xmm12:
+_CET_ENDBR
 	pxor	xmm12,xmm12
 	DB	0F3h,0C3h		;repret
 
@@ -452,6 +482,7 @@ abi_test_clobber_xmm12:
 global	abi_test_clobber_xmm13
 ALIGN	16
 abi_test_clobber_xmm13:
+_CET_ENDBR
 	pxor	xmm13,xmm13
 	DB	0F3h,0C3h		;repret
 
@@ -459,6 +490,7 @@ abi_test_clobber_xmm13:
 global	abi_test_clobber_xmm14
 ALIGN	16
 abi_test_clobber_xmm14:
+_CET_ENDBR
 	pxor	xmm14,xmm14
 	DB	0F3h,0C3h		;repret
 
@@ -466,6 +498,7 @@ abi_test_clobber_xmm14:
 global	abi_test_clobber_xmm15
 ALIGN	16
 abi_test_clobber_xmm15:
+_CET_ENDBR
 	pxor	xmm15,xmm15
 	DB	0F3h,0C3h		;repret
 
@@ -478,6 +511,7 @@ ALIGN	16
 abi_test_bad_unwind_wrong_register:
 
 $L$SEH_begin_abi_test_bad_unwind_wrong_register_1:
+_CET_ENDBR
 	push	r12
 
 $L$SEH_prolog_abi_test_bad_unwind_wrong_register_2:
@@ -501,6 +535,7 @@ ALIGN	16
 abi_test_bad_unwind_temporary:
 
 $L$SEH_begin_abi_test_bad_unwind_temporary_1:
+_CET_ENDBR
 	push	r12
 
 $L$SEH_prolog_abi_test_bad_unwind_temporary_2:
@@ -527,6 +562,7 @@ $L$SEH_end_abi_test_bad_unwind_temporary_3:
 
 global	abi_test_get_and_clear_direction_flag
 abi_test_get_and_clear_direction_flag:
+_CET_ENDBR
 	pushfq
 	pop	rax
 	and	rax,0x400
@@ -540,6 +576,7 @@ abi_test_get_and_clear_direction_flag:
 
 global	abi_test_set_direction_flag
 abi_test_set_direction_flag:
+_CET_ENDBR
 	std
 	DB	0F3h,0C3h		;repret
 

--- a/include/openssl/asm_base.h
+++ b/include/openssl/asm_base.h
@@ -33,7 +33,7 @@
 // - The file, on aarch64, uses the macros defined below to be compatible with
 //   BTI and PAC.
 //
-// - The file, on X86_64, requires the progrram to be compatible with Intel IBT
+// - The file, on x86_64, requires the program to be compatible with Intel IBT
 //   and SHSTK
 
 #if defined(__ASSEMBLER__)

--- a/include/openssl/asm_base.h
+++ b/include/openssl/asm_base.h
@@ -32,6 +32,10 @@
 //
 // - The file, on aarch64, uses the macros defined below to be compatible with
 //   BTI and PAC.
+//
+// - The file, on X86_64, requires the progrram to be compatible with Intel IBT
+//   and SHSTK
+
 #if defined(__ASSEMBLER__)
 
 #include <openssl/boringssl_prefix_symbols_asm.h>
@@ -41,6 +45,22 @@
 // https://www.airs.com/blog/archives/518.
 .pushsection .note.GNU-stack, "", %progbits
 .popsection
+#endif
+
+#if defined(__CET__) && defined(OPENSSL_X86_64)
+// Clang and GCC define __CET__ and provide <cet.h> when they support Intel's
+// Indirect Branch Tracking.
+// https://lpc.events/event/7/contributions/729/attachments/496/903/CET-LPC-2020.pdf
+//
+// cet.h defines _CET_ENDBR which is used to mark function entry points for IBT.
+// and adds the assembly marker. The value of _CET_ENDBR is made dependant on if
+// '-fcf-protection' is passed to the compiler. _CET_ENDBR is only required when
+// the function is the target of an indirect jump, but BoringSSL chooses to mark
+// all assembly entry points because it is easier, and allows BoringSSL's ABI
+// tester to call the assembly entry points via an indirect jump.
+#include <cet.h>
+#else
+#define _CET_ENDBR
 #endif
 
 #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)


### PR DESCRIPTION
### Issues:
* Addresses: CryptoAlg-2220

### Previous Work:
This change re-introduces changes from the following PRs:
* https://github.com/aws/aws-lc/pull/1628

Due to build failures with certain environments using gcc-4.8, the above was reverted:
* https://github.com/aws/aws-lc/pull/1656

The build failures were addressed in the following PR:
* https://github.com/aws/aws-lc/pull/1665

### Description of changes: 
Upstream commits: 
* https://github.com/google/boringssl/commit/9fc1c33e9c21439ce5f87855a6591a9324e569fd
* https://github.com/google/boringssl/commit/51ed32f1971956a904ce7b3a7ff10716e76eecd4


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
