### PR TITLE
Improve gcc-4.8 support/testing

### DIFF
--- a/.github/docker_images/gcc-4.8/Dockerfile
+++ b/.github/docker_images/gcc-4.8/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+FROM gcc:4.8
+
+VOLUME ["/awslc"]
+
+COPY awslc_build.sh /
+COPY entry.sh /
+
+WORKDIR /
+
+RUN curl -LOk "https://github.com/Kitware/CMake/releases/download/v3.6.3/cmake-3.6.3-Linux-x86_64.tar.gz"
+RUN sha256sum cmake-3.6.3-Linux-x86_64.tar.gz | grep -q "9d915d505c07d84b610e1be6242c7cad68b4b7a4090ce85ecf9cec5effa47c43"
+RUN tar -C /usr/local -xzf cmake-3.6.3-Linux-x86_64.tar.gz
+RUN rm cmake-3.6.3-Linux-x86_64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/cmake-3.6.3-Linux-x86_64/bin"
+
+ENTRYPOINT ["/entry.sh"]

--- a/.github/docker_images/gcc-4.8/awslc_build.sh
+++ b/.github/docker_images/gcc-4.8/awslc_build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -ex -o pipefail
+
+echo "Building with GCC Version: $(gcc --version)"
+
+BUILD_DIR=$(mktemp -d)
+SRC_DIR="${SRC_DIR:-/awslc}"
+
+pushd "${BUILD_DIR}"
+
+cmake "${SRC_DIR}" "-DDISABLE_GO=ON" "-DDISABLE_PERL=ON" "-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=1"
+make -j 4 ssl
+
+popd # ${BUILD_DIR}

--- a/.github/docker_images/gcc-4.8/entry.sh
+++ b/.github/docker_images/gcc-4.8/entry.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -ex -o pipefail
+
+/awslc_build.sh "${argv[@]}"

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -447,6 +447,20 @@ jobs:
             env
             tests/ci/run_openbsd_tests.sh ${{ matrix.args }}
             EOF
+  gcc-4_8:
+    needs: [sanity-test-run]
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker Image
+        working-directory: .github/docker_images/gcc-4.8
+        run: |
+          docker build -t "gcc-4.8"  .
+      - name: Build using pre-generated assembly
+        run: |
+          docker run -v "${{ github.workspace }}:/awslc" "gcc-4.8"
 
     # TODO: Investigate sudden hanging tests and failures in GHA runners (P114059413)
 #  MSVC-SDE-32-bit:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,23 +289,26 @@ endmacro()
 # can be set to handle such cases.
 option(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX "Exclude AVX code from the build" OFF)
 
-# Some assemblers know about AVX but not AVX512 instructions, e.g. gcc 4.8.2.
+# Some assemblers know about AVX but not ADX, AVX2 or AVX512 instructions, e.g. gcc 4.8.2.
 # This flag can be set to handle such cases.
-# Note that the flag's name has "512AVX" instead of "AVX512" so that it doesn't
-# include the entire flag -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX and match it
-# in the Perl files checks.
+# Note:
+# * Although this flag name implies an effect on AVX512 instructions, it's also
+#   intended to avoid generating ADX and AVX2 instructions.
+# * This flag name has "512AVX" instead of "AVX512" so that it doesn't
+#   include the entire flag -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX and match
+#   to it in the Perl files checks.
 option(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX "Exclude AVX512 code from the build" OFF)
 
 if(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
   add_definitions(-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
   add_definitions(-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
   set(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX ON)
-  message(STATUS "MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX selected, removing AVX optimisations")
+  message(STATUS "MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX selected, removing all AVX optimisations")
 endif()
 
 if(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
   add_definitions(-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
-  message(STATUS "MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX selected, removing AVX512 optimisations")
+  message(STATUS "MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX selected, removing ADX, AVX2 and AVX512 optimisations")
 endif()
 
 if (GCC)

--- a/crypto/curve25519/internal.h
+++ b/crypto/curve25519/internal.h
@@ -26,7 +26,7 @@ extern "C" {
 
 // If (1) x86_64 or aarch64, (2) linux or apple, and (3) OPENSSL_NO_ASM is not
 // set, s2n-bignum path is capable.
-#if ((defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)) || \
+#if ((defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)) || \
      defined(OPENSSL_AARCH64)) &&                                              \
     (defined(OPENSSL_LINUX) || defined(OPENSSL_APPLE) ||                       \
      defined(OPENSSL_OPENBSD)) &&                                              \

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -179,7 +179,7 @@ endif()
 
 # s2n-bignum files can be compiled on Unix platforms only (except Apple),
 # and on x86_64 and aarch64 systems only.
-if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) OR
+if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) OR
       ARCH STREQUAL "aarch64") AND UNIX)
 
   # Set the source directory for s2n-bignum assembly files

--- a/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
+++ b/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
@@ -1460,7 +1460,10 @@ ___
 
   my $rndsuffix = &random_string();
 
-  $code .= ".text\n";
+  $code .= <<___;
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.text
+___
 
   {
   $code.=<<___;
@@ -3108,6 +3111,7 @@ ___
     .byte  0xff, 0xff, 0xff, 0xff, 0xff
 
 .text
+#endif
 ___
 } else {
     $code .= <<___;

--- a/crypto/fipsmodule/bn/asm/x86_64-mont5.pl
+++ b/crypto/fipsmodule/bn/asm/x86_64-mont5.pl
@@ -52,7 +52,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 # versions, but BoringSSL is intended to be used with pre-generated perlasm
 # output, so this isn't useful anyway.
 $addx = 1;
-for (@ARGV) { $addx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
+for (@ARGV) { $addx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX/); }
 
 # int bn_mul_mont_gather5(
 $rp="%rdi";	# BN_ULONG *rp,
@@ -90,8 +90,10 @@ bn_mul_mont_gather5:
 	jnz	.Lmul_enter
 ___
 $code.=<<___ if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%r11
 	mov	8(%r11),%r11d
+#endif
 ___
 $code.=<<___;
 	jmp	.Lmul4x_enter
@@ -473,9 +475,11 @@ bn_mul4x_mont_gather5:
 .Lmul4x_enter:
 ___
 $code.=<<___ if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	and	\$0x80108,%r11d
 	cmp	\$0x80108,%r11d		# check for AD*X+BMI2+BMI1
 	je	.Lmulx4x_enter
+#endif
 ___
 $code.=<<___;
 	push	%rbx
@@ -1106,11 +1110,13 @@ bn_power5:
 .cfi_def_cfa_register	%rax
 ___
 $code.=<<___ if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%r11
 	mov	8(%r11),%r11d
 	and	\$0x80108,%r11d
 	cmp	\$0x80108,%r11d		# check for AD*X+BMI2+BMI1
 	je	.Lpowerx5_enter
+#endif
 ___
 $code.=<<___;
 	push	%rbx
@@ -2109,6 +2115,7 @@ if ($addx) {{{
 my $bp="%rdx";	# restore original value
 
 $code.=<<___;
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .type	bn_mulx4x_mont_gather5,\@function,6
 .align	32
 bn_mulx4x_mont_gather5:
@@ -3436,6 +3443,7 @@ __bn_postx4x_internal:
 	ret
 .cfi_endproc
 .size	__bn_postx4x_internal,.-__bn_postx4x_internal
+#endif
 ___
 }
 }}}
@@ -3716,6 +3724,7 @@ mul_handler:
 	.rva	.LSEH_info_bn_power5
 ___
 $code.=<<___ if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	.rva	.LSEH_begin_bn_mulx4x_mont_gather5
 	.rva	.LSEH_end_bn_mulx4x_mont_gather5
 	.rva	.LSEH_info_bn_mulx4x_mont_gather5
@@ -3723,6 +3732,7 @@ $code.=<<___ if ($addx);
 	.rva	.LSEH_begin_bn_powerx5
 	.rva	.LSEH_end_bn_powerx5
 	.rva	.LSEH_info_bn_powerx5
+#endif
 ___
 $code.=<<___;
 	.rva	.LSEH_begin_bn_gather5
@@ -3747,6 +3757,7 @@ $code.=<<___;
 	.rva	.Lpower5_prologue,.Lpower5_body,.Lpower5_epilogue	# HandlerData[]
 ___
 $code.=<<___ if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .align	8
 .LSEH_info_bn_mulx4x_mont_gather5:
 	.byte	9,0,0,0
@@ -3757,6 +3768,7 @@ $code.=<<___ if ($addx);
 	.byte	9,0,0,0
 	.rva	mul_handler
 	.rva	.Lpowerx5_prologue,.Lpowerx5_body,.Lpowerx5_epilogue	# HandlerData[]
+#endif
 ___
 $code.=<<___;
 .align	8

--- a/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl
@@ -59,7 +59,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
 
 $avx = 2;
 $addx = 1;
-for (@ARGV) { $avx = 0, $addx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX/); }
+for (@ARGV) { $avx = 0, $addx = 0 if (/-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX/); }
 
 $code.=<<___;
 .text
