### PR TITLE
Improve portability of CI integration script

### DIFF
--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -173,7 +173,7 @@ function aws_lc_build() {
 
   echo "Building AWS-LC to ${BUILD_FOLDER} and installing to ${INSTALL_FOLDER} with CFlags "${@:4}""
   ${CMAKE_COMMAND} ${AWS_LC_DIR} -GNinja "-B${BUILD_FOLDER}" "-DCMAKE_INSTALL_PREFIX=${INSTALL_FOLDER}" "${@:4}"
-  ninja -C ${BUILD_FOLDER} install
+  ${CMAKE_COMMAND} --build ${BUILD_FOLDER} -- install
   ls -R ${INSTALL_FOLDER}
   rm -rf "${BUILD_FOLDER:?}"/*
 }

--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -56,7 +56,7 @@ mkdir -p "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER"
 git clone --depth 1 https://repo.or.cz/socat.git "$SOCAT_SRC"
 
 aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_SHARED_LIBS=1 -DBUILD_TESTING=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib/:${LD_LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib/:${AWS_LC_INSTALL_FOLDER}/lib64/:${LD_LIBRARY_PATH:-}"
 build_and_test_socat
 
 ldd "${SOCAT_SRC}/socat" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1


### PR DESCRIPTION
### Issues:

V1497389456

### Description of changes: 

On Amazon Linux we install into `lib64` and the Ninja executable is called `ninja-build`. Teach the integration script this.

### Call-outs:

`cmake --build` was introduced in 3.0. Hence, should be portable for our minimal requirements.

### Testing:

This worked for me when I ran it on Amazon Linux 2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
