### PR TITLE
Build CMake with multiple jobs to save time

### DIFF
--- a/.github/docker_images/cmake_build_versions/cmake_build.sh
+++ b/.github/docker_images/cmake_build_versions/cmake_build.sh
@@ -10,5 +10,5 @@ echo "Building CMake Version: ${CMAKE_VERSION:-unknown}"
 # At the moment this works fine for all versions, in the future build logic can be modified to
 # look at it ${CMAKE_VERSION}.
 ./configure --prefix=/opt/cmake --system-curl --system-libarchive
-make
+make -j
 make install


### PR DESCRIPTION
### Description of changes: 
While working on https://github.com/aws/aws-lc/pull/1729 I noticed the CMake builds took a while because it was all single threaded. The GitHub runners [have 4 cores](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) so this should speed it up a bit.

### Testing:
Waiting to see what happens here. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
