### PR TITLE
Specifying CPU threads in cmake_build.sh to fix CI failures

### DIFF
--- a/.github/docker_images/cmake_build_versions/cmake_build.sh
+++ b/.github/docker_images/cmake_build_versions/cmake_build.sh
@@ -7,8 +7,10 @@ set -ex -o pipefail
 
 echo "Building CMake Version: ${CMAKE_VERSION:-unknown}"
 
+NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
+
 # At the moment this works fine for all versions, in the future build logic can be modified to
 # look at it ${CMAKE_VERSION}.
 ./configure --prefix=/opt/cmake --system-curl --system-libarchive
-make -j
+make -j"${NUM_CPU_THREADS}"
 make install


### PR DESCRIPTION
### Description of changes: 
A previous PR (https://github.com/aws/aws-lc/pull/1735/files) broke the CI but was merged in since the failed checks were not required. This PR fixes these failures by explicitly setting the number of threads to parallelize the make command (as opposed to using -j to spin up as many processes as possible). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
