### PR TITLE
Allow aarch64 CPUID capability check for all Linux platforms

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -97,9 +97,7 @@ void OPENSSL_cpuid_setup(void) {
   static const unsigned long kSHA256 = 1 << 6;
   static const unsigned long kSHA512 = 1 << 21;
   static const unsigned long kSHA3 = 1 << 17;
-#if defined(OPENSSL_ANDROID)
   static const unsigned long kCPUID = 1 << 11;
-#endif
 
   uint64_t OPENSSL_arm_midr = 0;
 
@@ -133,19 +131,14 @@ void OPENSSL_cpuid_setup(void) {
   // Before calling armv8_cpuid_probe and reading from MIDR_EL1 check that it
   // is supported. As of Valgrind 3.21 trying to read from that register will
   // cause Valgrind to crash.
-
-#if defined(OPENSSL_ANDROID)
   if (hwcap & kCPUID) {
-#endif
     // Check if the CPU model is Neoverse V1,
     // which has a wide crypto/SIMD pipeline.
     OPENSSL_arm_midr = armv8_cpuid_probe();
     if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V1)) {
       OPENSSL_armcap_P |= ARMV8_NEOVERSE_V1;
     }
-#if defined(OPENSSL_ANDROID)
   }
-#endif
 
   // OPENSSL_armcap is a 32-bit, unsigned value which may start with "0x" to
   // indicate a hex value. Prior to the 32-bit value, a '~' or '|' may be given.


### PR DESCRIPTION
### Issues:
Addresses P147929287

### Description of changes: 
Removes the `OPENSSL_ANDROID` guard around the aarch64 CPUID capability check and allows it for all aarch64 linux platforms. This is now inline with the original commit taken from main: https://github.com/aws/aws-lc/commit/24cb055cb48ae15b9b924ec939f4b993380723f7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
