### PR TITLE
Move EVP ed25519 function table under FIPS module

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -424,7 +424,6 @@ add_library(
   evp_extra/p_dh_asn1.c
   evp_extra/p_dsa_asn1.c
   evp_extra/p_ec_asn1.c
-  evp_extra/p_ed25519.c
   evp_extra/p_ed25519_asn1.c
   evp_extra/p_hmac_asn1.c
   evp_extra/p_kem.c

--- a/crypto/evp_extra/internal.h
+++ b/crypto/evp_extra/internal.h
@@ -9,15 +9,6 @@
 
 #include "../dilithium/sig_dilithium.h"
 
-typedef struct {
-  // key is the concatenation of the private seed and public key. It is stored
-  // as a single 64-bit array to allow passing to |ED25519_sign|. If
-  // |has_private| is false, the first 32 bytes are uninitialized and the public
-  // key is in the last 32 bytes.
-  uint8_t key[64];
-  char has_private;
-} ED25519_KEY;
-
 #define PKCS8_VERSION_ONE 0
 #define PKCS8_VERSION_TWO 1
 #define ED25519_PUBLIC_KEY_OFFSET 32
@@ -52,7 +43,6 @@ extern const EVP_PKEY_ASN1_METHOD kem_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD hmac_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD dh_asn1_meth;
 
-extern const EVP_PKEY_METHOD ed25519_pkey_meth;
 extern const EVP_PKEY_METHOD x25519_pkey_meth;
 extern const EVP_PKEY_METHOD hkdf_pkey_meth;
 extern const EVP_PKEY_METHOD dilithium3_pkey_meth;

--- a/crypto/evp_extra/p_methods.c
+++ b/crypto/evp_extra/p_methods.c
@@ -8,7 +8,6 @@
 #include "internal.h"
 
 static const EVP_PKEY_METHOD *const non_fips_pkey_evp_methods[] = {
-  &ed25519_pkey_meth,
   &x25519_pkey_meth,
 #ifdef ENABLE_DILITHIUM
   &dilithium3_pkey_meth,

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -112,6 +112,7 @@
 #include "evp/evp.c"
 #include "evp/evp_ctx.c"
 #include "evp/p_ec.c"
+#include "evp/p_ed25519.c"
 #include "evp/p_hkdf.c"
 #include "evp/p_hmac.c"
 #include "evp/p_rsa.c"

--- a/crypto/fipsmodule/evp/evp_ctx.c
+++ b/crypto/fipsmodule/evp/evp_ctx.c
@@ -73,6 +73,7 @@ DEFINE_LOCAL_DATA(struct fips_evp_pkey_methods, AWSLC_fips_evp_pkey_methods) {
   out->methods[2] = EVP_PKEY_ec_pkey_meth();
   out->methods[3] = EVP_PKEY_hkdf_pkey_meth();
   out->methods[4] = EVP_PKEY_hmac_pkey_meth();
+  out->methods[5] = EVP_PKEY_ed25519_pkey_meth();
 }
 
 static const EVP_PKEY_METHOD *evp_pkey_meth_find(int type) {

--- a/crypto/fipsmodule/evp/internal.h
+++ b/crypto/fipsmodule/evp/internal.h
@@ -324,13 +324,24 @@ typedef struct {
 // HMAC_KEY_new allocates and zeroizes a |HMAC_KEY| for internal use.
 HMAC_KEY *HMAC_KEY_new(void);
 
-#define FIPS_EVP_PKEY_METHODS 5
+typedef struct {
+  // key is the concatenation of the private seed and public key. It is stored
+  // as a single 64-bit array to allow passing to |ED25519_sign|. If
+  // |has_private| is false, the first 32 bytes are uninitialized and the public
+  // key is in the last 32 bytes.
+  uint8_t key[64];
+  char has_private;
+} ED25519_KEY;
+
+#define ED25519_PUBLIC_KEY_OFFSET 32
+
+#define FIPS_EVP_PKEY_METHODS 6
 
 #ifdef ENABLE_DILITHIUM
-#define NON_FIPS_EVP_PKEY_METHODS 5
+#define NON_FIPS_EVP_PKEY_METHODS 4
 #define ASN1_EVP_PKEY_METHODS 9
 #else
-#define NON_FIPS_EVP_PKEY_METHODS 4
+#define NON_FIPS_EVP_PKEY_METHODS 3
 #define ASN1_EVP_PKEY_METHODS 8
 #endif
 
@@ -343,6 +354,7 @@ const EVP_PKEY_METHOD *EVP_PKEY_rsa_pss_pkey_meth(void);
 const EVP_PKEY_METHOD *EVP_PKEY_ec_pkey_meth(void);
 const EVP_PKEY_METHOD *EVP_PKEY_hkdf_pkey_meth(void);
 const EVP_PKEY_METHOD *EVP_PKEY_hmac_pkey_meth(void);
+const EVP_PKEY_METHOD *EVP_PKEY_ed25519_pkey_meth(void);
 
 #if defined(__cplusplus)
 }  // extern C

--- a/crypto/fipsmodule/evp/p_ed25519.c
+++ b/crypto/fipsmodule/evp/p_ed25519.c
@@ -18,7 +18,6 @@
 #include <openssl/err.h>
 #include <openssl/mem.h>
 
-#include "../fipsmodule/evp/internal.h"
 #include "internal.h"
 
 
@@ -82,26 +81,26 @@ static int pkey_ed25519_verify_message(EVP_PKEY_CTX *ctx, const uint8_t *sig,
   return 1;
 }
 
-const EVP_PKEY_METHOD ed25519_pkey_meth = {
-    EVP_PKEY_ED25519,
-    NULL /* init */,
-    pkey_ed25519_copy,
-    NULL /* cleanup */,
-    pkey_ed25519_keygen,
-    NULL /* sign_init */,
-    NULL /* sign */,
-    pkey_ed25519_sign_message,
-    NULL /* verify_init */,
-    NULL /* verify */,
-    pkey_ed25519_verify_message,
-    NULL /* verify_recover */,
-    NULL /* encrypt */,
-    NULL /* decrypt */,
-    NULL /* derive */,
-    NULL /* paramgen */,
-    NULL /* ctrl */,
-    NULL /* keygen deterministic */,
-    NULL /* encapsulate deterministic */,
-    NULL /* encapsulate */,
-    NULL /* decapsulate */,
-};
+DEFINE_METHOD_FUNCTION(EVP_PKEY_METHOD, EVP_PKEY_ed25519_pkey_meth) {
+  out->pkey_id = EVP_PKEY_ED25519;
+  out->init = NULL;
+  out->copy = pkey_ed25519_copy;
+  out->cleanup = NULL;
+  out->keygen = pkey_ed25519_keygen;
+  out->sign_init = NULL;
+  out->sign = NULL;
+  out->sign_message = pkey_ed25519_sign_message;
+  out->verify_init = NULL;
+  out->verify = NULL;
+  out->verify_message = pkey_ed25519_verify_message;
+  out->verify_recover = NULL;
+  out->encrypt = NULL;
+  out->decrypt = NULL;
+  out->derive = NULL;
+  out->paramgen = NULL;
+  out->ctrl = NULL;
+  out->keygen_deterministic = NULL;
+  out->encapsulate_deterministic = NULL;
+  out->encapsulate = NULL;
+  out->decapsulate = NULL;
+}


### PR DESCRIPTION
### Description of changes: 

Follow-up to https://github.com/aws/aws-lc/pull/1809. We forgot to move the EVP Ed25519 function table to the FIPs module. I didn't move the X25519 function table because that is not an approved function with respect to FIPS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
