### PR TITLE
[fips-2022-11-02] Backport Latest TLS Transfer Version

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -680,10 +680,12 @@ OPENSSL_EXPORT int SSL_CTX_set_min_proto_version(SSL_CTX *ctx,
 OPENSSL_EXPORT int SSL_CTX_set_max_proto_version(SSL_CTX *ctx,
                                                  uint16_t version);
 
-// SSL_CTX_get_min_proto_version returns the minimum protocol version for |ctx|
+// SSL_CTX_get_min_proto_version returns the minimum protocol version for |ctx|.
+// If |ctx| is configured to use the default minimum version, 0 is returned.
 OPENSSL_EXPORT uint16_t SSL_CTX_get_min_proto_version(const SSL_CTX *ctx);
 
-// SSL_CTX_get_max_proto_version returns the maximum protocol version for |ctx|
+// SSL_CTX_get_max_proto_version returns the maximum protocol version for |ctx|.
+// If |ctx| is configured to use the default maximum version, 0 is returned.
 OPENSSL_EXPORT uint16_t SSL_CTX_get_max_proto_version(const SSL_CTX *ctx);
 
 // SSL_set_min_proto_version sets the minimum protocol version for |ssl| to
@@ -697,11 +699,13 @@ OPENSSL_EXPORT int SSL_set_min_proto_version(SSL *ssl, uint16_t version);
 OPENSSL_EXPORT int SSL_set_max_proto_version(SSL *ssl, uint16_t version);
 
 // SSL_get_min_proto_version returns the minimum protocol version for |ssl|. If
-// the connection's configuration has been shed, 0 is returned.
+// the connection's configuration has been shed or |ssl| is configured to use
+// the default min version, 0 is returned.
 OPENSSL_EXPORT uint16_t SSL_get_min_proto_version(const SSL *ssl);
 
 // SSL_get_max_proto_version returns the maximum protocol version for |ssl|. If
-// the connection's configuration has been shed, 0 is returned.
+// the connection's configuration has been shed or |ssl| is configured to use
+// the default max version, 0 is returned.
 OPENSSL_EXPORT uint16_t SSL_get_max_proto_version(const SSL *ssl);
 
 // SSL_version returns the TLS or DTLS protocol version used by |ssl|, which is

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -3150,6 +3150,20 @@ struct SSL_CONFIG {
 
   // permute_extensions is whether to permute extensions when sending messages.
   bool permute_extensions : 1;
+
+  // conf_max_version_use_default indicates whether the |SSL_CONFIG| is configured
+  // to use the default maximum protocol version for the relevant protocol
+  // method. By default, |SSL_new| will set this to true and connections will use
+  // the default max version. callers can change the max version used by calling
+  // |SSL_set_max_proto_version| with a non-zero value.
+  bool conf_max_version_use_default;
+
+  // conf_min_version_use_default indicates whether the |SSL_CONFIG| is configured
+  // to use the default minimum protocol version for the relevant protocol
+  // method. By default, |SSL_new| will set this to true and connections will use
+  // the default min version. callers can change the min version used by calling
+  // |SSL_set_min_proto_version| with a non-zero value.
+  bool conf_min_version_use_default;
 };
 
 // From RFC 8446, used in determining PSK modes.
@@ -3792,6 +3806,20 @@ struct ssl_ctx_st {
 
   // If enable_early_data is true, early data can be sent and accepted.
   bool enable_early_data : 1;
+
+  // conf_max_version_use_default indicates whether the |SSL_CTX| is configured
+  // to use the default maximum protocol version for the relevant protocol
+  // method. By default, |SSL_CTX_new| will set this to true and connections will
+  // use the default max version. callers can change the max version used by calling
+  // |SSL_CTX_set_max_proto_version| with a non-zero value.
+  bool conf_max_version_use_default;
+
+  // conf_min_version_use_default indicates whether the |SSL_CTX| is configured
+  // to use the default minimum protocol version for the relevant protocol
+  // method. By default, |SSL_CTX_new| will set this to true and connections will
+  // use the default min version. callers can change the min version used by calling
+  // |SSL_CTX_set_min_proto_version| with a non-zero value.
+  bool conf_min_version_use_default;
 
  private:
   ~ssl_ctx_st();

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -582,6 +582,13 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *method) {
     return nullptr;
   }
 
+  // By default, use the method's default min/max version. Make sure to set
+  // this after calls to |SSL_CTX_set_{min,max}_proto_version| because those
+  // calls modify these values if |method->version| is not 0. We should still
+  // defer to the protocol method's default min/max values in that case.
+  ret->conf_max_version_use_default = true;
+  ret->conf_min_version_use_default = true;
+
   return ret.release();
 }
 
