### PR TITLE
Add ML-KEM to speed.cc, bump AWSLC_API_VERSION to 30

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -114,7 +114,7 @@ extern "C" {
 // A consumer may use this symbol in the preprocessor to temporarily build
 // against multiple revisions of BoringSSL at the same time. It is not
 // recommended to do so for longer than is necessary.
-#define AWSLC_API_VERSION 29
+#define AWSLC_API_VERSION 30
 
 // This string tracks the most current production release version on Github
 // https://github.com/aws/aws-lc/releases.

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -851,7 +851,13 @@ static bool SpeedSingleKEM(const std::string &name, int nid, const std::string &
 }
 
 static bool SpeedKEM(std::string selected) {
-  return SpeedSingleKEM("Kyber512_R3", NID_KYBER512_R3, selected) &&
+  return
+#if AWSLC_API_VERSION >= 30
+         SpeedSingleKEM("ML-KEM-512", NID_MLKEM512, selected) &&
+         SpeedSingleKEM("ML-KEM-768", NID_MLKEM768, selected) &&
+         SpeedSingleKEM("ML-KEM-1024", NID_MLKEM1024, selected) &&
+#endif
+         SpeedSingleKEM("Kyber512_R3", NID_KYBER512_R3, selected) &&
          SpeedSingleKEM("Kyber768_R3", NID_KYBER768_R3, selected) &&
          SpeedSingleKEM("Kyber1024_R3", NID_KYBER1024_R3, selected);
 }


### PR DESCRIPTION
### Description of changes: 
Bump AWSLC_API_VERSION to 30 so speed.cc can tell which library versions have ML-KEM support. Add the ML-KEM benchmark for all future versions of AWS-LC that support it.

### Testing:
Ran speed locally:
```
./tool/bssl speed -filter ML-KEM
Did 85000 ML-KEM-512 keygen operations in 1002430us (84794.0 ops/sec)
Did 84000 ML-KEM-512 encaps operations in 1008991us (83251.5 ops/sec)
Did 70000 ML-KEM-512 decaps operations in 1009795us (69321.0 ops/sec)
Did 48000 ML-KEM-768 keygen operations in 1014221us (47327.0 ops/sec)
Did 52000 ML-KEM-768 encaps operations in 1011926us (51387.2 ops/sec)
Did 44000 ML-KEM-768 decaps operations in 1012853us (43441.6 ops/sec)
Did 30000 ML-KEM-1024 keygen operations in 1004572us (29863.5 ops/sec)
Did 34000 ML-KEM-1024 encaps operations in 1012471us (33581.2 ops/sec)
Did 29000 ML-KEM-1024 decaps operations in 1021323us (28394.5 ops/sec)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
