### PR TITLE
add basic support for dgst hmac in tool

### DIFF
--- a/crypto/test/test_util.h
+++ b/crypto/test/test_util.h
@@ -76,11 +76,11 @@ bssl::UniquePtr<X509> CertFromPEM(const char *pem);
 // unique_ptr will automatically call fclose on the file descriptior when the
 // variable goes out of scope, so we need to specify BIO_NOCLOSE close flags
 // to avoid a double-free condition.
-struct FileCloser {
+struct TempFileCloser {
   void operator()(FILE *f) const { fclose(f); }
 };
 
-using TempFILE = std::unique_ptr<FILE, FileCloser>;
+using TempFILE = std::unique_ptr<FILE, TempFileCloser>;
 
 #if defined(OPENSSL_WINDOWS)
 #include <windows.h>

--- a/tests/ci/run_openssl_comparison_tests.sh
+++ b/tests/ci/run_openssl_comparison_tests.sh
@@ -39,10 +39,7 @@ declare -A openssl_branches=(
 export AWSLC_TOOL_PATH="${BUILD_ROOT}/tool-openssl/openssl"
 for branch in "${!openssl_branches[@]}"; do
   export OPENSSL_TOOL_PATH="${install_dir}/openssl-${branch}/bin/openssl"
-  LD_LIBRARY_PATH="${install_dir}/openssl-${branch}/${openssl_branches[$branch]}"
-  for test in X509ComparisonTest RSAComparisonTest MD5ComparisonTest; do
-      echo "Running ${test} against OpenSSL ${branch}"
-      LD_LIBRARY_PATH="${install_dir}/openssl-${branch}/${openssl_branches[$branch]}" "${BUILD_ROOT}/tool-openssl/tool_openssl_test" --gtest_filter=${test}.*
-  done
+  echo "Running ${test} against OpenSSL ${branch}"
+  LD_LIBRARY_PATH="${install_dir}/openssl-${branch}/${openssl_branches[$branch]}" "${BUILD_ROOT}/tool-openssl/tool_openssl_test"
 done
 

--- a/tool-openssl/CMakeLists.txt
+++ b/tool-openssl/CMakeLists.txt
@@ -1,12 +1,15 @@
 add_executable(
-        openssl
+    openssl
 
-        ../tool/args.cc
-        ../tool/file.cc
-        tool.cc
-        x509.cc
-        rsa.cc
-        md5.cc
+    ../tool/args.cc
+    ../tool/file.cc
+    ../tool/fd.cc
+
+    dgst.cc
+    md5.cc
+    rsa.cc
+    tool.cc
+    x509.cc
 )
 
 target_include_directories(openssl PUBLIC ${PROJECT_SOURCE_DIR}/include)
@@ -43,16 +46,21 @@ endif()
 
 if(BUILD_TESTING)
     add_executable(
-            tool_openssl_test
+        tool_openssl_test
 
-            ../tool/args.cc
-            ../tool/file.cc
-            x509_test.cc
-            rsa_test.cc
-            md5_test.cc
-            x509.cc
-            rsa.cc
-            md5.cc
+        ../tool/args.cc
+        ../tool/file.cc
+        ../tool/fd.cc
+        ../crypto/test/test_util.cc
+
+        dgst.cc
+        dgst_test.cc
+        md5.cc
+        md5_test.cc
+        rsa.cc
+        rsa_test.cc
+        x509.cc
+        x509_test.cc
     )
 
     target_link_libraries(tool_openssl_test boringssl_gtest_main ssl crypto)

--- a/tool-openssl/dgst.cc
+++ b/tool-openssl/dgst.cc
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <fcntl.h>
+#include <iostream>
+
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include "internal.h"
+
+// MD5 command currently only supports stdin
+static const argument_t kArguments[] = {
+    {"-help", kBooleanArgument, "Display option summary"},
+    {"-hmac", kOptionalArgument,
+     "Create a hashed MAC with the corresponding key"},
+    {"", kOptionalArgument, ""}};
+
+static bool dgst_file_op(const std::string &filename, const EVP_MD *digest,
+                         const std::string &hmac_key) {
+  ScopedFD scoped_fd = OpenFD(filename.c_str(), O_RDONLY | O_BINARY);
+  int fd = scoped_fd.get();
+
+  static const size_t kBufSize = 8192;
+  std::unique_ptr<uint8_t[]> buf(new uint8_t[kBufSize]);
+
+  if (!hmac_key.empty()) {
+    bssl::ScopedHMAC_CTX ctx;
+    if (!HMAC_Init_ex(ctx.get(), hmac_key.data(), hmac_key.size(), digest,
+                      nullptr)) {
+      fprintf(stderr, "Failed to initialize HMAC_Init_ex.\n");
+      return false;
+    }
+
+    // Update |buf| from file continuously.
+    for (;;) {
+      size_t n;
+      if (!ReadFromFD(fd, &n, buf.get(), kBufSize)) {
+        fprintf(stderr, "%s: No such file or directory\n", filename.c_str());
+        return false;
+      }
+
+      if (n == 0) {
+        break;
+      }
+
+      if (!HMAC_Update(ctx.get(), buf.get(), n)) {
+        fprintf(stderr, "Failed to update HMAC.\n");
+        return false;
+      }
+    }
+
+    const unsigned expected_mac_len = EVP_MD_size(digest);
+    std::unique_ptr<uint8_t[]> mac(new uint8_t[expected_mac_len]);
+    unsigned mac_len;
+    if (!HMAC_Final(ctx.get(), mac.get(), &mac_len)) {
+      fprintf(stderr, "Failed to finalize HMAC.\n");
+      return false;
+    }
+
+    // Print HMAC output.
+    fprintf(stdout, "HMAC-%s(%s)= ", EVP_MD_get0_name(digest),
+            filename.c_str());
+    for (size_t i = 0; i < expected_mac_len; i++) {
+      fprintf(stdout, "%02x", mac[i]);
+    }
+    fprintf(stdout, "\n");
+    return true;
+  }
+
+
+  return false;
+}
+
+// Map arguments using tool/args.cc
+bool dgstTool(const args_list_t &args) {
+  std::vector<std::string> file_inputs;
+  // Default is SHA-256.
+  // TODO: Make this customizable when "-digest" is introduced.
+  const EVP_MD *digest = EVP_sha256();
+  std::string hmac_key_string;
+
+  auto it = args.begin();
+  while (it != args.end()) {
+    const std::string &arg = *it;
+    if (!arg.empty() && arg[0] != '-') {
+      // Any input without a '-' prefix is parsed as a file. This
+      // also marks the end of any option input.
+      while (it != args.end()) {
+        file_inputs.push_back(*it);
+        it++;
+      }
+      break;
+    }
+
+    if (!arg.empty() && arg[0] == '-') {
+      const std::string option = arg.substr(1);
+      if (option == "help") {
+        PrintUsage(kArguments);
+        return false;
+      } else if (option == "hmac") {
+        // Read next argument as key string.
+        it++;
+        hmac_key_string = *it;
+      } else {
+        fprintf(stderr, "Unknown option '%s'.\n", option.c_str());
+        return false;
+      }
+    } else {
+      fprintf(stderr, "Unknown option '%s'.\n", arg.c_str());
+      return false;
+    }
+
+    // Increment while loop.
+    it++;
+  }
+
+  if (hmac_key_string.empty()) {
+    fprintf(stderr, "Only HMAC is supported as of now\n");
+    return false;
+  }
+
+  if (file_inputs.empty()) {
+    fprintf(stderr, "stdin is not supported as of now\n");
+    return false;
+  };
+
+  // Do the dgst/hmac operation on all file inputs.
+  for (const auto &file_input : file_inputs) {
+    if (!dgst_file_op(file_input, digest, hmac_key_string)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/tool-openssl/dgst_test.cc
+++ b/tool-openssl/dgst_test.cc
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <gtest/gtest.h>
+#include <openssl/pem.h>
+#include "../crypto/test/test_util.h"
+#include "test_util.h"
+
+// -------------------- MD5 OpenSSL Comparison Test ---------------------------
+
+// Comparison tests cannot run without set up of environment variables:
+// AWSLC_TOOL_PATH and OPENSSL_TOOL_PATH.
+
+class DgstComparisonTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Skip gtests if env variables not set
+    awslc_executable_path = getenv("AWSLC_TOOL_PATH");
+    openssl_executable_path = getenv("OPENSSL_TOOL_PATH");
+    if (awslc_executable_path == nullptr ||
+        openssl_executable_path == nullptr) {
+      GTEST_SKIP() << "Skipping test: AWSLC_TOOL_PATH and/or OPENSSL_TOOL_PATH "
+                      "environment variables are not set";
+    }
+    ASSERT_GT(createTempFILEpath(in_path), 0u);
+    ASSERT_GT(createTempFILEpath(out_path_awslc), 0u);
+    ASSERT_GT(createTempFILEpath(out_path_openssl), 0u);
+  }
+  void TearDown() override {
+    if (awslc_executable_path != nullptr &&
+        openssl_executable_path != nullptr) {
+      RemoveFile(in_path);
+      RemoveFile(out_path_awslc);
+      RemoveFile(out_path_openssl);
+    }
+  }
+  char in_path[PATH_MAX];
+  char out_path_awslc[PATH_MAX];
+  char out_path_openssl[PATH_MAX];
+  const char *awslc_executable_path;
+  const char *openssl_executable_path;
+  std::string awslc_output_str;
+  std::string openssl_output_str;
+};
+
+// Test against OpenSSL output for "-hmac"
+TEST_F(DgstComparisonTest, HmacToolCompareOpenSSL) {
+  std::string input_file = std::string(in_path);
+  std::ofstream ofs(input_file);
+  ofs << "AWS_LC_TEST_STRING_INPUT";
+  ofs.close();
+
+  // Run -hmac against a single file.
+  std::string awslc_command = std::string(awslc_executable_path) +
+                              " dgst -hmac test_key_string " + input_file +
+                              " > " + out_path_awslc;
+  std::string openssl_command = std::string(openssl_executable_path) +
+                                " dgst -hmac test_key_string " + input_file +
+                                " > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
+                              out_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  std::string awslc_hash = GetHash(awslc_output_str);
+  std::string openssl_hash = GetHash(openssl_output_str);
+  awslc_hash = trim(awslc_hash);
+  openssl_hash = trim(openssl_hash);
+
+  ASSERT_EQ(awslc_hash, openssl_hash);
+
+  // Run -hmac again against multiple files.
+  char in_path2[PATH_MAX];
+  ASSERT_GT(createTempFILEpath(in_path2), 0u);
+  std::string input_file2 = std::string(in_path2);
+  ofs.open(input_file2);
+  ofs << "AWS_LC_TEST_STRING_INPUT_2";
+  ofs.close();
+
+  awslc_command = std::string(awslc_executable_path) +
+                  " dgst -hmac alternative_key_string " + input_file + " " +
+                  input_file2 + " > " + out_path_awslc;
+  openssl_command = std::string(openssl_executable_path) +
+                    " dgst -hmac alternative_key_string " + input_file + " " +
+                    input_file2 + +" > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
+                              out_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  awslc_hash = GetHash(awslc_output_str);
+  openssl_hash = GetHash(openssl_output_str);
+  awslc_hash = trim(awslc_hash);
+  openssl_hash = trim(openssl_hash);
+
+  ASSERT_EQ(awslc_hash, openssl_hash);
+
+  RemoveFile(input_file.c_str());
+}

--- a/tool-openssl/dgst_test.cc
+++ b/tool-openssl/dgst_test.cc
@@ -29,7 +29,7 @@ class DgstComparisonTest : public ::testing::Test {
   void TearDown() override {
     if (awslc_executable_path != nullptr &&
         openssl_executable_path != nullptr) {
-      RemoveFile(in_path);
+      //      RemoveFile(in_path);
       RemoveFile(out_path_awslc);
       RemoveFile(out_path_openssl);
     }
@@ -64,8 +64,6 @@ TEST_F(DgstComparisonTest, HmacToolCompareOpenSSL) {
 
   std::string awslc_hash = GetHash(awslc_output_str);
   std::string openssl_hash = GetHash(openssl_output_str);
-  awslc_hash = trim(awslc_hash);
-  openssl_hash = trim(openssl_hash);
 
   ASSERT_EQ(awslc_hash, openssl_hash);
 
@@ -90,10 +88,27 @@ TEST_F(DgstComparisonTest, HmacToolCompareOpenSSL) {
 
   awslc_hash = GetHash(awslc_output_str);
   openssl_hash = GetHash(openssl_output_str);
-  awslc_hash = trim(awslc_hash);
-  openssl_hash = trim(openssl_hash);
 
   ASSERT_EQ(awslc_hash, openssl_hash);
 
+  // Run -hmac with empty key
+  awslc_command = std::string(awslc_executable_path) +
+                  " dgst -hmac \"\" "
+                  " " +
+                  input_file + " " + input_file2 + " > " + out_path_awslc;
+  openssl_command = std::string(openssl_executable_path) + " dgst -hmac \"\" " +
+                    input_file + " " + input_file2 + +" > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
+                              out_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  awslc_hash = GetHash(awslc_output_str);
+  openssl_hash = GetHash(openssl_output_str);
+
+  ASSERT_EQ(awslc_hash, openssl_hash);
+
+
   RemoveFile(input_file.c_str());
+  RemoveFile(input_file2.c_str());
 }

--- a/tool-openssl/internal.h
+++ b/tool-openssl/internal.h
@@ -8,7 +8,9 @@
 #include <string>
 #include <vector>
 
-
+#if !defined(O_BINARY)
+#define O_BINARY 0
+#endif
 
 typedef bool (*tool_func_t)(const std::vector<std::string> &args);
 
@@ -23,8 +25,9 @@ bool LoadPrivateKeyAndSignCertificate(X509 *x509, const std::string &signkey_pat
 tool_func_t FindTool(const std::string &name);
 tool_func_t FindTool(int argc, char **argv, int &starting_arg);
 
-bool X509Tool(const args_list_t &args);
-bool rsaTool(const args_list_t &args);
+bool dgstTool(const args_list_t &args);
 bool md5Tool(const args_list_t &args);
+bool rsaTool(const args_list_t &args);
+bool X509Tool(const args_list_t &args);
 
 #endif //INTERNAL_H

--- a/tool-openssl/md5_test.cc
+++ b/tool-openssl/md5_test.cc
@@ -5,25 +5,8 @@
 #include <openssl/pem.h>
 #include "internal.h"
 #include "test_util.h"
+#include "../crypto/test/test_util.h"
 #include <cctype>
-
-
-#ifdef _WIN32
-#include <windows.h>
-#ifndef PATH_MAX
-#define PATH_MAX MAX_PATH
-#endif
-#else
-#include <unistd.h>
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
-#endif
-
-size_t createTempFILEpath(char buffer[PATH_MAX]);
-
-std::string GetHash(const std::string& str);
-
 
 // -------------------- MD5 OpenSSL Comparison Test ---------------------------
 

--- a/tool-openssl/rsa_test.cc
+++ b/tool-openssl/rsa_test.cc
@@ -6,22 +6,7 @@
 #include <openssl/pem.h>
 #include "internal.h"
 #include "test_util.h"
-#include <cctype>
-
-
-#ifdef _WIN32
-#include <windows.h>
-#ifndef PATH_MAX
-#define PATH_MAX MAX_PATH
-#endif
-#else
-#include <unistd.h>
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
-#endif
-
-size_t createTempFILEpath(char buffer[PATH_MAX]);
+#include "../crypto/test/test_util.h"
 
 bool CheckBoundaries(const std::string &content, const std::string &begin1, const std::string &end1, const std::string &begin2, const std::string &end2);
 

--- a/tool-openssl/test_util.h
+++ b/tool-openssl/test_util.h
@@ -64,4 +64,7 @@ inline void RemoveFile(const char* path) {
   }
 }
 
+// OpenSSL versions 3.1.0 and later change from "(stdin)= " to "MD5(stdin) ="
+std::string GetHash(const std::string& str);
+
 #endif //TEST_UTIL_H

--- a/tool-openssl/tool.cc
+++ b/tool-openssl/tool.cc
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+#include <openssl/ssl.h>
 #include <array>
 #include <iostream>
-#include <openssl/ssl.h>
 
 #if defined(OPENSSL_WINDOWS)
 #include <fcntl.h>
@@ -22,17 +22,18 @@ struct Tool {
   tool_func_t func;
 };
 
-static const std::array<Tool, 3> kTools = {{
-{ "x509", X509Tool },
-{"rsa", rsaTool},
-{"md5", md5Tool},
+static const std::array<Tool, 4> kTools = {{
+    {"dgst", dgstTool},
+    {"md5", md5Tool},
+    {"rsa", rsaTool},
+    {"x509", X509Tool},
 }};
 
 static void usage(const std::string &name) {
   std::cout << "Usage: " << name << " COMMAND\n\n";
   std::cout << "Available commands:\n";
 
-  for (const auto& tool : kTools) {
+  for (const auto &tool : kTools) {
     if (tool.func == nullptr) {
       break;
     }
@@ -67,7 +68,7 @@ static void initialize() {
 }
 
 tool_func_t FindTool(const std::string &name) {
-  for (const auto& tool : kTools) {
+  for (const auto &tool : kTools) {
     if (tool.name == name) {
       return tool.func;
     }

--- a/tool-openssl/x509_test.cc
+++ b/tool-openssl/x509_test.cc
@@ -6,22 +6,9 @@
 #include <openssl/pem.h>
 #include "internal.h"
 #include "test_util.h"
+#include "../crypto/test/test_util.h"
 #include <cctype>
 
-
-#ifdef _WIN32
-#include <windows.h>
-#ifndef PATH_MAX
-#define PATH_MAX MAX_PATH
-#endif
-#else
-#include <unistd.h>
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
-#endif
-
-size_t createTempFILEpath(char buffer[PATH_MAX]);
 
 X509* CreateAndSignX509Certificate() {
   bssl::UniquePtr<X509> x509(X509_new());


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2602`

### Description of changes: 
OpenSSL's hmac command line tool uses `dgst` with a `-hmac` option. Supporting the entire functionality of `dgst` will take a bit more work, but we can support `-hmac` with the default `SHA256` for the time being.

### Call-outs:
Rearranged some of the header file function calls to make things cleaner

### Testing:
Basic functionality tests against single and multiple /tmp files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
