### PR TITLE
NASM use default debug format

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -113,7 +113,11 @@ if(NOT OPENSSL_NO_ASM)
       endif()
       find_program(NASM_EXECUTABLE nasm)
       set(CMAKE_ASM_NASM_COMPILER ${NASM_EXECUTABLE})
-      set(CMAKE_ASM_NASM_FLAGS "${CMAKE_ASM_NASM_FLAGS} -gcv8")
+      if("${CMAKE_BUILD_TYPE_LOWER}" STREQUAL "relwithdebinfo" OR
+              NOT CMAKE_BUILD_TYPE_LOWER MATCHES "rel")
+        # Provide debug in the default format
+        set(CMAKE_ASM_NASM_FLAGS "${CMAKE_ASM_NASM_FLAGS} -g")
+      endif()
 
       # On Windows, we use the NASM output.
       set(ASM_EXT asm)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -114,7 +114,7 @@ if(NOT OPENSSL_NO_ASM)
       find_program(NASM_EXECUTABLE nasm)
       set(CMAKE_ASM_NASM_COMPILER ${NASM_EXECUTABLE})
       if("${CMAKE_BUILD_TYPE_LOWER}" STREQUAL "relwithdebinfo" OR
-              NOT CMAKE_BUILD_TYPE_LOWER MATCHES "rel")
+              "${CMAKE_BUILD_TYPE_LOWER}" STREQUAL "debug")
         # Provide debug in the default format
         set(CMAKE_ASM_NASM_FLAGS "${CMAKE_ASM_NASM_FLAGS} -g")
       endif()


### PR DESCRIPTION
### Issues
* Addresses: https://github.com/aws/aws-lc-rs/issues/470

### Description of changes: 
* NASM object files were previously setup to always contain debug information, including source file paths.
  *  `-gcv8` produces the ["CodeView 8" format](https://www.nasm.us/doc/nasmdoc8.html#section-8.5.3).
  * Simply using `-g` will produce the [default debug format](https://www.nasm.us/doc/nasmdoc2.html#section-2.1.14) for the target.
* For "release" and "minsizerel" builds, inclusion of debug information is not desirable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
