### PR TITLE
Updating Pyyaml Dependency

### DIFF
--- a/tests/ci/setup.py
+++ b/tests/ci/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         "aws-cdk-lib==2.74.0",
         "constructs==10.1.314",
         # PyYAML is a YAML parser and emitter for Python. Used to read build_spec.yaml.
-        "pyyaml==6.0",
+        "pyyaml==6.0.1",
         # A formatter for Python code.
         "yapf==0.30.0",
         # Introduced by benchmark framework.


### PR DESCRIPTION
### Description of changes: 
updating the pyyaml dependency from 6.0 to 6.0.1. Pyyaml 6.0 does not work with Python 3.12 and we should be able to support it: https://github.com/yaml/pyyaml/issues/756


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
