### PR TITLE
Lower required Go version, add CI test for specific version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,34 @@
+name: Go Compatability
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+env:
+  DOCKER_BUILDKIT: 1
+  GOPROXY: https://proxy.golang.org,direct
+jobs:
+  go-version-1_17_13:
+    if: github.repository_owner == 'aws'
+    env:
+      GOROOT: "/usr/local/go"
+      GO_ARCHIVE: "go1.17.13.linux-amd64.tar.gz"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OS Dependencies
+        run: |
+          which go
+          sudo apt-get update
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build make
+          sudo rm -rf /usr/local/go
+          sudo rm /usr/bin/go
+          wget -q "https://dl.google.com/go/${GO_ARCHIVE}"
+          sudo tar -C /usr/local -xf $GO_ARCHIVE
+          echo "${GOROOT}/bin" >> $GITHUB_PATH
+      - uses: actions/checkout@v3
+      - name: Run integration build
+        run: |
+          ./tests/ci/run_fips_tests.sh

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ If in doubt, use the most recent stable version of each build tool.
     `PERL_EXECUTABLE`.
     * To build without Perl (not recommended) see [this section.](#using-pre-generated-build-files)
 
-  * [Go](https://golang.org/dl/) 1.18 or later is required. If not found by
+  * [Go](https://golang.org/dl/) 1.17.13 or later is required. If not found by
     CMake, the go executable may be configured explicitly by setting
     `GO_EXECUTABLE`.
     * To build without Go (not recommended) see [this section.](#using-pre-generated-build-files)

--- a/cmake/go.cmake
+++ b/cmake/go.cmake
@@ -22,7 +22,7 @@ elseif(NOT DISABLE_GO)
   string(REGEX MATCH "([0-9]+\\.)*[0-9]+" go_version ${go_version_output})
 
   # This should track /go.mod and /BUILDING.md
-  set(minimum_go_version "1.18")
+  set(minimum_go_version "1.17.13")
   if(go_version VERSION_LESS minimum_go_version)
     message(FATAL_ERROR "Go compiler version must be at least ${minimum_go_version}. Found version ${go_version}")
   else()

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module boringssl.googlesource.com/boringssl
 
 // When this changes update /cmake/go.cmake minimum_go_version and /BUILDING.md
-go 1.18
+go 1.17
 
 require (
 	golang.org/x/crypto v0.10.0

--- a/ssl/test/runner/cipher_suites.go
+++ b/ssl/test/runner/cipher_suites.go
@@ -84,7 +84,7 @@ type cipherSuite struct {
 	ka     func(version uint16) keyAgreement
 	// flags is a bitmask of the suite* values, above.
 	flags  int
-	cipher func(key, iv []byte, isRead bool) any
+	cipher func(key, iv []byte, isRead bool) interface{}
 	mac    func(version uint16, macKey []byte) macFunction
 	aead   func(version uint16, key, fixedNonce []byte) *tlsAead
 }
@@ -155,11 +155,11 @@ func ivLen3DES(vers uint16) int {
 
 type nullCipher struct{}
 
-func cipherNull(key, iv []byte, isRead bool) any {
+func cipherNull(key, iv []byte, isRead bool) interface{} {
 	return nullCipher{}
 }
 
-func cipher3DES(key, iv []byte, isRead bool) any {
+func cipher3DES(key, iv []byte, isRead bool) interface{} {
 	block, _ := des.NewTripleDESCipher(key)
 	if isRead {
 		return cipher.NewCBCDecrypter(block, iv)
@@ -167,7 +167,7 @@ func cipher3DES(key, iv []byte, isRead bool) any {
 	return cipher.NewCBCEncrypter(block, iv)
 }
 
-func cipherAES(key, iv []byte, isRead bool) any {
+func cipherAES(key, iv []byte, isRead bool) interface{} {
 	block, _ := aes.NewCipher(key)
 	if isRead {
 		return cipher.NewCBCDecrypter(block, iv)

--- a/ssl/test/runner/common.go
+++ b/ssl/test/runner/common.go
@@ -2234,11 +2234,11 @@ type lruSessionCache struct {
 
 type lruSessionCacheEntry struct {
 	sessionKey string
-	state      any
+	state      interface{}
 }
 
 // Put adds the provided (sessionKey, cs) pair to the cache.
-func (c *lruSessionCache) Put(sessionKey string, cs any) {
+func (c *lruSessionCache) Put(sessionKey string, cs interface{}) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -2266,7 +2266,7 @@ func (c *lruSessionCache) Put(sessionKey string, cs any) {
 
 // Get returns the value associated with a given key. It returns (nil,
 // false) if no value is found.
-func (c *lruSessionCache) Get(sessionKey string) (any, bool) {
+func (c *lruSessionCache) Get(sessionKey string) (interface{}, bool) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -2380,7 +2380,7 @@ func initDefaultCipherSuites() {
 	}
 }
 
-func unexpectedMessageError(wanted, got any) error {
+func unexpectedMessageError(wanted, got interface{}) error {
 	return fmt.Errorf("tls: received unexpected handshake message of type %T when waiting for %T", got, wanted)
 }
 

--- a/ssl/test/runner/conn.go
+++ b/ssl/test/runner/conn.go
@@ -176,13 +176,13 @@ type halfConn struct {
 	version     uint16 // protocol version
 	wireVersion uint16 // wire version
 	isDTLS      bool
-	cipher      any // cipher algorithm
+	cipher      interface{} // cipher algorithm
 	mac         macFunction
 	seq         [8]byte // 64-bit sequence number
 	outSeq      [8]byte // Mapped sequence number
 	bfree       *block  // list of free blocks
 
-	nextCipher any         // next encryption state
+	nextCipher interface{} // next encryption state
 	nextMac    macFunction // next MAC algorithm
 	nextSeq    [6]byte     // next epoch's starting sequence number in DTLS
 
@@ -209,7 +209,7 @@ func (hc *halfConn) error() error {
 
 // prepareCipherSpec sets the encryption and MAC states
 // that a subsequent changeCipherSpec will use.
-func (hc *halfConn) prepareCipherSpec(version uint16, cipher any, mac macFunction) {
+func (hc *halfConn) prepareCipherSpec(version uint16, cipher interface{}, mac macFunction) {
 	hc.wireVersion = version
 	protocolVersion, ok := wireToVersion(version, hc.isDTLS)
 	if !ok {
@@ -1343,7 +1343,7 @@ func (c *Conn) doReadHandshake() ([]byte, error) {
 // readHandshake reads the next handshake message from
 // the record layer.
 // c.in.Mutex < L; c.out.Mutex < L.
-func (c *Conn) readHandshake() (any, error) {
+func (c *Conn) readHandshake() (interface{}, error) {
 	data, err := c.doReadHandshake()
 	if err != nil {
 		return nil, err

--- a/ssl/test/runner/handshake_client.go
+++ b/ssl/test/runner/handshake_client.go
@@ -936,7 +936,7 @@ func (hs *clientHandshakeState) encryptClientHello(hello, innerHello *clientHell
 	return nil
 }
 
-func (hs *clientHandshakeState) checkECHConfirmation(msg any, hello *clientHelloMsg, finishedHash *finishedHash) bool {
+func (hs *clientHandshakeState) checkECHConfirmation(msg interface{}, hello *clientHelloMsg, finishedHash *finishedHash) bool {
 	var offset int
 	var raw, label []byte
 	if hrr, ok := msg.(*helloRetryRequestMsg); ok {
@@ -961,7 +961,7 @@ func (hs *clientHandshakeState) checkECHConfirmation(msg any, hello *clientHello
 	return bytes.Equal(confirmation, raw[offset:offset+echAcceptConfirmationLength])
 }
 
-func (hs *clientHandshakeState) doTLS13Handshake(msg any) error {
+func (hs *clientHandshakeState) doTLS13Handshake(msg interface{}) error {
 	c := hs.c
 
 	// The first message may be a ServerHello or HelloRetryRequest.
@@ -1919,7 +1919,7 @@ func (hs *clientHandshakeState) establishKeys() error {
 
 	clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV :=
 		keysFromMasterSecret(c.vers, hs.suite, hs.masterSecret, hs.hello.random, hs.serverHello.random, hs.suite.macLen, hs.suite.keyLen, hs.suite.ivLen(c.vers))
-	var clientCipher, serverCipher any
+	var clientCipher, serverCipher interface{}
 	var clientHash, serverHash macFunction
 	if hs.suite.cipher != nil {
 		clientCipher = hs.suite.cipher(clientKey, clientIV, false /* not for reading */)

--- a/ssl/test/runner/handshake_server.go
+++ b/ssl/test/runner/handshake_server.go
@@ -2115,7 +2115,7 @@ func (hs *serverHandshakeState) establishKeys() error {
 	clientMAC, serverMAC, clientKey, serverKey, clientIV, serverIV :=
 		keysFromMasterSecret(c.vers, hs.suite, hs.masterSecret, hs.clientHello.random, hs.hello.random, hs.suite.macLen, hs.suite.keyLen, hs.suite.ivLen(c.vers))
 
-	var clientCipher, serverCipher any
+	var clientCipher, serverCipher interface{}
 	var clientHash, serverHash macFunction
 
 	if hs.suite.aead == nil {

--- a/ssl/test/runner/prf.go
+++ b/ssl/test/runner/prf.go
@@ -452,7 +452,7 @@ var (
 
 // deriveTrafficAEAD derives traffic keys and constructs an AEAD given a traffic
 // secret.
-func deriveTrafficAEAD(version uint16, suite *cipherSuite, secret []byte, side trafficDirection) any {
+func deriveTrafficAEAD(version uint16, suite *cipherSuite, secret []byte, side trafficDirection) interface{} {
 	key := hkdfExpandLabel(suite.hash(), secret, keyTLS13, nil, suite.keyLen)
 	iv := hkdfExpandLabel(suite.hash(), secret, ivTLS13, nil, suite.ivLen(version))
 

--- a/ssl/test/runner/sign.go
+++ b/ssl/test/runner/sign.go
@@ -272,7 +272,7 @@ func (e *ed25519Signer) verifyMessage(key crypto.PublicKey, msg, sig []byte) err
 	return nil
 }
 
-func getSigner(version uint16, key any, config *Config, sigAlg signatureAlgorithm, isVerify bool) (signer, error) {
+func getSigner(version uint16, key interface{}, config *Config, sigAlg signatureAlgorithm, isVerify bool) (signer, error) {
 	// TLS 1.1 and below use legacy signature algorithms.
 	if version < VersionTLS12 || (!isVerify && config.Bugs.AlwaysSignAsLegacyVersion) {
 		if config.Bugs.SigningAlgorithmForLegacyVersions == 0 || isVerify {

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -100,14 +100,14 @@ var sdeCPUs = []string{
 
 func targetArchMatchesRuntime(target string) bool {
 	if (target == "") ||
-	   (target == "x86" && runtime.GOARCH == "amd64") ||
-		 (target == "arm" && (runtime.GOARCH == "arm" || runtime.GOARCH == "arm64")) {
+		(target == "x86" && runtime.GOARCH == "amd64") ||
+		(target == "arm" && (runtime.GOARCH == "arm" || runtime.GOARCH == "arm64")) {
 		return true
 	}
 	return false
 }
 
-func valgrindOf(dbAttach bool, supps []string, path string, args ...string) *exec.Cmd {
+func valgrindOf(ctx context.Context, dbAttach bool, supps []string, path string, args ...string) (context.Context, *exec.Cmd) {
 	valgrindArgs := []string{"--error-exitcode=99", "--track-origins=yes", "--leak-check=full", "--trace-children=yes", "--quiet"}
 	for _, supp := range supps {
 		valgrindArgs = append(valgrindArgs, "--suppressions="+*valgrindSuppDir+"/"+supp)
@@ -118,26 +118,26 @@ func valgrindOf(dbAttach bool, supps []string, path string, args ...string) *exe
 	valgrindArgs = append(valgrindArgs, path)
 	valgrindArgs = append(valgrindArgs, args...)
 
-	return exec.Command("valgrind", valgrindArgs...)
+	return ctx, exec.CommandContext(ctx, "valgrind", valgrindArgs...)
 }
 
-func callgrindOf(path string, args ...string) *exec.Cmd {
+func callgrindOf(ctx context.Context, path string, args ...string) (context.Context, *exec.Cmd) {
 	valgrindArgs := []string{"-q", "--tool=callgrind", "--dump-instr=yes", "--collect-jumps=yes", "--callgrind-out-file=" + *buildDir + "/callgrind/callgrind.out.%p"}
 	valgrindArgs = append(valgrindArgs, path)
 	valgrindArgs = append(valgrindArgs, args...)
 
-	return exec.Command("valgrind", valgrindArgs...)
+	return ctx, exec.CommandContext(ctx, "valgrind", valgrindArgs...)
 }
 
-func gdbOf(path string, args ...string) *exec.Cmd {
+func gdbOf(ctx context.Context, path string, args ...string) (context.Context, *exec.Cmd) {
 	xtermArgs := []string{"-e", "gdb", "--args"}
 	xtermArgs = append(xtermArgs, path)
 	xtermArgs = append(xtermArgs, args...)
 
-	return exec.Command("xterm", xtermArgs...)
+	return ctx, exec.CommandContext(ctx, "xterm", xtermArgs...)
 }
 
-func sdeOf(cpu, path string, args ...string) (*exec.Cmd, context.CancelFunc) {
+func sdeOf(ctx context.Context, cpu, path string, args ...string) (context.Context, context.CancelFunc, *exec.Cmd) {
 	sdeArgs := []string{"-" + cpu}
 	// The kernel's vdso code for gettimeofday sometimes uses the RDTSCP
 	// instruction. Although SDE has a -chip_check_vsyscall flag that
@@ -152,9 +152,9 @@ func sdeOf(cpu, path string, args ...string) (*exec.Cmd, context.CancelFunc) {
 
 	// TODO(CryptoAlg-2154):SDE+ASAN tests will hang without exiting if tests pass for an unknown reason.
 	// Current workaround is to manually cancel the run after 20 minutes and check the output.
-	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 1200*time.Second)
 
-	return exec.CommandContext(ctx, *sdePath, sdeArgs...), cancel
+	return ctx, cancel, exec.CommandContext(ctx, *sdePath, sdeArgs...)
 }
 
 var (
@@ -173,23 +173,20 @@ func runTestOnce(test test, mallocNumToFail int64) (passed bool, err error) {
 	}
 	var cmd *exec.Cmd
 	var cancel context.CancelFunc
-	cancelled := false
-	if *useValgrind {
-		cmd = valgrindOf(false, test.ValgrindSupp, prog, args...)
-	} else if *useCallgrind {
-		cmd = callgrindOf(prog, args...)
-	} else if *useGDB {
-		cmd = gdbOf(prog, args...)
-	} else if *useSDE {
-		cmd, cancel = sdeOf(test.cpu, prog, args...)
-		defer cancel()
 
-		cmd.Cancel = func() error {
-			cancelled = true
-			return cmd.Process.Kill()
-		}
+	ctx := context.Background()
+
+	if *useValgrind {
+		ctx, cmd = valgrindOf(ctx, false, test.ValgrindSupp, prog, args...)
+	} else if *useCallgrind {
+		ctx, cmd = callgrindOf(ctx, prog, args...)
+	} else if *useGDB {
+		ctx, cmd = gdbOf(ctx, prog, args...)
+	} else if *useSDE {
+		ctx, cancel, cmd = sdeOf(ctx, test.cpu, prog, args...)
+		defer cancel()
 	} else {
-		cmd = exec.Command(prog, args...)
+		cmd = exec.CommandContext(ctx, prog, args...)
 	}
 	if test.Env != nil || test.numShards != 0 {
 		cmd.Env = make([]string, len(os.Environ()))
@@ -219,7 +216,8 @@ func runTestOnce(test test, mallocNumToFail int64) (passed bool, err error) {
 	}
 
 	if err := cmd.Wait(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
 			switch exitError.Sys().(syscall.WaitStatus).ExitStatus() {
 			case 88:
 				return false, errMoreMallocs
@@ -227,14 +225,20 @@ func runTestOnce(test test, mallocNumToFail int64) (passed bool, err error) {
 				fmt.Print(string(outBuf.Bytes()))
 				return false, errTestSkipped
 			}
-			if cancelled {
-				return testPass(outBuf), errTestHanging
+			select {
+			case <-ctx.Done():
+				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					return testPass(outBuf), errTestHanging
+				} else if ctx.Err() != nil {
+					return false, ctx.Err()
+				}
+			default:
+				// Nothing
 			}
 		}
 		fmt.Print(string(outBuf.Bytes()))
 		return false, err
 	}
-
 
 	return testPass(outBuf), nil
 }

--- a/util/convert_wycheproof/convert_wycheproof.go
+++ b/util/convert_wycheproof/convert_wycheproof.go
@@ -33,10 +33,10 @@ type wycheproofTest struct {
 	Header           []string       `json:"header"`
 	// encoding/json does not support collecting unused keys, so we leave
 	// everything past this point as generic.
-	TestGroups []map[string]any `json:"testGroups"`
+	TestGroups []map[string]interface{} `json:"testGroups"`
 }
 
-func sortedKeys(m map[string]any) []string {
+func sortedKeys(m map[string]interface{}) []string {
 	keys := make([]string, 0, len(m))
 	for k, _ := range m {
 		keys = append(keys, k)
@@ -45,8 +45,8 @@ func sortedKeys(m map[string]any) []string {
 	return keys
 }
 
-func printAttribute(w io.Writer, key string, valueAny any, isInstruction bool) error {
-	switch value := valueAny.(type) {
+func printAttribute(w io.Writer, key string, valueI interface{}, isInstruction bool) error {
+	switch value := valueI.(type) {
 	case float64:
 		if float64(int(value)) != value {
 			panic(key + "was not an integer.")
@@ -73,14 +73,14 @@ func printAttribute(w io.Writer, key string, valueAny any, isInstruction bool) e
 				return err
 			}
 		}
-	case map[string]any:
+	case map[string]interface{}:
 		for _, k := range sortedKeys(value) {
 			if err := printAttribute(w, key+"."+k, value[k], isInstruction); err != nil {
 				return err
 			}
 		}
 	default:
-		panic(fmt.Sprintf("Unknown type for %q: %T", key, valueAny))
+		panic(fmt.Sprintf("Unknown type for %q: %T", key, valueI))
 	}
 	return nil
 }
@@ -154,9 +154,9 @@ func convertWycheproof(f io.Writer, jsonPath string) error {
 			}
 		}
 		fmt.Fprintf(f, "\n")
-		tests := group["tests"].([]any)
-		for _, testAny := range tests {
-			test := testAny.(map[string]any)
+		tests := group["tests"].([]interface{})
+		for _, testI := range tests {
+			test := testI.(map[string]interface{})
 			if _, err := fmt.Fprintf(f, "# tcId = %d\n", int(test["tcId"].(float64))); err != nil {
 				return err
 			}
@@ -173,10 +173,10 @@ func convertWycheproof(f io.Writer, jsonPath string) error {
 					return err
 				}
 			}
-			if flagsAny, ok := test["flags"]; ok {
+			if flagsI, ok := test["flags"]; ok {
 				var flags []string
-				for _, flagAny := range flagsAny.([]any) {
-					flag := flagAny.(string)
+				for _, flagI := range flagsI.([]interface{}) {
+					flag := flagI.(string)
 					flags = append(flags, flag)
 				}
 				if len(flags) != 0 {

--- a/util/fipstools/acvp/acvptool/acvp.go
+++ b/util/fipstools/acvp/acvptool/acvp.go
@@ -80,7 +80,7 @@ func isCommentLine(line []byte) bool {
 	return false
 }
 
-func jsonFromFile(out any, filename string) error {
+func jsonFromFile(out interface{}, filename string) error {
 	in, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func TOTP(secret []byte) string {
 type Middle interface {
 	Close()
 	Config() ([]byte, error)
-	Process(algorithm string, vectorSet []byte) (any, error)
+	Process(algorithm string, vectorSet []byte) (interface{}, error)
 }
 
 func loadCachedSessionTokens(server *acvp.Server, cachePath string) error {
@@ -198,7 +198,7 @@ func looksLikeVectorSetHeader(element json.RawMessage) bool {
 
 // processFile reads a file containing vector sets, at least in the format
 // preferred by our lab, and writes the results to stdout.
-func processFile(filename string, supportedAlgos []map[string]any, middle Middle) error {
+func processFile(filename string, supportedAlgos []map[string]interface{}, middle Middle) error {
 	jsonBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return err
@@ -267,7 +267,7 @@ func processFile(filename string, supportedAlgos []map[string]any, middle Middle
 			return fmt.Errorf("while processing vector set #%d: %s", i+1, err)
 		}
 
-		group := map[string]any{
+		group := map[string]interface{}{
 			"vsId":       commonFields.ID,
 			"testGroups": replyGroups,
 			"algorithm":  algo,
@@ -540,13 +540,13 @@ func main() {
 		log.Fatalf("failed to get config from middle: %s", err)
 	}
 
-	var supportedAlgos []map[string]any
+	var supportedAlgos []map[string]interface{}
 	if err := json.Unmarshal(configBytes, &supportedAlgos); err != nil {
 		log.Fatalf("failed to parse configuration from Middle: %s", err)
 	}
 
 	if *dumpRegcap {
-		nonTestAlgos := make([]map[string]any, 0, len(supportedAlgos))
+		nonTestAlgos := make([]map[string]interface{}, 0, len(supportedAlgos))
 		for _, algo := range supportedAlgos {
 			if value, ok := algo["acvptoolTestOnly"]; ok {
 				testOnly, ok := value.(bool)
@@ -560,9 +560,9 @@ func main() {
 			nonTestAlgos = append(nonTestAlgos, algo)
 		}
 
-		regcap := []map[string]any{
-			{"acvVersion": "1.0"},
-			{"algorithms": nonTestAlgos},
+		regcap := []map[string]interface{}{
+			map[string]interface{}{"acvVersion": "1.0"},
+			map[string]interface{}{"algorithms": nonTestAlgos},
 		}
 		regcapBytes, err := json.MarshalIndent(regcap, "", "    ")
 		if err != nil {
@@ -615,7 +615,7 @@ func main() {
 		}
 	}
 
-	var algorithms []map[string]any
+	var algorithms []map[string]interface{}
 	for _, supportedAlgo := range supportedAlgos {
 		algoInterface, ok := supportedAlgo["algorithm"]
 		if !ok {

--- a/util/fipstools/acvp/acvptool/acvp/acvp.go
+++ b/util/fipstools/acvp/acvptool/acvp/acvp.go
@@ -195,7 +195,7 @@ func parseReplyToBytes(in io.Reader) ([]byte, error) {
 // parseReply parses the contents of an ACVP reply (after removing the header
 // element) into out. See the documentation of the encoding/json package for
 // details of the parsing.
-func parseReply(out any, in io.Reader) error {
+func parseReply(out interface{}, in io.Reader) error {
 	if out == nil {
 		// No reply expected.
 		return nil
@@ -379,7 +379,7 @@ func (server *Server) newRequestWithToken(method, endpoint string, body io.Reade
 	return req, nil
 }
 
-func (server *Server) Get(out any, endPoint string) error {
+func (server *Server) Get(out interface{}, endPoint string) error {
 	req, err := server.newRequestWithToken("GET", endPoint, nil)
 	if err != nil {
 		return err
@@ -417,7 +417,7 @@ func (server *Server) GetBytes(endPoint string) ([]byte, error) {
 	return parseReplyToBytes(resp.Body)
 }
 
-func (server *Server) write(method string, reply any, endPoint string, contents []byte) error {
+func (server *Server) write(method string, reply interface{}, endPoint string, contents []byte) error {
 	var buf bytes.Buffer
 	buf.WriteString(requestPrefix)
 	buf.Write(contents)
@@ -442,7 +442,7 @@ func (server *Server) write(method string, reply any, endPoint string, contents 
 	return parseReply(reply, resp.Body)
 }
 
-func (server *Server) postMessage(reply any, endPoint string, request any) error {
+func (server *Server) postMessage(reply interface{}, endPoint string, request interface{}) error {
 	contents, err := json.Marshal(request)
 	if err != nil {
 		return err
@@ -450,11 +450,11 @@ func (server *Server) postMessage(reply any, endPoint string, request any) error
 	return server.write("POST", reply, endPoint, contents)
 }
 
-func (server *Server) Post(out any, endPoint string, contents []byte) error {
+func (server *Server) Post(out interface{}, endPoint string, contents []byte) error {
 	return server.write("POST", out, endPoint, contents)
 }
 
-func (server *Server) Put(out any, endPoint string, contents []byte) error {
+func (server *Server) Put(out interface{}, endPoint string, contents []byte) error {
 	return server.write("PUT", out, endPoint, contents)
 }
 
@@ -481,7 +481,7 @@ var (
 
 // GetPaged returns an array of records of some type using one or more requests to the server. See
 // https://pages.nist.gov/ACVP/draft-fussell-acvp-spec.html#paging_response
-func (server *Server) GetPaged(out any, endPoint string, condition Query) error {
+func (server *Server) GetPaged(out interface{}, endPoint string, condition Query) error {
 	output := reflect.ValueOf(out)
 	if output.Kind() != reflect.Ptr {
 		panic(fmt.Sprintf("GetPaged output parameter of non-pointer type %T", out))
@@ -618,22 +618,22 @@ type OperationalEnvironment struct {
 	Dependencies   []Dependency `json:"dependencies,omitempty"`
 }
 
-type Dependency map[string]any
+type Dependency map[string]interface{}
 
-type Algorithm map[string]any
+type Algorithm map[string]interface{}
 
 type TestSession struct {
-	URL           string           `json:"url,omitempty"`
-	ACVPVersion   string           `json:"acvpVersion,omitempty"`
-	Created       string           `json:"createdOn,omitempty"`
-	Expires       string           `json:"expiresOn,omitempty"`
-	VectorSetURLs []string         `json:"vectorSetUrls,omitempty"`
-	AccessToken   string           `json:"accessToken,omitempty"`
-	Algorithms    []map[string]any `json:"algorithms,omitempty"`
-	EncryptAtRest bool             `json:"encryptAtRest,omitempty"`
-	IsSample      bool             `json:"isSample,omitempty"`
-	Publishable   bool             `json:"publishable,omitempty"`
-	Passed        bool             `json:"passed,omitempty"`
+	URL           string                   `json:"url,omitempty"`
+	ACVPVersion   string                   `json:"acvpVersion,omitempty"`
+	Created       string                   `json:"createdOn,omitempty"`
+	Expires       string                   `json:"expiresOn,omitempty"`
+	VectorSetURLs []string                 `json:"vectorSetUrls,omitempty"`
+	AccessToken   string                   `json:"accessToken,omitempty"`
+	Algorithms    []map[string]interface{} `json:"algorithms,omitempty"`
+	EncryptAtRest bool                     `json:"encryptAtRest,omitempty"`
+	IsSample      bool                     `json:"isSample,omitempty"`
+	Publishable   bool                     `json:"publishable,omitempty"`
+	Passed        bool                     `json:"passed,omitempty"`
 }
 
 type Vectors struct {

--- a/util/fipstools/acvp/acvptool/interactive.go
+++ b/util/fipstools/acvp/acvptool/interactive.go
@@ -142,7 +142,7 @@ func (set ServerObjectSet) Action(action string, args []string) error {
 			return nil
 		}
 
-		var result map[string]any
+		var result map[string]interface{}
 		if err := set.env.server.Post(&result, "acvp/v1/"+set.name, newContents); err != nil {
 			return err
 		}
@@ -308,7 +308,7 @@ type Algorithms struct {
 
 func (algos Algorithms) String() (string, error) {
 	var result struct {
-		Algorithms []map[string]any `json:"algorithms"`
+		Algorithms []map[string]interface{} `json:"algorithms"`
 	}
 	if err := algos.env.server.Get(&result, "acvp/v1/algorithms"); err != nil {
 		return "", err
@@ -360,7 +360,7 @@ func (s stringLiteral) Action(action string, args []string) error {
 			return fmt.Errorf("found %d arguments but %q takes none", len(args), action)
 		}
 
-		var results map[string]any
+		var results map[string]interface{}
 		if err := s.env.server.Get(&results, s.contents); err != nil {
 			return err
 		}
@@ -379,7 +379,7 @@ type results struct {
 }
 
 func (r results) String() (string, error) {
-	var results map[string]any
+	var results map[string]interface{}
 	if err := r.env.server.Get(&results, "acvp/v1/"+r.prefix+"/results"); err != nil {
 		return "", err
 	}

--- a/util/fipstools/acvp/acvptool/subprocess/aead.go
+++ b/util/fipstools/acvp/acvptool/subprocess/aead.go
@@ -63,7 +63,7 @@ type aeadTestResponse struct {
 	IVHex         string  `json:"iv,omitempty"`
 }
 
-func (a *aead) Process(vectorSet []byte, m Transactable) (any, error) {
+func (a *aead) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed aeadVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/block.go
+++ b/util/fipstools/acvp/acvptool/subprocess/block.go
@@ -288,7 +288,7 @@ type blockCipherMCTResult struct {
 	Key3Hex string `json:"key3,omitempty"`
 }
 
-func (b *blockCipher) Process(vectorSet []byte, m Transactable) (any, error) {
+func (b *blockCipher) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed blockCipherVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/drbg.go
+++ b/util/fipstools/acvp/acvptool/subprocess/drbg.go
@@ -73,7 +73,7 @@ type drbg struct {
 	modes map[string]bool // the supported underlying primitives for the DRBG
 }
 
-func (d *drbg) Process(vectorSet []byte, m Transactable) (any, error) {
+func (d *drbg) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed drbgTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/ecdsa.go
+++ b/util/fipstools/acvp/acvptool/subprocess/ecdsa.go
@@ -72,7 +72,7 @@ type ecdsa struct {
 	primitives map[string]primitive
 }
 
-func (e *ecdsa) Process(vectorSet []byte, m Transactable) (any, error) {
+func (e *ecdsa) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed ecdsaTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/hash.go
+++ b/util/fipstools/acvp/acvptool/subprocess/hash.go
@@ -75,7 +75,7 @@ type hashPrimitive struct {
 	size int
 }
 
-func (h *hashPrimitive) Process(vectorSet []byte, m Transactable) (any, error) {
+func (h *hashPrimitive) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed hashTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/hkdf.go
+++ b/util/fipstools/acvp/acvptool/subprocess/hkdf.go
@@ -124,7 +124,7 @@ type hkdfTestResponse struct {
 
 type hkdf struct{}
 
-func (k *hkdf) Process(vectorSet []byte, m Transactable) (any, error) {
+func (k *hkdf) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed hkdfTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/hmac.go
+++ b/util/fipstools/acvp/acvptool/subprocess/hmac.go
@@ -76,7 +76,7 @@ func (h *hmacPrimitive) hmac(msg []byte, key []byte, outBits int, m Transactable
 	return result[0][:outBytes]
 }
 
-func (h *hmacPrimitive) Process(vectorSet []byte, m Transactable) (any, error) {
+func (h *hmacPrimitive) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed hmacTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/kas.go
+++ b/util/fipstools/acvp/acvptool/subprocess/kas.go
@@ -68,7 +68,7 @@ type kasTestResponse struct {
 
 type kas struct{}
 
-func (k *kas) Process(vectorSet []byte, m Transactable) (any, error) {
+func (k *kas) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed kasVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/kasdh.go
+++ b/util/fipstools/acvp/acvptool/subprocess/kasdh.go
@@ -59,7 +59,7 @@ type kasDHTestResponse struct {
 
 type kasDH struct{}
 
-func (k *kasDH) Process(vectorSet []byte, m Transactable) (any, error) {
+func (k *kasDH) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed kasDHVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/kdf.go
+++ b/util/fipstools/acvp/acvptool/subprocess/kdf.go
@@ -59,7 +59,7 @@ type kdfTestResponse struct {
 
 type kdfPrimitive struct{}
 
-func (k *kdfPrimitive) Process(vectorSet []byte, m Transactable) (any, error) {
+func (k *kdfPrimitive) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed kdfTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/keyedMac.go
+++ b/util/fipstools/acvp/acvptool/subprocess/keyedMac.go
@@ -57,7 +57,7 @@ type keyedMACPrimitive struct {
 	algo string
 }
 
-func (k *keyedMACPrimitive) Process(vectorSet []byte, m Transactable) (any, error) {
+func (k *keyedMACPrimitive) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var vs keyedMACTestVectorSet
 	if err := json.Unmarshal(vectorSet, &vs); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/rsa.go
+++ b/util/fipstools/acvp/acvptool/subprocess/rsa.go
@@ -117,7 +117,7 @@ type rsaSigVerTestResponse struct {
 	Passed bool   `json:"testPassed"`
 }
 
-func processKeyGen(vectorSet []byte, m Transactable) (any, error) {
+func processKeyGen(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed rsaKeyGenTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func processKeyGen(vectorSet []byte, m Transactable) (any, error) {
 	return ret, nil
 }
 
-func processSigGen(vectorSet []byte, m Transactable) (any, error) {
+func processSigGen(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed rsaSigGenTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err
@@ -227,7 +227,7 @@ func processSigGen(vectorSet []byte, m Transactable) (any, error) {
 	return ret, nil
 }
 
-func processSigVer(vectorSet []byte, m Transactable) (any, error) {
+func processSigVer(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed rsaSigVerTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err
@@ -289,7 +289,7 @@ func processSigVer(vectorSet []byte, m Transactable) (any, error) {
 
 type rsa struct{}
 
-func (*rsa) Process(vectorSet []byte, m Transactable) (any, error) {
+func (*rsa) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed rsaTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/subprocess.go
+++ b/util/fipstools/acvp/acvptool/subprocess/subprocess.go
@@ -373,7 +373,7 @@ func (m *Subprocess) Config() ([]byte, error) {
 }
 
 // Process runs a set of test vectors and returns the result.
-func (m *Subprocess) Process(algorithm string, vectorSet []byte) (any, error) {
+func (m *Subprocess) Process(algorithm string, vectorSet []byte) (interface{}, error) {
 	prim, ok := m.primitives[algorithm]
 	if !ok {
 		return nil, fmt.Errorf("unknown algorithm %q", algorithm)
@@ -386,7 +386,7 @@ func (m *Subprocess) Process(algorithm string, vectorSet []byte) (any, error) {
 }
 
 type primitive interface {
-	Process(vectorSet []byte, t Transactable) (any, error)
+	Process(vectorSet []byte, t Transactable) (interface{}, error)
 }
 
 func uint32le(n uint32) []byte {

--- a/util/fipstools/acvp/acvptool/subprocess/tls13.go
+++ b/util/fipstools/acvp/acvptool/subprocess/tls13.go
@@ -69,7 +69,7 @@ type tls13TestResponse struct {
 
 type tls13 struct{}
 
-func (k *tls13) Process(vectorSet []byte, m Transactable) (any, error) {
+func (k *tls13) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed tls13TestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/subprocess/xts.go
+++ b/util/fipstools/acvp/acvptool/subprocess/xts.go
@@ -59,7 +59,7 @@ type xtsTestResponse struct {
 // encrypt/decrypt with AES-XTS.
 type xts struct{}
 
-func (h *xts) Process(vectorSet []byte, m Transactable) (any, error) {
+func (h *xts) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 	var parsed xtsTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err

--- a/util/fipstools/acvp/acvptool/test/trim_vectors.go
+++ b/util/fipstools/acvp/acvptool/test/trim_vectors.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	var vectorSets []any
+	var vectorSets []interface{}
 	decoder := json.NewDecoder(os.Stdin)
 	if err := decoder.Decode(&vectorSets); err != nil {
 		panic(err)
@@ -33,18 +33,18 @@ func main() {
 
 	// The first element is the metadata which is left unmodified.
 	for i := 1; i < len(vectorSets); i++ {
-		vectorSet := vectorSets[i].(map[string]any)
-		testGroups := vectorSet["testGroups"].([]any)
+		vectorSet := vectorSets[i].(map[string]interface{})
+		testGroups := vectorSet["testGroups"].([]interface{})
 		for _, testGroupInterface := range testGroups {
-			testGroup := testGroupInterface.(map[string]any)
-			tests := testGroup["tests"].([]any)
+			testGroup := testGroupInterface.(map[string]interface{})
+			tests := testGroup["tests"].([]interface{})
 
 			keepIndex := 10
 			if keepIndex >= len(tests) {
 				keepIndex = len(tests) - 1
 			}
 
-			testGroup["tests"] = []any{tests[keepIndex]}
+			testGroup["tests"] = []interface{}{tests[keepIndex]}
 		}
 	}
 

--- a/util/read_symbols.go
+++ b/util/read_symbols.go
@@ -61,7 +61,7 @@ func defaultObjFileFormat(goos string) string {
 	}
 }
 
-func printAndExit(format string, args ...any) {
+func printAndExit(format string, args ...interface{}) {
 	s := fmt.Sprintf(format, args...)
 	fmt.Fprintln(os.Stderr, s)
 	os.Exit(1)


### PR DESCRIPTION
### Description of changes: 
Add back support for Go 1.17.13 which is used by NetOS. Fix a few language compatibility issues for interface{} and cmd struct. This change does not affect the integrity value of the FIPS module. 

### Testing:
This change adds a new CI test which uses Go 1.17.13. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

---------

Co-authored-by: Sean McGrail <mcgrails@amazon.com>

---------

    Revert "Replace interface{} with any"

    This reverts commit 6a90c15f3f901b90acb91fcb4c11cf4c5f3bcfff.