### PR TITLE
Include FIPS mode in OpenSSL_version return value

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   macOS:
-    runs-on: macos-11 # latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build ${{ env.PACKAGE_NAME }}
@@ -22,7 +22,7 @@ jobs:
         ./tests/ci/run_posix_tests.sh
 
   macOS-FIPS:
-    runs-on: macos-11 # latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build ${{ env.PACKAGE_NAME }} with FIPS mode

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '>=1.18'
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         ./tests/ci/run_posix_tests.sh
@@ -25,6 +28,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '>=1.18'
     - name: Build ${{ env.PACKAGE_NAME }} with FIPS mode
       run: |
         ./tests/ci/run_fips_tests.sh

--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -13,6 +13,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 
 #include <openssl/crypto.h>
+#include <openssl/service_indicator.h>
 
 #include <assert.h>
 
@@ -118,7 +119,7 @@ const char *SSLeay_version(int which) { return OpenSSL_version(which); }
 const char *OpenSSL_version(int which) {
   switch (which) {
     case OPENSSL_VERSION:
-      return AWSLC_VERSION_NAME;
+      return AWSLC_VERSION_STRING;
     case OPENSSL_CFLAGS:
       return "compiler: n/a";
     case OPENSSL_BUILT_ON:

--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -22,6 +22,7 @@
 #include <openssl/crypto.h>
 #include <openssl/cipher.h>
 #include <openssl/mem.h>
+#include <openssl/service_indicator.h>
 
 #include <gtest/gtest.h>
 
@@ -35,6 +36,9 @@ TEST(CryptoTest, Version) {
            (OPENSSL_VERSION_NUMBER >> 12) & 0xff);
   EXPECT_EQ(expected,
             std::string(OPENSSL_VERSION_TEXT).substr(0, strlen(expected)));
+  std::string full_expected = AWSLC_VERSION_STRING;
+  std::string actual = std::string(OpenSSL_version(OPENSSL_VERSION));
+  EXPECT_EQ(actual, full_expected);
 }
 
 TEST(CryptoTest, Strndup) {


### PR DESCRIPTION
### Issues:
Resolves t/P138681213

### Description of changes: 

This backports PR 1419 to the 2022 FIPS branch.  Confirmed that modifying `crypto.c` does not affect the FIPS module.

### Call-outs:

- n/a

### Testing:
- CI
- verified FIPS module hash is unchanged

#### Setup

```
$ git diff
diff --git a/util/fipstools/inject_hash/inject_hash.go b/util/fipstools/inject_hash/inject_hash.go
index e4905be6b..0ba118fb3 100644
--- a/util/fipstools/inject_hash/inject_hash.go
+++ b/util/fipstools/inject_hash/inject_hash.go
@@ -24,6 +24,7 @@ import (
        "debug/elf"
        "debug/macho"
        "encoding/binary"
+       "encoding/hex"
        "errors"
        "flag"
        "fmt"
@@ -390,7 +391,10 @@ func do(outPath, oInput string, arInput string, appleOS bool) error {
        } else {
                mac.Write(moduleText)
        }
+
        calculated := mac.Sum(nil)
+       fmt.Fprintf(os.Stdout, "CALCULATED MODULE HASH: %s\n", hex.EncodeToString(calculated[:]))
+       return nil

        // Replace the default hash value in the object with the calculated
        // value and write it out.
```

#### Before this PR

```
$ git show -q
commit d0c62be0b9083ffc20056649b0719c3990f553d0 (HEAD -> pr-1419-fips-backport)
Author: Will Childs-Klein <childw@amazon.com>
Date:   Wed Jul 3 14:54:50 2024 +0000

    Revert "Include FIPS mode in OpenSSL_version return value (#1419)"

    This reverts commit 3f78067363523cc2aaaeeb31b75c450571cfcd56.

$ rm -rf build && cmake-build.sh && go run util/fipstools/inject_hash/inject_hash.go -in-object ./build/crypto/libcrypto.so
...
CALCULATED MODULE HASH: 02af10f6b9bbfe07a126c8c883e1be339f52a94ba3c69e6dad78605ad5ffcb5a
```

#### After this PR

```
$ git show -q
commit 3f78067363523cc2aaaeeb31b75c450571cfcd56 (HEAD -> pr-1419-fips-backport, origin/pr-1419-fips-backport)
Author: Will Childs-Klein <childw@amazon.com>
Date:   Thu Feb 15 18:54:44 2024 -0500

    Include FIPS mode in OpenSSL_version return value (#1419)

    This change includes FIPS mode information in the return value of
    `OpenSSL_version(OPENSSL_VERSION)`. This will allow consumers of CPython (and
    likely other tools or language runtimes) to detect FIPS mode without calling to
    an AWS-LC-specific API, which would require either patching or forking the
    language or tool in question.

$ rm -rf build && cmake-build.sh && go run util/fipstools/inject_hash/inject_hash.go -in-object ./build/crypto/libcrypto.so
...
CALCULATED MODULE HASH: 02af10f6b9bbfe07a126c8c883e1be339f52a94ba3c69e6dad78605ad5ffcb5a
```

#### Ensure that Modifying Module Source Affects Hash

```
$ git diff
diff --git a/crypto/fipsmodule/sha/sha256.c b/crypto/fipsmodule/sha/sha256.c
index 38164535c..8f5a9b534 100644
--- a/crypto/fipsmodule/sha/sha256.c
+++ b/crypto/fipsmodule/sha/sha256.c
@@ -87,7 +87,7 @@ int SHA256_Init(SHA256_CTX *sha) {
   sha->h[3] = 0xa54ff53aUL;
   sha->h[4] = 0x510e527fUL;
   sha->h[5] = 0x9b05688cUL;
-  sha->h[6] = 0x1f83d9abUL;
+  sha->h[6] = 0x1f83d9acUL;
   sha->h[7] = 0x5be0cd19UL;
   sha->md_len = SHA256_DIGEST_LENGTH;
   return 1;
diff --git a/util/fipstools/inject_hash/inject_hash.go b/util/fipstools/inject_hash/inject_hash.go
index e4905be6b..0ba118fb3 100644
--- a/util/fipstools/inject_hash/inject_hash.go
+++ b/util/fipstools/inject_hash/inject_hash.go
@@ -24,6 +24,7 @@ import (
        "debug/elf"
        "debug/macho"
        "encoding/binary"
+       "encoding/hex"
        "errors"
        "flag"
        "fmt"
@@ -390,7 +391,10 @@ func do(outPath, oInput string, arInput string, appleOS bool) error {
        } else {
                mac.Write(moduleText)
        }
+
        calculated := mac.Sum(nil)
+       fmt.Fprintf(os.Stdout, "CALCULATED MODULE HASH: %s\n", hex.EncodeToString(calculated[:]))
+       return nil

        // Replace the default hash value in the object with the calculated
        // value and write it out.

$ rm -rf build && cmake-build.sh && go run util/fipstools/inject_hash/inject_hash.go -in-object ./build/crypto/libcrypto.so
...
CALCULATED MODULE HASH: 3fe78abfc13f00d09fd2b2483e4dbe61c99b4119d369b2d40044d2965b8ea944
```
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
