### PR TITLE
Handle systems defining ATOMIC_LONG_LOCK_FREE as expression

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4321,7 +4321,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.34.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.34.1");
 }
 
 #else
@@ -4364,6 +4364,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.34.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.34.1");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.34.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.34.1"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 

--- a/tests/compiler_features_tests/c11.c
+++ b/tests/compiler_features_tests/c11.c
@@ -7,6 +7,18 @@
 #include <stdlib.h>
 #include <stdatomic.h>
 
+// Some platforms define ATOMIC_LONG_LOCK_FREE as an expression like:
+//  (__atomic_always_lock_free (sizeof (atomic_long), (void *) 0) ? 2 :
+//     (__atomic_is_lock_free (sizeof (atomic_long), (void *) 0) ? 1 : 0))
+// which relies on __atomic_is_lock_free which is a runtime function and not a
+// compile time constant. This means ATOMIC_LONG_LOCK_FREE can not be used in a
+// preprocessor check which AWS-LC needs to do to swap implementations of
+// CRYPTO_refcount_inc at compile time. If that is the case the following #if
+// won't compile, the following message is helpful to debug any future issues.
+#if ATOMIC_LONG_LOCK_FREE < 0
+#error "Should not get here, the above line should be false or invalid"
+#endif
+
 int main(int argc, char **argv) {
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### Description of changes: 
Fix an issue with some old system that define ATOMIC_LONG_LOCK_FREE as an expression that uses runtime checks. These are invalid in preprocessor conditions such as how we swap between the pthread and c11 atomic implementation at compile time.

### Call-outs:
This could be made a runtime check and swap, but that would be a much larger refactor and that might introduce it's own performance overhead. Customers with this behavior are strongly encouraged to upgrade. 

### Testing:
Verified legacy build works, and modern compilers still get the performance improvement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
