### PR TITLE
Silence tmpname warning

### DIFF
--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -15,6 +15,7 @@
 #include "test_util.h"
 
 #include <ostream>
+#include <unistd.h>
 
 #include "../internal.h"
 #include "openssl/pem.h"
@@ -107,14 +108,14 @@ FILE* createRawTempFILE() {
 #else
 #include <cstdlib>
 size_t createTempFILEpath(char buffer[PATH_MAX]) {
-OPENSSL_BEGIN_ALLOW_DEPRECATED
-  OPENSSL_STATIC_ASSERT(PATH_MAX >= L_tmpnam, PATH_MAX_too_short);
-  // Functions for constructing a tempfile path (i.e., tmpname and mktemp)
-  // are deprecated in C99.
-  if(nullptr == tmpnam(buffer)) {
+  snprintf(buffer, PATH_MAX, "awslcTestTmpFileXXXXXX");
+
+  int fd = mkstemp(buffer);
+  if (fd == -1) {
     return 0;
   }
-OPENSSL_END_ALLOW_DEPRECATED
+
+  close(fd);
   return strnlen(buffer, PATH_MAX);
 }
 FILE* createRawTempFILE() {

--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -15,7 +15,6 @@
 #include "test_util.h"
 
 #include <ostream>
-#include <unistd.h>
 
 #include "../internal.h"
 #include "openssl/pem.h"
@@ -107,6 +106,7 @@ FILE* createRawTempFILE() {
 }
 #else
 #include <cstdlib>
+#include <unistd.h>
 size_t createTempFILEpath(char buffer[PATH_MAX]) {
   snprintf(buffer, PATH_MAX, "awslcTestTmpFileXXXXXX");
 


### PR DESCRIPTION
### Description of changes: 

Before:
```
$ ninja-build
[578/584] Linking CXX executable tool-openssl/tool_openssl_test
tool-openssl/CMakeFiles/tool_openssl_test.dir/__/crypto/test/test_util.cc.o: In function `createTempFILEpath(char*)':
/home/ec2-user/humble/aws-lc/awslc-build/../crypto/test/test_util.cc:114: warning: the use of `tmpnam' is dangerous, better use `
mkstemp'
[580/584] Linking CXX executable ssl/integration_test
crypto/test/libtest_support_lib.a(test_util.cc.o): In function `createTempFILEpath(char*)':
/home/ec2-user/humble/aws-lc/awslc-build/../crypto/test/test_util.cc:114: warning: the use of `tmpnam' is dangerous, better use `
mkstemp'
[582/584] Linking CXX executable crypto/crypto_test
crypto/test/libtest_support_lib.a(test_util.cc.o): In function `createTempFILEpath(char*)':
/home/ec2-user/humble/aws-lc/awslc-build/../crypto/test/test_util.cc:114: warning: the use of `tmpnam' is dangerous, better use `
mkstemp'
[584/584] Linking CXX executable ssl/ssl_test
crypto/test/libtest_support_lib.a(test_util.cc.o): In function `createTempFILEpath(char*)':
/home/ec2-user/humble/aws-lc/awslc-build/../crypto/test/test_util.cc:114: warning: the use of `tmpnam' is dangerous, better use `
mkstemp'
```

Now:
```
$ ninja-build
[106/106] Linking CXX executable tool-openssl/tool_openssl_test
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
