### PR TITLE
Adds const qualifier to ciphertext parameter in EVP_PKEY_decapsulate

### DIFF
--- a/crypto/fipsmodule/evp/evp_ctx.c
+++ b/crypto/fipsmodule/evp/evp_ctx.c
@@ -587,7 +587,7 @@ int EVP_PKEY_encapsulate(EVP_PKEY_CTX *ctx,
 
 int EVP_PKEY_decapsulate(EVP_PKEY_CTX *ctx,
                          uint8_t *shared_secret, size_t *shared_secret_len,
-                         uint8_t *ciphertext, size_t ciphertext_len) {
+                         const uint8_t *ciphertext, size_t ciphertext_len) {
   if (ctx == NULL || ctx->pmeth == NULL || ctx->pmeth->decapsulate == NULL) {
       OPENSSL_PUT_ERROR(EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
       return 0;

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -763,7 +763,7 @@ OPENSSL_EXPORT int EVP_PKEY_encapsulate(EVP_PKEY_CTX *ctx          /* IN  */,
 OPENSSL_EXPORT int EVP_PKEY_decapsulate(EVP_PKEY_CTX *ctx          /* IN  */,
                                         uint8_t *shared_secret     /* OUT */,
                                         size_t  *shared_secret_len /* OUT */,
-                                        uint8_t *ciphertext        /* IN  */,
+                                        const uint8_t *ciphertext  /* IN  */,
                                         size_t   ciphertext_len    /* IN  */);
 
 // EVP_PKEY_paramgen_init initialises an |EVP_PKEY_CTX| for a parameter


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Adds a const qualifier to the ciphertext parameter in the EVP_PKEY_decapsulate API. This seems to match the internal implementation of decapsulate. 

### Call-outs:
N/A

### Testing:
I didn't see any tests fail for this change? Maybe I missed something...


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
