### PR TITLE
Add PQ key exchange OIDs

### DIFF
--- a/crypto/obj/obj_dat.h
+++ b/crypto/obj/obj_dat.h
@@ -7218,6 +7218,18 @@ static const uint8_t kObjectData[] = {
     0x04,
     0x02,
     0x0c,
+    /* NID_SecP256r1Kyber768Draft00 */
+    0x2b,
+    0xce,
+    0x0f,
+    0x63,
+    0x34,
+    /* NID_X25519Kyber768Draft00 */
+    0x2b,
+    0xce,
+    0x0f,
+    0x63,
+    0x33,
 };
 
 static const ASN1_OBJECT kObjects[NUM_NID] = {
@@ -8883,9 +8895,9 @@ static const ASN1_OBJECT kObjects[NUM_NID] = {
     {"SHAKE128", "shake128", NID_shake128, 9, &kObjectData[6252], 0},
     {"SHAKE256", "shake256", NID_shake256, 9, &kObjectData[6261], 0},
     {"SecP256r1Kyber768Draft00", "SecP256r1Kyber768Draft00",
-     NID_SecP256r1Kyber768Draft00, 0, NULL, 0},
+     NID_SecP256r1Kyber768Draft00, 5, &kObjectData[6270], 0},
     {"X25519Kyber768Draft00", "X25519Kyber768Draft00",
-     NID_X25519Kyber768Draft00, 0, NULL, 0},
+     NID_X25519Kyber768Draft00, 5, &kObjectData[6275], 0},
     {"ffdhe3072", "ffdhe3072", NID_ffdhe3072, 0, NULL, 0},
     {"ffdhe8192", "ffdhe8192", NID_ffdhe8192, 0, NULL, 0},
     {"MLKEM512IPD", "MLKEM512IPD", NID_MLKEM512IPD, 0, NULL, 0},
@@ -11137,6 +11149,8 @@ static const uint16_t kNIDsInOIDOrder[] = {
     732 /* 1.3.132.0.37 (OBJ_sect409r1) */,
     733 /* 1.3.132.0.38 (OBJ_sect571k1) */,
     734 /* 1.3.132.0.39 (OBJ_sect571r1) */,
+    982 /* 1.3.9999.99.51 (OBJ_X25519Kyber768Draft00) */,
+    981 /* 1.3.9999.99.52 (OBJ_SecP256r1Kyber768Draft00) */,
     624 /* 2.23.42.3.0.0 (OBJ_set_rootKeyThumb) */,
     625 /* 2.23.42.3.0.1 (OBJ_set_addPolicy) */,
     626 /* 2.23.42.3.2.1 (OBJ_setAttr_Token_EMV) */,

--- a/crypto/obj/objects.txt
+++ b/crypto/obj/objects.txt
@@ -133,9 +133,9 @@ secg-ellipticCurve 39		: sect571r1
  : ffdhe4096
  : ffdhe8192
 
-# PQ Groups
- : SecP256r1Kyber768Draft00
- : X25519Kyber768Draft00
+# PQ Group OIDs from OQS
+1 3 9999 99 51 : X25519Kyber768Draft00
+1 3 9999 99 52 : SecP256r1Kyber768Draft00
 
 # WAP/TLS curve OIDs (http://www.wapforum.org/)
 !Alias wap-wsg-idm-ecid wap-wsg 4

--- a/include/openssl/nid.h
+++ b/include/openssl/nid.h
@@ -4321,9 +4321,11 @@ extern "C" {
 
 #define SN_SecP256r1Kyber768Draft00 "SecP256r1Kyber768Draft00"
 #define NID_SecP256r1Kyber768Draft00 981
+#define OBJ_SecP256r1Kyber768Draft00 1L, 3L, 9999L, 99L, 52L
 
 #define SN_X25519Kyber768Draft00 "X25519Kyber768Draft00"
 #define NID_X25519Kyber768Draft00 982
+#define OBJ_X25519Kyber768Draft00 1L, 3L, 9999L, 99L, 51L
 
 #define SN_ffdhe3072 "ffdhe3072"
 #define NID_ffdhe3072 983


### PR DESCRIPTION
### Description of changes: 

The OID values are taken from OQS's [openssl provider][1].

The only manual changes in this PR were to `crypto/obj/objects.txt`. The rest were generated by running `go run objects.go` in the `crypto/obj/` directory.

[1]: https://github.com/open-quantum-safe/oqs-provider/blob/acd7181ae34ff05261d30d111eb5102d4f8c623a/ALGORITHMS.md?plain=1#L253-L254

### Call-outs:
n/a

### Testing:

```
# tested using this python fork https://github.com/WillChilds-Klein/cpython/tree/pq-tls

$ cat test.py
import ssl
import socket

assert "AWS-LC" in ssl.OPENSSL_VERSION

ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
ctx.set_ecdh_curve("X25519Kyber768Draft00")
ctx.load_verify_locations("/etc/ssl/certs/ca-certificates.crt")

host = "secretsmanager.us-east-1.amazonaws.com"
sock = socket.create_connection((host, 443))
ssock = ctx.wrap_socket(sock, server_hostname=host)
ssock.close()
print("success!")

$ ./python test.py
success!
```
<img width="1436" alt="Screenshot 2024-07-31 at 8 08 58 PM" src="https://github.com/user-attachments/assets/71ad3d40-7c58-4801-a719-934064b44165">

pcap screenshot of above client Hello:



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
