### PR TITLE
Reduce collision probability for variable names

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,6 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 DerivePointerAlignment: false
 PointerAlignment: Right
-InsertBraces: true
 # TODO(davidben): The default for Google style is now Regroup, but the default
 # IncludeCategories does not recognize <openssl/header.h>. We should
 # reconfigure IncludeCategories to match. For now, keep it at Preserve.

--- a/crypto/curve25519/curve25519_nohw.c
+++ b/crypto/curve25519/curve25519_nohw.c
@@ -503,7 +503,7 @@ int x25519_ge_frombytes_vartime(ge_p3 *h, const uint8_t s[32]) {
   fe_frombytes(&h->Y, s);
   fe_1(&h->Z);
   fe_sq_tt(&w, &h->Y);
-  fe_mul_ttt(&vxx, &w, &d);
+  fe_mul_ttt(&vxx, &w, &k25519d);
   fe_sub(&v, &w, &h->Z);  // u = y^2-1
   fe_carry(&u, &v);
   fe_add(&v, &vxx, &h->Z);  // v = dy^2+1
@@ -520,7 +520,7 @@ int x25519_ge_frombytes_vartime(ge_p3 *h, const uint8_t s[32]) {
     if (fe_isnonzero(&check)) {
       return 0;
     }
-    fe_mul_ttt(&h->X, &h->X, &sqrtm1);
+    fe_mul_ttt(&h->X, &h->X, &k25519sqrtm1);
   }
 
   if (fe_isnegative(&h->X) != (s[31] >> 7)) {
@@ -571,7 +571,7 @@ void x25519_ge_p3_to_cached(ge_cached *r, const ge_p3 *p) {
   fe_add(&r->YplusX, &p->Y, &p->X);
   fe_sub(&r->YminusX, &p->Y, &p->X);
   fe_copy_lt(&r->Z, &p->Z);
-  fe_mul_ltt(&r->T2d, &p->T, &d2);
+  fe_mul_ltt(&r->T2d, &p->T, &k25519d2);
 }
 
 // r = p
@@ -727,7 +727,7 @@ void x25519_ge_scalarmult_small_precomp(
     fe_add(&out->yplusx, &y, &x);
     fe_sub(&out->yminusx, &y, &x);
     fe_mul_ltt(&out->xy2d, &x, &y);
-    fe_mul_llt(&out->xy2d, &out->xy2d, &d2);
+    fe_mul_llt(&out->xy2d, &out->xy2d, &k25519d2);
   }
 
   // See the comment above |k25519SmallPrecomp| about the structure of the

--- a/crypto/curve25519/curve25519_tables.h
+++ b/crypto/curve25519/curve25519_tables.h
@@ -16,7 +16,7 @@
 //    ./make_curve25519_tables.py > curve25519_tables.h
 
 
-static const fe d = {{
+static const fe k25519d = {{
 #if defined(BORINGSSL_CURVE25519_64BIT)
     929955233495203, 466365720129213, 1662059464998953, 2033849074728123,
     1442794654840575
@@ -26,7 +26,7 @@ static const fe d = {{
 #endif
 }};
 
-static const fe sqrtm1 = {{
+static const fe k25519sqrtm1 = {{
 #if defined(BORINGSSL_CURVE25519_64BIT)
     1718705420411056, 234908883556509, 2233514472574048, 2117202627021982,
     765476049583133
@@ -36,7 +36,7 @@ static const fe sqrtm1 = {{
 #endif
 }};
 
-static const fe d2 = {{
+static const fe k25519d2 = {{
 #if defined(BORINGSSL_CURVE25519_64BIT)
     1859910466990425, 932731440258426, 1072319116312658, 1815898335770999,
     633789495995903

--- a/crypto/curve25519/make_curve25519_tables.py
+++ b/crypto/curve25519/make_curve25519_tables.py
@@ -159,15 +159,15 @@ def main():
 //    ./make_curve25519_tables.py > curve25519_tables.h
 
 
-static const fe d = """)
+static const fe k25519d = """)
     buf.write(to_literal(d))
     buf.write(""";
 
-static const fe sqrtm1 = """)
+static const fe k25519sqrtm1 = """)
     buf.write(to_literal(modp_sqrt_m1))
     buf.write(""";
 
-static const fe d2 = """)
+static const fe k25519d2 = """)
     buf.write(to_literal(d2))
     buf.write(""";
 


### PR DESCRIPTION
### Issues:
Related to CryptoAlg-2625

### Description of changes: 

Using names such as `d` for global variables works if they are only ever used in small scope. However, Ed25519 is being moved under the fips module, which increase the scope by a lot. To allow this, reduce the likelihood of variable name collisions by prefixing variable names with some context information. In this case `k25519`, following convention in the rest of the file.

I removed the line `.clang-format` because the clang version I have is too old. `InsertBraces` was introduced in clang-format 15. A quite new version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
