### PR TITLE
Set ret to NULL before return in EC_POINT_bn2point

### DIFF
--- a/crypto/ec_extra/ec_asn1.c
+++ b/crypto/ec_extra/ec_asn1.c
@@ -656,6 +656,7 @@ EC_POINT *EC_POINT_bn2point(const EC_GROUP *group, const BIGNUM *bn,
       // If the user did not provide a |point|, we free the |EC_POINT| we
       // allocated.
       EC_POINT_free(ret);
+      ret = NULL;
     }
   }
 

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1184,7 +1184,7 @@ TEST(ECTest, BIGNUMConvert) {
   // Test specific openssl/openssl#10258 case for |BN_zero|.
   bssl::UniquePtr<BIGNUM> zero(BN_new());
   BN_zero(zero.get());
-  EXPECT_TRUE(EC_POINT_bn2point(group.get(), zero.get(), nullptr, nullptr));
+  EXPECT_FALSE(EC_POINT_bn2point(group.get(), zero.get(), nullptr, nullptr));
 }
 
 TEST(ECTest, SetKeyWithoutGroup) {


### PR DESCRIPTION
### Issues:
Resolves `P138896891`

### Description of changes: 
Static analysis was complaining about us using the pointer after it was freed. I don't believe this is an actual "issue", but we might as well make the NULL explicit before returning.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
