### PR TITLE
Move OCSP functions for Ruby out of internal.h

### DIFF
--- a/crypto/ocsp/internal.h
+++ b/crypto/ocsp/internal.h
@@ -264,13 +264,6 @@ OPENSSL_EXPORT int OCSP_REQ_CTX_nbio(OCSP_REQ_CTX *rctx);
 int OCSP_REQ_CTX_nbio_d2i(OCSP_REQ_CTX *rctx, ASN1_VALUE **pval,
                           const ASN1_ITEM *it);
 
-// Parses ASN.1 contents of |OCSP_REQ_CTX| into a der format.
-int OCSP_REQ_CTX_i2d(OCSP_REQ_CTX *rctx, const ASN1_ITEM *it, ASN1_VALUE *val);
-
-OCSP_CERTID *OCSP_cert_id_new(const EVP_MD *dgst, const X509_NAME *issuerName,
-                              const ASN1_BIT_STRING *issuerKey,
-                              const ASN1_INTEGER *serialNumber);
-
 // Returns the internal memory BIO of the |OCSP_REQ_CTX|. For AWS-LC, this is
 // only used for testing if contents of |OCSP_REQ_CTX| have been written
 // correctly.
@@ -292,13 +285,6 @@ OPENSSL_EXPORT int OCSP_REQUEST_get_ext_by_NID(OCSP_REQUEST *req, int nid,
 // by its position in the extension list.
 OPENSSL_EXPORT X509_EXTENSION *OCSP_REQUEST_get_ext(OCSP_REQUEST *req, int loc);
 
-// OCSP_BASICRESP_get_ext_by_NID returns the index of an extension from an
-// |OCSP_BASICRESP| by its NID. Returns -1 if not found.
-int OCSP_BASICRESP_get_ext_by_NID(OCSP_BASICRESP *bs, int nid, int lastpos);
-
-// OCSP_BASICRESP_get_ext retrieves an |X509_EXTENSION| from an |OCSP_BASICRESP|
-// by its position in the extension list.
-X509_EXTENSION *OCSP_BASICRESP_get_ext(OCSP_BASICRESP *bs, int loc);
 
 #define IS_OCSP_FLAG_SET(flags, query) (flags & query)
 #define OCSP_MAX_RESP_LENGTH (100 * 1024)

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -149,6 +149,9 @@ OPENSSL_EXPORT int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,
                                             const char *name,
                                             const char *value);
 
+// OCSP_REQ_CTX_i2d parses the ASN.1 contents of |rctx| into the der format.
+int OCSP_REQ_CTX_i2d(OCSP_REQ_CTX *rctx, const ASN1_ITEM *it, ASN1_VALUE *val);
+
 // OCSP_request_add0_id adds |cid| to |req|. Returns the new |OCSP_ONEREQ|
 // pointer allocated on the stack within |req|. This is useful if we want to
 // add extensions.
@@ -288,6 +291,13 @@ OPENSSL_EXPORT int OCSP_check_validity(ASN1_GENERALIZEDTIME *thisUpdate,
 OPENSSL_EXPORT int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
                                      X509_STORE *st, unsigned long flags);
 
+// OCSP_cert_id_new creates and returns a new |OCSP_CERTID| using |dgst|,
+// |issuerName|, |issuerKey|, and |serialNumber| as its contents.
+OPENSSL_EXPORT OCSP_CERTID *OCSP_cert_id_new(const EVP_MD *dgst,
+                                             const X509_NAME *issuerName,
+                                             const ASN1_BIT_STRING *issuerKey,
+                                             const ASN1_INTEGER *serialNumber);
+
 // OCSP_cert_to_id returns a |OCSP_CERTID| converted from a certificate and its
 // issuer.
 //
@@ -374,6 +384,15 @@ OPENSSL_EXPORT int OCSP_REQUEST_print(BIO *bp, OCSP_REQUEST *req,
 OPENSSL_EXPORT int OCSP_RESPONSE_print(BIO *bp, OCSP_RESPONSE *resp,
                                        unsigned long flags);
 
+// OCSP_BASICRESP_get_ext_by_NID returns the index of an extension |bs| by its
+// NID. Returns -1 if not found.
+OPENSSL_EXPORT int OCSP_BASICRESP_get_ext_by_NID(OCSP_BASICRESP *bs, int nid,
+                                                 int lastpos);
+
+// OCSP_SINGLERESP_get_ext returns the |X509_EXTENSION| in |bs| at index |loc|,
+// or NULL if |loc| is out of bounds.
+OPENSSL_EXPORT X509_EXTENSION *OCSP_BASICRESP_get_ext(OCSP_BASICRESP *bs,
+                                                      int loc);
 
 #if defined(__cplusplus)
 }  // extern C

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -389,10 +389,11 @@ OPENSSL_EXPORT int OCSP_RESPONSE_print(BIO *bp, OCSP_RESPONSE *resp,
 OPENSSL_EXPORT int OCSP_BASICRESP_get_ext_by_NID(OCSP_BASICRESP *bs, int nid,
                                                  int lastpos);
 
-// OCSP_SINGLERESP_get_ext returns the |X509_EXTENSION| in |bs| at index |loc|,
+// OCSP_BASICRESP_get_ext returns the |X509_EXTENSION| in |bs| at index |loc|,
 // or NULL if |loc| is out of bounds.
 OPENSSL_EXPORT X509_EXTENSION *OCSP_BASICRESP_get_ext(OCSP_BASICRESP *bs,
                                                       int loc);
+
 
 #if defined(__cplusplus)
 }  // extern C


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2420`

### Description of changes: 
A few of the OCSP symbols Ruby uses were only in our internal header. This pulls them out for consumers to use.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
