### PR TITLE
Match using CMAKE_SYSTEM_PROCESSOR_LOWER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -769,10 +769,14 @@ if(OPENSSL_NO_SSE2_FOR_TESTING)
   add_definitions(-DOPENSSL_NO_SSE2_FOR_TESTING)
 endif()
 
+# Some consumers might use upper-case (e.g.) "X86" or "X86_64".
+# Matching below is based on lower-case.
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" CMAKE_SYSTEM_PROCESSOR_LOWER)
+
 if(OPENSSL_NO_ASM)
   add_definitions(-DOPENSSL_NO_ASM)
   set(ARCH "generic")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
+elseif(CMAKE_SYSTEM_PROCESSOR_LOWER MATCHES "x86_64|amd64")
   # If ARCH is originally detected as 64-bit, perform an additional check
   # to determine whether to build as 32-bit or 64-bit. This happens in some
   # cases such as when building in Docker, where the host-level architecture is 64-bit
@@ -782,9 +786,9 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
   else()
     set(ARCH "x86")
   endif()
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|i386|i686")
+elseif(CMAKE_SYSTEM_PROCESSOR_LOWER MATCHES "x86|i386|i686")
   set(ARCH "x86")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64.*|ARM64|aarch64")
+elseif(CMAKE_SYSTEM_PROCESSOR_LOWER MATCHES "arm64.*|aarch64")
   # If ARCH is originally detected as 64-bit, perform an additional check
   # to determine whether to build as 32-bit or 64-bit. This happens in some
   # cases such as when building on an 64-bit CPU where the OS is 32-bit.
@@ -793,15 +797,15 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64.*|ARM64|aarch64")
   else()
     set(ARCH "arm")
   endif()
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm*")
+elseif(CMAKE_SYSTEM_PROCESSOR_LOWER MATCHES "^arm*")
   set(ARCH "arm")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "powerpc64le|ppc64le")
+elseif(CMAKE_SYSTEM_PROCESSOR_LOWER MATCHES "powerpc64le|ppc64le")
   set(ARCH "ppc64le")
-elseif (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "riscv64")
+elseif (${CMAKE_SYSTEM_PROCESSOR_LOWER} STREQUAL "riscv64")
   set(ARCH "riscv64")
-elseif (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "s390x")
+elseif (${CMAKE_SYSTEM_PROCESSOR_LOWER} STREQUAL "s390x")
   set(ARCH "s390x")
-elseif (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "loongarch64")
+elseif (${CMAKE_SYSTEM_PROCESSOR_LOWER} STREQUAL "loongarch64")
   set(ARCH "loongarch64")
 else()
   message(STATUS "Unknown processor found. Using generic implementations. Processor: " ${CMAKE_SYSTEM_PROCESSOR})

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -685,7 +685,7 @@ if(FIPS_SHARED)
     #
     # Note: we use CMAKE_SYSTEM_PROCESSOR directly instead of the ARCH variable
     # because if NO_ASM build flag is defined then ARCH is set to "generic".
-    if (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64.*|ARM64|aarch64")
+    if (APPLE AND CMAKE_SYSTEM_PROCESSOR_LOWER MATCHES "arm64.*|aarch64")
       add_custom_command(
         TARGET crypto POST_BUILD
         COMMAND codesign -s - $<TARGET_FILE:crypto>


### PR DESCRIPTION
### Description of changes: 
* I found that some downstream consumers use upper-case "X86" ([for example](https://github.com/rust-lang/cmake-rs/blob/c4a60dd154dd90e469dffc41a1faa717704f90b3/src/lib.rs#L487)) which fails to match in our [CMakeLists.txt](https://github.com/aws/aws-lc/blob/main/CMakeLists.txt#L785).
* This change creates a `CMAKE_SYSTEM_PROCESSOR_LOWER` variable and uses that when matching.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
