### PR TITLE
Support OCSP_basic_add1_nonce

### DIFF
--- a/crypto/ocsp/ocsp_extension.c
+++ b/crypto/ocsp/ocsp_extension.c
@@ -103,6 +103,18 @@ int OCSP_request_add1_nonce(OCSP_REQUEST *req, unsigned char *val, int len) {
   return ocsp_add_nonce(&req->tbsRequest->requestExtensions, val, len);
 }
 
+int OCSP_basic_add1_nonce(OCSP_BASICRESP *resp, unsigned char *val, int len) {
+  if (resp == NULL) {
+    OPENSSL_PUT_ERROR(OCSP, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  }
+  if (val != NULL && len <= 0) {
+    OPENSSL_PUT_ERROR(OCSP, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
+    return 0;
+  }
+  return ocsp_add_nonce(&resp->tbsResponseData->responseExtensions, val, len);
+}
+
 int OCSP_check_nonce(OCSP_REQUEST *req, OCSP_BASICRESP *bs) {
   if (req == NULL || bs == NULL) {
     OPENSSL_PUT_ERROR(OCSP, ERR_R_PASSED_NULL_PARAMETER);

--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -1427,12 +1427,13 @@ TEST(OCSPTest, OCSPNonce) {
       OCSP_basic_add1_nonce(basicResponse.get(), ocsp_response_nonce, 0));
 
   // Adding a random nonce with the default length should succeed.
-  // |OCSP_REQUEST_get_ext_by_NID| returns a negative number if a nonce does
+  // |OCSP_BASICRESP_get_ext_by_NID| returns a negative number if a nonce does
   // not exist.
+  // Add a random nonce with a specified length this time around.
   EXPECT_LT(OCSP_BASICRESP_get_ext_by_NID(basicResponse.get(),
                                           NID_id_pkix_OCSP_Nonce, -1),
             0);
-  EXPECT_TRUE(OCSP_basic_add1_nonce(basicResponse.get(), nullptr, 0));
+  EXPECT_TRUE(OCSP_basic_add1_nonce(basicResponse.get(), nullptr, 10));
   EXPECT_GE(OCSP_BASICRESP_get_ext_by_NID(basicResponse.get(),
                                           NID_id_pkix_OCSP_Nonce, -1),
             0);

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -171,10 +171,15 @@ OPENSSL_EXPORT OCSP_CERTID *OCSP_onereq_get0_id(OCSP_ONEREQ *one);
 // |req|. If |val| is NULL, a random nonce is generated and used. If |len| is
 // zero or negative, a default length of 16 bytes will be used.
 // If |val| is non-NULL, |len| must equal the length of |val|. This is different
-// from OpenSSL, which allows a default length for |len| to be used. Misusage
+// from OpenSSL, which allows a default length for |len| to be used. Mis-usage
 // of the default length could result in a read overflow, so we disallow it.
 OPENSSL_EXPORT int OCSP_request_add1_nonce(OCSP_REQUEST *req,
                                            unsigned char *val, int len);
+
+// OCSP_basic_add1_nonce is identical to |OCSP_request_add1_nonce|, but adds the
+// nonce to |resp| instead (the response).
+OPENSSL_EXPORT int OCSP_basic_add1_nonce(OCSP_BASICRESP *resp,
+                                         unsigned char *val, int len);
 
 // OCSP_check_nonce checks nonce existence and equality in |req| and |bs|. If
 // there is parsing issue with |req| or |bs|, it will be determined that a


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2420`

### Description of changes: 
Ruby happens to depend on `OCSP_basic_add1_nonce` which is identical to `OCSP_request_add1_nonce`, but does the operation on the `OCSP_BASICRESP` instead. This extends upon the same underlying function/logic as the identical function.

### Call-outs:
N/A

### Testing:
Add the same test coverage as what we had for `OCSP_request_add1_nonce`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