@@ -172,11 +172,13 @@ ecp_nistz256_ord_mul_mont:
 .cfi_startproc
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip), %rcx
 	mov	8(%rcx), %rcx
 	and	\$0x80100, %ecx
 	cmp	\$0x80100, %ecx
 	je	.Lecp_nistz256_ord_mul_montx
+#endif
 ___
 $code.=<<___;
 	push	%rbp
@@ -503,11 +505,13 @@ ecp_nistz256_ord_sqr_mont:
 .cfi_startproc
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip), %rcx
 	mov	8(%rcx), %rcx
 	and	\$0x80100, %ecx
 	cmp	\$0x80100, %ecx
 	je	.Lecp_nistz256_ord_sqr_montx
+#endif
 ___
 $code.=<<___;
 	push	%rbp
@@ -793,6 +797,7 @@ $code.=<<___;
 ___
 
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 ################################################################################
 .type	ecp_nistz256_ord_mul_montx,\@function,3
 .align	32
@@ -1237,6 +1242,7 @@ ecp_nistz256_ord_sqr_montx:
 	ret
 .cfi_endproc
 .size	ecp_nistz256_ord_sqr_montx,.-ecp_nistz256_ord_sqr_montx
+#endif
 ___
 
 $code.=<<___;
@@ -1253,9 +1259,11 @@ ecp_nistz256_mul_mont:
 .cfi_startproc
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip), %rcx
 	mov	8(%rcx), %rcx
 	and	\$0x80100, %ecx
+#endif
 ___
 $code.=<<___;
 .Lmul_mont:
@@ -1274,8 +1282,10 @@ $code.=<<___;
 .Lmul_body:
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	cmp	\$0x80100, %ecx
 	je	.Lmul_montx
+#endif
 ___
 $code.=<<___;
 	mov	$b_org, $b_ptr
@@ -1288,6 +1298,7 @@ $code.=<<___;
 	call	__ecp_nistz256_mul_montq
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	jmp	.Lmul_mont_done
 
 .align	32
@@ -1301,6 +1312,7 @@ $code.=<<___	if ($addx);
 	lea	-128($a_ptr), $a_ptr	# control u-op density
 
 	call	__ecp_nistz256_mul_montx
+#endif
 ___
 $code.=<<___;
 .Lmul_mont_done:
@@ -1555,9 +1567,11 @@ ecp_nistz256_sqr_mont:
 .cfi_startproc
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip), %rcx
 	mov	8(%rcx), %rcx
 	and	\$0x80100, %ecx
+#endif
 ___
 $code.=<<___;
 	push	%rbp
@@ -1575,8 +1589,10 @@ $code.=<<___;
 .Lsqr_body:
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	cmp	\$0x80100, %ecx
 	je	.Lsqr_montx
+#endif
 ___
 $code.=<<___;
 	mov	8*0($a_ptr), %rax
@@ -1587,6 +1603,7 @@ $code.=<<___;
 	call	__ecp_nistz256_sqr_montq
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	jmp	.Lsqr_mont_done
 
 .align	32
@@ -1598,6 +1615,7 @@ $code.=<<___	if ($addx);
 	lea	-128($a_ptr), $a_ptr	# control u-op density
 
 	call	__ecp_nistz256_sqr_montx
+#endif
 ___
 $code.=<<___;
 .Lsqr_mont_done:
@@ -1787,6 +1805,7 @@ ___
 
 if ($addx) {
 $code.=<<___;
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .type	__ecp_nistz256_mul_montx,\@abi-omnipotent
 .align	32
 __ecp_nistz256_mul_montx:
@@ -2085,6 +2104,7 @@ __ecp_nistz256_sqr_montx:
 	ret
 .cfi_endproc
 .size	__ecp_nistz256_sqr_montx,.-__ecp_nistz256_sqr_montx
+#endif
 ___
 }
 }
@@ -2104,10 +2124,12 @@ ecp_nistz256_select_w5:
 .cfi_startproc
 ___
 $code.=<<___	if ($avx>1);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip), %rax
 	mov	8(%rax), %rax
 	test	\$`1<<5`, %eax
 	jnz	.Lavx2_select_w5
+#endif
 ___
 $code.=<<___	if ($win64);
 	lea	-0x88(%rsp), %rax
@@ -2204,10 +2226,12 @@ ecp_nistz256_select_w7:
 .cfi_startproc
 ___
 $code.=<<___	if ($avx>1);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip), %rax
 	mov	8(%rax), %rax
 	test	\$`1<<5`, %eax
 	jnz	.Lavx2_select_w7
+#endif
 ___
 $code.=<<___	if ($win64);
 	lea	-0x88(%rsp), %rax
@@ -2292,6 +2316,7 @@ my ($M0,$T0a,$T0b,$T0c,$TMP0)=map("%ymm$_",(5..9));
 my ($M1,$T1a,$T1b,$T1c,$TMP1)=map("%ymm$_",(10..14));
 
 $code.=<<___;
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 ################################################################################
 # void ecp_nistz256_avx2_select_w5(uint64_t *val, uint64_t *in_t, int index);
 .type	ecp_nistz256_avx2_select_w5,\@abi-omnipotent
@@ -2388,6 +2413,7 @@ $code.=<<___;
 .cfi_endproc
 .LSEH_end_ecp_nistz256_avx2_select_w5:
 .size	ecp_nistz256_avx2_select_w5,.-ecp_nistz256_avx2_select_w5
+#endif
 ___
 }
 if ($avx>1) {
@@ -2398,7 +2424,7 @@ my ($M1,$T1a,$T1b,$TMP1)=map("%ymm$_",(8..11));
 my ($M2,$T2a,$T2b,$TMP2)=map("%ymm$_",(12..15));
 
 $code.=<<___;
-
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 ################################################################################
 # void ecp_nistz256_avx2_select_w7(uint64_t *val, uint64_t *in_t, int index);
 .globl	ecp_nistz256_avx2_select_w7
@@ -2511,6 +2537,7 @@ $code.=<<___;
 .cfi_endproc
 .LSEH_end_ecp_nistz256_avx2_select_w7:
 .size	ecp_nistz256_avx2_select_w7,.-ecp_nistz256_avx2_select_w7
+#endif
 ___
 } else {
 $code.=<<___;
@@ -2724,11 +2751,13 @@ ecp_nistz256_point_double:
 .cfi_startproc
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip), %rcx
 	mov	8(%rcx), %rcx
 	and	\$0x80100, %ecx
 	cmp	\$0x80100, %ecx
 	je	.Lpoint_doublex
+#endif
 ___
     } else {
 	$src0 = "%rdx";
@@ -2976,11 +3005,13 @@ ecp_nistz256_point_add:
 .cfi_startproc
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip), %rcx
 	mov	8(%rcx), %rcx
 	and	\$0x80100, %ecx
 	cmp	\$0x80100, %ecx
 	je	.Lpoint_addx
+#endif
 ___
     } else {
 	$src0 = "%rdx";
@@ -3374,11 +3405,13 @@ ecp_nistz256_point_add_affine:
 .cfi_startproc
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip), %rcx
 	mov	8(%rcx), %rcx
 	and	\$0x80100, %ecx
 	cmp	\$0x80100, %ecx
 	je	.Lpoint_add_affinex
+#endif
 ___
     } else {
 	$src0 = "%rdx";
@@ -3687,6 +3720,7 @@ if ($addx) {								{
 my ($a0,$a1,$a2,$a3,$t3,$t4)=($acc4,$acc5,$acc0,$acc1,$acc2,$acc3);
 
 $code.=<<___;
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .type	__ecp_nistz256_add_tox,\@abi-omnipotent
 .align	32
 __ecp_nistz256_add_tox:
@@ -3827,6 +3861,10 @@ ___
 &gen_double("x");
 &gen_add("x");
 &gen_add_affine("x");
+
+  $code.=<<___;
+#endif
+___
 }
 }}}
 
@@ -3986,6 +4024,7 @@ full_handler:
 	.rva	.LSEH_info_ecp_nistz256_ord_sqr_mont
 ___
 $code.=<<___	if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	.rva	.LSEH_begin_ecp_nistz256_ord_mul_montx
 	.rva	.LSEH_end_ecp_nistz256_ord_mul_montx
 	.rva	.LSEH_info_ecp_nistz256_ord_mul_montx
@@ -3993,6 +4032,7 @@ $code.=<<___	if ($addx);
 	.rva	.LSEH_begin_ecp_nistz256_ord_sqr_montx
 	.rva	.LSEH_end_ecp_nistz256_ord_sqr_montx
 	.rva	.LSEH_info_ecp_nistz256_ord_sqr_montx
+#endif
 ___
 $code.=<<___;
 	.rva	.LSEH_begin_ecp_nistz256_mul_mont
