### PR TITLE
bn: Move x86-64 argument-based dispatching of bn_mul_mont to C.

### DIFF
--- a/crypto/fipsmodule/bn/bn_test.cc
+++ b/crypto/fipsmodule/bn/bn_test.cc
@@ -2843,10 +2843,33 @@ TEST_F(BNTest, BNMulMontABI) {
     a[0] = 1;
     b[0] = 42;
 
+#if defined(OPENSSL_X86_64)
+    if (bn_mulx4x_mont_capable(words)) {
+      CHECK_ABI(bn_mulx4x_mont, r.data(), a.data(), b.data(), mont->N.d,
+                mont->n0, words);
+      CHECK_ABI(bn_mulx4x_mont, r.data(), a.data(), a.data(), mont->N.d,
+                mont->n0, words);
+    }
+    if (bn_mul4x_mont_capable(words)) {
+      CHECK_ABI(bn_mul4x_mont, r.data(), a.data(), b.data(), mont->N.d,
+                mont->n0, words);
+      CHECK_ABI(bn_mul4x_mont, r.data(), a.data(), a.data(), mont->N.d,
+                mont->n0, words);
+    }
+    CHECK_ABI(bn_mul_mont_nohw, r.data(), a.data(), b.data(), mont->N.d,
+              mont->n0, words);
+    CHECK_ABI(bn_mul_mont_nohw, r.data(), a.data(), a.data(), mont->N.d,
+              mont->n0, words);
+    if (bn_sqr8x_mont_capable(words)) {
+      CHECK_ABI(bn_sqr8x_mont, r.data(), a.data(), a.data(), mont->N.d,
+                mont->n0, words);
+    }
+#else
     CHECK_ABI(bn_mul_mont, r.data(), a.data(), b.data(), mont->N.d, mont->n0,
               words);
     CHECK_ABI(bn_mul_mont, r.data(), a.data(), a.data(), mont->N.d, mont->n0,
               words);
+#endif
   }
 }
 #endif   // OPENSSL_BN_ASM_MONT && SUPPORTS_ABI_TEST

--- a/crypto/fipsmodule/bn/bn_test.cc
+++ b/crypto/fipsmodule/bn/bn_test.cc
@@ -2844,12 +2844,14 @@ TEST_F(BNTest, BNMulMontABI) {
     b[0] = 42;
 
 #if defined(OPENSSL_X86_64)
+#if !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
     if (bn_mulx4x_mont_capable(words)) {
       CHECK_ABI(bn_mulx4x_mont, r.data(), a.data(), b.data(), mont->N.d,
                 mont->n0, words);
       CHECK_ABI(bn_mulx4x_mont, r.data(), a.data(), a.data(), mont->N.d,
                 mont->n0, words);
     }
+#endif // !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
     if (bn_mul4x_mont_capable(words)) {
       CHECK_ABI(bn_mul4x_mont, r.data(), a.data(), b.data(), mont->N.d,
                 mont->n0, words);
@@ -2860,10 +2862,12 @@ TEST_F(BNTest, BNMulMontABI) {
               mont->n0, words);
     CHECK_ABI(bn_mul_mont_nohw, r.data(), a.data(), a.data(), mont->N.d,
               mont->n0, words);
+#if !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
     if (bn_sqr8x_mont_capable(words)) {
       CHECK_ABI(bn_sqr8x_mont, r.data(), a.data(), a.data(), mont->N.d,
                 mont->n0, words);
     }
+#endif // !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
 #else
     CHECK_ABI(bn_mul_mont, r.data(), a.data(), b.data(), mont->N.d, mont->n0,
               words);

--- a/crypto/fipsmodule/bn/internal.h
+++ b/crypto/fipsmodule/bn/internal.h
@@ -133,6 +133,7 @@ OPENSSL_MSVC_PRAGMA(warning(pop))
 #endif
 
 #include "../../internal.h"
+#include "../cpucap/internal.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -404,6 +405,29 @@ int bn_rand_secret_range(BIGNUM *r, int *out_is_uniform, BN_ULONG min_inclusive,
 // inputs.
 int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                 const BN_ULONG *np, const BN_ULONG *n0, size_t num);
+
+#if defined(OPENSSL_X86_64)
+int bn_mul_mont_nohw(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                     const BN_ULONG *np, const BN_ULONG *n0, size_t num);
+OPENSSL_INLINE int bn_mul4x_mont_capable(size_t num) {
+  return (num >= 8) && ((num & 3) == 0);
+}
+int bn_mul4x_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                  const BN_ULONG *np, const BN_ULONG *n0, size_t num);
+OPENSSL_INLINE int bn_mulx4x_mont_capable(size_t num) {
+  // MULX is in BMI2.
+  return bn_mul4x_mont_capable(num) && CRYPTO_is_BMI2_capable() &&
+         CRYPTO_is_ADX_capable();
+}
+int bn_mulx4x_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                   const BN_ULONG *np, const BN_ULONG *n0, size_t num);
+OPENSSL_INLINE int bn_sqr8x_mont_capable(size_t num) {
+  return (num >= 8) && ((num & 7) == 0);
+}
+int bn_sqr8x_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *unused_bp,
+                  const BN_ULONG *np, const BN_ULONG *n0, size_t num);
+#endif // defined(OPENSSL_X86_64)
+
 #endif
 
 #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64)

