### PR TITLE
add support for OCSP_copy_nonce

### DIFF
--- a/crypto/ocsp/internal.h
+++ b/crypto/ocsp/internal.h
@@ -287,11 +287,6 @@ OPENSSL_EXPORT X509_EXTENSION *OCSP_REQUEST_get_ext(OCSP_REQUEST *req, int loc);
 // out of bounds, the new extension is appended to the list.
 int OCSP_BASICRESP_add_ext(OCSP_BASICRESP *bs, X509_EXTENSION *ex, int loc);
 
-// OCSP_BASICRESP_delete_ext removes the extension in |x| at index |loc| and
-// returns the removed extension, or NULL if |loc| was out of bounds. If an
-// extension was returned, the caller must release it with
-// |X509_EXTENSION_free|.
-X509_EXTENSION *OCSP_BASICRESP_delete_ext(OCSP_BASICRESP *x, int loc);
 
 #define IS_OCSP_FLAG_SET(flags, query) (flags & query)
 #define OCSP_MAX_RESP_LENGTH (100 * 1024)

--- a/crypto/ocsp/internal.h
+++ b/crypto/ocsp/internal.h
@@ -287,6 +287,11 @@ OPENSSL_EXPORT X509_EXTENSION *OCSP_REQUEST_get_ext(OCSP_REQUEST *req, int loc);
 // out of bounds, the new extension is appended to the list.
 int OCSP_BASICRESP_add_ext(OCSP_BASICRESP *bs, X509_EXTENSION *ex, int loc);
 
+// OCSP_BASICRESP_delete_ext removes the extension in |x| at index |loc| and
+// returns the removed extension, or NULL if |loc| was out of bounds. If an
+// extension was returned, the caller must release it with
+// |X509_EXTENSION_free|.
+X509_EXTENSION *OCSP_BASICRESP_delete_ext(OCSP_BASICRESP *x, int loc);
 
 #define IS_OCSP_FLAG_SET(flags, query) (flags & query)
 #define OCSP_MAX_RESP_LENGTH (100 * 1024)