@@ -642,6 +649,8 @@ SSL *SSL_new(SSL_CTX *ctx) {
   }
   ssl->config->conf_min_version = ctx->conf_min_version;
   ssl->config->conf_max_version = ctx->conf_max_version;
+  ssl->config->conf_min_version_use_default = ctx->conf_min_version_use_default;
+  ssl->config->conf_max_version_use_default = ctx->conf_max_version_use_default;
 
   ssl->config->cert = ssl_cert_dup(ctx->cert.get());
   if (ssl->config->cert == nullptr) {

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -1236,8 +1236,21 @@ static void ExpectDefaultVersion(uint16_t min_version, uint16_t max_version,
                                  const SSL_METHOD *(*method)(void)) {
   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(method()));
   ASSERT_TRUE(ctx);
+  bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
+  ASSERT_TRUE(ssl);
+  EXPECT_EQ(0, SSL_CTX_get_min_proto_version(ctx.get()));
+  EXPECT_EQ(0, SSL_CTX_get_max_proto_version(ctx.get()));
+  EXPECT_EQ(0, SSL_get_min_proto_version(ssl.get()));
+  EXPECT_EQ(0, SSL_get_max_proto_version(ssl.get()));
+
+  EXPECT_TRUE(SSL_CTX_set_min_proto_version(ctx.get(), min_version));
+  EXPECT_TRUE(SSL_CTX_set_max_proto_version(ctx.get(), max_version));
   EXPECT_EQ(min_version, SSL_CTX_get_min_proto_version(ctx.get()));
   EXPECT_EQ(max_version, SSL_CTX_get_max_proto_version(ctx.get()));
+  EXPECT_TRUE(SSL_set_min_proto_version(ssl.get(), min_version));
+  EXPECT_TRUE(SSL_set_max_proto_version(ssl.get(), max_version));
+  EXPECT_EQ(min_version, SSL_get_min_proto_version(ssl.get()));
+  EXPECT_EQ(max_version, SSL_get_max_proto_version(ssl.get()));
 }
 
 TEST(SSLTest, DefaultVersion) {
@@ -4158,6 +4171,8 @@ TEST(SSLTest, EarlyCallbackVersionSwitch) {
 TEST(SSLTest, SetVersion) {
   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
   ASSERT_TRUE(ctx);
+  bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
+  ASSERT_TRUE(ssl);
 
   // Set valid TLS versions.
   for (const auto &vers : kAllVersions) {
@@ -4167,6 +4182,10 @@ TEST(SSLTest, SetVersion) {
       EXPECT_EQ(SSL_CTX_get_max_proto_version(ctx.get()), vers.version);
       EXPECT_TRUE(SSL_CTX_set_min_proto_version(ctx.get(), vers.version));
       EXPECT_EQ(SSL_CTX_get_min_proto_version(ctx.get()), vers.version);
+      EXPECT_TRUE(SSL_set_max_proto_version(ssl.get(), vers.version));
+      EXPECT_EQ(SSL_get_max_proto_version(ssl.get()), vers.version);
+      EXPECT_TRUE(SSL_set_min_proto_version(ssl.get(), vers.version));
+      EXPECT_EQ(SSL_get_min_proto_version(ssl.get()), vers.version);
     }
   }
 
@@ -4177,18 +4196,30 @@ TEST(SSLTest, SetVersion) {
   EXPECT_FALSE(SSL_CTX_set_min_proto_version(ctx.get(), DTLS1_VERSION));
   EXPECT_FALSE(SSL_CTX_set_min_proto_version(ctx.get(), 0x0200));
   EXPECT_FALSE(SSL_CTX_set_min_proto_version(ctx.get(), 0x1234));
+  EXPECT_FALSE(SSL_set_max_proto_version(ssl.get(), 0x0200));
+  EXPECT_FALSE(SSL_set_max_proto_version(ssl.get(), 0x1234));
+  EXPECT_FALSE(SSL_set_min_proto_version(ssl.get(), DTLS1_VERSION));
+  EXPECT_FALSE(SSL_set_min_proto_version(ssl.get(), 0x0200));
+  EXPECT_FALSE(SSL_set_min_proto_version(ssl.get(), 0x1234));
 
-  // Zero is the default version.
+  // Zero represents the default version.
   EXPECT_TRUE(SSL_CTX_set_max_proto_version(ctx.get(), 0));
-  EXPECT_EQ(TLS1_3_VERSION, SSL_CTX_get_max_proto_version(ctx.get()));
+  EXPECT_EQ(0, SSL_CTX_get_max_proto_version(ctx.get()));
   EXPECT_TRUE(SSL_CTX_set_min_proto_version(ctx.get(), 0));
-  EXPECT_EQ(TLS1_VERSION, SSL_CTX_get_min_proto_version(ctx.get()));
+  EXPECT_EQ(0, SSL_CTX_get_min_proto_version(ctx.get()));
+  EXPECT_TRUE(SSL_set_max_proto_version(ssl.get(), 0));
+  EXPECT_EQ(0, SSL_get_max_proto_version(ssl.get()));
+  EXPECT_TRUE(SSL_set_min_proto_version(ssl.get(), 0));
+  EXPECT_EQ(0, SSL_get_min_proto_version(ssl.get()));
 
   // SSL 3.0 is not available.
   EXPECT_FALSE(SSL_CTX_set_min_proto_version(ctx.get(), SSL3_VERSION));
+  EXPECT_FALSE(SSL_set_min_proto_version(ssl.get(), SSL3_VERSION));
 
   ctx.reset(SSL_CTX_new(DTLS_method()));
   ASSERT_TRUE(ctx);
+  ssl.reset(SSL_new(ctx.get()));
+  ASSERT_TRUE(ssl);
 
   // Set valid DTLS versions.
   for (const auto &vers : kAllVersions) {
@@ -4211,11 +4242,11 @@ TEST(SSLTest, SetVersion) {
   EXPECT_FALSE(SSL_CTX_set_min_proto_version(ctx.get(), 0xfffe /* DTLS 0.1 */));
   EXPECT_FALSE(SSL_CTX_set_min_proto_version(ctx.get(), 0x1234));
 
-  // Zero is the default version.
+  // Zero represents the default version.
   EXPECT_TRUE(SSL_CTX_set_max_proto_version(ctx.get(), 0));
-  EXPECT_EQ(DTLS1_2_VERSION, SSL_CTX_get_max_proto_version(ctx.get()));
+  EXPECT_EQ(0, SSL_CTX_get_max_proto_version(ctx.get()));
   EXPECT_TRUE(SSL_CTX_set_min_proto_version(ctx.get(), 0));
-  EXPECT_EQ(DTLS1_VERSION, SSL_CTX_get_min_proto_version(ctx.get()));
+  EXPECT_EQ(0, SSL_CTX_get_min_proto_version(ctx.get()));
 }
 
 static const char *GetVersionName(uint16_t version) {

--- a/ssl/ssl_transfer_asn1.cc
+++ b/ssl/ssl_transfer_asn1.cc
@@ -181,91 +181,7 @@ static const unsigned kS3AeadWriteCtxTag =
 // ssl3_state_to_bytes serializes |in| to bytes stored in |cbb|.
 // It returns one on success and zero on failure.
 //
-// An SSL3_STATE is serialized as the following ASN.1 structure, a complete
-// description can be found in tls_transfer.asn:
-//
-// SSL3StateSerializationVersion ::= INTEGER {
-//                   v1 (1),
-//                   v2 (2) -- Added additional fields to support TLS 1.3
-//               }
-//
-// SSL3State ::= SEQUENCE {
-//   serializationVersion SSL3StateSerializationVersion,
-//   readSequence   OCTET STRING,
-//   writeSequence  OCTET STRING,
-//   serverRandom   OCTET STRING,
-//   clientRandom   OCTET STRING,
-//   sendAlert      OCTET STRING,
-//   rwstate        INTEGER,
-//   earlyDataReason INTEGER,
-//   previousClientFinished OCTET STRING,
-//   previousClientFinishedLen INTEGER,
-//   previousServerFinished OCTET STRING,
-//   previousServerFinishedLen INTEGER,
-//   emptyRecordCount INTEGER,
-//   warningAlertCount INTEGER,
-//   totalRenegotiations INTEGER,
-//   -- Simplified to SEQUENCE here, uses SSL_SESSION_to_bytes_full
-//   establishedSession [0] SEQUENCE {...},
-//   sessionReused  [1] BOOLEAN OPTIONAL,
-//   hostname       [2] OCTET STRING OPTIONAL,
-//   alpnSelected   [3] OCTET STRING OPTIONAL,
-//   nextProtoNegotiated [4] OCTET STRING OPTIONAL,
-//   channelIdValid [5] BOOLEAN OPTIONAL,
-//   channelId      [6] OCTET STRING OPTIONAL,
-//   sendConnectionBinding [7] BOOLEAN OPTIONAL,
-//   -- pending_app_data is a Span in the SS3_STATE that points into read_buffer
-//   pendingAppData [8] Span OPTIONAL,
-//   readBuffer     [9] SSLBuffer OPTIONAL,
-//   notResumable   [10] BOOLEAN OPTIONAL,
-//   ...,
-//   -- Extension describing v2 serialization format for TLS 1.3 support.
-//   [[ 2:
-//   earlyDataSkipped [11] INTEGER OPTIONAL,
-//   delegatedCredentialUsed [12] BOOLEAN OPTIONAL,
-//   earlyDataAccepted [13] BOOLEAN OPTIONAL,
-//   usedHelloRetryRequest [14] BOOLEAN OPTIONAL,
-//   ticketAgeSkew  [15] INTEGER OPTIONAL,
-//   writeTrafficSecret [16] OCTET STRING OPTIONAL,
-//   writeTrafficSecretLen [17] INTEGER OPTIONAL,
-//   readTrafficSecret [18] OCTET STRING OPTIONAL,
-//   readTrafficSecretLen [19] INTEGER OPTIONAL,
-//   exporterSecret [20] OCTET STRING OPTIONAL,
-//   exporterSecretLen [21] INTEGER OPTIONAL,
-//   hsBuffer       [22] OCTET STRING OPTIONAL,
-//   echStatus      [23] INTEGER OPTIONAL,
-//   pendingHsData  [24] OCTET STRING OPTIONAL,
-//   pendingFlight  [25] OCTET STRING OPTIONAL,
-//   aeadReadCtx    [26] SSLAEADContext OPTIONAL,
-//   aeadWriteCtx   [27] SSLAEADContext OPTIONAL
-//   ]],
-//   ...
-// }
-//
-// Span ::= SEQUENCE {
-//   offset         INTEGER,
-//   size           INTEGER
-// }
-//
-// SSLBufferSerializationVersion ::= INTEGER {v1 (1)}
-//
-// SSLBuffer ::= SEQUENCE {
-//   serializationVersion SSLBufferSerializationVersion,
-//   bufferAllocated BOOLEAN,
-//   offset         INTEGER,
-//   size           INTEGER,
-//   capacity       INTEGER
-// }
-//
-// SSLConfigSerializationVersion ::= INTEGER {v1 (1)}
-//
-// SSLConfig ::= SEQUENCE {
-//   serializationVersion SSLConfigSerializationVersion,
-//   confMaxVersion INTEGER,
-//   confMinVersion INTEGER,
-//   ocspStaplingEnabled [0] BOOLEAN OPTIONAL,
-//   jdk11Workaround [1] BOOLEAN OPTIONAL
-// }
+// SSL3_STATE ASN.1 structure: see ssl_transfer_asn1.cc
 static int SSL3_STATE_to_bytes(SSL3_STATE *in, uint16_t protocol_version,
                                CBB *cbb) {
   if (in == NULL || cbb == NULL) {
@@ -607,7 +523,7 @@ static int SSL3_STATE_from_bytes(SSL *ssl, CBS *cbs, const SSL_CTX *ctx) {
     return 0;
   }
 
-  bool is_v2 = serde_version == SSL3_STATE_SERDE_VERSION_TWO;
+  bool is_v2 = (serde_version == SSL3_STATE_SERDE_VERSION_TWO);
 
   // We should have no more data at this point if we are deserializing v1
   // encoding.
@@ -917,7 +833,7 @@ static int SSL3_STATE_from_bytes(SSL *ssl, CBS *cbs, const SSL_CTX *ctx) {
 
 // SSL_CONFIG serialization.
 
-static const unsigned kSSLConfigVersion = 1;
+static const unsigned kSSLConfigVersion = 2;
 
 static const unsigned kSSLConfigOcspStaplingEnabledTag =
     CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0;
@@ -939,17 +855,7 @@ static const unsigned kSSLConfigConfMinVersionUseDefault =
 // SSL_CONFIG_to_bytes serializes |in| to bytes stored in |cbb|.
 // It returns one on success and zero on failure.
 //
-// An SSL_CONFIG is serialized as the following ASN.1 structure:
-//
-// SSL_CONFIG ::= SEQUENCE {
-//    version                           INTEGER (1),  -- SSL_CONFIG structure version
-//    confMaxVersion                    INTEGER,
-//    confMinVersion                    INTEGER,
-//    ocspStaplingEnabled               [0] BOOLEAN OPTIONAL,
-//    jdk11Workaround                   [1] BOOLEAN OPTIONAL,
-//    confMaxVersionUseDefault          [2] BOOLEAN OPTIONAL,
-//    confMinVersionUseDefault          [3] BOOLEAN OPTIONAL
-// }
+// SSL_CONFIG ASN.1 structure: see ssl_transfer_asn1.cc
 static int SSL_CONFIG_to_bytes(SSL_CONFIG *in, CBB *cbb) {
   if (in == NULL || cbb == NULL) {
     return 0;
@@ -998,8 +904,7 @@ static int SSL_CONFIG_from_bytes(SSL_CONFIG *out, CBS *cbs) {
   int conf_max_version_use_default, conf_min_version_use_default;
   uint64_t version, conf_max_version, conf_min_version;
   if (!CBS_get_asn1(cbs, &config, CBS_ASN1_SEQUENCE) ||
-      !CBS_get_asn1_uint64(&config, &version) ||
-      version != kSSLConfigVersion ||
+      !CBS_get_asn1_uint64(&config, &version) || version > kSSLConfigVersion ||
       !CBS_get_asn1_uint64(&config, &conf_max_version) ||
       !CBS_get_asn1_uint64(&config, &conf_min_version) ||
       !CBS_get_optional_asn1_bool(&config, &ocsp_stapling_enabled,
@@ -1007,8 +912,21 @@ static int SSL_CONFIG_from_bytes(SSL_CONFIG *out, CBS *cbs) {
                                   0 /* default to false */) ||
       !CBS_get_optional_asn1_bool(&config, &jdk11_workaround,
                                   kSSLConfigJdk11WorkaroundTag,
-                                  0 /* default to false */) ||
-      !CBS_get_optional_asn1_bool(&config, &conf_max_version_use_default,
+                                  0 /* default to false */)) {
+    OPENSSL_PUT_ERROR(SSL, SSL_R_SERIALIZATION_INVALID_SSL_CONFIG);
+    return 0;
+  }
+
+  bool is_atleast_v2 = (version >= 2);
+
+  if (!is_atleast_v2 && CBS_len(&config) != 0) {
+    // We are parsing version 1 of config format, but there is more data to
+    // parse than expected. That is, the input is not v1 formatted.
+    OPENSSL_PUT_ERROR(SSL, SSL_R_SERIALIZATION_INVALID_SSL_CONFIG);
+    return 0;
+  }
+
+  if (!CBS_get_optional_asn1_bool(&config, &conf_max_version_use_default,
                                   kSSLConfigConfMaxVersionUseDefault,
                                   1 /* default to true */) ||
       !CBS_get_optional_asn1_bool(&config, &conf_min_version_use_default,
@@ -1018,6 +936,7 @@ static int SSL_CONFIG_from_bytes(SSL_CONFIG *out, CBS *cbs) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_SERIALIZATION_INVALID_SSL_CONFIG);
     return 0;
   }
+
   out->conf_max_version = conf_max_version;
   out->conf_min_version = conf_min_version;
   out->conf_max_version_use_default = !!conf_max_version_use_default;
@@ -1046,18 +965,7 @@ static const unsigned kSSLConfigTag =
 // SSL_to_bytes_full serializes |in| to bytes stored in |cbb|.
 // It returns one on success and zero on failure.
 //
-// An SSL is serialized as the following ASN.1 structure:
-//
-// SSL ::= SEQUENCE {
-//     sslSerialVer      UINT64   -- version of the SSL serialization format
-//     version           UINT64
-//     maxSendFragement  UINT64
-//     s3                SSL3State
-//     mode              UINT64
-//     options           UINT64
-//     quietShutdown     [0] BOOLEAN OPTIONAL
-//     config            [1] SEQUENCE OPTIONAL
-// }
+// SSL ASN.1 structure: see ssl_transfer_asn1.cc
 static int SSL_to_bytes_full(const SSL *in, CBB *cbb) {
   CBB ssl, child;
 
@@ -1098,16 +1006,12 @@ static int SSL_parse(SSL *ssl, CBS *cbs, SSL_CTX *ctx) {
   int quiet_shutdown;
   int ssl_config_present = 0;
 
-  if (!CBS_get_asn1(cbs, &ssl_cbs, CBS_ASN1_SEQUENCE) ||
-      CBS_len(cbs) != 0 ||
-      !CBS_get_asn1_uint64(&ssl_cbs, &ssl_serial_ver)) {
+  if (!CBS_get_asn1(cbs, &ssl_cbs, CBS_ASN1_SEQUENCE) || CBS_len(cbs) != 0 ||
+      !CBS_get_asn1_uint64(&ssl_cbs, &ssl_serial_ver)
+      || ssl_serial_ver > SSL_SERIAL_VERSION) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_SERIALIZATION_INVALID_SSL);
     return 0;
   }
-  // At the moment we're simply asserting the version is correct. However
-  // future updates could use SSL serial version to figure out what data
-  // was actually serialized and act accordingly.
-  assert(ssl_serial_ver <= SSL_SERIAL_VERSION);
 
   //    FIXME add hash of SSL_CTX
   // This TODO is actually a part of SSL DER struct revisit.

--- a/ssl/ssl_transfer_asn1.cc
+++ b/ssl/ssl_transfer_asn1.cc
@@ -925,6 +925,12 @@ static const unsigned kSSLConfigOcspStaplingEnabledTag =
 static const unsigned kSSLConfigJdk11WorkaroundTag =
     CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 1;
 
+static const unsigned kSSLConfigConfMaxVersionUseDefault =
+    CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 2;
+
+static const unsigned kSSLConfigConfMinVersionUseDefault =
+    CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 3;
+
 // *** EXPERIMENTAL — DO NOT USE WITHOUT CHECKING ***
 // These SSL_CONFIG serialization functions are developed to support SSL transfer.
 // Most fields of SSL_CONFIG are not used after handshake completes.
@@ -940,7 +946,9 @@ static const unsigned kSSLConfigJdk11WorkaroundTag =
 //    confMaxVersion                    INTEGER,
 //    confMinVersion                    INTEGER,
 //    ocspStaplingEnabled               [0] BOOLEAN OPTIONAL,
-//    jdk11Workaround                   [1] BOOLEAN OPTIONAL
+//    jdk11Workaround                   [1] BOOLEAN OPTIONAL,
+//    confMaxVersionUseDefault          [2] BOOLEAN OPTIONAL,
+//    confMinVersionUseDefault          [3] BOOLEAN OPTIONAL
 // }
 static int SSL_CONFIG_to_bytes(SSL_CONFIG *in, CBB *cbb) {
   if (in == NULL || cbb == NULL) {
@@ -966,7 +974,18 @@ static int SSL_CONFIG_to_bytes(SSL_CONFIG *in, CBB *cbb) {
   if (in->jdk11_workaround) {
     if (!CBB_add_asn1(&config, &child, kSSLConfigJdk11WorkaroundTag) ||
         !CBB_add_asn1_bool(&child, true)) {
-      OPENSSL_PUT_ERROR(SSL, ERR_R_MALLOC_FAILURE);
+      return 0;
+    }
+  }
+  if (in->conf_max_version_use_default) {
+    if (!CBB_add_asn1(&config, &child, kSSLConfigConfMaxVersionUseDefault) ||
+        !CBB_add_asn1_bool(&child, true)) {
+      return 0;
+    }
+  }
+  if (in->conf_min_version_use_default) {
+    if (!CBB_add_asn1(&config, &child, kSSLConfigConfMinVersionUseDefault) ||
+        !CBB_add_asn1_bool(&child, true)) {
       return 0;
     }
   }
@@ -976,20 +995,33 @@ static int SSL_CONFIG_to_bytes(SSL_CONFIG *in, CBB *cbb) {
 static int SSL_CONFIG_from_bytes(SSL_CONFIG *out, CBS *cbs) {
   CBS config;
   int ocsp_stapling_enabled, jdk11_workaround;
+  int conf_max_version_use_default, conf_min_version_use_default;
   uint64_t version, conf_max_version, conf_min_version;
   if (!CBS_get_asn1(cbs, &config, CBS_ASN1_SEQUENCE) ||
       !CBS_get_asn1_uint64(&config, &version) ||
       version != kSSLConfigVersion ||
       !CBS_get_asn1_uint64(&config, &conf_max_version) ||
       !CBS_get_asn1_uint64(&config, &conf_min_version) ||
-      !CBS_get_optional_asn1_bool(&config, &ocsp_stapling_enabled, kSSLConfigOcspStaplingEnabledTag, 0 /* default to false */) ||
-      !CBS_get_optional_asn1_bool(&config, &jdk11_workaround, kSSLConfigJdk11WorkaroundTag, 0 /* default to false */) ||
+      !CBS_get_optional_asn1_bool(&config, &ocsp_stapling_enabled,
+                                  kSSLConfigOcspStaplingEnabledTag,
+                                  0 /* default to false */) ||
+      !CBS_get_optional_asn1_bool(&config, &jdk11_workaround,
+                                  kSSLConfigJdk11WorkaroundTag,
+                                  0 /* default to false */) ||
+      !CBS_get_optional_asn1_bool(&config, &conf_max_version_use_default,
+                                  kSSLConfigConfMaxVersionUseDefault,
+                                  1 /* default to true */) ||
+      !CBS_get_optional_asn1_bool(&config, &conf_min_version_use_default,
+                                  kSSLConfigConfMinVersionUseDefault,
+                                  1 /* default to true */) ||
       CBS_len(&config) != 0) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_SERIALIZATION_INVALID_SSL_CONFIG);
     return 0;
   }
   out->conf_max_version = conf_max_version;
   out->conf_min_version = conf_min_version;
+  out->conf_max_version_use_default = !!conf_max_version_use_default;
+  out->conf_min_version_use_default = !!conf_min_version_use_default;
   out->ocsp_stapling_enabled = !!ocsp_stapling_enabled;
   out->jdk11_workaround = !!jdk11_workaround;
   // handoff will always be the normal state(false) after handshake completes.

--- a/ssl/ssl_versions.cc
+++ b/ssl/ssl_versions.cc
@@ -332,18 +332,26 @@ BSSL_NAMESPACE_END
 using namespace bssl;
 
 int SSL_CTX_set_min_proto_version(SSL_CTX *ctx, uint16_t version) {
+  ctx->conf_min_version_use_default = (version == 0);
   return set_min_version(ctx->method, &ctx->conf_min_version, version);
 }
 
 int SSL_CTX_set_max_proto_version(SSL_CTX *ctx, uint16_t version) {
+  ctx->conf_max_version_use_default = (version == 0);
   return set_max_version(ctx->method, &ctx->conf_max_version, version);
 }
 
 uint16_t SSL_CTX_get_min_proto_version(const SSL_CTX *ctx) {
+  if (ctx->conf_min_version_use_default) {
+    return 0;
+  }
   return ctx->conf_min_version;
 }
 
 uint16_t SSL_CTX_get_max_proto_version(const SSL_CTX *ctx) {
+  if (ctx->conf_max_version_use_default) {
+    return 0;
+  }
   return ctx->conf_max_version;
 }
 
@@ -351,6 +359,7 @@ int SSL_set_min_proto_version(SSL *ssl, uint16_t version) {
   if (!ssl->config) {
     return 0;
   }
+  ssl->config->conf_min_version_use_default = (version == 0);
   return set_min_version(ssl->method, &ssl->config->conf_min_version, version);
 }
 
@@ -358,18 +367,19 @@ int SSL_set_max_proto_version(SSL *ssl, uint16_t version) {
   if (!ssl->config) {
     return 0;
   }
+  ssl->config->conf_max_version_use_default = (version == 0);
   return set_max_version(ssl->method, &ssl->config->conf_max_version, version);
 }
 
 uint16_t SSL_get_min_proto_version(const SSL *ssl) {
-  if (!ssl->config) {
+  if (!ssl->config || ssl->config->conf_min_version_use_default) {
     return 0;
   }
   return ssl->config->conf_min_version;
 }
 
 uint16_t SSL_get_max_proto_version(const SSL *ssl) {
-  if (!ssl->config) {
+  if (!ssl->config || ssl->config->conf_max_version_use_default) {
     return 0;
   }
   return ssl->config->conf_max_version;

--- a/ssl/tls_transfer.asn
+++ b/ssl/tls_transfer.asn
@@ -126,7 +126,9 @@ SSLConfig ::= SEQUENCE {
     confMaxVersion INTEGER,
     confMinVersion INTEGER,
     ocspStaplingEnabled [0] BOOLEAN OPTIONAL,
-    jdk11Workaround [1] BOOLEAN OPTIONAL
+    jdk11Workaround [1] BOOLEAN OPTIONAL,
+    confMaxVersionUseDefault [2] BOOLEAN OPTIONAL,
+    confMinVersionUseDefault [3] BOOLEAN OPTIONAL
 }
 
 END

--- a/ssl/tls_transfer.asn
+++ b/ssl/tls_transfer.asn
@@ -119,7 +119,10 @@ SSLBuffer ::= SEQUENCE {
     capacity       INTEGER
 }
 
-SSLConfigSerializationVersion ::= INTEGER {v1 (1)}
+SSLConfigSerializationVersion ::= INTEGER {
+    v1 (1),
+    v2 (2) -- Added confMaxVersionUseDefault and confMinVersionUseDefault fields
+}
 
 SSLConfig ::= SEQUENCE {
     serializationVersion SSLConfigSerializationVersion,


### PR DESCRIPTION
### Issues:
Addresses P147941517

### Description of changes: 
Backports https://github.com/aws/aws-lc/pull/1322 and https://github.com/aws/aws-lc/pull/1337 to the fips-2022-11-02 branch.

This changes does not modify the FIPS module boundary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
