### PR TITLE
Add KDA OneStep (SSKDF_digest and SSKDF_hmac) to FIPS indicator

### DIFF
--- a/crypto/fipsmodule/service_indicator/internal.h
+++ b/crypto/fipsmodule/service_indicator/internal.h
@@ -53,6 +53,8 @@ void PBKDF2_verify_service_indicator(const EVP_MD *evp_md, size_t password_len,
 void SSHKDF_verify_service_indicator(const EVP_MD *evp_md);
 void TLSKDF_verify_service_indicator(const EVP_MD *dgst, const char *label,
                                      size_t label_len);
+void SSKDF_digest_verify_service_indicator(const EVP_MD *dgst);
+void SSKDF_hmac_verify_service_indicator(const EVP_MD *dgst);
 void KBKDF_ctr_hmac_verify_service_indicator(const EVP_MD *dgst);
 
 #else
@@ -116,6 +118,12 @@ OPENSSL_INLINE void TLSKDF_verify_service_indicator(
     OPENSSL_UNUSED const EVP_MD *dgst,
     OPENSSL_UNUSED const char *label,
     OPENSSL_UNUSED size_t label_len) {}
+
+OPENSSL_INLINE void SSKDF_digest_verify_service_indicator(
+    OPENSSL_UNUSED const EVP_MD *dgst) {}
+
+OPENSSL_INLINE void SSKDF_hmac_verify_service_indicator(
+    OPENSSL_UNUSED const EVP_MD *dgst) {}
 
 OPENSSL_INLINE void KBKDF_ctr_hmac_verify_service_indicator(OPENSSL_UNUSED const EVP_MD *dgst) {}
 

--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -494,7 +494,6 @@ void TLSKDF_verify_service_indicator(const EVP_MD *dgst, const char *label,
 //
 // Sourced from NIST.SP.800-56Cr2 Section 7: Selecting Hash Functions and MAC Algorithms
 // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf
-
 void SSKDF_digest_verify_service_indicator(const EVP_MD *dgst) {
   switch (dgst->type) {
     case NID_sha1:

--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -485,6 +485,42 @@ void TLSKDF_verify_service_indicator(const EVP_MD *dgst, const char *label,
   }
 }
 
+void SSKDF_digest_verify_service_indicator(const EVP_MD *dgst) {
+  switch (dgst->type) {
+    case NID_sha1:
+    case NID_sha224:
+    case NID_sha256:
+    case NID_sha384:
+    case NID_sha512:
+    case NID_sha512_224:
+    case NID_sha512_256:
+    case NID_sha3_224:
+    case NID_sha3_256:
+    case NID_sha3_384:
+    case NID_sha3_512:
+      FIPS_service_indicator_update_state();
+      break;
+    default:
+      break;
+  }
+}
+
+void SSKDF_hmac_verify_service_indicator(const EVP_MD *dgst) {
+  switch (dgst->type) {
+    case NID_sha1:
+    case NID_sha224:
+    case NID_sha256:
+    case NID_sha384:
+    case NID_sha512:
+    case NID_sha512_224:
+    case NID_sha512_256:
+      FIPS_service_indicator_update_state();
+      break;
+    default:
+      break;
+  }
+}
+
 // "For key derivation, this Recommendation approves the use of the keyed-Hash Message
 // Authentication Code (HMAC) specified in FIPS 198-1".
 

--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -485,6 +485,16 @@ void TLSKDF_verify_service_indicator(const EVP_MD *dgst, const char *label,
   }
 }
 
+// "Whenever a hash function is employed (including as the primitive used by HMAC), an
+// approved hash function shall be used. FIPS 180 and FIPS 202 specify approved hash
+// functions"
+//
+// * FIPS 180 covers the SHA-1 and SHA-2* family of algorithms
+// * FIPS 202 covers the SHA3-* family of algorithms
+//
+// Sourced from NIST.SP.800-56Cr2 Section 7: Selecting Hash Functions and MAC Algorithms
+// https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf
+
 void SSKDF_digest_verify_service_indicator(const EVP_MD *dgst) {
   switch (dgst->type) {
     case NID_sha1:
@@ -505,6 +515,15 @@ void SSKDF_digest_verify_service_indicator(const EVP_MD *dgst) {
   }
 }
 
+// "Whenever a hash function is employed (including as the primitive used by HMAC), an
+// approved hash function shall be used. FIPS 180 and FIPS 202 specify approved hash
+// functions"
+//
+// * FIPS 180 covers the SHA-1 and SHA-2* family of algorithms
+// * FIPS 202 covers the SHA3-* family of algorithms (Note: AWS-LC does not currently support SHA-3 with HMAC)
+//
+// Sourced from NIST.SP.800-56Cr2 Section 7: Selecting Hash Functions and MAC Algorithms
+// https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf
 void SSKDF_hmac_verify_service_indicator(const EVP_MD *dgst) {
   switch (dgst->type) {
     case NID_sha1:

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4317,6 +4317,147 @@ TEST(ServiceIndicatorTest, DRBG) {
   EXPECT_EQ(approved, AWSLC_APPROVED);
 }
 
+static const struct SSKDFDigestTestVector {
+  const EVP_MD *(*md)();
+  const FIPSStatus expectation;
+} kSSKDFDigestTestVectors[] = {{
+                                   &EVP_sha1,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha224,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha256,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha384,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha512,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha512_224,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha512_256,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha3_224,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha3_256,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha3_384,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                   &EVP_sha3_512,
+                                   AWSLC_APPROVED,
+                               },
+                               {
+                                &EVP_md5,
+                                AWSLC_NOT_APPROVED,
+                               }};
+
+class SSKDFDigestIndicatorTest : public TestWithNoErrors<SSKDFDigestTestVector> {};
+
+INSTANTIATE_TEST_SUITE_P(All, SSKDFDigestIndicatorTest,
+                         testing::ValuesIn(kSSKDFDigestTestVectors));
+
+
+TEST_P(SSKDFDigestIndicatorTest, SSKDF) {
+  const SSKDFDigestTestVector &vector = GetParam();
+
+  const uint8_t secret[23] = {'A', 'W', 'S', '-', 'L', 'C', ' ', 'S',
+                              'S', 'K', 'D', 'F', '-', 'D', 'I', 'G',
+                              'E', 'S', 'T', ' ', 'K', 'E', 'Y'};
+  const uint8_t info[19] = {'A', 'W', 'S', '-', 'L', 'C', ' ', 'S', 'S', 'K',
+                            'D', 'F', '-', 'D', 'I', 'G', 'E', 'S', 'T'};
+  uint8_t output[16] = {0};
+
+  FIPSStatus approved = AWSLC_NOT_APPROVED;
+
+  CALL_SERVICE_AND_CHECK_APPROVED(
+      approved, ASSERT_TRUE(SSKDF_digest(
+                    &output[0], sizeof(output), vector.md(), &secret[0],
+                    sizeof(secret), &info[0], sizeof(info))));
+  ASSERT_EQ(vector.expectation, approved);
+}
+
+static const struct SSKDFHmacTestVector {
+  const EVP_MD *(*md)();
+  const FIPSStatus expectation;
+} kSSKDFHmacTestVectors[] = {{
+                                 &EVP_sha1,
+                                 AWSLC_APPROVED,
+                             },
+                             {
+                                 &EVP_sha224,
+                                 AWSLC_APPROVED,
+                             },
+                             {
+                                 &EVP_sha256,
+                                 AWSLC_APPROVED,
+                             },
+                             {
+                                 &EVP_sha384,
+                                 AWSLC_APPROVED,
+                             },
+                             {
+                                 &EVP_sha512,
+                                 AWSLC_APPROVED,
+                             },
+                             {
+                                 &EVP_sha512_224,
+                                 AWSLC_APPROVED,
+                             },
+                             {
+                                 &EVP_sha512_256,
+                                 AWSLC_APPROVED,
+                             },
+                             {
+                                 &EVP_md5,
+                                 AWSLC_NOT_APPROVED,
+                             }};
+
+class SSKDFHmacIndicatorTest : public TestWithNoErrors<SSKDFHmacTestVector> {};
+
+INSTANTIATE_TEST_SUITE_P(All, SSKDFHmacIndicatorTest,
+                         testing::ValuesIn(kSSKDFHmacTestVectors));
+
+
+TEST_P(SSKDFHmacIndicatorTest, SSKDF) {
+  const SSKDFHmacTestVector &vector = GetParam();
+
+  const uint8_t secret[21] = {'A', 'W', 'S', '-', 'L', 'C', ' ',
+                              'S', 'S', 'K', 'D', 'F', '-', 'H',
+                              'M', 'A', 'C', ' ', 'K', 'E', 'Y'};
+  const uint8_t info[17] = {'A', 'W', 'S', '-', 'L', 'C', ' ', 'S', 'S', 'K',
+                            'D', 'F', '-', 'H', 'M', 'A', 'C'};
+  const uint8_t salt[22] = {'A', 'W', 'S', '-', 'L', 'C', ' ', 'S',
+                            'S', 'K', 'D', 'F', '-', 'H', 'M', 'A',
+                            'C', ' ', 'S', 'A', 'L', 'T'};
+  uint8_t output[16] = {0};
+
+  FIPSStatus approved = AWSLC_NOT_APPROVED;
+
+  CALL_SERVICE_AND_CHECK_APPROVED(
+      approved, ASSERT_TRUE(SSKDF_hmac(&output[0], sizeof(output), vector.md(),
+                                       &secret[0], sizeof(secret), &info[0],
+                                       sizeof(info), &salt[0], sizeof(salt))));
+  ASSERT_EQ(vector.expectation, approved);
+}
+
 static const struct KBKDFCtrHmacTestVector {
   const EVP_MD *(*md)();
   const FIPSStatus expectation;


### PR DESCRIPTION
### Description of changes: 
Adds the FIPS service indicator APIs to `SSKDF_digest` and `SSKDF_hmac`.

**NOTE**: AWS-LC doesn't currently support using SHA3-* digest algorithms with our HMAC APIs. So that is why it is missing from the approved digest list for `SSKDF_hmac`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
