### PR TITLE
Improving corner-case instruction flow in `aes_hw_ctr32_encrypt_blocks`

### DIFF
--- a/crypto/fipsmodule/aes/asm/aesv8-armx.pl
+++ b/crypto/fipsmodule/aes/asm/aesv8-armx.pl
@@ -897,9 +897,9 @@ $code.=<<___;
 
 .Lctr32_tail:
 	cmp			$len,#1
+	b.lt		.Lctr32_done	// if len = 0, go to done
 	mov			$step,#16
 	cclr		$step,eq
-	b.lt		.Lctr32_done	// if len = 0, go to done
 	aese		$dat0,q8
 	aesmc		$dat0,$dat0
 	aese		$dat1,q8

--- a/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/aesv8-armx.S
@@ -761,9 +761,9 @@ Loop3x_ctr32:
 
 Lctr32_tail:
 	cmp	x2,#1
+	b.lt	Lctr32_done	// if len = 0, go to done
 	mov	x12,#16
 	csel	x12,xzr,x12,eq
-	b.lt	Lctr32_done	// if len = 0, go to done
 	aese	v0.16b,v16.16b
 	aesmc	v0.16b,v0.16b
 	aese	v1.16b,v16.16b

--- a/generated-src/ios-arm/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/ios-arm/crypto/fipsmodule/aesv8-armx.S
@@ -743,9 +743,9 @@ Loop3x_ctr32:
 
 Lctr32_tail:
 	cmp	r2,#1
+	blt	Lctr32_done	@ if len = 0, go to done
 	mov	r12,#16
 	moveq	r12,#0
-	blt	Lctr32_done	@ if len = 0, go to done
 .byte	0x20,0x03,0xb0,0xf3	@ aese q0,q8
 .byte	0x80,0x03,0xb0,0xf3	@ aesmc q0,q0
 .byte	0x20,0x23,0xb0,0xf3	@ aese q1,q8

--- a/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/aesv8-armx.S
@@ -761,9 +761,9 @@ aes_hw_ctr32_encrypt_blocks:
 
 .Lctr32_tail:
 	cmp	x2,#1
+	b.lt	.Lctr32_done	// if len = 0, go to done
 	mov	x12,#16
 	csel	x12,xzr,x12,eq
-	b.lt	.Lctr32_done	// if len = 0, go to done
 	aese	v0.16b,v16.16b
 	aesmc	v0.16b,v0.16b
 	aese	v1.16b,v16.16b

--- a/generated-src/linux-arm/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/linux-arm/crypto/fipsmodule/aesv8-armx.S
@@ -731,9 +731,9 @@ aes_hw_ctr32_encrypt_blocks:
 
 .Lctr32_tail:
 	cmp	r2,#1
+	blt	.Lctr32_done	@ if len = 0, go to done
 	mov	r12,#16
 	moveq	r12,#0
-	blt	.Lctr32_done	@ if len = 0, go to done
 .byte	0x20,0x03,0xb0,0xf3	@ aese q0,q8
 .byte	0x80,0x03,0xb0,0xf3	@ aesmc q0,q0
 .byte	0x20,0x23,0xb0,0xf3	@ aese q1,q8

--- a/generated-src/win-aarch64/crypto/fipsmodule/aesv8-armx.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/aesv8-armx.S
@@ -773,9 +773,9 @@ Loop3x_ctr32:
 
 Lctr32_tail:
 	cmp	x2,#1
+	b.lt	Lctr32_done	// if len = 0, go to done
 	mov	x12,#16
 	csel	x12,xzr,x12,eq
-	b.lt	Lctr32_done	// if len = 0, go to done
 	aese	v0.16b,v16.16b
 	aesmc	v0.16b,v0.16b
 	aese	v1.16b,v16.16b


### PR DESCRIPTION
### Issues:
Addresses #CryptoAlg-2498

### Description of changes: 
The change in https://github.com/aws/aws-lc/pull/1690 showed a 0.01 usec more in EVP-AES-256-CTR on Graviton4. This change optimises the sequence of operations to make use of instruction fusion in the sequence CMP + B.cond.; that is, the `b.le` instruction is placed after the cmp instruction, also avoiding executing unneeded instructions if the jump is to be taken. 

### Testing:
Tested the performance on Graviton4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
