### PR TITLE
Add aes-256-xts to EVP_get_cipherbyname

### DIFF
--- a/crypto/cipher_extra/cipher_extra.c
+++ b/crypto/cipher_extra/cipher_extra.c
@@ -95,6 +95,7 @@ static const struct {
     {NID_des_ede3_cbc, "des-ede3-cbc", EVP_des_ede3_cbc},
     {NID_rc2_cbc, "rc2-cbc", EVP_rc2_cbc},
     {NID_rc4, "rc4", EVP_rc4},
+    {NID_aes_256_xts, "aes-256-xts", EVP_aes_256_xts},
 };
 
 static const struct {

--- a/crypto/cipher_extra/cipher_extra.c
+++ b/crypto/cipher_extra/cipher_extra.c
@@ -87,6 +87,7 @@ static const struct {
     {NID_aes_256_ecb, "aes-256-ecb", EVP_aes_256_ecb},
     {NID_aes_256_gcm, "aes-256-gcm", EVP_aes_256_gcm},
     {NID_aes_256_ofb128, "aes-256-ofb", EVP_aes_256_ofb},
+    {NID_aes_256_xts, "aes-256-xts", EVP_aes_256_xts},
     {NID_chacha20_poly1305, "chacha20-poly1305", EVP_chacha20_poly1305},
     {NID_des_cbc, "des-cbc", EVP_des_cbc},
     {NID_des_ecb, "des-ecb", EVP_des_ecb},
@@ -95,7 +96,6 @@ static const struct {
     {NID_des_ede3_cbc, "des-ede3-cbc", EVP_des_ede3_cbc},
     {NID_rc2_cbc, "rc2-cbc", EVP_rc2_cbc},
     {NID_rc4, "rc4", EVP_rc4},
-    {NID_aes_256_xts, "aes-256-xts", EVP_aes_256_xts},
 };
 
 static const struct {


### PR DESCRIPTION
### Description of changes: 

`EVP_get_cipherbyname()` is deprecated. But cryptsetup use it to query for the implementation of XTS.

### Testing:

We already test `EVP_get_cipherbyname()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
