### PR TITLE
Show number of pruned ec2 instances in dashboard

### DIFF
--- a/tests/ci/lambda/src/bin/purge-stale-builds.rs
+++ b/tests/ci/lambda/src/bin/purge-stale-builds.rs
@@ -172,7 +172,7 @@ async fn handle(_event: LambdaEvent<Value>) -> Result<(), Error> {
             },
             "Project": &project,
             "PrunedGitHubBuilds": stopped_builds,
-            "Terminated EC2 Instances": ec2_terminated_instances
+            "Terminated EC2 Instances": ec2_terminated_instances.len()
         })
         .to_string()
     );

--- a/tests/ci/lambda/src/bin/purge-stale-builds.rs
+++ b/tests/ci/lambda/src/bin/purge-stale-builds.rs
@@ -165,6 +165,11 @@ async fn handle(_event: LambdaEvent<Value>) -> Result<(), Error> {
                             "Name": "PrunedGitHubBuilds",
                             "Unit": "Count",
                             "StorageResolution": 60
+                        },
+                        {
+                            "Name": "TerminatedEC2Instances",
+                            "Unit": "Count",
+                            "StorageResolution": 60
                         }
                     ]
                 }],
@@ -172,7 +177,7 @@ async fn handle(_event: LambdaEvent<Value>) -> Result<(), Error> {
             },
             "Project": &project,
             "PrunedGitHubBuilds": stopped_builds,
-            "Terminated EC2 Instances": ec2_terminated_instances.len()
+            "TerminatedEC2Instances": ec2_terminated_instances.len()
         })
         .to_string()
     );

--- a/util/whitespace.txt
+++ b/util/whitespace.txt
@@ -1,1 +1,1 @@
-This file is ignored. It exists to make no-op commits to trigger new builds.
+This file is ignored. It exists to make no-op commits to trigger new builds. 


### PR DESCRIPTION
Small fix to show number of pruned instances in dashboard.

Test PR: https://github.com/samuel40791765/aws-lc/pull/34

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
