### PR TITLE
Tighten up experimental pointer guard macro

### DIFF
--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -27,6 +27,25 @@
 #include <gtest/gtest.h>
 #include "test/test_util.h"
 
+static int AWS_LC_ERROR_return(void) {
+  GUARD_PTR(NULL);
+  return 1;
+}
+
+static int AWS_LC_SUCCESS_return(void) {
+  char non_null_ptr[1];
+  GUARD_PTR(non_null_ptr);
+  return 1;
+}
+
+TEST(CryptoTest, SafetyMacro) {
+  // It is assumed that |GUARD_PTR| returns 0 for fail/false and 1 for
+  // success/true. Change these default values with care because code might not
+  // use the related macros |AWS_LC_ERROR| or |AWS_LC_SUCCESS|.
+  EXPECT_EQ(AWS_LC_ERROR_return(), 0);
+  EXPECT_EQ(AWS_LC_SUCCESS_return(), 1);
+}
+
 // Test that OPENSSL_VERSION_NUMBER and OPENSSL_VERSION_TEXT are consistent.
 // Node.js parses the version out of OPENSSL_VERSION_TEXT instead of using
 // OPENSSL_VERSION_NUMBER.

--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1345,11 +1345,9 @@ OPENSSL_EXPORT int OPENSSL_vasprintf_internal(char **str, const char *format,
     OPENSSL_PRINTF_FORMAT_FUNC(2, 0);
 
 
-// Experimental Safety Macros
+// Experimental safety macros inspired by s2n-tls.
 
-// Inspired by s2n-tls
-
-// __AWS_LC_ENSURE checks if |cond| is true nothing happens, else |action| is called
+// If |cond| is false |action| is invoked, otherwise nothing happens.
 #define __AWS_LC_ENSURE(cond, action) \
     do {                           \
         if (!(cond)) {             \
@@ -1360,8 +1358,9 @@ OPENSSL_EXPORT int OPENSSL_vasprintf_internal(char **str, const char *format,
 #define AWS_LC_ERROR 0
 #define AWS_LC_SUCCESS 1
 
-// RESULT_GUARD_PTR checks |ptr|: if it is null it adds ERR_R_PASSED_NULL_PARAMETER
-// to the error queue and returns 0, if it is not null nothing happens.
+// GUARD_PTR checks |ptr|: if it is NULL it adds |ERR_R_PASSED_NULL_PARAMETER|
+// to the error queue and returns 0, if it is not NULL nothing happens.
+//
 // NOTE: this macro should only be used with functions that return 0 (for error)
 // and 1 (for success).
 #define GUARD_PTR(ptr) __AWS_LC_ENSURE((ptr) != NULL, OPENSSL_PUT_ERROR(CRYPTO, ERR_R_PASSED_NULL_PARAMETER); \


### PR DESCRIPTION
### Description of changes: 

Tighten descriptions and ensure return value assumptions can't just be changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
