### PR TITLE
Update MySQL to 9.0.0

### DIFF
--- a/tests/ci/integration/run_mysql_integration.sh
+++ b/tests/ci/integration/run_mysql_integration.sh
@@ -6,7 +6,7 @@ set -exu
 
 source tests/ci/common_posix_setup.sh
 
-MYSQL_VERSION_TAG="mysql-cluster-8.4.0"
+MYSQL_VERSION_TAG="mysql-cluster-9.0.0"
 # This directory is specific to the docker image used. Use -DDOWNLOAD_BOOST=1 -DWITH_BOOST=<directory>
 # with mySQL to download a compatible boost version locally.
 BOOST_INSTALL_FOLDER=/home/dependencies/boost

--- a/tests/ci/integration/run_mysql_integration.sh
+++ b/tests/ci/integration/run_mysql_integration.sh
@@ -136,4 +136,3 @@ ldd "${MYSQL_BUILD_FOLDER}/lib/libmysqlharness_tls.so" | grep "${AWS_LC_INSTALL_
 ldd "${MYSQL_BUILD_FOLDER}/lib/libmysqlrouter_routing.so" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
 ldd "${MYSQL_BUILD_FOLDER}/lib/libmysqlrouter_routing.so" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libssl.so" || exit 1
 ldd "${MYSQL_BUILD_FOLDER}/lib/libmysqlrouter_http.so" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
-ldd "${MYSQL_BUILD_FOLDER}/lib/libmysqlrouter_http.so" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libssl.so" || exit 1


### PR DESCRIPTION
### Issues:
Resolves `P138386170`

### Description of changes: 
Update MySQL CI to 9.0.0. `libmysqlrouter_http` no longer links to `libssl.so`, so removing ldd checks against that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