--- a/crypto/ocsp/internal.h
+++ b/crypto/ocsp/internal.h
@@ -281,6 +281,12 @@ OPENSSL_EXPORT int OCSP_REQUEST_get_ext_by_NID(OCSP_REQUEST *req, int nid,
 // by its position in the extension list.
 OPENSSL_EXPORT X509_EXTENSION *OCSP_REQUEST_get_ext(OCSP_REQUEST *req, int loc);
 
+// OCSP_BASICRESP_add_ext adds a copy of |ex| to the extension list in
+// |*bs|. It returns 1 on success and 0 on error. The new extension is
+// inserted at index |loc|, shifting extensions to the right. If |loc| is -1 or
+// out of bounds, the new extension is appended to the list.
+int OCSP_BASICRESP_add_ext(OCSP_BASICRESP *bs, X509_EXTENSION *ex, int loc);
+
 
 #define IS_OCSP_FLAG_SET(flags, query) (flags & query)
 #define OCSP_MAX_RESP_LENGTH (100 * 1024)

--- a/crypto/ocsp/ocsp_extension.c
+++ b/crypto/ocsp/ocsp_extension.c
@@ -165,15 +165,6 @@ int OCSP_copy_nonce(OCSP_BASICRESP *resp, OCSP_REQUEST *req) {
   // This shouldn't happen under normal circumstances.
   GUARD_PTR(req_ext);
 
-  // Delete the original nonce in |resp| if one exists.
-  int resp_idx =
-      OCSP_BASICRESP_get_ext_by_NID(resp, NID_id_pkix_OCSP_Nonce, -1);
-  if (resp_idx >= 0) {
-    X509_EXTENSION *old_resp_ext = OCSP_BASICRESP_delete_ext(resp, resp_idx);
-    GUARD_PTR(old_resp_ext);
-    X509_EXTENSION_free(old_resp_ext);
-  }
-
   // Append the nonce.
   return OCSP_BASICRESP_add_ext(resp, req_ext, -1);
 }

--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -1387,6 +1387,16 @@ TEST_P(OCSPNonceTest, OCSPNonce) {
   }
   EXPECT_EQ(OCSP_check_nonce(ocspRequest.get(), basicResponse.get()),
             t.nonce_check_status);
+
+  // Check that nonce copying from |req| to |bs| also works as expected.
+  if (t.nonce_check_status == OCSP_NONCE_RESPONSE_ONLY ||
+      t.nonce_check_status == OCSP_NONCE_BOTH_ABSENT) {
+    EXPECT_EQ(OCSP_copy_nonce(basicResponse.get(), ocspRequest.get()), 2);
+  } else {
+    EXPECT_EQ(OCSP_copy_nonce(basicResponse.get(), ocspRequest.get()), 1);
+    EXPECT_EQ(OCSP_check_nonce(ocspRequest.get(), basicResponse.get()),
+              OCSP_NONCE_EQUAL);
+  }
 }
 
 TEST(OCSPTest, OCSPNonce) {

--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -1392,6 +1392,8 @@ TEST_P(OCSPNonceTest, OCSPNonce) {
   if (t.nonce_check_status == OCSP_NONCE_RESPONSE_ONLY ||
       t.nonce_check_status == OCSP_NONCE_BOTH_ABSENT) {
     EXPECT_EQ(OCSP_copy_nonce(basicResponse.get(), ocspRequest.get()), 2);
+    EXPECT_EQ(OCSP_check_nonce(ocspRequest.get(), basicResponse.get()),
+            t.nonce_check_status);
   } else {
     EXPECT_EQ(OCSP_copy_nonce(basicResponse.get(), ocspRequest.get()), 1);
     EXPECT_EQ(OCSP_check_nonce(ocspRequest.get(), basicResponse.get()),

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -199,10 +199,10 @@ OPENSSL_EXPORT int OCSP_check_nonce(OCSP_REQUEST *req, OCSP_BASICRESP *bs);
 // 1 on success and 0 on failure. If the optional nonce value does not exist in
 // |req|, we return 2 instead.
 //
-// Note: Contrary to OpenSSL's |OCSP_copy_nonce| which allows for
-// multiple OCSP nonces to exist and appends the new nonce to the end of the
-// extension list, AWS-LC replaces the already existing OCSP nonce in |resp|, if
-// any.
+// Note: |OCSP_copy_nonce| allows for multiple OCSP nonces to exist and appends
+// the new nonce to the end of the extension list. This causes issues with
+// |OCSP_check_nonce|, since it looks for the first one in the list. The old
+// nonce extension should be deleted prior to calling |OCSP_copy_nonce|.
 OPENSSL_EXPORT int OCSP_copy_nonce(OCSP_BASICRESP *resp, OCSP_REQUEST *req);
 
 // OCSP_request_set1_name sets |requestorName| from an |X509_NAME| structure.
@@ -362,7 +362,8 @@ OPENSSL_EXPORT int OCSP_parse_url(const char *url, char **phost, char **pport,
 
 // OCSP_id_issuer_cmp compares the issuers' name and key hash of |a| and |b|. It
 // returns 0 on equal.
-OPENSSL_EXPORT int OCSP_id_issuer_cmp(const OCSP_CERTID *a, const OCSP_CERTID *b);
+OPENSSL_EXPORT int OCSP_id_issuer_cmp(const OCSP_CERTID *a,
+                                      const OCSP_CERTID *b);
 
 // OCSP_id_cmp calls |OCSP_id_issuer_cmp| and additionally compares the
 // |serialNumber| of |a| and |b|. It returns 0 on equal.
@@ -422,6 +423,13 @@ OPENSSL_EXPORT X509_EXTENSION *OCSP_BASICRESP_get_ext(OCSP_BASICRESP *bs,
 
 
 // OCSP |X509_EXTENSION| Functions
+
+// OCSP_BASICRESP_delete_ext removes the extension in |x| at index |loc| and
+// returns the removed extension, or NULL if |loc| was out of bounds. If an
+// extension was returned, the caller must release it with
+// |X509_EXTENSION_free|.
+OPENSSL_EXPORT X509_EXTENSION *OCSP_BASICRESP_delete_ext(OCSP_BASICRESP *x,
+                                                         int loc);
 
 // OCSP_SINGLERESP_add_ext adds a copy of |ex| to the extension list in
 // |*sresp|. It returns 1 on success and 0 on error. The new extension is

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -195,6 +195,11 @@ OPENSSL_EXPORT int OCSP_request_add1_nonce(OCSP_REQUEST *req,
 //  but aren't equal.
 OPENSSL_EXPORT int OCSP_check_nonce(OCSP_REQUEST *req, OCSP_BASICRESP *bs);
 
+// OCSP_copy_nonce copies the nonce value (if any) from |req| to |resp|. Returns
+// 1 on success and 0 on failure. If the optional nonce value does not exist in
+// |req|, we return 2 instead.
+OPENSSL_EXPORT int OCSP_copy_nonce(OCSP_BASICRESP *resp, OCSP_REQUEST *req);
+
 // OCSP_request_set1_name sets |requestorName| from an |X509_NAME| structure.
 OPENSSL_EXPORT int OCSP_request_set1_name(OCSP_REQUEST *req, X509_NAME *nm);
 

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -198,6 +198,11 @@ OPENSSL_EXPORT int OCSP_check_nonce(OCSP_REQUEST *req, OCSP_BASICRESP *bs);
 // OCSP_copy_nonce copies the nonce value (if any) from |req| to |resp|. Returns
 // 1 on success and 0 on failure. If the optional nonce value does not exist in
 // |req|, we return 2 instead.
+//
+// Note: Contrary to OpenSSL's |OCSP_copy_nonce| which allows for
+// multiple OCSP nonces to exist and appends the new nonce to the end of the
+// extension list, AWS-LC replaces the already existing OCSP nonce in |resp|, if
+// any.
 OPENSSL_EXPORT int OCSP_copy_nonce(OCSP_BASICRESP *resp, OCSP_REQUEST *req);
 
 // OCSP_request_set1_name sets |requestorName| from an |X509_NAME| structure.


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2420`

### Description of changes: 
Ruby consumes `OCSP_copy_nonce`, which copies the nonce from the request to the OCSP response.
OpenSSL's `OCSP_copy_nonce` directly appends the new OCSP nonce to the list of extensions in the response. This allows multiple OCSP nonces to exist the same response since the existing nonces are not deleted. It's a bit strange to allow multiple nonces to exist in a single response. To make things stranger, `OCSP_check_nonce` directly takes the first OCSP nonce in the list to compare, so any newer  nonces are ignored. 
We ultimately decided to follow OpenSSL's faulty implementation and document/test the behavior, there doesn't seem to be much value in diverging from the original and will only introduce more unanticipated behavioral changes.

### Call-outs:
N/A

### Testing:
Extend upon original OCSP nonce tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
