### PR TITLE
No-op impls for several EVP_PKEY_CTX functions

### DIFF
--- a/crypto/fipsmodule/evp/evp_ctx.c
+++ b/crypto/fipsmodule/evp/evp_ctx.c
@@ -621,3 +621,28 @@ int EVP_PKEY_decapsulate(EVP_PKEY_CTX *ctx,
   return ctx->pmeth->decapsulate(ctx, shared_secret, shared_secret_len,
                                  ciphertext, ciphertext_len);
 }
+
+// Deprecated keygen NO-OP functions
+int EVP_PKEY_CTX_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
+                            const char *value) {
+  // No-op
+  return 0;
+}
+
+void EVP_PKEY_CTX_set_cb(EVP_PKEY_CTX *ctx, EVP_PKEY_gen_cb *cb) {
+  // No-op
+}
+
+void EVP_PKEY_CTX_set_app_data(EVP_PKEY_CTX *ctx, void *data) {
+  // No-op
+}
+
+void *EVP_PKEY_CTX_get_app_data(EVP_PKEY_CTX *ctx) {
+  // No-op
+  return NULL;
+}
+
+int EVP_PKEY_CTX_get_keygen_info(EVP_PKEY_CTX *ctx, int idx) {
+  // No-op
+  return 0;
+}

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1214,6 +1214,27 @@ OPENSSL_EXPORT DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
 // EVP_PKEY_get1_DH returns NULL.
 OPENSSL_EXPORT OPENSSL_DEPRECATED DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
 
+// EVP_PKEY_CTX No-ops [Deprecated].
+
+// EVP_PKEY_CTX_ctrl_str is a no-op.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_PKEY_CTX_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
+                            const char *value);
+
+// EVP_PKEY_CTX keygen no-ops [Deprecated].
+
+typedef int EVP_PKEY_gen_cb(EVP_PKEY_CTX *ctx);
+
+// EVP_PKEY_CTX_set_cb is a no-op.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_PKEY_CTX_set_cb(EVP_PKEY_CTX *ctx, EVP_PKEY_gen_cb *cb);
+
+// EVP_PKEY_CTX_set_app_data is a no-op.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EVP_PKEY_CTX_set_app_data(EVP_PKEY_CTX *ctx, void *data);
+
+// EVP_PKEY_CTX_get_app_data is a no-op. Return value is |NULL|.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void *EVP_PKEY_CTX_get_app_data(EVP_PKEY_CTX *ctx);
+
+//  EVP_PKEY_CTX_get_keygen_info is a no-op. Return value is 0.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int EVP_PKEY_CTX_get_keygen_info(EVP_PKEY_CTX *ctx, int idx);
 
 // Preprocessor compatibility section (hidden).
 //


### PR DESCRIPTION
### Issues:
Addresses: CryptoAlg-1716

### Description of changes: 
* Added no-op implementations for several `EVP_PKEY_CTX` functions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