@@ -4012,6 +4052,7 @@ $code.=<<___;
 	.rva	.LSEH_info_ecp_nistz256_select_wX
 ___
 $code.=<<___	if ($avx>1);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	.rva	.LSEH_begin_ecp_nistz256_avx2_select_w5
 	.rva	.LSEH_end_ecp_nistz256_avx2_select_w5
 	.rva	.LSEH_info_ecp_nistz256_avx2_select_wX
@@ -4019,6 +4060,7 @@ $code.=<<___	if ($avx>1);
 	.rva	.LSEH_begin_ecp_nistz256_avx2_select_w7
 	.rva	.LSEH_end_ecp_nistz256_avx2_select_w7
 	.rva	.LSEH_info_ecp_nistz256_avx2_select_wX
+#endif
 ___
 $code.=<<___;
 	.rva	.LSEH_begin_ecp_nistz256_point_double
@@ -4034,6 +4076,7 @@ $code.=<<___;
 	.rva	.LSEH_info_ecp_nistz256_point_add_affine
 ___
 $code.=<<___ if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	.rva	.LSEH_begin_ecp_nistz256_point_doublex
 	.rva	.LSEH_end_ecp_nistz256_point_doublex
 	.rva	.LSEH_info_ecp_nistz256_point_doublex
@@ -4045,6 +4088,7 @@ $code.=<<___ if ($addx);
 	.rva	.LSEH_begin_ecp_nistz256_point_add_affinex
 	.rva	.LSEH_end_ecp_nistz256_point_add_affinex
 	.rva	.LSEH_info_ecp_nistz256_point_add_affinex
+#endif
 ___
 $code.=<<___;
 
@@ -4066,6 +4110,7 @@ $code.=<<___;
 	.long	48,0
 ___
 $code.=<<___ if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .LSEH_info_ecp_nistz256_ord_mul_montx:
 	.byte	9,0,0,0
 	.rva	full_handler
@@ -4076,6 +4121,7 @@ $code.=<<___ if ($addx);
 	.rva	full_handler
 	.rva	.Lord_sqrx_body,.Lord_sqrx_epilogue	# HandlerData[]
 	.long	48,0
+#endif
 ___
 $code.=<<___;
 .LSEH_info_ecp_nistz256_mul_mont:
@@ -4104,6 +4150,7 @@ $code.=<<___;
 	.align	8
 ___
 $code.=<<___	if ($avx>1);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .LSEH_info_ecp_nistz256_avx2_select_wX:
 	.byte	0x01,0x36,0x17,0x0b
 	.byte	0x36,0xf8,0x09,0x00	# vmovaps 0x90(rsp),xmm15
@@ -4119,6 +4166,7 @@ $code.=<<___	if ($avx>1);
 	.byte	0x04,0x01,0x15,0x00	# sub	  rsp,0xa8
 	.byte	0x00,0xb3,0x00,0x00	# set_frame r11
 	.align	8
+#endif
 ___
 $code.=<<___;
 .LSEH_info_ecp_nistz256_point_double:
@@ -4138,6 +4186,7 @@ $code.=<<___;
 	.long	32*15+56,0
 ___
 $code.=<<___ if ($addx);
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .align	8
 .LSEH_info_ecp_nistz256_point_doublex:
 	.byte	9,0,0,0
@@ -4154,6 +4203,7 @@ $code.=<<___ if ($addx);
 	.rva	full_handler
 	.rva	.Ladd_affinex_body,.Ladd_affinex_epilogue	# HandlerData[]
 	.long	32*15+56,0
+#endif
 ___
 }
 

--- a/crypto/fipsmodule/ec/ec_nistp.h
+++ b/crypto/fipsmodule/ec/ec_nistp.h
@@ -17,7 +17,7 @@
 // set, s2n-bignum path is capable.
 #if !defined(OPENSSL_NO_ASM) &&                                                \
     (defined(OPENSSL_LINUX) || defined(OPENSSL_APPLE)) &&                      \
-    ((defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)) || \
+    ((defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)) || \
      defined(OPENSSL_AARCH64))
 #  define EC_NISTP_USE_S2N_BIGNUM
 #  define EC_NISTP_USE_64BIT_LIMB

--- a/crypto/fipsmodule/modes/asm/aesni-gcm-avx512.pl
+++ b/crypto/fipsmodule/modes/asm/aesni-gcm-avx512.pl
@@ -4176,7 +4176,10 @@ ___
 # ;;; Functions definitions
 # ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-$code .= ".text\n";