--- a/crypto/fipsmodule/bn/internal.h
+++ b/crypto/fipsmodule/bn/internal.h
@@ -414,6 +414,7 @@ OPENSSL_INLINE int bn_mul4x_mont_capable(size_t num) {
 }
 int bn_mul4x_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                   const BN_ULONG *np, const BN_ULONG *n0, size_t num);
+#if !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
 OPENSSL_INLINE int bn_mulx4x_mont_capable(size_t num) {
   // MULX is in BMI2.
   return bn_mul4x_mont_capable(num) && CRYPTO_is_BMI2_capable() &&
@@ -426,6 +427,7 @@ OPENSSL_INLINE int bn_sqr8x_mont_capable(size_t num) {
 }
 int bn_sqr8x_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *unused_bp,
                   const BN_ULONG *np, const BN_ULONG *n0, size_t num);
+#endif // !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
 #endif // defined(OPENSSL_X86_64)
 
 #endif

--- a/crypto/fipsmodule/bn/montgomery.c
+++ b/crypto/fipsmodule/bn/montgomery.c
@@ -632,3 +632,20 @@ void bn_mod_mul_montgomery_small(BN_ULONG *r, const BN_ULONG *a,
   }
   OPENSSL_cleanse(tmp, 2 * num * sizeof(BN_ULONG));
 }
+
+#if defined(OPENSSL_BN_ASM_MONT) && defined(OPENSSL_X86_64)
+int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                const BN_ULONG *np, const BN_ULONG *n0, size_t num)
+{
+  if (ap == bp && bn_sqr8x_mont_capable(num)) {
+    return bn_sqr8x_mont(rp, ap, bp, np, n0, num);
+  }
+  if (bn_mulx4x_mont_capable(num)) {
+    return bn_mulx4x_mont(rp, ap, bp, np, n0, num);
+  }
+  if (bn_mul4x_mont_capable(num)) {
+    return bn_mul4x_mont(rp, ap, bp, np, n0, num);
+  }
+  return bn_mul_mont_nohw(rp, ap, bp, np, n0, num);
+}
+#endif

