### PR TITLE
Fix for BIO_gets and update documentation

### DIFF
--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -212,6 +212,10 @@ int BIO_gets(BIO *bio, char *buf, int len) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNSUPPORTED_METHOD);
     return -2;
   }
+  if (len <= 0) {
+    return 0;
+  }
+
   int ret = 0;
   if (HAS_CALLBACK(bio)) {
     ret = (int)bio->callback_ex(bio, BIO_CB_GETS, buf, len, 0, 0L, 1L, NULL);
@@ -222,9 +226,6 @@ int BIO_gets(BIO *bio, char *buf, int len) {
   if (!bio->init) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNINITIALIZED);
     return -2;
-  }
-  if (len <= 0) {
-    return 0;
   }
   ret = bio->method->bgets(bio, buf, len);
   if (ret > 0) {

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -162,6 +162,10 @@ int BIO_read(BIO *bio, void *buf, int len) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNSUPPORTED_METHOD);
     return -2;
   }
+  if (len <= 0) {
+    return 0;
+  }
+
   if (HAS_CALLBACK(bio)) {
     ret = (int)bio->callback_ex(bio, BIO_CB_READ, buf, len, 0, 0L, 1L, NULL);
     if (ret <= 0) {
@@ -171,9 +175,6 @@ int BIO_read(BIO *bio, void *buf, int len) {
   if (!bio->init) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNINITIALIZED);
     return -2;
-  }
-  if (len <= 0) {
-    return 0;
   }
   ret = bio->method->bread(bio, buf, len);
   if (ret > 0) {
@@ -242,6 +243,10 @@ int BIO_write(BIO *bio, const void *in, int inl) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNSUPPORTED_METHOD);
     return -2;
   }
+  if (inl <= 0) {
+    return 0;
+  }
+
   if (HAS_CALLBACK(bio)) {
     ret = (int)bio->callback_ex(bio, BIO_CB_WRITE, in, inl, 0, 0L, 1L, NULL);
     if (ret <= 0) {
@@ -252,9 +257,6 @@ int BIO_write(BIO *bio, const void *in, int inl) {
   if (!bio->init) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNINITIALIZED);
     return -2;
-  }
-  if (inl <= 0) {
-    return 0;
   }
   ret = bio->method->bwrite(bio, in, inl);
   if (ret > 0) {

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -119,14 +119,16 @@ OPENSSL_EXPORT int BIO_read(BIO *bio, void *data, int len);
 OPENSSL_EXPORT int BIO_read_ex(BIO *bio, void *data, size_t data_len,
                                size_t *read_bytes);
 
-// BIO_gets calls the |bio| |callback_ex| if set with |BIO_CB_GETS|, attempts
-// to read a line from |bio| and write at most |size| bytes into |buf|, then 
-// calls |callback_ex| with |BIO_CB_GETS|+|BIO_CB_RETURN|. If |callback_ex| is
-// set BIO_gets returns the value from calling the |callback_ex|, otherwise
-// |BIO_gets| returns the number of bytes read, or a negative number on error. 
-// This function's output always includes a trailing NUL byte, so it will read at
-// most |size - 1| bytes.
+// BIO_gets calls |callback_ex| from |bio| if set with |BIO_CB_GETS|, attempts
+// to read a line from |bio| and writes at most |size| bytes into |buf|. Then it
+// calls |callback_ex| with |BIO_CB_GETS|+|BIO_CB_RETURN|. If |size| is less
+// than or equal to zero, the function does nothing and returns zero.
+// If |callback_ex| is set, |BIO_gets| returns the value from calling
+// |callback_ex|, otherwise |BIO_gets| returns the number of bytes read, or a
+// negative number on error.
 //
+// This function's output always includes a trailing NUL byte, so it will read
+// at most |size - 1| bytes.
 // If the function read a complete line, the output will include the newline
 // character, '\n'. If no newline was found before |size - 1| bytes or EOF, it
 // outputs the bytes which were available.

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -105,9 +105,10 @@ OPENSSL_EXPORT int BIO_up_ref(BIO *bio);
 
 // BIO_read calls the |bio| |callback_ex| if set with |BIO_CB_READ|, attempts to
 // read |len| bytes into |data|, then calls |callback_ex| with
-// |BIO_CB_READ|+|BIO_CB_RETURN|. If |callback_ex| is set BIO_read returns the
-// value from calling the |callback_ex|, otherwise |BIO_read| returns the number
-// of bytes read, zero on EOF, or a negative number on error.
+// |BIO_CB_READ|+|BIO_CB_RETURN|. If |len| is less than or equal to zero, the
+// function does nothing and return zero. If |callback_ex| is set BIO_read
+// returns the value from calling the |callback_ex|, otherwise |BIO_read|
+// returns the number of bytes read, zero on EOF, or a negative number on error.
 OPENSSL_EXPORT int BIO_read(BIO *bio, void *data, int len);
 
 // BIO_read_ex calls |BIO_read| and stores the number of bytes read in
@@ -136,9 +137,10 @@ OPENSSL_EXPORT int BIO_gets(BIO *bio, char *buf, int size);
 
 // BIO_write call the |bio| |callback_ex| if set with |BIO_CB_WRITE|, writes
 // |len| bytes from |data| to |bio|, then calls |callback_ex| with
-// |BIO_CB_WRITE|+|BIO_CB_RETURN|. If |callback_ex| is set BIO_write returns the
-// value from calling the |callback_ex|, otherwise |BIO_write| returns the
-// number of bytes written, or a negative number on error.
+// |BIO_CB_WRITE|+|BIO_CB_RETURN|. If |len| is less than or equal to zero, the
+// function does nothing and return zero. If |callback_ex| is set BIO_write
+// returns the value from calling the |callback_ex|, otherwise |BIO_write|
+// returns the number of bytes written, or a negative number on error.
 OPENSSL_EXPORT int BIO_write(BIO *bio, const void *data, int len);
 
 // BIO_write_ex calls |BIO_write| and stores the number of bytes written in


### PR DESCRIPTION
### Description of changes: 
BIO_gets takes a len/size parameter which is of type int and can be negative. Previously, this param was passed into callback_ex without a check for len being positive. This is an issue since callback_ex defines this size/len param as a size_t var. Passing in a negative number to size_t could lead to unexpected behavior. 
A similar issue exists in BIO_read and BIO_write

This PR moves the check for len to before calling the callback and updates documentation for BIO_gets, BIO_read, and BIO_write.