+  $code .= <<___;
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.text
+___
 {
   # ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   # ;void gcm_init_avx512(u128 Htable[16],
@@ -4689,6 +4692,7 @@ byte64_len_to_mask_table:
         .quad      0x3fffffffffffffff, 0x7fffffffffffffff
         .quad      0xffffffffffffffff
 .text
+#endif
 ___
 
 } else {

--- a/crypto/fipsmodule/modes/gcm.c
+++ b/crypto/fipsmodule/modes/gcm.c
@@ -234,6 +234,7 @@ void CRYPTO_ghash_init(gmult_func *out_mult, ghash_func *out_hash,
                    CRYPTO_load_u64_be(gcm_key + 8)};
 
 #if defined(GHASH_ASM_X86_64)
+#if !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
   if (crypto_gcm_avx512_enabled()) {
     gcm_init_avx512(out_table, H);
     *out_mult = gcm_gmult_avx512;
@@ -241,6 +242,7 @@ void CRYPTO_ghash_init(gmult_func *out_mult, ghash_func *out_hash,
     *out_is_avx = 1;
     return;
   }
+#endif
   if (crypto_gcm_clmul_enabled()) {
     if (CRYPTO_is_AVX_capable() && CRYPTO_is_MOVBE_capable()) {
       gcm_init_avx(out_table, H);
@@ -335,7 +337,7 @@ void CRYPTO_gcm128_setiv(GCM128_CONTEXT *ctx, const AES_KEY *key,
   ctx->ares = 0;
   ctx->mres = 0;
 
-#if defined(GHASH_ASM_X86_64)
+#if defined(GHASH_ASM_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
   if (ctx->gcm_key.use_hw_gcm_crypt && crypto_gcm_avx512_enabled()) {
     gcm_setiv_avx512(key, ctx, iv, len);
     return;
@@ -621,7 +623,7 @@ int CRYPTO_gcm128_encrypt_ctr32(GCM128_CONTEXT *ctx, const AES_KEY *key,
     ctx->ares = 0;
   }
 
-#if defined(GHASH_ASM_X86_64)
+#if defined(GHASH_ASM_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
   if (ctx->gcm_key.use_hw_gcm_crypt && crypto_gcm_avx512_enabled() && len > 0) {
     aes_gcm_encrypt_avx512(key, ctx, &ctx->mres, in, len, out);
     return 1;
@@ -715,7 +717,7 @@ int CRYPTO_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx, const AES_KEY *key,
     ctx->ares = 0;
   }
 
-#if defined(GHASH_ASM_X86_64)
+#if defined(GHASH_ASM_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
   if (ctx->gcm_key.use_hw_gcm_crypt && crypto_gcm_avx512_enabled() && len > 0) {
     aes_gcm_decrypt_avx512(key, ctx, &ctx->mres, in, len, out);
     return 1;

--- a/crypto/fipsmodule/modes/internal.h
+++ b/crypto/fipsmodule/modes/internal.h
@@ -299,10 +299,12 @@ void gcm_init_avx(u128 Htable[16], const uint64_t Xi[2]);
 void gcm_gmult_avx(uint8_t Xi[16], const u128 Htable[16]);
 void gcm_ghash_avx(uint8_t Xi[16], const u128 Htable[16], const uint8_t *in,
                    size_t len);
+#if  !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
 void gcm_init_avx512(u128 Htable[16], const uint64_t Xi[2]);
 void gcm_gmult_avx512(uint8_t Xi[2], const u128 Htable[16]);
 void gcm_ghash_avx512(uint8_t Xi[2], const u128 Htable[16], const uint8_t *in,
                       size_t len);
+#endif
 #define HW_GCM
 size_t aesni_gcm_encrypt(const uint8_t *in, uint8_t *out, size_t len,
                          const AES_KEY *key, uint8_t ivec[16],

--- a/generated-src/linux-x86_64/crypto/fipsmodule/aesni-gcm-avx512.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/aesni-gcm-avx512.S
@@ -4,6 +4,7 @@
 #include <openssl/asm_base.h>
 
 #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64) && defined(__ELF__)
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .text	
 .globl	gcm_init_avx512
 .hidden gcm_init_avx512
@@ -136463,4 +136464,5 @@ byte64_len_to_mask_table:
 .quad	0x3fffffffffffffff, 0x7fffffffffffffff
 .quad	0xffffffffffffffff
 .text	
+#endif
 #endif

--- a/generated-src/linux-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
@@ -4,6 +4,7 @@
 #include <openssl/asm_base.h>
 
 #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64) && defined(__ELF__)
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .text	
 .globl	aes_hw_xts_encrypt_avx512
 .hidden aes_hw_xts_encrypt_avx512
@@ -5225,4 +5226,5 @@ shufb_15_7:
 .byte	0xff, 0xff, 0xff, 0xff, 0xff
 
 .text	
+#endif
 #endif

--- a/generated-src/linux-x86_64/crypto/fipsmodule/p256-x86_64-asm.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/p256-x86_64-asm.S
@@ -100,11 +100,13 @@ ecp_nistz256_neg:
 .align	32
 ecp_nistz256_ord_mul_mont:
 .cfi_startproc	
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	.Lecp_nistz256_ord_mul_montx
+#endif
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%rbp,-16
@@ -434,11 +436,13 @@ ecp_nistz256_ord_mul_mont:
 .align	32
 ecp_nistz256_ord_sqr_mont:
 .cfi_startproc	
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	.Lecp_nistz256_ord_sqr_montx
+#endif
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%rbp,-16
@@ -725,6 +729,7 @@ ecp_nistz256_ord_sqr_mont:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	ecp_nistz256_ord_sqr_mont,.-ecp_nistz256_ord_sqr_mont
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 .type	ecp_nistz256_ord_mul_montx,@function
 .align	32
@@ -1181,6 +1186,7 @@ ecp_nistz256_ord_sqr_montx:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	ecp_nistz256_ord_sqr_montx,.-ecp_nistz256_ord_sqr_montx
+#endif
 
 
 
@@ -1193,9 +1199,11 @@ ecp_nistz256_ord_sqr_montx:
 .align	32
 ecp_nistz256_mul_mont:
 .cfi_startproc	
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
+#endif
 .Lmul_mont:
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
@@ -1216,8 +1224,10 @@ ecp_nistz256_mul_mont:
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%r15,-56
 .Lmul_body:
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	cmpl	$0x80100,%ecx
 	je	.Lmul_montx
+#endif
 	movq	%rdx,%rbx
 	movq	0(%rdx),%rax
 	movq	0(%rsi),%r9
@@ -1226,6 +1236,7 @@ ecp_nistz256_mul_mont:
 	movq	24(%rsi),%r12
 
 	call	__ecp_nistz256_mul_montq
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	jmp	.Lmul_mont_done
 
 .align	32
@@ -1239,6 +1250,7 @@ ecp_nistz256_mul_mont:
 	leaq	-128(%rsi),%rsi
 
 	call	__ecp_nistz256_mul_montx
+#endif
 .Lmul_mont_done:
 	movq	0(%rsp),%r15
 .cfi_restore	%r15
@@ -1490,9 +1502,11 @@ __ecp_nistz256_mul_montq:
 .align	32
 ecp_nistz256_sqr_mont:
 .cfi_startproc	
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
+#endif
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%rbp,-16
@@ -1512,14 +1526,17 @@ ecp_nistz256_sqr_mont:
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%r15,-56
 .Lsqr_body:
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	cmpl	$0x80100,%ecx
 	je	.Lsqr_montx
+#endif
 	movq	0(%rsi),%rax
 	movq	8(%rsi),%r14
 	movq	16(%rsi),%r15
 	movq	24(%rsi),%r8
 
 	call	__ecp_nistz256_sqr_montq
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	jmp	.Lsqr_mont_done
 
 .align	32
@@ -1531,6 +1548,7 @@ ecp_nistz256_sqr_mont:
 	leaq	-128(%rsi),%rsi
 
 	call	__ecp_nistz256_sqr_montx
+#endif
 .Lsqr_mont_done:
 	movq	0(%rsp),%r15
 .cfi_restore	%r15
@@ -1714,6 +1732,7 @@ __ecp_nistz256_sqr_montq:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	__ecp_nistz256_sqr_montq,.-__ecp_nistz256_sqr_montq
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .type	__ecp_nistz256_mul_montx,@function
 .align	32
 __ecp_nistz256_mul_montx:
@@ -2012,6 +2031,7 @@ __ecp_nistz256_sqr_montx:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	__ecp_nistz256_sqr_montx,.-__ecp_nistz256_sqr_montx
+#endif
 
 
 .globl	ecp_nistz256_select_w5
@@ -2020,10 +2040,12 @@ __ecp_nistz256_sqr_montx:
 .align	32
 ecp_nistz256_select_w5:
 .cfi_startproc	
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rax
 	movq	8(%rax),%rax
 	testl	$32,%eax
 	jnz	.Lavx2_select_w5
+#endif
 	movdqa	.LOne(%rip),%xmm0
 	movd	%edx,%xmm1
 
@@ -2087,10 +2109,12 @@ ecp_nistz256_select_w5:
 .align	32
 ecp_nistz256_select_w7:
 .cfi_startproc	
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rax
 	movq	8(%rax),%rax
 	testl	$32,%eax
 	jnz	.Lavx2_select_w7
+#endif
 	movdqa	.LOne(%rip),%xmm8
 	movd	%edx,%xmm1
 
@@ -2134,6 +2158,7 @@ ecp_nistz256_select_w7:
 .cfi_endproc	
 .LSEH_end_ecp_nistz256_select_w7:
 .size	ecp_nistz256_select_w7,.-ecp_nistz256_select_w7
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 
 .type	ecp_nistz256_avx2_select_w5,@function
@@ -2197,7 +2222,8 @@ ecp_nistz256_avx2_select_w5:
 .cfi_endproc	
 .LSEH_end_ecp_nistz256_avx2_select_w5:
 .size	ecp_nistz256_avx2_select_w5,.-ecp_nistz256_avx2_select_w5
-
+#endif
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 
 .globl	ecp_nistz256_avx2_select_w7
@@ -2278,6 +2304,7 @@ ecp_nistz256_avx2_select_w7:
 .cfi_endproc	
 .LSEH_end_ecp_nistz256_avx2_select_w7:
 .size	ecp_nistz256_avx2_select_w7,.-ecp_nistz256_avx2_select_w7
+#endif
 .type	__ecp_nistz256_add_toq,@function
 .align	32
 __ecp_nistz256_add_toq:
@@ -2413,11 +2440,13 @@ __ecp_nistz256_mul_by_2q:
 .align	32
 ecp_nistz256_point_double:
 .cfi_startproc	
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	.Lpoint_doublex
+#endif
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%rbp,-16
@@ -2647,11 +2676,13 @@ ecp_nistz256_point_double:
 .align	32
 ecp_nistz256_point_add:
 .cfi_startproc	
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	.Lpoint_addx
+#endif
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%rbp,-16
@@ -3084,11 +3115,13 @@ ecp_nistz256_point_add:
 .align	32
 ecp_nistz256_point_add_affine:
 .cfi_startproc	
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	.Lpoint_add_affinex
+#endif
 	pushq	%rbp
 .cfi_adjust_cfa_offset	8
 .cfi_offset	%rbp,-16
@@ -3412,6 +3445,7 @@ ecp_nistz256_point_add_affine:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	ecp_nistz256_point_add_affine,.-ecp_nistz256_point_add_affine
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .type	__ecp_nistz256_add_tox,@function
 .align	32
 __ecp_nistz256_add_tox:
@@ -4534,4 +4568,5 @@ ecp_nistz256_point_add_affinex:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	ecp_nistz256_point_add_affinex,.-ecp_nistz256_point_add_affinex
+#endif
 #endif

--- a/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont.S
@@ -22,8 +22,10 @@ bn_mul_mont:
 	jnz	.Lmul_enter
 	cmpl	$8,%r9d
 	jb	.Lmul_enter
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%r11
 	movl	8(%r11),%r11d
+#endif
 	cmpq	%rsi,%rdx
 	jne	.Lmul4x_enter
 	testl	$7,%r9d
@@ -272,9 +274,11 @@ bn_mul4x_mont:
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
 .Lmul4x_enter:
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	andl	$0x80100,%r11d
 	cmpl	$0x80100,%r11d
 	je	.Lmulx4x_enter
+#endif
 	pushq	%rbx
 .cfi_offset	%rbx,-16
 	pushq	%rbp
@@ -698,8 +702,10 @@ bn_mul4x_mont:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	bn_mul4x_mont,.-bn_mul4x_mont
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .extern	bn_sqrx8x_internal
 .hidden bn_sqrx8x_internal
+#endif
 .extern	bn_sqr8x_internal
 .hidden bn_sqr8x_internal
 
@@ -784,6 +790,7 @@ bn_sqr8x_mont:
 	pxor	%xmm0,%xmm0
 .byte	102,72,15,110,207
 .byte	102,73,15,110,218
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%rax
 	movl	8(%rax),%eax
 	andl	$0x80100,%eax
@@ -804,6 +811,7 @@ bn_sqr8x_mont:
 
 .align	32
 .Lsqr8x_nox:
+#endif
 	call	bn_sqr8x_internal
 
 
@@ -891,6 +899,7 @@ bn_sqr8x_mont:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	bn_sqr8x_mont,.-bn_sqr8x_mont
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .type	bn_mulx4x_mont,@function
 .align	32
 bn_mulx4x_mont:
@@ -1247,6 +1256,7 @@ bn_mulx4x_mont:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	bn_mulx4x_mont,.-bn_mulx4x_mont
+#endif
 .byte	77,111,110,116,103,111,109,101,114,121,32,77,117,108,116,105,112,108,105,99,97,116,105,111,110,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
 .align	16
 #endif

--- a/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont5.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont5.S
@@ -20,8 +20,10 @@ bn_mul_mont_gather5:
 .cfi_def_cfa_register	%rax
 	testl	$7,%r9d
 	jnz	.Lmul_enter
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%r11
 	movl	8(%r11),%r11d
+#endif
 	jmp	.Lmul4x_enter
 
 .align	16
@@ -460,9 +462,11 @@ bn_mul4x_mont_gather5:
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
 .Lmul4x_enter:
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	andl	$0x80108,%r11d
 	cmpl	$0x80108,%r11d
 	je	.Lmulx4x_enter
+#endif
 	pushq	%rbx
 .cfi_offset	%rbx,-16
 	pushq	%rbp
@@ -1095,11 +1099,13 @@ bn_power5:
 .cfi_startproc	
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	OPENSSL_ia32cap_P(%rip),%r11
 	movl	8(%r11),%r11d
 	andl	$0x80108,%r11d
 	cmpl	$0x80108,%r11d
 	je	.Lpowerx5_enter
+#endif
 	pushq	%rbx
 .cfi_offset	%rbx,-16
 	pushq	%rbp
@@ -2064,6 +2070,7 @@ __bn_post4x_internal:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	__bn_post4x_internal,.-__bn_post4x_internal
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .type	bn_mulx4x_mont_gather5,@function
 .align	32
 bn_mulx4x_mont_gather5:
@@ -3410,6 +3417,7 @@ __bn_postx4x_internal:
 	.byte	0xf3,0xc3
 .cfi_endproc	
 .size	__bn_postx4x_internal,.-__bn_postx4x_internal
+#endif
 .globl	bn_scatter5
 .hidden bn_scatter5
 .type	bn_scatter5,@function

--- a/generated-src/mac-x86_64/crypto/fipsmodule/aesni-gcm-avx512.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/aesni-gcm-avx512.S
@@ -4,6 +4,7 @@
 #include <openssl/asm_base.h>
 
 #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64) && defined(__APPLE__)
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .text	
 .globl	_gcm_init_avx512
 .private_extern _gcm_init_avx512
@@ -136414,4 +136415,5 @@ byte64_len_to_mask_table:
 .quad	0x3fffffffffffffff, 0x7fffffffffffffff
 .quad	0xffffffffffffffff
 .text	
+#endif
 #endif

--- a/generated-src/mac-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
@@ -4,6 +4,7 @@
 #include <openssl/asm_base.h>
 
 #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64) && defined(__APPLE__)
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 .text	
 .globl	_aes_hw_xts_encrypt_avx512
 .private_extern _aes_hw_xts_encrypt_avx512
@@ -5225,4 +5226,5 @@ shufb_15_7:
 .byte	0xff, 0xff, 0xff, 0xff, 0xff
 
 .text	
+#endif
 #endif

--- a/generated-src/mac-x86_64/crypto/fipsmodule/p256-x86_64-asm.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/p256-x86_64-asm.S
@@ -97,11 +97,13 @@ L$neg_epilogue:
 .p2align	5
 _ecp_nistz256_ord_mul_mont:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	L$ecp_nistz256_ord_mul_montx
+#endif
 	pushq	%rbp
 
 	pushq	%rbx
@@ -425,11 +427,13 @@ L$ord_mul_epilogue:
 .p2align	5
 _ecp_nistz256_ord_sqr_mont:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	L$ecp_nistz256_ord_sqr_montx
+#endif
 	pushq	%rbp
 
 	pushq	%rbx
@@ -710,6 +714,7 @@ L$ord_sqr_epilogue:
 	.byte	0xf3,0xc3
 
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 
 .p2align	5
@@ -1154,6 +1159,7 @@ L$ord_sqrx_epilogue:
 	.byte	0xf3,0xc3
 
 
+#endif
 
 
 
@@ -1166,9 +1172,11 @@ L$ord_sqrx_epilogue:
 .p2align	5
 _ecp_nistz256_mul_mont:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
+#endif
 L$mul_mont:
 	pushq	%rbp
 
@@ -1183,8 +1191,10 @@ L$mul_mont:
 	pushq	%r15
 
 L$mul_body:
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	cmpl	$0x80100,%ecx
 	je	L$mul_montx
+#endif
 	movq	%rdx,%rbx
 	movq	0(%rdx),%rax
 	movq	0(%rsi),%r9
@@ -1193,6 +1203,7 @@ L$mul_body:
 	movq	24(%rsi),%r12
 
 	call	__ecp_nistz256_mul_montq
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	jmp	L$mul_mont_done
 
 .p2align	5
@@ -1206,6 +1217,7 @@ L$mul_montx:
 	leaq	-128(%rsi),%rsi
 
 	call	__ecp_nistz256_mul_montx
+#endif
 L$mul_mont_done:
 	movq	0(%rsp),%r15
 
@@ -1457,9 +1469,11 @@ __ecp_nistz256_mul_montq:
 .p2align	5
 _ecp_nistz256_sqr_mont:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
+#endif
 	pushq	%rbp
 
 	pushq	%rbx
@@ -1473,14 +1487,17 @@ _ecp_nistz256_sqr_mont:
 	pushq	%r15
 
 L$sqr_body:
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	cmpl	$0x80100,%ecx
 	je	L$sqr_montx
+#endif
 	movq	0(%rsi),%rax
 	movq	8(%rsi),%r14
 	movq	16(%rsi),%r15
 	movq	24(%rsi),%r8
 
 	call	__ecp_nistz256_sqr_montq
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	jmp	L$sqr_mont_done
 
 .p2align	5
@@ -1492,6 +1509,7 @@ L$sqr_montx:
 	leaq	-128(%rsi),%rsi
 
 	call	__ecp_nistz256_sqr_montx
+#endif
 L$sqr_mont_done:
 	movq	0(%rsp),%r15
 
@@ -1675,6 +1693,7 @@ __ecp_nistz256_sqr_montq:
 	.byte	0xf3,0xc3
 
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 .p2align	5
 __ecp_nistz256_mul_montx:
@@ -1973,6 +1992,7 @@ __ecp_nistz256_sqr_montx:
 	.byte	0xf3,0xc3
 
 
+#endif
 
 
 .globl	_ecp_nistz256_select_w5
@@ -1981,10 +2001,12 @@ __ecp_nistz256_sqr_montx:
 .p2align	5
 _ecp_nistz256_select_w5:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rax
 	movq	8(%rax),%rax
 	testl	$32,%eax
 	jnz	L$avx2_select_w5
+#endif
 	movdqa	L$One(%rip),%xmm0
 	movd	%edx,%xmm1
 
@@ -2048,10 +2070,12 @@ L$SEH_end_ecp_nistz256_select_w5:
 .p2align	5
 _ecp_nistz256_select_w7:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rax
 	movq	8(%rax),%rax
 	testl	$32,%eax
 	jnz	L$avx2_select_w7
+#endif
 	movdqa	L$One(%rip),%xmm8
 	movd	%edx,%xmm1
 
@@ -2095,6 +2119,7 @@ L$select_loop_sse_w7:
 
 L$SEH_end_ecp_nistz256_select_w7:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 
 
@@ -2158,7 +2183,8 @@ L$select_loop_avx2_w5:
 
 L$SEH_end_ecp_nistz256_avx2_select_w5:
 
-
+#endif
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 
 .globl	_ecp_nistz256_avx2_select_w7
@@ -2239,6 +2265,7 @@ L$select_loop_avx2_w7:
 
 L$SEH_end_ecp_nistz256_avx2_select_w7:
 
+#endif
 
 .p2align	5
 __ecp_nistz256_add_toq:
@@ -2374,11 +2401,13 @@ __ecp_nistz256_mul_by_2q:
 .p2align	5
 _ecp_nistz256_point_double:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	L$point_doublex
+#endif
 	pushq	%rbp
 
 	pushq	%rbx
@@ -2602,11 +2631,13 @@ L$point_doubleq_epilogue:
 .p2align	5
 _ecp_nistz256_point_add:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	L$point_addx
+#endif
 	pushq	%rbp
 
 	pushq	%rbx
@@ -3033,11 +3064,13 @@ L$point_addq_epilogue:
 .p2align	5
 _ecp_nistz256_point_add_affine:
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rcx
 	movq	8(%rcx),%rcx
 	andl	$0x80100,%ecx
 	cmpl	$0x80100,%ecx
 	je	L$point_add_affinex
+#endif
 	pushq	%rbp
 
 	pushq	%rbx
@@ -3355,6 +3388,7 @@ L$add_affineq_epilogue:
 	.byte	0xf3,0xc3
 
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 .p2align	5
 __ecp_nistz256_add_tox:
@@ -4459,4 +4493,5 @@ L$add_affinex_epilogue:
 	.byte	0xf3,0xc3
 
 
+#endif
 #endif

--- a/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont.S
@@ -21,8 +21,10 @@ _bn_mul_mont:
 	jnz	L$mul_enter
 	cmpl	$8,%r9d
 	jb	L$mul_enter
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%r11
 	movl	8(%r11),%r11d
+#endif
 	cmpq	%rsi,%rdx
 	jne	L$mul4x_enter
 	testl	$7,%r9d
@@ -271,9 +273,11 @@ bn_mul4x_mont:
 	movq	%rsp,%rax
 
 L$mul4x_enter:
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	andl	$0x80100,%r11d
 	cmpl	$0x80100,%r11d
 	je	L$mulx4x_enter
+#endif
 	pushq	%rbx
 
 	pushq	%rbp
@@ -697,7 +701,9 @@ L$mul4x_epilogue:
 	.byte	0xf3,0xc3
 
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
+#endif
 
 
 
@@ -781,6 +787,7 @@ L$sqr8x_body:
 	pxor	%xmm0,%xmm0
 .byte	102,72,15,110,207
 .byte	102,73,15,110,218
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%rax
 	movl	8(%rax),%eax
 	andl	$0x80100,%eax
@@ -801,6 +808,7 @@ L$sqr8x_body:
 
 .p2align	5
 L$sqr8x_nox:
+#endif
 	call	_bn_sqr8x_internal
 
 
@@ -888,6 +896,7 @@ L$sqr8x_epilogue:
 	.byte	0xf3,0xc3
 
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 .p2align	5
 bn_mulx4x_mont:
@@ -1244,6 +1253,7 @@ L$mulx4x_epilogue:
 	.byte	0xf3,0xc3
 
 
+#endif
 .byte	77,111,110,116,103,111,109,101,114,121,32,77,117,108,116,105,112,108,105,99,97,116,105,111,110,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
 .p2align	4
 #endif

--- a/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont5.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont5.S
@@ -19,8 +19,10 @@ _bn_mul_mont_gather5:
 
 	testl	$7,%r9d
 	jnz	L$mul_enter
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%r11
 	movl	8(%r11),%r11d
+#endif
 	jmp	L$mul4x_enter
 
 .p2align	4
@@ -459,9 +461,11 @@ bn_mul4x_mont_gather5:
 	movq	%rsp,%rax
 
 L$mul4x_enter:
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	andl	$0x80108,%r11d
 	cmpl	$0x80108,%r11d
 	je	L$mulx4x_enter
+#endif
 	pushq	%rbx
 
 	pushq	%rbp
@@ -1094,11 +1098,13 @@ _bn_power5:
 
 	movq	%rsp,%rax
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	leaq	_OPENSSL_ia32cap_P(%rip),%r11
 	movl	8(%r11),%r11d
 	andl	$0x80108,%r11d
 	cmpl	$0x80108,%r11d
 	je	L$powerx5_enter
+#endif
 	pushq	%rbx
 
 	pushq	%rbp
@@ -2063,6 +2069,7 @@ L$sqr4x_sub_entry:
 	.byte	0xf3,0xc3
 
 
+#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 .p2align	5
 bn_mulx4x_mont_gather5:
@@ -3409,6 +3416,7 @@ L$sqrx4x_sub_entry:
 	.byte	0xf3,0xc3
 
 
+#endif
 .globl	_bn_scatter5
 .private_extern _bn_scatter5
 

--- a/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
@@ -8,6 +8,7 @@ default	rel
 %define ZMMWORD
 
 %include "openssl/boringssl_prefix_symbols_nasm.inc"
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 section	.text code align=64
 
 global	aes_hw_xts_encrypt_avx512
@@ -5311,6 +5312,7 @@ shufb_15_7:
 
 section	.text
 
+%endif
 %else
 ; Work around https://bugzilla.nasm.us/show_bug.cgi?id=3392738
 ret

--- a/generated-src/win-x86_64/crypto/fipsmodule/p256-x86_64-asm.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/p256-x86_64-asm.asm
@@ -120,11 +120,13 @@ $L$SEH_begin_ecp_nistz256_ord_mul_mont:
 
 
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
 	and	ecx,0x80100
 	cmp	ecx,0x80100
 	je	NEAR $L$ecp_nistz256_ord_mul_montx
+%endif
 	push	rbp
 
 	push	rbx
@@ -458,11 +460,13 @@ $L$SEH_begin_ecp_nistz256_ord_sqr_mont:
 
 
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
 	and	ecx,0x80100
 	cmp	ecx,0x80100
 	je	NEAR $L$ecp_nistz256_ord_sqr_montx
+%endif
 	push	rbp
 
 	push	rbx
@@ -745,6 +749,7 @@ $L$ord_sqr_epilogue:
 	DB	0F3h,0C3h		;repret
 
 $L$SEH_end_ecp_nistz256_ord_sqr_mont:
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 
 ALIGN	32
@@ -1211,6 +1216,7 @@ $L$ord_sqrx_epilogue:
 	DB	0F3h,0C3h		;repret
 
 $L$SEH_end_ecp_nistz256_ord_sqr_montx:
+%endif
 
 
 
@@ -1231,9 +1237,11 @@ $L$SEH_begin_ecp_nistz256_mul_mont:
 
 
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
 	and	ecx,0x80100
+%endif
 $L$mul_mont:
 	push	rbp
 
@@ -1248,8 +1256,10 @@ $L$mul_mont:
 	push	r15
 
 $L$mul_body:
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	cmp	ecx,0x80100
 	je	NEAR $L$mul_montx
+%endif
 	mov	rbx,rdx
 	mov	rax,QWORD[rdx]
 	mov	r9,QWORD[rsi]
@@ -1258,6 +1268,7 @@ $L$mul_body:
 	mov	r12,QWORD[24+rsi]
 
 	call	__ecp_nistz256_mul_montq
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	jmp	NEAR $L$mul_mont_done
 
 ALIGN	32
@@ -1271,6 +1282,7 @@ $L$mul_montx:
 	lea	rsi,[((-128))+rsi]
 
 	call	__ecp_nistz256_mul_montx
+%endif
 $L$mul_mont_done:
 	mov	r15,QWORD[rsp]
 
@@ -1531,9 +1543,11 @@ $L$SEH_begin_ecp_nistz256_sqr_mont:
 
 
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
 	and	ecx,0x80100
+%endif
 	push	rbp
 
 	push	rbx
@@ -1547,14 +1561,17 @@ $L$SEH_begin_ecp_nistz256_sqr_mont:
 	push	r15
 
 $L$sqr_body:
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	cmp	ecx,0x80100
 	je	NEAR $L$sqr_montx
+%endif
 	mov	rax,QWORD[rsi]
 	mov	r14,QWORD[8+rsi]
 	mov	r15,QWORD[16+rsi]
 	mov	r8,QWORD[24+rsi]
 
 	call	__ecp_nistz256_sqr_montq
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	jmp	NEAR $L$sqr_mont_done
 
 ALIGN	32
@@ -1566,6 +1583,7 @@ $L$sqr_montx:
 	lea	rsi,[((-128))+rsi]
 
 	call	__ecp_nistz256_sqr_montx
+%endif
 $L$sqr_mont_done:
 	mov	r15,QWORD[rsp]
 
@@ -1751,6 +1769,7 @@ __ecp_nistz256_sqr_montq:
 	DB	0F3h,0C3h		;repret
 
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 ALIGN	32
 __ecp_nistz256_mul_montx:
@@ -2049,6 +2068,7 @@ __ecp_nistz256_sqr_montx:
 	DB	0F3h,0C3h		;repret
 
 
+%endif
 
 
 global	ecp_nistz256_select_w5
@@ -2056,10 +2076,12 @@ global	ecp_nistz256_select_w5
 ALIGN	32
 ecp_nistz256_select_w5:
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rax,[OPENSSL_ia32cap_P]
 	mov	rax,QWORD[8+rax]
 	test	eax,32
 	jnz	NEAR $L$avx2_select_w5
+%endif
 	lea	rax,[((-136))+rsp]
 $L$SEH_begin_ecp_nistz256_select_w5:
 	DB	0x48,0x8d,0x60,0xe0
@@ -2146,10 +2168,12 @@ global	ecp_nistz256_select_w7
 ALIGN	32
 ecp_nistz256_select_w7:
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rax,[OPENSSL_ia32cap_P]
 	mov	rax,QWORD[8+rax]
 	test	eax,32
 	jnz	NEAR $L$avx2_select_w7
+%endif
 	lea	rax,[((-136))+rsp]
 $L$SEH_begin_ecp_nistz256_select_w7:
 	DB	0x48,0x8d,0x60,0xe0
@@ -2217,6 +2241,7 @@ $L$select_loop_sse_w7:
 
 $L$SEH_end_ecp_nistz256_select_w7:
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 
 
@@ -2305,7 +2330,8 @@ $L$select_loop_avx2_w5:
 
 $L$SEH_end_ecp_nistz256_avx2_select_w5:
 
-
+%endif
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 
 global	ecp_nistz256_avx2_select_w7
@@ -2410,6 +2436,7 @@ $L$select_loop_avx2_w7:
 
 $L$SEH_end_ecp_nistz256_avx2_select_w7:
 
+%endif
 
 ALIGN	32
 __ecp_nistz256_add_toq:
@@ -2552,11 +2579,13 @@ $L$SEH_begin_ecp_nistz256_point_double:
 
 
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
 	and	ecx,0x80100
 	cmp	ecx,0x80100
 	je	NEAR $L$point_doublex
+%endif
 	push	rbp
 
 	push	rbx
@@ -2790,11 +2819,13 @@ $L$SEH_begin_ecp_nistz256_point_add:
 
 
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
 	and	ecx,0x80100
 	cmp	ecx,0x80100
 	je	NEAR $L$point_addx
+%endif
 	push	rbp
 
 	push	rbx
@@ -3231,11 +3262,13 @@ $L$SEH_begin_ecp_nistz256_point_add_affine:
 
 
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rcx,[OPENSSL_ia32cap_P]
 	mov	rcx,QWORD[8+rcx]
 	and	ecx,0x80100
 	cmp	ecx,0x80100
 	je	NEAR $L$point_add_affinex
+%endif
 	push	rbp
 
 	push	rbx
@@ -3555,6 +3588,7 @@ $L$add_affineq_epilogue:
 	DB	0F3h,0C3h		;repret
 
 $L$SEH_end_ecp_nistz256_point_add_affine:
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 ALIGN	32
 __ecp_nistz256_add_tox:
@@ -4691,6 +4725,7 @@ $L$add_affinex_epilogue:
 	DB	0F3h,0C3h		;repret
 
 $L$SEH_end_ecp_nistz256_point_add_affinex:
+%endif
 EXTERN	__imp_RtlVirtualUnwind
 
 
@@ -4836,6 +4871,7 @@ ALIGN	4
 	DD	$L$SEH_begin_ecp_nistz256_ord_sqr_mont wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_ord_sqr_mont wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_ord_sqr_mont wrt ..imagebase
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	DD	$L$SEH_begin_ecp_nistz256_ord_mul_montx wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_ord_mul_montx wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_ord_mul_montx wrt ..imagebase
@@ -4843,6 +4879,7 @@ ALIGN	4
 	DD	$L$SEH_begin_ecp_nistz256_ord_sqr_montx wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_ord_sqr_montx wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_ord_sqr_montx wrt ..imagebase
+%endif
 	DD	$L$SEH_begin_ecp_nistz256_mul_mont wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_mul_mont wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_mul_mont wrt ..imagebase
@@ -4858,6 +4895,7 @@ ALIGN	4
 	DD	$L$SEH_begin_ecp_nistz256_select_w7 wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_select_w7 wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_select_wX wrt ..imagebase
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	DD	$L$SEH_begin_ecp_nistz256_avx2_select_w5 wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_avx2_select_w5 wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_avx2_select_wX wrt ..imagebase
@@ -4865,6 +4903,7 @@ ALIGN	4
 	DD	$L$SEH_begin_ecp_nistz256_avx2_select_w7 wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_avx2_select_w7 wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_avx2_select_wX wrt ..imagebase
+%endif
 	DD	$L$SEH_begin_ecp_nistz256_point_double wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_point_double wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_point_double wrt ..imagebase
@@ -4876,6 +4915,7 @@ ALIGN	4
 	DD	$L$SEH_begin_ecp_nistz256_point_add_affine wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_point_add_affine wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_point_add_affine wrt ..imagebase
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	DD	$L$SEH_begin_ecp_nistz256_point_doublex wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_point_doublex wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_point_doublex wrt ..imagebase
@@ -4887,6 +4927,7 @@ ALIGN	4
 	DD	$L$SEH_begin_ecp_nistz256_point_add_affinex wrt ..imagebase
 	DD	$L$SEH_end_ecp_nistz256_point_add_affinex wrt ..imagebase
 	DD	$L$SEH_info_ecp_nistz256_point_add_affinex wrt ..imagebase
+%endif
 
 section	.xdata rdata align=8
 ALIGN	8
@@ -4904,6 +4945,7 @@ $L$SEH_info_ecp_nistz256_ord_sqr_mont:
 	DD	full_handler wrt ..imagebase
 	DD	$L$ord_sqr_body wrt ..imagebase,$L$ord_sqr_epilogue wrt ..imagebase
 	DD	48,0
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 $L$SEH_info_ecp_nistz256_ord_mul_montx:
 	DB	9,0,0,0
 	DD	full_handler wrt ..imagebase
@@ -4914,6 +4956,7 @@ $L$SEH_info_ecp_nistz256_ord_sqr_montx:
 	DD	full_handler wrt ..imagebase
 	DD	$L$ord_sqrx_body wrt ..imagebase,$L$ord_sqrx_epilogue wrt ..imagebase
 	DD	48,0
+%endif
 $L$SEH_info_ecp_nistz256_mul_mont:
 	DB	9,0,0,0
 	DD	full_handler wrt ..imagebase
@@ -4938,6 +4981,7 @@ $L$SEH_info_ecp_nistz256_select_wX:
 	DB	0x08,0x68,0x00,0x00
 	DB	0x04,0x01,0x15,0x00
 ALIGN	8
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 $L$SEH_info_ecp_nistz256_avx2_select_wX:
 	DB	0x01,0x36,0x17,0x0b
 	DB	0x36,0xf8,0x09,0x00
@@ -4953,6 +4997,7 @@ $L$SEH_info_ecp_nistz256_avx2_select_wX:
 	DB	0x04,0x01,0x15,0x00
 	DB	0x00,0xb3,0x00,0x00
 ALIGN	8
+%endif
 $L$SEH_info_ecp_nistz256_point_double:
 	DB	9,0,0,0
 	DD	full_handler wrt ..imagebase
@@ -4968,6 +5013,7 @@ $L$SEH_info_ecp_nistz256_point_add_affine:
 	DD	full_handler wrt ..imagebase
 	DD	$L$add_affineq_body wrt ..imagebase,$L$add_affineq_epilogue wrt ..imagebase
 	DD	32*15+56,0
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 ALIGN	8
 $L$SEH_info_ecp_nistz256_point_doublex:
 	DB	9,0,0,0
@@ -4984,6 +5030,7 @@ $L$SEH_info_ecp_nistz256_point_add_affinex:
 	DD	full_handler wrt ..imagebase
 	DD	$L$add_affinex_body wrt ..imagebase,$L$add_affinex_epilogue wrt ..imagebase
 	DD	32*15+56,0
+%endif
 %else
 ; Work around https://bugzilla.nasm.us/show_bug.cgi?id=3392738
 ret

--- a/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont.asm
@@ -37,8 +37,10 @@ $L$SEH_begin_bn_mul_mont:
 	jnz	NEAR $L$mul_enter
 	cmp	r9d,8
 	jb	NEAR $L$mul_enter
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	r11,[OPENSSL_ia32cap_P]
 	mov	r11d,DWORD[8+r11]
+%endif
 	cmp	rdx,rsi
 	jne	NEAR $L$mul4x_enter
 	test	r9d,7
@@ -301,9 +303,11 @@ $L$SEH_begin_bn_mul4x_mont:
 	mov	rax,rsp
 
 $L$mul4x_enter:
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	and	r11d,0x80100
 	cmp	r11d,0x80100
 	je	NEAR $L$mulx4x_enter
+%endif
 	push	rbx
 
 	push	rbp
@@ -729,7 +733,9 @@ $L$mul4x_epilogue:
 	DB	0F3h,0C3h		;repret
 
 $L$SEH_end_bn_mul4x_mont:
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 EXTERN	bn_sqrx8x_internal
+%endif
 EXTERN	bn_sqr8x_internal
 
 
@@ -825,6 +831,7 @@ DB	102,72,15,110,209
 	pxor	xmm0,xmm0
 DB	102,72,15,110,207
 DB	102,73,15,110,218
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	rax,[OPENSSL_ia32cap_P]
 	mov	eax,DWORD[8+rax]
 	and	eax,0x80100
@@ -845,6 +852,7 @@ DB	102,72,15,126,207
 
 ALIGN	32
 $L$sqr8x_nox:
+%endif
 	call	bn_sqr8x_internal
 
 
@@ -934,6 +942,7 @@ $L$sqr8x_epilogue:
 	DB	0F3h,0C3h		;repret
 
 $L$SEH_end_bn_sqr8x_mont:
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 ALIGN	32
 bn_mulx4x_mont:
@@ -1304,6 +1313,7 @@ $L$mulx4x_epilogue:
 	DB	0F3h,0C3h		;repret
 
 $L$SEH_end_bn_mulx4x_mont:
+%endif
 	DB	77,111,110,116,103,111,109,101,114,121,32,77,117,108,116,105
 	DB	112,108,105,99,97,116,105,111,110,32,102,111,114,32,120,56
 	DB	54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83
@@ -1455,9 +1465,11 @@ ALIGN	4
 	DD	$L$SEH_begin_bn_sqr8x_mont wrt ..imagebase
 	DD	$L$SEH_end_bn_sqr8x_mont wrt ..imagebase
 	DD	$L$SEH_info_bn_sqr8x_mont wrt ..imagebase
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	DD	$L$SEH_begin_bn_mulx4x_mont wrt ..imagebase
 	DD	$L$SEH_end_bn_mulx4x_mont wrt ..imagebase
 	DD	$L$SEH_info_bn_mulx4x_mont wrt ..imagebase
+%endif
 section	.xdata rdata align=8
 ALIGN	8
 $L$SEH_info_bn_mul_mont:
@@ -1473,11 +1485,13 @@ $L$SEH_info_bn_sqr8x_mont:
 	DD	sqr_handler wrt ..imagebase
 	DD	$L$sqr8x_prologue wrt ..imagebase,$L$sqr8x_body wrt ..imagebase,$L$sqr8x_epilogue wrt ..imagebase
 ALIGN	8
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 $L$SEH_info_bn_mulx4x_mont:
 	DB	9,0,0,0
 	DD	sqr_handler wrt ..imagebase
 	DD	$L$mulx4x_prologue wrt ..imagebase,$L$mulx4x_body wrt ..imagebase,$L$mulx4x_epilogue wrt ..imagebase
 ALIGN	8
+%endif
 %else
 ; Work around https://bugzilla.nasm.us/show_bug.cgi?id=3392738
 ret

--- a/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont5.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont5.asm
@@ -35,8 +35,10 @@ $L$SEH_begin_bn_mul_mont_gather5:
 
 	test	r9d,7
 	jnz	NEAR $L$mul_enter
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	r11,[OPENSSL_ia32cap_P]
 	mov	r11d,DWORD[8+r11]
+%endif
 	jmp	NEAR $L$mul4x_enter
 
 ALIGN	16
@@ -489,9 +491,11 @@ $L$SEH_begin_bn_mul4x_mont_gather5:
 	mov	rax,rsp
 
 $L$mul4x_enter:
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	and	r11d,0x80108
 	cmp	r11d,0x80108
 	je	NEAR $L$mulx4x_enter
+%endif
 	push	rbx
 
 	push	rbp
@@ -1137,11 +1141,13 @@ $L$SEH_begin_bn_power5:
 
 	mov	rax,rsp
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	lea	r11,[OPENSSL_ia32cap_P]
 	mov	r11d,DWORD[8+r11]
 	and	r11d,0x80108
 	cmp	r11d,0x80108
 	je	NEAR $L$powerx5_enter
+%endif
 	push	rbx
 
 	push	rbp
@@ -2107,6 +2113,7 @@ $L$sqr4x_sub_entry:
 	DB	0F3h,0C3h		;repret
 
 
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 
 ALIGN	32
 bn_mulx4x_mont_gather5:
@@ -3480,6 +3487,7 @@ $L$sqrx4x_sub_entry:
 	DB	0F3h,0C3h		;repret
 
 
+%endif
 global	bn_scatter5
 
 ALIGN	16
@@ -3806,6 +3814,7 @@ ALIGN	4
 	DD	$L$SEH_begin_bn_power5 wrt ..imagebase
 	DD	$L$SEH_end_bn_power5 wrt ..imagebase
 	DD	$L$SEH_info_bn_power5 wrt ..imagebase
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 	DD	$L$SEH_begin_bn_mulx4x_mont_gather5 wrt ..imagebase
 	DD	$L$SEH_end_bn_mulx4x_mont_gather5 wrt ..imagebase
 	DD	$L$SEH_info_bn_mulx4x_mont_gather5 wrt ..imagebase
@@ -3813,6 +3822,7 @@ ALIGN	4
 	DD	$L$SEH_begin_bn_powerx5 wrt ..imagebase
 	DD	$L$SEH_end_bn_powerx5 wrt ..imagebase
 	DD	$L$SEH_info_bn_powerx5 wrt ..imagebase
+%endif
 	DD	$L$SEH_begin_bn_gather5 wrt ..imagebase
 	DD	$L$SEH_end_bn_gather5 wrt ..imagebase
 	DD	$L$SEH_info_bn_gather5 wrt ..imagebase
@@ -3833,6 +3843,7 @@ $L$SEH_info_bn_power5:
 	DB	9,0,0,0
 	DD	mul_handler wrt ..imagebase
 	DD	$L$power5_prologue wrt ..imagebase,$L$power5_body wrt ..imagebase,$L$power5_epilogue wrt ..imagebase
+%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 ALIGN	8
 $L$SEH_info_bn_mulx4x_mont_gather5:
 	DB	9,0,0,0
@@ -3843,6 +3854,7 @@ $L$SEH_info_bn_powerx5:
 	DB	9,0,0,0
 	DD	mul_handler wrt ..imagebase
 	DD	$L$powerx5_prologue wrt ..imagebase,$L$powerx5_body wrt ..imagebase,$L$powerx5_epilogue wrt ..imagebase
+%endif
 ALIGN	8
 $L$SEH_info_bn_gather5:
 	DB	0x01,0x0b,0x03,0x0a

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -27,10 +27,13 @@ build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
 echo "Testing building shared lib."
 build_and_test -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 
-echo "Testing building with a SysGenId."
+echo "Testing with a SysGenId."
 TEST_SYSGENID_PATH=$(mktemp)
 dd if=/dev/zero of="${TEST_SYSGENID_PATH}" bs=1 count=4096
 build_and_test -DTEST_SYSGENID_PATH="${TEST_SYSGENID_PATH}"
+
+echo "Testing with pre-generated assembly code."
+build_and_test -DDISABLE_PERL=ON
 
 if [[ "${AWSLC_C99_TEST}" == "1" ]]; then
     echo "Testing the C99 compatability of AWS-LC headers."
@@ -44,7 +47,7 @@ fi
 
 # Lightly verify that uncommon build options does not break the build. Fist
 # define a list of typical build options to verify the special build option with
-build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release")
+build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DDISABLE_PERL=ON -DDISABLE_GO=ON")
 
 ## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
 for build_option in "${build_options_to_test[@]}"; do

--- a/tests/docker_images/gcc/4.8/Dockerfile
+++ b/tests/docker_images/gcc/4.8/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+FROM --platform=linux/amd64 gcc:4.8
+
+SHELL ["/bin/bash", "-c"]
+
+COPY cmake-3.6.3-Linux-x86_64.tar.gz /
+COPY go1.18.10.linux-amd64.tar.gz /
+RUN tar -C /usr/local -xzf cmake-3.6.3-Linux-x86_64.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.10.linux-amd64.tar.gz
+RUN rm cmake-3.6.3-Linux-x86_64.tar.gz
+RUN rm go1.18.10.linux-amd64.tar.gz
+ENV PATH="${PATH}:/usr/local/cmake-3.6.3-Linux-x86_64/bin:/usr/local/go/bin"
+
+
+CMD ["/bin/bash"]

--- a/tests/docker_images/gcc/build_images.sh
+++ b/tests/docker_images/gcc/build_images.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -ex
+
+# Log Docker hub limit https://docs.docker.com/docker-hub/download-rate-limit/#how-can-i-check-my-current-rate
+TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+
+
+SCRIPT_DIR=$(dirname "$(readlink -f "${0}")")
+
+
+BUILDER_NAME=aws-lc-gcc-builder
+if ! docker buildx inspect ${BUILDER_NAME}; then
+    docker buildx create --name ${BUILDER_NAME} --use
+fi
+
+## GCC-4.8
+curl --output-dir "${SCRIPT_DIR}"/4.8 -LO https://go.dev/dl/go1.18.10.linux-amd64.tar.gz
+curl --output-dir "${SCRIPT_DIR}"/4.8 -LO https://github.com/Kitware/CMake/releases/download/v3.6.3/cmake-3.6.3-Linux-x86_64.tar.gz
+docker buildx build -t aws-lc:gcc-4.8 "${SCRIPT_DIR}"/4.8 --load
+rm "${SCRIPT_DIR}"/4.8/go1.18.10.linux-amd64.tar.gz
+rm "${SCRIPT_DIR}"/4.8/cmake-3.6.3-Linux-x86_64.tar.gz
+
+docker buildx rm ${BUILDER_NAME}
+


### PR DESCRIPTION
### Description of changes: 
* Pre-generated assembly was not usable with certain older compilers/assemblers such as gcc-4.8.
  * This change injects preprocessor macros to guard the portions of ADX/AVX2/AVX-512 assembly that would break GCC-4.8, allowing GCC-4.8 to now use the pre-generated assembly.

### Call-out
* The pre-generated assembly is still not usable on the oldest supported compilers (e.g., gcc-4.1)

### Testing:
* Added tests that build using the pregenerated assembly code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
