### PR TITLE
extend ec2-test-framework instance timeout

### DIFF
--- a/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
+++ b/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
@@ -10,9 +10,12 @@ mainSteps:
     inputs:
       timeoutSeconds: '7200'
       runCommand:
-        # Fallback plan to shut down the ec2 instance in 60 minutes in case it's not terminated.
+        # TODO (P131897680): Parallelize the FIPS and sanitizer tests. The instance timeout can be lowered
+        #       once we do so.
+        #
+        # Fallback plan to shut down the ec2 instance in 90 minutes in case it's not terminated.
         # Codebuild just "stops" the instance calling the script, so "trap cleanup" is not executed.
-        - shutdown -P +60
+        - shutdown -P +90
         - sudo -i
         - systemctl stop apt-daily.timer
         - export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Description of changes: 
ec2-test-framework is having failures due to the instance timeout we originally set. The ultimate goal is to parallelize this, but extending the timeout for now.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
