### PR TITLE
AT_HWCAP2 not always defined

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_arm_freebsd.c
+++ b/crypto/fipsmodule/cpucap/cpu_arm_freebsd.c
@@ -30,7 +30,9 @@ void OPENSSL_cpuid_setup(void) {
   // left at zero. The rest of this function will then gracefully report
   // the features are absent.
   elf_aux_info(AT_HWCAP, &hwcap, sizeof(hwcap));
+#if defined(AT_HWCAP2)
   elf_aux_info(AT_HWCAP2, &hwcap2, sizeof(hwcap2));
+#endif
 
   // Matching OpenSSL, only report other features if NEON is present.
   if (hwcap & HWCAP_NEON) {

--- a/crypto/fipsmodule/cpucap/cpu_arm_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_arm_linux.c
@@ -118,7 +118,11 @@ void OPENSSL_cpuid_setup(void) {
     // this is now rare (see Chrome's Net.NeedsHWCAP2Workaround metric), but AES
     // and PMULL extensions are very useful, so we still carry the workaround
     // for now.
+#if defined(AT_HWCAP2)
     unsigned long hwcap2 = getauxval(AT_HWCAP2);
+#else
+    unsigned long hwcap2 = 0;
+#endif
     if (hwcap2 == 0) {
       hwcap2 = crypto_get_arm_hwcap2_from_cpuinfo(&cpuinfo);
       g_needs_hwcap2_workaround = hwcap2 != 0;

--- a/crypto/fipsmodule/cpucap/cpu_ppc64le.c
+++ b/crypto/fipsmodule/cpucap/cpu_ppc64le.c
@@ -68,7 +68,11 @@ static void handle_cpu_env(unsigned long *out, const char *in) {
 extern uint8_t OPENSSL_cpucap_initialized;
 
 void OPENSSL_cpuid_setup(void) {
+#if defined(AT_HWCAP2)
   OPENSSL_ppc64le_hwcap2 = getauxval(AT_HWCAP2);
+#else
+  OPENSSL_ppc64le_hwcap2 = 0;
+#endif
   OPENSSL_cpucap_initialized = 1;
 
   // OPENSSL_ppccap is a 64-bit hex string which may start with "0x".


### PR DESCRIPTION
### Issues:
Addresses: https://github.com/aws/aws-lc-rs/issues/427

### Description of changes: 
* Allow fallback when `AT_HWCAP2` is not defined (for older glibc).
> 
>       AT_HWCAP2 (since glibc 2.18)
>              Further machine-dependent hints about processor
>              capabilities.
>

### Testing:
* I've not yet been able to setup an environment that replicates [the failure seen downstream](https://github.com/rust-lang/rustup/actions/runs/9720503984/job/26831972336?pr=3898) for `arm-unknown-linux-gnueabihf`:
```
  In file included from /cargo/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.18.0/aws-lc/crypto/fipsmodule/bcm.c:81:
  /cargo/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.18.0/aws-lc/crypto/fipsmodule/cpucap/cpu_arm_linux.c: In function 'aws_lc_0_18_0_OPENSSL_cpuid_setup':
  /cargo/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.18.0/aws-lc/crypto/fipsmodule/cpucap/cpu_arm_linux.c:121:38: error: 'AT_HWCAP2' undeclared (first use in this function); did you mean 'AT_HWCAP'?
       unsigned long hwcap2 = getauxval(AT_HWCAP2);
                                        ^~~~~~~~~
                                        AT_HWCAP
  /cargo/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.18.0/aws-lc/crypto/fipsmodule/cpucap/cpu_arm_linux.c:121:38: note: each undeclared identifier is reported only once for each function it appears in
  /cargo/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.18.0/aws-lc/crypto/fipsmodule/bcm.c: At top level:
  cc1: error: unrecognized command line option '-Wno-c11-extensions' [-Werror]
  cc1: all warnings being treated as errors
  ninja: build stopped: subcommand failed.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
