### PR TITLE
Use OPENSSL_STATIC_ASSERT which handles all the platform/compiler/C s…

### DIFF
--- a/crypto/refcount_c11.c
+++ b/crypto/refcount_c11.c
@@ -26,13 +26,13 @@
 
 
 // See comment above the typedef of CRYPTO_refcount_t about these tests.
-_Static_assert(alignof(CRYPTO_refcount_t) == alignof(_Atomic CRYPTO_refcount_t),
-              "_Atomic alters the needed alignment of a reference count");
-_Static_assert(sizeof(CRYPTO_refcount_t) == sizeof(_Atomic CRYPTO_refcount_t),
-              "_Atomic alters the size of a reference count");
+OPENSSL_STATIC_ASSERT(alignof(CRYPTO_refcount_t) == alignof(_Atomic CRYPTO_refcount_t),
+              _Atomic_alters_the_needed_alignment_of_a_reference_count);
+OPENSSL_STATIC_ASSERT(sizeof(CRYPTO_refcount_t) == sizeof(_Atomic CRYPTO_refcount_t),
+              _Atomic_alters_the_size_of_a_reference_count);
 
-_Static_assert((CRYPTO_refcount_t)-1 == CRYPTO_REFCOUNT_MAX,
-              "CRYPTO_REFCOUNT_MAX is incorrect");
+OPENSSL_STATIC_ASSERT((CRYPTO_refcount_t)-1 == CRYPTO_REFCOUNT_MAX,
+              CRYPTO_REFCOUNT_MAX_is_incorrect);
 
 void CRYPTO_refcount_inc(CRYPTO_refcount_t *in_count) {
   _Atomic CRYPTO_refcount_t *count = (_Atomic CRYPTO_refcount_t *) in_count;

--- a/crypto/refcount_c11.c
+++ b/crypto/refcount_c11.c
@@ -27,12 +27,12 @@
 
 // See comment above the typedef of CRYPTO_refcount_t about these tests.
 OPENSSL_STATIC_ASSERT(alignof(CRYPTO_refcount_t) == alignof(_Atomic CRYPTO_refcount_t),
-              _Atomic_alters_the_needed_alignment_of_a_reference_count);
+              _Atomic_alters_the_needed_alignment_of_a_reference_count)
 OPENSSL_STATIC_ASSERT(sizeof(CRYPTO_refcount_t) == sizeof(_Atomic CRYPTO_refcount_t),
-              _Atomic_alters_the_size_of_a_reference_count);
+              _Atomic_alters_the_size_of_a_reference_count)
 
 OPENSSL_STATIC_ASSERT((CRYPTO_refcount_t)-1 == CRYPTO_REFCOUNT_MAX,
-              CRYPTO_REFCOUNT_MAX_is_incorrect);
+              CRYPTO_REFCOUNT_MAX_is_incorrect)
 
 void CRYPTO_refcount_inc(CRYPTO_refcount_t *in_count) {
   _Atomic CRYPTO_refcount_t *count = (_Atomic CRYPTO_refcount_t *) in_count;


### PR DESCRIPTION
…tandard version differences in refcount_c11.c

### Description of changes: 
Follow up from https://github.com/aws/aws-lc/pull/1789#discussion_r1726016942

### Testing:
Tested locally and on old platforms, this is the same safety macro we use everywhere else in our code and is well supported.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
