### PR TITLE
Add support for parsing ECPKParameter PEM files

### DIFF
--- a/crypto/ec_extra/ec_asn1.c
+++ b/crypto/ec_extra/ec_asn1.c
@@ -484,9 +484,7 @@ EC_KEY *d2i_ECParameters(EC_KEY **out_key, const uint8_t **inp, long len) {
     return NULL;
   }
 
-  CBS cbs;
-  CBS_init(&cbs, *inp, (size_t)len);
-  const EC_GROUP *group = EC_KEY_parse_parameters(&cbs);
+  EC_GROUP *group = d2i_ECPKParameters(NULL, inp, len);
   if (group == NULL) {
     return NULL;
   }
@@ -501,8 +499,28 @@ EC_KEY *d2i_ECParameters(EC_KEY **out_key, const uint8_t **inp, long len) {
     EC_KEY_free(*out_key);
     *out_key = ret;
   }
-  *inp = CBS_data(&cbs);
   return ret;
+}
+
+EC_GROUP *d2i_ECPKParameters(EC_GROUP **out_group, const uint8_t **inp,
+                             long len) {
+  if (len < 0) {
+    return NULL;
+  }
+
+  CBS cbs;
+  CBS_init(&cbs, *inp, (size_t)len);
+  EC_GROUP *group = EC_KEY_parse_parameters(&cbs);
+  if (group == NULL) {
+    return NULL;
+  }
+
+  if (out_group != NULL) {
+    EC_GROUP_free(*out_group);
+    *out_group = group;
+  }
+  *inp = CBS_data(&cbs);
+  return group;
 }
 
 int i2d_ECParameters(const EC_KEY *key, uint8_t **outp) {
@@ -511,9 +529,17 @@ int i2d_ECParameters(const EC_KEY *key, uint8_t **outp) {
     return -1;
   }
 
+  return i2d_ECPKParameters(key->group, outp);
+}
+
+int i2d_ECPKParameters(const EC_GROUP *group, uint8_t **outp) {
+  if (group == NULL) {
+    OPENSSL_PUT_ERROR(EC, ERR_R_PASSED_NULL_PARAMETER);
+    return -1;
+  }
+
   CBB cbb;
-  if (!CBB_init(&cbb, 0) ||
-      !EC_KEY_marshal_curve_name(&cbb, key->group)) {
+  if (!CBB_init(&cbb, 0) || !EC_KEY_marshal_curve_name(&cbb, group)) {
     CBB_cleanup(&cbb);
     return -1;
   }

--- a/crypto/ec_extra/ec_asn1.c
+++ b/crypto/ec_extra/ec_asn1.c
@@ -504,7 +504,7 @@ EC_KEY *d2i_ECParameters(EC_KEY **out_key, const uint8_t **inp, long len) {
 
 EC_GROUP *d2i_ECPKParameters(EC_GROUP **out_group, const uint8_t **inp,
                              long len) {
-  if (len < 0) {
+  if (inp == NULL || len < 0) {
     return NULL;
   }
 

--- a/crypto/fipsmodule/ec/internal.h
+++ b/crypto/fipsmodule/ec/internal.h
@@ -81,13 +81,14 @@
 extern "C" {
 #endif
 
-// ECDH_compute_shared_secret calculates the shared key between |pub_key| and |priv_key|.
-// This function is called internally by |ECDH_compute_key| and |ECDH_compute_key_fips|.
-// The shared secret is returned in |buf|, the value stored in |buflen| on entry is expected
-// to be EC_MAX_BYTES or the number of bytes of the field element of the underlying curve.
-// On exit, |buflen| is set to the actual number of bytes of the shared secret.
-int ECDH_compute_shared_secret(uint8_t *buf, size_t *buflen, const EC_POINT *pub_key,
-                               const EC_KEY *priv_key);
+// ECDH_compute_shared_secret calculates the shared key between |pub_key| and
+// |priv_key|. This function is called internally by |ECDH_compute_key| and
+// |ECDH_compute_key_fips|. The shared secret is returned in |buf|, the value
+// stored in |buflen| on entry is expected to be EC_MAX_BYTES or the number of
+// bytes of the field element of the underlying curve. On exit, |buflen| is set
+// to the actual number of bytes of the shared secret.
+int ECDH_compute_shared_secret(uint8_t *buf, size_t *buflen,
+                               const EC_POINT *pub_key, const EC_KEY *priv_key);
 
 // EC internals.
 
@@ -770,6 +771,16 @@ struct ec_key_st {
   CRYPTO_EX_DATA ex_data;
 } /* EC_KEY */;
 
+// d2i_ECPKParameters deserializes the |ECPKParameters| specified in RFC 3279
+// to an |EC_GROUP| from |inp|. Only deserialization of namedCurves or
+// explicitly-encoded versions of namedCurves are supported.
+EC_GROUP *d2i_ECPKParameters(EC_GROUP **out_group, const uint8_t **inp,
+                             long len);
+
+// i2d_ECPKParameters serializes an |EC_GROUP| from |outp| according to the
+// |ECPKParameters| specified in RFC 3279. Only serialization of namedCurves
+// are supported.
+int i2d_ECPKParameters(const EC_GROUP *group, uint8_t **outp);
 
 #if defined(__cplusplus)
 }  // extern C

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -546,7 +546,7 @@ int PEM_write_bio(BIO *bp, const char *name, const char *header,
     goto err;
   }
 
-  i = strlen(header);
+  i = (header != NULL) ? strlen(header) : 0;
   if (i > 0) {
     if ((BIO_write(bp, header, i) != i) || (BIO_write(bp, "\n", 1) != 1)) {
       goto err;

--- a/include/openssl/ec_key.h
+++ b/include/openssl/ec_key.h
@@ -329,14 +329,17 @@ OPENSSL_EXPORT int i2d_ECPrivateKey(const EC_KEY *key, uint8_t **outp);
 // d2i_ECParameters parses a DER-encoded ECParameters structure (RFC 5480) from
 // |len| bytes at |*inp|, as described in |d2i_SAMPLE|.
 //
-// Use |EC_KEY_parse_parameters| or |EC_KEY_parse_curve_name| instead.
+// Use |EC_KEY_parse_parameters| or |EC_KEY_parse_curve_name| instead. Only
+// deserialization of namedCurves or explicitly-encoded versions of named curves
+// are supported.
 OPENSSL_EXPORT EC_KEY *d2i_ECParameters(EC_KEY **out_key, const uint8_t **inp,
                                         long len);
 
 // i2d_ECParameters marshals |key|'s parameters as a DER-encoded OBJECT
 // IDENTIFIER, as described in |i2d_SAMPLE|.
 //
-// Use |EC_KEY_marshal_curve_name| instead.
+// Use |EC_KEY_marshal_curve_name| instead. Only serialization of namedCurves
+// are supported.
 OPENSSL_EXPORT int i2d_ECParameters(const EC_KEY *key, uint8_t **outp);
 
 // o2i_ECPublicKey parses an EC point from |len| bytes at |*inp| into

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -105,6 +105,7 @@ extern "C" {
 #define PEM_STRING_SSL_SESSION "SSL SESSION PARAMETERS"
 #define PEM_STRING_DSAPARAMS "DSA PARAMETERS"
 #define PEM_STRING_ECDSA_PUBLIC "ECDSA PUBLIC KEY"
+#define PEM_STRING_ECPARAMETERS "EC PARAMETERS"
 #define PEM_STRING_ECPRIVATEKEY "EC PRIVATE KEY"
 #define PEM_STRING_CMS "CMS"
 
@@ -472,6 +473,21 @@ OPENSSL_EXPORT int PEM_write_PKCS8PrivateKey(FILE *fp, const EVP_PKEY *x,
                                              int klen, pem_password_cb *cd,
                                              void *u);
 
+// PEM_read_bio_ECPKParameters deserializes the PEM file written in |bio|
+// according to |ECPKParameters| in RFC 3279. It returns the |EC_GROUP|
+// corresponding to deserialized output and also writes it to |out_group|. Only
+// deserialization of namedCurves or explicitly-encoded versions of namedCurves
+// are supported.
+OPENSSL_EXPORT EC_GROUP *PEM_read_bio_ECPKParameters(BIO *bio,
+                                                     EC_GROUP **out_group,
+                                                     pem_password_cb *cb,
+                                                     void *u);
+
+// PEM_write_bio_ECPKParameters serializes |group| as a PEM file to |out|
+// according to |ECPKParameters| in RFC 3279. Only serialization of namedCurves
+// are supported.
+OPENSSL_EXPORT int PEM_write_bio_ECPKParameters(BIO *out,
+                                                const EC_GROUP *group);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1715`

### Description of changes: 
Ruby depends on reading/writing PEM files that are defined as `EcpkParameters ` (See [RFC 3279](https://datatracker.ietf.org/doc/html/rfc3279#section-2.3.5) for more details).`EcpkParameters` actually just refer to potential different ways of serializing EC Groups and we already have basic support for this. OpenSSL's implementation of `d2i/i2d_ECParameters` actually [calls `d2i/i2d_ECPKParameters`](https://github.com/openssl/openssl/blob/fbd6609bb21b125c9454d07c484d166a33b4815b/crypto/ec/ec_asn1.c#L1088-L1114) internally.

* I've borrowed some of the logic for `d2i/i2d_ECParameters` and worked them into the new functions. Apparently we only support parsing named curves or explicitly encoded versions of them, so I've documented that and followed the same pattern. No new parsing logic has been added for `EC_GROUP`s. 
* We do not support writing custom curves to any ASN.1 output and this PR continues that trend.

### Call-outs:
* Code change in `crypto/pem/pem_lib.c` was taken from OpenSSL: https://github.com/openssl/openssl/commit/205957405d08ef199e6ab654e333a627bbca9ccc It was worth taking, so the call to `PEM_write_bio` could be cleaner.

### Testing:
* Tests for named curves and a explicitly encoded versions of P256. The same PEM file works fine with OpenSSL as well
* We don't support writing custom curves, so I have a test to make sure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