--- a/crypto/fipsmodule/bn/montgomery.c
+++ b/crypto/fipsmodule/bn/montgomery.c
@@ -637,12 +637,14 @@ void bn_mod_mul_montgomery_small(BN_ULONG *r, const BN_ULONG *a,
 int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                 const BN_ULONG *np, const BN_ULONG *n0, size_t num)
 {
+#if !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
   if (ap == bp && bn_sqr8x_mont_capable(num)) {
     return bn_sqr8x_mont(rp, ap, bp, np, n0, num);
   }
   if (bn_mulx4x_mont_capable(num)) {
     return bn_mulx4x_mont(rp, ap, bp, np, n0, num);
   }
+#endif // !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
   if (bn_mul4x_mont_capable(num)) {
     return bn_mul4x_mont(rp, ap, bp, np, n0, num);
   }

--- a/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/x86_64-mont.S
@@ -9,32 +9,16 @@
 .extern	OPENSSL_ia32cap_P
 .hidden OPENSSL_ia32cap_P
 
-.globl	bn_mul_mont
-.hidden bn_mul_mont
-.type	bn_mul_mont,@function
+.globl	bn_mul_mont_nohw
+.hidden bn_mul_mont_nohw
+.type	bn_mul_mont_nohw,@function
 .align	16
-bn_mul_mont:
+bn_mul_mont_nohw:
 .cfi_startproc	
 _CET_ENDBR
 	movl	%r9d,%r9d
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
-	testl	$3,%r9d
-	jnz	.Lmul_enter
-	cmpl	$8,%r9d
-	jb	.Lmul_enter
-#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-	leaq	OPENSSL_ia32cap_P(%rip),%r11
-	movl	8(%r11),%r11d
-#endif
-	cmpq	%rsi,%rdx
-	jne	.Lmul4x_enter
-	testl	$7,%r9d
-	jz	.Lsqr8x_enter
-	jmp	.Lmul4x_enter
-
-.align	16
-.Lmul_enter:
 	pushq	%rbx
 .cfi_offset	%rbx,-16
 	pushq	%rbp
@@ -266,20 +250,17 @@ _CET_ENDBR
 .Lmul_epilogue:
 	.byte	0xf3,0xc3
 .cfi_endproc	
-.size	bn_mul_mont,.-bn_mul_mont
+.size	bn_mul_mont_nohw,.-bn_mul_mont_nohw
+.globl	bn_mul4x_mont
+.hidden bn_mul4x_mont
 .type	bn_mul4x_mont,@function
 .align	16
 bn_mul4x_mont:
 .cfi_startproc	
+_CET_ENDBR
 	movl	%r9d,%r9d
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
-.Lmul4x_enter:
-#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-	andl	$0x80100,%r11d
-	cmpl	$0x80100,%r11d
-	je	.Lmulx4x_enter
-#endif
 	pushq	%rbx
 .cfi_offset	%rbx,-16
 	pushq	%rbp
@@ -710,13 +691,16 @@ bn_mul4x_mont:
 .extern	bn_sqr8x_internal
 .hidden bn_sqr8x_internal
 
+.globl	bn_sqr8x_mont
+.hidden bn_sqr8x_mont
 .type	bn_sqr8x_mont,@function
 .align	32
 bn_sqr8x_mont:
 .cfi_startproc	
+_CET_ENDBR
+	movl	%r9d,%r9d
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
-.Lsqr8x_enter:
 	pushq	%rbx
 .cfi_offset	%rbx,-16
 	pushq	%rbp
@@ -901,13 +885,15 @@ bn_sqr8x_mont:
 .cfi_endproc	
 .size	bn_sqr8x_mont,.-bn_sqr8x_mont
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.globl	bn_mulx4x_mont
+.hidden bn_mulx4x_mont
 .type	bn_mulx4x_mont,@function
 .align	32
 bn_mulx4x_mont:
 .cfi_startproc	
+_CET_ENDBR
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
-.Lmulx4x_enter:
 	pushq	%rbx
 .cfi_offset	%rbx,-16
 	pushq	%rbp

--- a/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/x86_64-mont.S
@@ -8,32 +8,16 @@
 
 
 
-.globl	_bn_mul_mont
-.private_extern _bn_mul_mont
+.globl	_bn_mul_mont_nohw
+.private_extern _bn_mul_mont_nohw
 
 .p2align	4
-_bn_mul_mont:
+_bn_mul_mont_nohw:
 
 _CET_ENDBR
 	movl	%r9d,%r9d
 	movq	%rsp,%rax
 
-	testl	$3,%r9d
-	jnz	L$mul_enter
-	cmpl	$8,%r9d
-	jb	L$mul_enter
-#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-	leaq	_OPENSSL_ia32cap_P(%rip),%r11
-	movl	8(%r11),%r11d
-#endif
-	cmpq	%rsi,%rdx
-	jne	L$mul4x_enter
-	testl	$7,%r9d
-	jz	L$sqr8x_enter
-	jmp	L$mul4x_enter
-
-.p2align	4
-L$mul_enter:
 	pushq	%rbx
 
 	pushq	%rbp
@@ -266,19 +250,16 @@ L$mul_epilogue:
 	.byte	0xf3,0xc3
 
 
+.globl	_bn_mul4x_mont
+.private_extern _bn_mul4x_mont
 
 .p2align	4
-bn_mul4x_mont:
+_bn_mul4x_mont:
 
+_CET_ENDBR
 	movl	%r9d,%r9d
 	movq	%rsp,%rax
 
-L$mul4x_enter:
-#ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-	andl	$0x80100,%r11d
-	cmpl	$0x80100,%r11d
-	je	L$mulx4x_enter
-#endif
 	pushq	%rbx
 
 	pushq	%rbp
@@ -707,13 +688,16 @@ L$mul4x_epilogue:
 #endif
 
 
+.globl	_bn_sqr8x_mont
+.private_extern _bn_sqr8x_mont
 
 .p2align	5
-bn_sqr8x_mont:
+_bn_sqr8x_mont:
 
+_CET_ENDBR
+	movl	%r9d,%r9d
 	movq	%rsp,%rax
 
-L$sqr8x_enter:
 	pushq	%rbx
 
 	pushq	%rbp
@@ -898,13 +882,15 @@ L$sqr8x_epilogue:
 
 
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.globl	_bn_mulx4x_mont
+.private_extern _bn_mulx4x_mont
 
 .p2align	5
-bn_mulx4x_mont:
+_bn_mulx4x_mont:
 
+_CET_ENDBR
 	movq	%rsp,%rax
 
-L$mulx4x_enter:
 	pushq	%rbx
 
 	pushq	%rbp

--- a/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/x86_64-mont.asm
@@ -14,14 +14,14 @@ section	.text code align=64
 
 EXTERN	OPENSSL_ia32cap_P
 
-global	bn_mul_mont
+global	bn_mul_mont_nohw
 
 ALIGN	16
-bn_mul_mont:
+bn_mul_mont_nohw:
 	mov	QWORD[8+rsp],rdi	;WIN64 prologue
 	mov	QWORD[16+rsp],rsi
 	mov	rax,rsp
-$L$SEH_begin_bn_mul_mont:
+$L$SEH_begin_bn_mul_mont_nohw:
 	mov	rdi,rcx
 	mov	rsi,rdx
 	mov	rdx,r8
@@ -35,22 +35,6 @@ _CET_ENDBR
 	mov	r9d,r9d
 	mov	rax,rsp
 
-	test	r9d,3
-	jnz	NEAR $L$mul_enter
-	cmp	r9d,8
-	jb	NEAR $L$mul_enter
-%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-	lea	r11,[OPENSSL_ia32cap_P]
-	mov	r11d,DWORD[8+r11]
-%endif
-	cmp	rdx,rsi
-	jne	NEAR $L$mul4x_enter
-	test	r9d,7
-	jz	NEAR $L$sqr8x_enter
-	jmp	NEAR $L$mul4x_enter
-
-ALIGN	16
-$L$mul_enter:
 	push	rbx
 
 	push	rbp
@@ -284,7 +268,8 @@ $L$mul_epilogue:
 	mov	rsi,QWORD[16+rsp]
 	DB	0F3h,0C3h		;repret
 
-$L$SEH_end_bn_mul_mont:
+$L$SEH_end_bn_mul_mont_nohw:
+global	bn_mul4x_mont
 
 ALIGN	16
 bn_mul4x_mont:
@@ -301,15 +286,10 @@ $L$SEH_begin_bn_mul4x_mont:
 
 
 
+_CET_ENDBR
 	mov	r9d,r9d
 	mov	rax,rsp
 
-$L$mul4x_enter:
-%ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-	and	r11d,0x80100
-	cmp	r11d,0x80100
-	je	NEAR $L$mulx4x_enter
-%endif
 	push	rbx
 
 	push	rbp
@@ -740,6 +720,7 @@ EXTERN	bn_sqrx8x_internal
 %endif
 EXTERN	bn_sqr8x_internal
 
+global	bn_sqr8x_mont
 
 ALIGN	32
 bn_sqr8x_mont:
@@ -756,9 +737,10 @@ $L$SEH_begin_bn_sqr8x_mont:
 
 
 
+_CET_ENDBR
+	mov	r9d,r9d
 	mov	rax,rsp
 
-$L$sqr8x_enter:
 	push	rbx
 
 	push	rbp
@@ -945,6 +927,7 @@ $L$sqr8x_epilogue:
 
 $L$SEH_end_bn_sqr8x_mont:
 %ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+global	bn_mulx4x_mont
 
 ALIGN	32
 bn_mulx4x_mont:
@@ -961,9 +944,9 @@ $L$SEH_begin_bn_mulx4x_mont:
 
 
 
+_CET_ENDBR
 	mov	rax,rsp
 
-$L$mulx4x_enter:
 	push	rbx
 
 	push	rbp
@@ -1456,9 +1439,9 @@ $L$common_seh_tail:
 
 section	.pdata rdata align=4
 ALIGN	4
-	DD	$L$SEH_begin_bn_mul_mont wrt ..imagebase
-	DD	$L$SEH_end_bn_mul_mont wrt ..imagebase
-	DD	$L$SEH_info_bn_mul_mont wrt ..imagebase
+	DD	$L$SEH_begin_bn_mul_mont_nohw wrt ..imagebase
+	DD	$L$SEH_end_bn_mul_mont_nohw wrt ..imagebase
+	DD	$L$SEH_info_bn_mul_mont_nohw wrt ..imagebase
 
 	DD	$L$SEH_begin_bn_mul4x_mont wrt ..imagebase
 	DD	$L$SEH_end_bn_mul4x_mont wrt ..imagebase
@@ -1474,7 +1457,7 @@ ALIGN	4
 %endif
 section	.xdata rdata align=8
 ALIGN	8
-$L$SEH_info_bn_mul_mont:
+$L$SEH_info_bn_mul_mont_nohw:
 	DB	9,0,0,0
 	DD	mul_handler wrt ..imagebase
 	DD	$L$mul_body wrt ..imagebase,$L$mul_epilogue wrt ..imagebase


### PR DESCRIPTION
### Upstream Commit: https://github.com/google/boringssl/commit/7cb8df579329b70cd4ede09d6d228636b8e31e89

-----
Take a step towards moving the OPENSSL_ia32cap_P usage out of x86_64-mont.pl. The MULX+ADX dispatching within |bn_sqr8x_mont| is deferred to a future change.

Bug: 673
Change-Id: I8768bb33d2c289fd7ccf8743b51721e55ab74f35
Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/65527
Reviewed-by: Bob Beck <bbe@google.com>
Reviewed-by: David Benjamin <davidben@google.com>
Commit-Queue: David Benjamin <davidben@google.com>

(cherry picked from commit 7cb8df579329b70cd4ede09d6d228636b8e31e89)

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
