### PR TITLE
Replace OPENSSL_NO_TLS_PHA with SSL_VERIFY_POST_HANDSHAKE

### DIFF
--- a/include/openssl/opensslconf.h
+++ b/include/openssl/opensslconf.h
@@ -53,11 +53,6 @@ extern "C" {
 #define OPENSSL_NO_MD2
 #define OPENSSL_NO_MDC2
 #define OPENSSL_NO_OCB
-
-// OPENSSL_NO_TLS_PHA indicates lack of support for post-handshake
-// authentication (PHA) in TLS >= 1.3
-#define OPENSSL_NO_TLS_PHA
-
 #define OPENSSL_NO_RC2
 #define OPENSSL_NO_RC5
 #define OPENSSL_NO_RFC3779

--- a/tests/ci/integration/python_patch/3.13/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/3.13/aws-lc-cpython.patch
@@ -147,7 +147,7 @@ index f7fdbf4..204d501 100644
  #endif
 
 
-+#if defined(OPENSSL_NO_TLS_PHA) || !defined(TLS1_3_VERSION) || defined(OPENSSL_NO_TLS1_3)
++#if !defined(SSL_VERIFY_POST_HANDSHAKE) || !defined(TLS1_3_VERSION) || defined(OPENSSL_NO_TLS1_3)
 +  #define PY_SSL_NO_POST_HS_AUTH
 +#endif
 +

--- a/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
@@ -147,7 +147,7 @@ index f7fdbf4..204d501 100644
  #endif
 
 
-+#if defined(OPENSSL_NO_TLS_PHA) || !defined(TLS1_3_VERSION) || defined(OPENSSL_NO_TLS1_3)
++#if !defined(SSL_VERIFY_POST_HANDSHAKE) || !defined(TLS1_3_VERSION) || defined(OPENSSL_NO_TLS1_3)
 +  #define PY_SSL_NO_POST_HS_AUTH
 +#endif
 +


### PR DESCRIPTION
# Notes

PR #1526 introduced the `OPENSSL_NO_TLS_PHA` directive mostly for the purposes of AWS-LC's compatibility with CPython, but in [cpython PR #117785](https://github.com/python/cpython/pull/117785) @encukou points out that detecting the absence of OpenSSL's own `SSL_VERIFY_POST_HANDSHAKE` directive is sufficient. This change removes AWS-LC's `OPENSSL_NO_TLS_PHA` directive in favor of detecting absence of `SSL_VERIFY_POST_HANDSHAKE`.

# Testing
- existing CI integration tests
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
