### PR TITLE
Add -text support to X509 tool, add Version tool

### DIFF
--- a/tool-openssl/CMakeLists.txt
+++ b/tool-openssl/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(
     rsa.cc
     tool.cc
     x509.cc
+    version.cc
 )
 
 target_include_directories(openssl PUBLIC ${PROJECT_SOURCE_DIR}/include)

--- a/tool-openssl/internal.h
+++ b/tool-openssl/internal.h
@@ -34,5 +34,6 @@ bool dgstTool(const args_list_t &args);
 bool md5Tool(const args_list_t &args);
 bool rsaTool(const args_list_t &args);
 bool X509Tool(const args_list_t &args);
+bool VersionTool(const args_list_t &args);
 
 #endif //INTERNAL_H

--- a/tool-openssl/tool.cc
+++ b/tool-openssl/tool.cc
@@ -15,11 +15,12 @@
 
 #include "./internal.h"
 
-static const std::array<Tool, 4> kTools = {{
+static const std::array<Tool, 5> kTools = {{
     {"dgst", dgstTool},
     {"md5", md5Tool},
     {"rsa", rsaTool},
     {"x509", X509Tool},
+    {"version", VersionTool}
 }};
 
 static void usage(const std::string &name) {

--- a/tool-openssl/version.cc
+++ b/tool-openssl/version.cc
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <openssl/base.h>
+#include "internal.h"
+
+static const argument_t kArguments[] = {
+    { "", kOptionalArgument, "" }
+};
+
+bool VersionTool(const args_list_t &args) {
+  args_map_t parsed_args;
+  if (!ParseKeyValueArguments(&parsed_args, args, kArguments)) {
+    PrintUsage(kArguments);
+    return false;
+  }
+  printf("%s\n", OPENSSL_VERSION_TEXT);
+  return true;
+}

--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -18,6 +18,7 @@ static const argument_t kArguments[] = {
   { "-modulus", kBooleanArgument, "Prints out value of the modulus of the public key contained in the certificate" },
   { "-checkend", kOptionalArgument, "Check whether cert expires in the next arg seconds" },
   { "-days", kOptionalArgument, "Number of days until newly generated certificate expires - default 30" },
+  {"-text", kBooleanArgument, "Pretty print the contents of the certificate"},
   { "", kOptionalArgument, "" }
 };
 
@@ -69,7 +70,7 @@ bool X509Tool(const args_list_t &args) {
   }
 
   std::string in_path, out_path, signkey_path, checkend_str, days_str;
-  bool noout = false, modulus = false, dates = false, req = false, help = false;
+  bool noout = false, modulus = false, dates = false, req = false, help = false, text = false;
   std::unique_ptr<unsigned> checkend, days;
 
   GetBoolArgument(&help, "-help", parsed_args);
@@ -80,6 +81,7 @@ bool X509Tool(const args_list_t &args) {
   GetBoolArgument(&noout, "-noout", parsed_args);
   GetBoolArgument(&dates, "-dates", parsed_args);
   GetBoolArgument(&modulus, "-modulus", parsed_args);
+  GetBoolArgument(&text, "-text", parsed_args);
 
   // Display x509 tool option summary
   if (help) {
@@ -199,6 +201,10 @@ bool X509Tool(const args_list_t &args) {
       fprintf(stderr, "Error: error parsing certificate from '%s'\n", in_path.c_str());
       ERR_print_errors_fp(stderr);
       return false;
+    }
+    if(text) {
+      bssl::UniquePtr<BIO> bio(BIO_new_fp(stdout, BIO_NOCLOSE));
+      X509_print(bio.get(), x509.get());
     }
 
     if (dates) {

--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -18,7 +18,7 @@ static const argument_t kArguments[] = {
   { "-modulus", kBooleanArgument, "Prints out value of the modulus of the public key contained in the certificate" },
   { "-checkend", kOptionalArgument, "Check whether cert expires in the next arg seconds" },
   { "-days", kOptionalArgument, "Number of days until newly generated certificate expires - default 30" },
-  {"-text", kBooleanArgument, "Pretty print the contents of the certificate"},
+  { "-text", kBooleanArgument, "Pretty print the contents of the certificate"},
   { "", kOptionalArgument, "" }
 };
 


### PR DESCRIPTION
### Description of changes: 
Add the -text option to the X509 tool which prints a certificate's contents in a human readable format. Also add the version tool which only supports printing the basic version information.

### Testing:
Added a new test for X509 -text with some minor caveats due to difference in between OpenSSL versions. I didn't add a test for the version as that will always be different:
```
AWS-LC:
OpenSSL 1.1.1 (compatible; AWS-LC 1.33.0)

OpenSSL:
OpenSSL 3.3.1 4 Jun 2024 (Library: OpenSSL 3.3.1 4 Jun 2024)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
