### PR TITLE
Avoid C11 Atomics on Windows

### DIFF
--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -580,7 +580,8 @@ OPENSSL_EXPORT void CRYPTO_once(CRYPTO_once_t *once, void (*init)(void));
 
 // Reference counting.
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#if !defined(__STDC_NO_ATOMICS__) && defined(__STDC_VERSION__) && \
+    __STDC_VERSION__ >= 201112L
 #include <stdatomic.h>
 // CRYPTO_refcount_t is a |uint32_t|
 #define AWS_LC_ATOMIC_LOCK_FREE ATOMIC_LONG_LOCK_FREE
@@ -589,9 +590,8 @@ OPENSSL_EXPORT void CRYPTO_once(CRYPTO_once_t *once, void (*init)(void));
 #endif
 
 // Automatically enable C11 atomics if implemented and lock free
-#if !defined(OPENSSL_C11_ATOMIC) && defined(OPENSSL_THREADS) &&   \
-    !defined(__STDC_NO_ATOMICS__) && defined(__STDC_VERSION__) && \
-    __STDC_VERSION__ >= 201112L && AWS_LC_ATOMIC_LOCK_FREE == 2
+#if !defined(OPENSSL_C11_ATOMIC) && defined(OPENSSL_THREADS) && \
+    AWS_LC_ATOMIC_LOCK_FREE == 2
 #define OPENSSL_C11_ATOMIC
 #endif
 


### PR DESCRIPTION
### Issue
When building with `-DCMAKE_C_STANDARD=11` and using the MSBuild generator (e.g., `-DCMAKE_GENERATOR="Visual Studio 17 2022"`. The build fails with [numerous error messages](https://github.com/aws/aws-lc-rs/actions/runs/10701757878/job/29668443100#step:4:43850) related to an error parsing `vcruntime_c11_stdatomic.h`. 
```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\vcruntime_c11_stdatomic.h(122,1): error C2059: syntax error: '}' [D:\a\aws-lc-rs\aws-lc-rs\target\debug\build\aws-lc-sys-491cb29895f6cb6c\out\build\aws-lc\crypto\fipsmodule\fipsmodule.vcxproj]
```

### Description of changes: 
This change updates out internal header so that it avoids `#include <stdatomic.h>` when the `__STDC_NO_ATOMICS__` macro is set.

### Testing:
I tested and verified it works on my Windows host. I didn't add a CI test for this as it's an unusual case, but I will if requested.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
