### PR TITLE
Use _Static_assert in refcount_c11.c to support old compilers that don't support the macro static_assert

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4321,7 +4321,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.34.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.34.2");
 }
 
 #else
@@ -4364,6 +4364,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.34.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.34.2");
 }
 #endif // AWSLC_FIPS

--- a/crypto/refcount_c11.c
+++ b/crypto/refcount_c11.c
@@ -26,12 +26,12 @@
 
 
 // See comment above the typedef of CRYPTO_refcount_t about these tests.
-static_assert(alignof(CRYPTO_refcount_t) == alignof(_Atomic CRYPTO_refcount_t),
+_Static_assert(alignof(CRYPTO_refcount_t) == alignof(_Atomic CRYPTO_refcount_t),
               "_Atomic alters the needed alignment of a reference count");
-static_assert(sizeof(CRYPTO_refcount_t) == sizeof(_Atomic CRYPTO_refcount_t),
+_Static_assert(sizeof(CRYPTO_refcount_t) == sizeof(_Atomic CRYPTO_refcount_t),
               "_Atomic alters the size of a reference count");
 
-static_assert((CRYPTO_refcount_t)-1 == CRYPTO_REFCOUNT_MAX,
+_Static_assert((CRYPTO_refcount_t)-1 == CRYPTO_REFCOUNT_MAX,
               "CRYPTO_REFCOUNT_MAX is incorrect");
 
 void CRYPTO_refcount_inc(CRYPTO_refcount_t *in_count) {

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.34.1"
+#define AWSLC_VERSION_NUMBER_STRING "1.34.2"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Some other old compilers don't support the convince macro `static_assert` but do support the C11 keyword `_Static_assert` even though both should be in [assert.h](https://en.cppreference.com/w/c/error/static_assert). 

### Testing:
Built all old platforms internally. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
