### PR TITLE
Fix for select point from table in ec_nistp scalar_mul

### DIFF
--- a/crypto/fipsmodule/ec/ec_nistp.c
+++ b/crypto/fipsmodule/ec/ec_nistp.c
@@ -360,16 +360,27 @@ static void generate_table(const ec_nistp_meth *ctx,
   }
 }
 
-// Writes to xyz_out the idx-th point from table in constant-time.
-static void select_point_from_table(const ec_nistp_meth *ctx,
-                                    ec_nistp_felem_limb *xyz_out,
-                                    const ec_nistp_felem_limb *table,
-                                    const size_t idx) {
-  size_t entry_size = 3 * ctx->felem_num_limbs * sizeof(ec_nistp_felem_limb);
+// Writes to out the idx-th point from table in constant-time.
+static inline void select_point_from_table(const ec_nistp_meth *ctx,
+                                           ec_nistp_felem_limb *out,
+                                           const ec_nistp_felem_limb *table,
+                                           const size_t idx,
+                                           const size_t projective) {
+  // if projective != 0 then a point is (x, y, z), otherwise (x, y).
+  size_t point_num_coord = 2 + (projective != 0 ? 1 : 0);
+  size_t point_num_limbs = ctx->felem_num_limbs * point_num_coord;
 
-  constant_time_select_entry_from_table_8(
-          (uint8_t*)xyz_out, (uint8_t*)table,
+  // The ifdef branching below is temporary. Using only constant_..._table_8
+  // would be best for simplicity, but unfortunatelly, on x86 systems it is
+  // significantly slower than constant_..._table_w.
+#if defined(EC_NISTP_USE_64BIT_LIMB) && defined(OPENSSL_64_BIT)
+  constant_time_select_entry_from_table_w(out, (crypto_word_t*) table, idx,
+          SCALAR_MUL_TABLE_NUM_POINTS, point_num_limbs);
+#else
+  size_t entry_size = point_num_limbs * sizeof(ec_nistp_felem_limb);
+  constant_time_select_entry_from_table_8((uint8_t*)out, (uint8_t*)table,
           idx, SCALAR_MUL_TABLE_NUM_POINTS, entry_size);
+#endif
 }
 
 // Multiplication of an arbitrary point by a scalar, r = [scalar]P.
@@ -443,7 +454,7 @@ void ec_nistp_scalar_mul(const ec_nistp_meth *ctx,
   // can't be negative).
   int16_t idx = rwnaf[num_windows - 1];
   idx >>= 1;
-  select_point_from_table(ctx, res, table, idx);
+  select_point_from_table(ctx, res, table, idx, 1);
 
   // Step 2. Process the remaining digits of the scalar (s_{m-2} to s_0).
   for (int i = num_windows - 2; i >= 0; i--) {
@@ -459,7 +470,7 @@ void ec_nistp_scalar_mul(const ec_nistp_meth *ctx,
 
     // Step 4b. Select from table the point corresponding to abs(s_i).
     idx = d >> 1;
-    select_point_from_table(ctx, tmp, table, idx);
+    select_point_from_table(ctx, tmp, table, idx, 1);
 
     // Step 4c. Negate the point if s_i < 0.
     ec_nistp_felem ftmp;


### PR DESCRIPTION
Previous change unified and simplified selecting a point from table by using constant_time_select_entry_from_table_8 function. Unfortunatelly, on x86 this function is significantly slower than constant_time_select_entry_from_table_w. This commit fixes the performance regression.

Measured on Intel(R) Xeon(R) Platinum 8488C:
P-384 scalar_mul from 4091 to 5461 ops/s,
P-521 scalar_mul from 2520 to 3731 ops/s.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
