### PR TITLE
add ECPKParameters_print as no-op

### DIFF
--- a/crypto/ec_extra/ec_asn1.c
+++ b/crypto/ec_extra/ec_asn1.c
@@ -62,8 +62,8 @@
 #include <openssl/mem.h>
 #include <openssl/nid.h>
 
-#include "../fipsmodule/ec/internal.h"
 #include "../bytestring/internal.h"
+#include "../fipsmodule/ec/internal.h"
 #include "../internal.h"
 
 
@@ -664,3 +664,6 @@ EC_POINT *EC_POINT_bn2point(const EC_GROUP *group, const BIGNUM *bn,
   return ret;
 }
 
+int ECPKParameters_print(BIO *bio, const EC_GROUP *group, int offset) {
+  return 1;
+}

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -475,6 +475,9 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED unsigned char *EC_GROUP_get0_seed(
 OPENSSL_EXPORT OPENSSL_DEPRECATED size_t
 EC_GROUP_get_seed_len(const EC_GROUP *group);
 
+// ECPKParameters_print returns 1.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int ECPKParameters_print(BIO *bio, const EC_GROUP *group,
+                                               int offset );
 
 // EC_METHOD No-ops [Deprecated].
 //

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -475,9 +475,9 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED unsigned char *EC_GROUP_get0_seed(
 OPENSSL_EXPORT OPENSSL_DEPRECATED size_t
 EC_GROUP_get_seed_len(const EC_GROUP *group);
 
-// ECPKParameters_print returns 1.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int ECPKParameters_print(BIO *bio, const EC_GROUP *group,
-                                               int offset );
+// ECPKParameters_print prints nothing and returns 1.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int ECPKParameters_print(
+    BIO *bio, const EC_GROUP *group, int offset);
 
 // EC_METHOD No-ops [Deprecated].
 //


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-1715`

### Description of changes: 
Ruby [consumes](https://github.com/ruby/ruby/blob/ruby_3_1/ext/openssl/ossl_pkey_ec.c#L1071-L1088) `ECPKParameters_print`. The entire function is a bit convoluted and not really beneficial unless you're using custom curves. We can expose this as a no-op until there's a more proper use case for this.

### Call-outs:
N/A

### Testing:
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
