### PR TITLE
Add support to detect Neoverse V2 cores

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -80,11 +80,14 @@ void OPENSSL_cpuid_setup(void) {
   // is supported. As of Valgrind 3.21 trying to read from that register will
   // cause Valgrind to crash.
   if (hwcap & kCPUID) {
-    // Check if the CPU model is Neoverse V1,
+    // Check if the CPU model is Neoverse V1 or V2,
     // which has a wide crypto/SIMD pipeline.
     OPENSSL_arm_midr = armv8_cpuid_probe();
     if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V1)) {
       OPENSSL_armcap_P |= ARMV8_NEOVERSE_V1;
+    }
+    if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V2)) {
+      OPENSSL_armcap_P |= ARMV8_NEOVERSE_V2;
     }
   }
 

--- a/crypto/fipsmodule/cpucap/cpucap.c
+++ b/crypto/fipsmodule/cpucap/cpucap.c
@@ -75,6 +75,9 @@ HIDDEN uint32_t OPENSSL_armcap_P =
 #if defined(OPENSSL_STATIC_ARMCAP_NEOVERSE_V1) || defined(__ARM_FEATURE_NEOVERSE_V1)
     ARMV8_NEOVERSE_V1 |
 #endif
+#if defined(OPENSSL_STATIC_ARMCAP_NEOVERSE_V2) || defined(__ARM_FEATURE_NEOVERSE_V2)
+    ARMV8_NEOVERSE_V2 |
+#endif
     0;
 
 #else

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -186,11 +186,13 @@ OPENSSL_INLINE int CRYPTO_is_ARMv8_PMULL_capable(void) {
 OPENSSL_INLINE int CRYPTO_is_ARMv8_GCM_8x_capable(void) {
   return ((OPENSSL_armcap_P & ARMV8_SHA3) != 0 &&
           ((OPENSSL_armcap_P & ARMV8_NEOVERSE_V1) != 0 ||
+           (OPENSSL_armcap_P & ARMV8_NEOVERSE_V2) != 0 ||
            (OPENSSL_armcap_P & ARMV8_APPLE_M1) != 0));
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_wide_multiplier_capable(void) {
   return (OPENSSL_armcap_P & ARMV8_NEOVERSE_V1) != 0 ||
+           (OPENSSL_armcap_P & ARMV8_NEOVERSE_V2) != 0 ||
            (OPENSSL_armcap_P & ARMV8_APPLE_M1) != 0;
 }
 

--- a/include/openssl/arm_arch.h
+++ b/include/openssl/arm_arch.h
@@ -82,11 +82,12 @@
 // ARMV8_SHA3 indicates support for hardware SHA-3 instructions including EOR3.
 #define ARMV8_SHA3  (1 << 11)
 
-// The Neoverse V1 and Apple M1 micro-architectures are detected to enable
+// The Neoverse V1, V2, and Apple M1 micro-architectures are detected to enable
 // high unrolling factor of AES-GCM and other algorithms that leverage a
 // wide crypto pipeline and fast multiplier.
 #define ARMV8_NEOVERSE_V1 (1 << 12)
 #define ARMV8_APPLE_M1 (1 << 13)
+#define ARMV8_NEOVERSE_V2 (1 << 14)
 
 //
 // MIDR_EL1 system register
@@ -102,6 +103,7 @@
 # define ARM_CPU_PART_CORTEX_A72   0xD08
 # define ARM_CPU_PART_N1           0xD0C
 # define ARM_CPU_PART_V1           0xD40
+# define ARM_CPU_PART_V2           0xD4F
 
 # define MIDR_PARTNUM_SHIFT       4
 # define MIDR_PARTNUM_MASK        (0xfffUL << MIDR_PARTNUM_SHIFT)


### PR DESCRIPTION
### Description of changes: 
Graviton 4 uses Neoverse V2 cores which we were previously not detecting which resulted in poor performing implementations being used. It still produced the correct answer, it just didn't take full advantage of the CPU's capabilities.

### Call-outs:
I thought about combining the ARM CPU capability flag for Neoverse V1 and V2 cores into one flag but we might have a future usecase that would need specific handling even though right now they behave the same. 

We also need to test Apple M2 and M3 CPUs which will probably also want the same optimizations as M1. This also might make sense to combine into a single Apple "M" ARM capability flag.

### Testing:
Built and ran locally. On a Graviton 4 instance:
|Algorithm|Before|After|
|---|---|---|
|RSA 2048 sign|929.6 ops/sec|1,397.5 ops/sec|
|ECDH P-384|3,541.2 ops/sec|3,744.8 ops/sec|
|ECDH P-521|1,885.1 ops/sec|2,406.7 ops/sec
|AES 256 GCM 16 bytes|204.4 MB/s|203.9 MB/s|
|AES 256 GCM 16kb bytes|4,500.5 MB/s|6,019.0 MB/s|


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
