### PR TITLE
[fips-2022-11-02] Prepare v2.0.15 release

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4051,7 +4051,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 2.0.14");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 2.0.15");
 }
 
 #else
@@ -4094,6 +4094,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 2.0.14");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 2.0.15");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -214,7 +214,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "2.0.14"
+#define AWSLC_VERSION_NUMBER_STRING "2.0.15"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Fix aws-lc-rs  GH CI for FIPS-2.x branch by @justsmth in https://github.com/aws/aws-lc/pull/1651
* Allow aarch64 CPUID capability check for all Linux platforms by @skmcgrail in https://github.com/aws/aws-lc/pull/1762
* [fips-2022-11-02] Backport Latest TLS Transfer Version by @skmcgrail in https://github.com/aws/aws-lc/pull/1764

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
