### PR TITLE
Run clang-format on pkcs7 code

### DIFF
--- a/crypto/pkcs7/internal.h
+++ b/crypto/pkcs7/internal.h
@@ -49,13 +49,13 @@ DEFINE_STACK_OF(PKCS7)
 //       [1] IMPLICIT CertificateRevocationLists OPTIONAL,
 //     signerInfos SignerInfos }
 struct pkcs7_sign_envelope_st {
-    ASN1_INTEGER *version;
-    STACK_OF(PKCS7_RECIP_INFO) *recipientinfo;
-    STACK_OF(X509_ALGOR) *md_algs;
-    PKCS7_ENC_CONTENT *enc_data;
-    STACK_OF(X509) *cert;
-    STACK_OF(X509_CRL) *crl;
-    STACK_OF(PKCS7_SIGNER_INFO) *signer_info;
+  ASN1_INTEGER *version;
+  STACK_OF(PKCS7_RECIP_INFO) *recipientinfo;
+  STACK_OF(X509_ALGOR) *md_algs;
+  PKCS7_ENC_CONTENT *enc_data;
+  STACK_OF(X509) *cert;
+  STACK_OF(X509_CRL) *crl;
+  STACK_OF(PKCS7_SIGNER_INFO) *signer_info;
 };
 
 // ASN.1 defined here https://datatracker.ietf.org/doc/html/rfc2315#section-6.7
@@ -64,8 +64,8 @@ struct pkcs7_sign_envelope_st {
 //     issuer Name,
 //     serialNumber CertificateSerialNumber }
 struct pkcs7_issuer_and_serial_st {
-    X509_NAME *issuer;
-    ASN1_INTEGER *serial;
+  X509_NAME *issuer;
+  ASN1_INTEGER *serial;
 };
 
 // ASN.1 defined here https://datatracker.ietf.org/doc/html/rfc2315#section-9.2
@@ -84,14 +84,14 @@ struct pkcs7_issuer_and_serial_st {
 //
 //   EncryptedDigest ::= OCTET STRING
 struct pkcs7_signer_info_st {
-    ASN1_INTEGER *version;
-    PKCS7_ISSUER_AND_SERIAL *issuer_and_serial;
-    X509_ALGOR *digest_alg;
-    STACK_OF(X509_ATTRIBUTE) *auth_attr;
-    X509_ALGOR *digest_enc_alg;
-    ASN1_OCTET_STRING *enc_digest;
-    STACK_OF(X509_ATTRIBUTE) *unauth_attr;
-    EVP_PKEY *pkey; // NOTE: |pkey| is not seriliazed.
+  ASN1_INTEGER *version;
+  PKCS7_ISSUER_AND_SERIAL *issuer_and_serial;
+  X509_ALGOR *digest_alg;
+  STACK_OF(X509_ATTRIBUTE) *auth_attr;
+  X509_ALGOR *digest_enc_alg;
+  ASN1_OCTET_STRING *enc_digest;
+  STACK_OF(X509_ATTRIBUTE) *unauth_attr;
+  EVP_PKEY *pkey;  // NOTE: |pkey| is not seriliazed.
 };
 
 // ASN.1 defined here https://datatracker.ietf.org/doc/html/rfc2315#section-10.2
@@ -106,11 +106,11 @@ struct pkcs7_signer_info_st {
 //
 //   EncryptedKey ::= OCTET STRING
 struct pkcs7_recip_info_st {
-    ASN1_INTEGER *version;
-    PKCS7_ISSUER_AND_SERIAL *issuer_and_serial;
-    X509_ALGOR *key_enc_algor;
-    ASN1_OCTET_STRING *enc_key;
-    X509 *cert; // NOTE: |cert| is not serialized
+  ASN1_INTEGER *version;
+  PKCS7_ISSUER_AND_SERIAL *issuer_and_serial;
+  X509_ALGOR *key_enc_algor;
+  ASN1_OCTET_STRING *enc_key;
+  X509 *cert;  // NOTE: |cert| is not serialized
 };
 
 // ASN.1 defined here https://datatracker.ietf.org/doc/html/rfc2315#section-10.1
@@ -124,10 +124,10 @@ struct pkcs7_recip_info_st {
 //
 //   EncryptedContent ::= OCTET STRING
 struct pkcs7_enc_content_st {
-    ASN1_OBJECT *content_type;
-    X509_ALGOR *algorithm;
-    ASN1_OCTET_STRING *enc_data;
-    const EVP_CIPHER *cipher;   // NOTE: |cipher| is not serialized
+  ASN1_OBJECT *content_type;
+  X509_ALGOR *algorithm;
+  ASN1_OCTET_STRING *enc_data;
+  const EVP_CIPHER *cipher;  // NOTE: |cipher| is not serialized
 };
 
 // ASN.1 defined here https://datatracker.ietf.org/doc/html/rfc2315#section-10.1
@@ -154,11 +154,11 @@ struct pkcs7_envelope_st {
 //
 //   Digest ::= OCTET STRING
 struct pkcs7_digest_st {
-    ASN1_INTEGER *version;
-    X509_ALGOR *digest_alg;
-    PKCS7 *contents;
-    ASN1_OCTET_STRING *digest;
-    const EVP_MD *md;   // NOTE: |md| is not serialized
+  ASN1_INTEGER *version;
+  X509_ALGOR *digest_alg;
+  PKCS7 *contents;
+  ASN1_OCTET_STRING *digest;
+  const EVP_MD *md;  // NOTE: |md| is not serialized
 };
 
 // ASN.1 defined here https://datatracker.ietf.org/doc/html/rfc2315#section-13
@@ -167,8 +167,8 @@ struct pkcs7_digest_st {
 //     version Version,
 //     encryptedContentInfo EncryptedContentInfo }
 struct pkcs7_encrypt_st {
-    ASN1_INTEGER *version;
-    PKCS7_ENC_CONTENT *enc_data;
+  ASN1_INTEGER *version;
+  PKCS7_ENC_CONTENT *enc_data;
 };
 
 // pkcs7_parse_header reads the non-certificate/non-CRL prefix of a PKCS#7

--- a/crypto/pkcs7/pkcs7.c
+++ b/crypto/pkcs7/pkcs7.c
@@ -22,9 +22,9 @@
 #include <openssl/pool.h>
 #include <openssl/stack.h>
 
-#include "internal.h"
-#include "../internal.h"
 #include "../bytestring/internal.h"
+#include "../internal.h"
+#include "internal.h"
 
 
 // 1.2.840.113549.1.7.1
@@ -112,8 +112,7 @@ int PKCS7_get_raw_certificates(STACK_OF(CRYPTO_BUFFER) *out_certs, CBS *cbs,
     }
 
     CRYPTO_BUFFER *buf = CRYPTO_BUFFER_new_from_CBS(&cert, pool);
-    if (buf == NULL ||
-        !sk_CRYPTO_BUFFER_push(out_certs, buf)) {
+    if (buf == NULL || !sk_CRYPTO_BUFFER_push(out_certs, buf)) {
       CRYPTO_BUFFER_free(buf);
       goto err;
     }
@@ -196,429 +195,425 @@ int pkcs7_add_signed_data(CBB *out,
 }
 
 int PKCS7_set_type(PKCS7 *p7, int type) {
-    if (p7 == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
-    ASN1_OBJECT *obj = OBJ_nid2obj(type);
-    if (obj == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_UNSUPPORTED_CONTENT_TYPE);
-        return 0;
-    }
-
-    switch (type) {
-    case NID_pkcs7_signed:
-        p7->type = obj;
-        PKCS7_SIGNED_free(p7->d.sign);
-        p7->d.sign = PKCS7_SIGNED_new();
-        if (p7->d.sign == NULL) {
-            return 0;
-        }
-        if (!ASN1_INTEGER_set(p7->d.sign->version, 1)) {
-            PKCS7_SIGNED_free(p7->d.sign);
-            p7->d.sign = NULL;
-            return 0;
-        }
-        break;
-    case NID_pkcs7_digest:
-        p7->type = obj;
-        PKCS7_DIGEST_free(p7->d.digest);
-        p7->d.digest = PKCS7_DIGEST_new();
-        if (p7->d.digest == NULL) {
-            return 0;
-        }
-        if (!ASN1_INTEGER_set(p7->d.digest->version, 0)) {
-            PKCS7_DIGEST_free(p7->d.digest);
-            p7->d.digest = NULL;
-            return 0;
-        }
-        break;
-    case NID_pkcs7_data:
-        p7->type = obj;
-        ASN1_OCTET_STRING_free(p7->d.data);
-        p7->d.data = ASN1_OCTET_STRING_new();
-        if (p7->d.data == NULL) {
-            return 0;
-        }
-        break;
-    case NID_pkcs7_signedAndEnveloped:
-        p7->type = obj;
-        PKCS7_SIGN_ENVELOPE_free(p7->d.signed_and_enveloped);
-        p7->d.signed_and_enveloped = PKCS7_SIGN_ENVELOPE_new();
-        if (p7->d.signed_and_enveloped == NULL) {
-            return 0;
-        }
-        if (!ASN1_INTEGER_set(p7->d.signed_and_enveloped->version, 1)) {
-            PKCS7_SIGN_ENVELOPE_free(p7->d.signed_and_enveloped);
-            p7->d.signed_and_enveloped = NULL;
-            return 0;
-        }
-        p7->d.signed_and_enveloped->enc_data->content_type = OBJ_nid2obj(NID_pkcs7_data);
-        break;
-    case NID_pkcs7_enveloped:
-        p7->type = obj;
-        PKCS7_ENVELOPE_free(p7->d.enveloped);
-        p7->d.enveloped = PKCS7_ENVELOPE_new();
-        if (p7->d.enveloped == NULL) {
-            return 0;
-        }
-        if (!ASN1_INTEGER_set(p7->d.enveloped->version, 0)) {
-            PKCS7_ENVELOPE_free(p7->d.enveloped);
-            p7->d.enveloped = NULL;
-            return 0;
-        }
-        p7->d.enveloped->enc_data->content_type = OBJ_nid2obj(NID_pkcs7_data);
-        break;
-    case NID_pkcs7_encrypted:
-        p7->type = obj;
-        PKCS7_ENCRYPT_free(p7->d.encrypted);
-        p7->d.encrypted = PKCS7_ENCRYPT_new();
-        if (p7->d.encrypted == NULL) {
-            return 0;
-        }
-        if (!ASN1_INTEGER_set(p7->d.encrypted->version, 0)) {
-            PKCS7_ENCRYPT_free(p7->d.encrypted);
-            p7->d.encrypted = NULL;
-            return 0;
-        }
-        p7->d.encrypted->enc_data->content_type = OBJ_nid2obj(NID_pkcs7_data);
-        break;
-    default:
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_UNSUPPORTED_CONTENT_TYPE);
-        return 0;
-    }
-    return 1;
-}
-
-int PKCS7_set_cipher(PKCS7 *p7, const EVP_CIPHER *cipher)
-{
-    if (p7 == NULL || cipher == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
-    if (EVP_get_cipherbynid(EVP_CIPHER_nid(cipher)) == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_CIPHER_HAS_NO_OBJECT_IDENTIFIER);
-        return 0;
-    }
-
-    PKCS7_ENC_CONTENT *ec;
-    switch (OBJ_obj2nid(p7->type)) {
-    case NID_pkcs7_signedAndEnveloped:
-        ec = p7->d.signed_and_enveloped->enc_data;
-        break;
-    case NID_pkcs7_enveloped:
-        ec = p7->d.enveloped->enc_data;
-        break;
-    default:
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
-        return 0;
-    }
-
-    ec->cipher = cipher;
-    return 1;
-}
-
-int PKCS7_set_content(PKCS7 *p7, PKCS7 *p7_data)
-{
-    if (p7 == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
-
-    switch (OBJ_obj2nid(p7->type)) {
-    case NID_pkcs7_signed:
-        PKCS7_free(p7->d.sign->contents);
-        p7->d.sign->contents = p7_data;
-        break;
-    case NID_pkcs7_digest:
-        PKCS7_free(p7->d.digest->contents);
-        p7->d.digest->contents = p7_data;
-        break;
-    default:
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_UNSUPPORTED_CONTENT_TYPE);
-        return 0;
-    }
-    return 1;
-}
-
-int PKCS7_content_new(PKCS7 *p7, int type)
-{
-    PKCS7 *ret = PKCS7_new();
-    if (ret == NULL) {
-        goto err;
-    }
-    if (!PKCS7_set_type(ret, type)) {
-        goto err;
-    }
-    if (!PKCS7_set_content(p7, ret)) {
-        goto err;
-    }
-    return 1;
- err:
-    PKCS7_free(ret);
+  if (p7 == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
     return 0;
+  }
+  ASN1_OBJECT *obj = OBJ_nid2obj(type);
+  if (obj == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_UNSUPPORTED_CONTENT_TYPE);
+    return 0;
+  }
+
+  switch (type) {
+    case NID_pkcs7_signed:
+      p7->type = obj;
+      PKCS7_SIGNED_free(p7->d.sign);
+      p7->d.sign = PKCS7_SIGNED_new();
+      if (p7->d.sign == NULL) {
+        return 0;
+      }
+      if (!ASN1_INTEGER_set(p7->d.sign->version, 1)) {
+        PKCS7_SIGNED_free(p7->d.sign);
+        p7->d.sign = NULL;
+        return 0;
+      }
+      break;
+    case NID_pkcs7_digest:
+      p7->type = obj;
+      PKCS7_DIGEST_free(p7->d.digest);
+      p7->d.digest = PKCS7_DIGEST_new();
+      if (p7->d.digest == NULL) {
+        return 0;
+      }
+      if (!ASN1_INTEGER_set(p7->d.digest->version, 0)) {
+        PKCS7_DIGEST_free(p7->d.digest);
+        p7->d.digest = NULL;
+        return 0;
+      }
+      break;
+    case NID_pkcs7_data:
+      p7->type = obj;
+      ASN1_OCTET_STRING_free(p7->d.data);
+      p7->d.data = ASN1_OCTET_STRING_new();
+      if (p7->d.data == NULL) {
+        return 0;
+      }
+      break;
+    case NID_pkcs7_signedAndEnveloped:
+      p7->type = obj;
+      PKCS7_SIGN_ENVELOPE_free(p7->d.signed_and_enveloped);
+      p7->d.signed_and_enveloped = PKCS7_SIGN_ENVELOPE_new();
+      if (p7->d.signed_and_enveloped == NULL) {
+        return 0;
+      }
+      if (!ASN1_INTEGER_set(p7->d.signed_and_enveloped->version, 1)) {
+        PKCS7_SIGN_ENVELOPE_free(p7->d.signed_and_enveloped);
+        p7->d.signed_and_enveloped = NULL;
+        return 0;
+      }
+      p7->d.signed_and_enveloped->enc_data->content_type =
+          OBJ_nid2obj(NID_pkcs7_data);
+      break;
+    case NID_pkcs7_enveloped:
+      p7->type = obj;
+      PKCS7_ENVELOPE_free(p7->d.enveloped);
+      p7->d.enveloped = PKCS7_ENVELOPE_new();
+      if (p7->d.enveloped == NULL) {
+        return 0;
+      }
+      if (!ASN1_INTEGER_set(p7->d.enveloped->version, 0)) {
+        PKCS7_ENVELOPE_free(p7->d.enveloped);
+        p7->d.enveloped = NULL;
+        return 0;
+      }
+      p7->d.enveloped->enc_data->content_type = OBJ_nid2obj(NID_pkcs7_data);
+      break;
+    case NID_pkcs7_encrypted:
+      p7->type = obj;
+      PKCS7_ENCRYPT_free(p7->d.encrypted);
+      p7->d.encrypted = PKCS7_ENCRYPT_new();
+      if (p7->d.encrypted == NULL) {
+        return 0;
+      }
+      if (!ASN1_INTEGER_set(p7->d.encrypted->version, 0)) {
+        PKCS7_ENCRYPT_free(p7->d.encrypted);
+        p7->d.encrypted = NULL;
+        return 0;
+      }
+      p7->d.encrypted->enc_data->content_type = OBJ_nid2obj(NID_pkcs7_data);
+      break;
+    default:
+      OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_UNSUPPORTED_CONTENT_TYPE);
+      return 0;
+  }
+  return 1;
+}
+
+int PKCS7_set_cipher(PKCS7 *p7, const EVP_CIPHER *cipher) {
+  if (p7 == NULL || cipher == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  }
+  if (EVP_get_cipherbynid(EVP_CIPHER_nid(cipher)) == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_CIPHER_HAS_NO_OBJECT_IDENTIFIER);
+    return 0;
+  }
+
+  PKCS7_ENC_CONTENT *ec;
+  switch (OBJ_obj2nid(p7->type)) {
+    case NID_pkcs7_signedAndEnveloped:
+      ec = p7->d.signed_and_enveloped->enc_data;
+      break;
+    case NID_pkcs7_enveloped:
+      ec = p7->d.enveloped->enc_data;
+      break;
+    default:
+      OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
+      return 0;
+  }
+
+  ec->cipher = cipher;
+  return 1;
+}
+
+int PKCS7_set_content(PKCS7 *p7, PKCS7 *p7_data) {
+  if (p7 == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  }
+
+  switch (OBJ_obj2nid(p7->type)) {
+    case NID_pkcs7_signed:
+      PKCS7_free(p7->d.sign->contents);
+      p7->d.sign->contents = p7_data;
+      break;
+    case NID_pkcs7_digest:
+      PKCS7_free(p7->d.digest->contents);
+      p7->d.digest->contents = p7_data;
+      break;
+    default:
+      OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_UNSUPPORTED_CONTENT_TYPE);
+      return 0;
+  }
+  return 1;
+}
+
+int PKCS7_content_new(PKCS7 *p7, int type) {
+  PKCS7 *ret = PKCS7_new();
+  if (ret == NULL) {
+    goto err;
+  }
+  if (!PKCS7_set_type(ret, type)) {
+    goto err;
+  }
+  if (!PKCS7_set_content(p7, ret)) {
+    goto err;
+  }
+  return 1;
+err:
+  PKCS7_free(ret);
+  return 0;
 }
 
 int PKCS7_add_recipient_info(PKCS7 *p7, PKCS7_RECIP_INFO *ri) {
-    STACK_OF(PKCS7_RECIP_INFO) *sk;
+  STACK_OF(PKCS7_RECIP_INFO) *sk;
 
-    if (p7 == NULL || ri == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
+  if (p7 == NULL || ri == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  }
 
-    switch (OBJ_obj2nid(p7->type)) {
+  switch (OBJ_obj2nid(p7->type)) {
     case NID_pkcs7_signedAndEnveloped:
-        sk = p7->d.signed_and_enveloped->recipientinfo;
-        break;
+      sk = p7->d.signed_and_enveloped->recipientinfo;
+      break;
     case NID_pkcs7_enveloped:
-        sk = p7->d.enveloped->recipientinfo;
-        break;
+      sk = p7->d.enveloped->recipientinfo;
+      break;
     default:
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
-        return 0;
-    }
+      OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
+      return 0;
+  }
 
-    if (!sk_PKCS7_RECIP_INFO_push(sk, ri)) {
-        return 0;
-    }
-    return 1;
+  if (!sk_PKCS7_RECIP_INFO_push(sk, ri)) {
+    return 0;
+  }
+  return 1;
 }
 
 int PKCS7_add_signer(PKCS7 *p7, PKCS7_SIGNER_INFO *p7i) {
-    ASN1_OBJECT *obj;
-    X509_ALGOR *alg;
-    STACK_OF(PKCS7_SIGNER_INFO) *signer_sk;
-    STACK_OF(X509_ALGOR) *md_sk;
+  ASN1_OBJECT *obj;
+  X509_ALGOR *alg;
+  STACK_OF(PKCS7_SIGNER_INFO) *signer_sk;
+  STACK_OF(X509_ALGOR) *md_sk;
 
-    if (p7 == NULL || p7i == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
+  if (p7 == NULL || p7i == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  }
 
-    switch (OBJ_obj2nid(p7->type)) {
+  switch (OBJ_obj2nid(p7->type)) {
     case NID_pkcs7_signed:
-        signer_sk = p7->d.sign->signer_info;
-        md_sk = p7->d.sign->md_algs;
-        break;
+      signer_sk = p7->d.sign->signer_info;
+      md_sk = p7->d.sign->md_algs;
+      break;
     case NID_pkcs7_signedAndEnveloped:
-        signer_sk = p7->d.signed_and_enveloped->signer_info;
-        md_sk = p7->d.signed_and_enveloped->md_algs;
-        break;
+      signer_sk = p7->d.signed_and_enveloped->signer_info;
+      md_sk = p7->d.signed_and_enveloped->md_algs;
+      break;
     default:
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
-        return 0;
-    }
+      OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
+      return 0;
+  }
 
 
-    obj = p7i->digest_alg->algorithm;
-    /* If the digest is not currently listed, add it */
-    int alg_found = 0;
-    for (size_t i = 0; i < sk_X509_ALGOR_num(md_sk); i++) {
-        alg = sk_X509_ALGOR_value(md_sk, i);
-        if (OBJ_cmp(obj, alg->algorithm) == 0) {
-            alg_found = 1;
-            break;
-        }
+  obj = p7i->digest_alg->algorithm;
+  /* If the digest is not currently listed, add it */
+  int alg_found = 0;
+  for (size_t i = 0; i < sk_X509_ALGOR_num(md_sk); i++) {
+    alg = sk_X509_ALGOR_value(md_sk, i);
+    if (OBJ_cmp(obj, alg->algorithm) == 0) {
+      alg_found = 1;
+      break;
     }
-    if (!alg_found) {
-        if ((alg = X509_ALGOR_new()) == NULL
-            || (alg->parameter = ASN1_TYPE_new()) == NULL) {
-            X509_ALGOR_free(alg);
-            OPENSSL_PUT_ERROR(PKCS7, ERR_R_ASN1_LIB);
-            return 0;
-        }
-        /*
-         * If there is a constant copy of the ASN1 OBJECT in libcrypto, then
-         * use that.  Otherwise, use a dynamically duplicated copy
-         */
-        int nid = OBJ_obj2nid(obj);
-        if (nid != NID_undef) {
-            alg->algorithm = OBJ_nid2obj(nid);
-        } else {
-            alg->algorithm = OBJ_dup(obj);
-        }
-        alg->parameter->type = V_ASN1_NULL;
-        if (alg->algorithm == NULL || !sk_X509_ALGOR_push(md_sk, alg)) {
-            X509_ALGOR_free(alg);
-            return 0;
-        }
+  }
+  if (!alg_found) {
+    if ((alg = X509_ALGOR_new()) == NULL ||
+        (alg->parameter = ASN1_TYPE_new()) == NULL) {
+      X509_ALGOR_free(alg);
+      OPENSSL_PUT_ERROR(PKCS7, ERR_R_ASN1_LIB);
+      return 0;
     }
+    /*
+     * If there is a constant copy of the ASN1 OBJECT in libcrypto, then
+     * use that.  Otherwise, use a dynamically duplicated copy
+     */
+    int nid = OBJ_obj2nid(obj);
+    if (nid != NID_undef) {
+      alg->algorithm = OBJ_nid2obj(nid);
+    } else {
+      alg->algorithm = OBJ_dup(obj);
+    }
+    alg->parameter->type = V_ASN1_NULL;
+    if (alg->algorithm == NULL || !sk_X509_ALGOR_push(md_sk, alg)) {
+      X509_ALGOR_free(alg);
+      return 0;
+    }
+  }
 
-    if (!sk_PKCS7_SIGNER_INFO_push(signer_sk, p7i)) {
-        return 0;
-    }
-    return 1;
+  if (!sk_PKCS7_SIGNER_INFO_push(signer_sk, p7i)) {
+    return 0;
+  }
+  return 1;
 }
 
 ASN1_TYPE *PKCS7_get_signed_attribute(const PKCS7_SIGNER_INFO *si, int nid) {
-    if (si == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return NULL;
-    }
-    for (size_t i = 0; i < sk_X509_ATTRIBUTE_num(si->auth_attr); i++) {
-        X509_ATTRIBUTE *attr = sk_X509_ATTRIBUTE_value(si->auth_attr, i);
-        ASN1_OBJECT *obj = X509_ATTRIBUTE_get0_object(attr);
-        if (OBJ_obj2nid(obj) == nid) {
-            return X509_ATTRIBUTE_get0_type(attr, 0);
-        }
-    }
+  if (si == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
     return NULL;
+  }
+  for (size_t i = 0; i < sk_X509_ATTRIBUTE_num(si->auth_attr); i++) {
+    X509_ATTRIBUTE *attr = sk_X509_ATTRIBUTE_value(si->auth_attr, i);
+    ASN1_OBJECT *obj = X509_ATTRIBUTE_get0_object(attr);
+    if (OBJ_obj2nid(obj) == nid) {
+      return X509_ATTRIBUTE_get0_type(attr, 0);
+    }
+  }
+  return NULL;
 }
 
 STACK_OF(PKCS7_SIGNER_INFO) *PKCS7_get_signer_info(PKCS7 *p7) {
-    if (p7 == NULL || p7->d.ptr == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return NULL;
-    }
+  if (p7 == NULL || p7->d.ptr == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return NULL;
+  }
 
-    switch (OBJ_obj2nid(p7->type)) {
+  switch (OBJ_obj2nid(p7->type)) {
     case NID_pkcs7_signed:
-        return p7->d.sign->signer_info;
+      return p7->d.sign->signer_info;
     case NID_pkcs7_signedAndEnveloped:
-        return p7->d.signed_and_enveloped->signer_info;
+      return p7->d.signed_and_enveloped->signer_info;
     default:
-        return NULL;
-    }
+      return NULL;
+  }
 }
 
 int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
                           const EVP_MD *dgst) {
-    /* We now need to add another PKCS7_SIGNER_INFO entry */
-    if (!p7i || !x509 || !pkey || !dgst) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    } else if (!ASN1_INTEGER_set(p7i->version, 1)) {
-        return 0;
-    } else if (!X509_NAME_set(&p7i->issuer_and_serial->issuer,
-                              X509_get_issuer_name(x509))) {
-        return 0;
-    }
+  /* We now need to add another PKCS7_SIGNER_INFO entry */
+  if (!p7i || !x509 || !pkey || !dgst) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  } else if (!ASN1_INTEGER_set(p7i->version, 1)) {
+    return 0;
+  } else if (!X509_NAME_set(&p7i->issuer_and_serial->issuer,
+                            X509_get_issuer_name(x509))) {
+    return 0;
+  }
 
-    /*
-     * because ASN1_INTEGER_set is used to set a 'long' we will do things the
-     * ugly way.
-     */
-    ASN1_INTEGER_free(p7i->issuer_and_serial->serial);
-    if (!(p7i->issuer_and_serial->serial =
-          ASN1_INTEGER_dup(X509_get0_serialNumber(x509)))) {
-        return 0;
-    }
+  /*
+   * because ASN1_INTEGER_set is used to set a 'long' we will do things the
+   * ugly way.
+   */
+  ASN1_INTEGER_free(p7i->issuer_and_serial->serial);
+  if (!(p7i->issuer_and_serial->serial =
+            ASN1_INTEGER_dup(X509_get0_serialNumber(x509)))) {
+    return 0;
+  }
 
-    // NOTE: OpenSSL does not free |p7i->pkey| before setting it. we do so here
-    // to avoid potential memory leaks.
-    EVP_PKEY_free(p7i->pkey);
-    EVP_PKEY_up_ref(pkey);
-    p7i->pkey = pkey;
+  // NOTE: OpenSSL does not free |p7i->pkey| before setting it. we do so here
+  // to avoid potential memory leaks.
+  EVP_PKEY_free(p7i->pkey);
+  EVP_PKEY_up_ref(pkey);
+  p7i->pkey = pkey;
 
-    /* Set the algorithms */
+  /* Set the algorithms */
 
-    if (!X509_ALGOR_set0(p7i->digest_alg, OBJ_nid2obj(EVP_MD_type(dgst)),
-                         V_ASN1_NULL, NULL)) {
-        return 0;
-    }
+  if (!X509_ALGOR_set0(p7i->digest_alg, OBJ_nid2obj(EVP_MD_type(dgst)),
+                       V_ASN1_NULL, NULL)) {
+    return 0;
+  }
 
-    switch(EVP_PKEY_id(pkey)) {
+  switch (EVP_PKEY_id(pkey)) {
     case EVP_PKEY_EC:
     case EVP_PKEY_DH: {
-        int snid, hnid;
-        X509_ALGOR *alg1, *alg2;
-        PKCS7_SIGNER_INFO_get0_algs(p7i, NULL, &alg1, &alg2);
-        if (alg1 == NULL || alg1->algorithm == NULL) {
-            return 0;
-        }
-        hnid = OBJ_obj2nid(alg1->algorithm);
-        if (hnid == NID_undef
-                || !OBJ_find_sigid_by_algs(&snid, hnid, EVP_PKEY_id(pkey))
-                || !X509_ALGOR_set0(alg2, OBJ_nid2obj(snid), V_ASN1_UNDEF, NULL)) {
-            return 0;
-        }
-        break;
+      int snid, hnid;
+      X509_ALGOR *alg1, *alg2;
+      PKCS7_SIGNER_INFO_get0_algs(p7i, NULL, &alg1, &alg2);
+      if (alg1 == NULL || alg1->algorithm == NULL) {
+        return 0;
+      }
+      hnid = OBJ_obj2nid(alg1->algorithm);
+      if (hnid == NID_undef ||
+          !OBJ_find_sigid_by_algs(&snid, hnid, EVP_PKEY_id(pkey)) ||
+          !X509_ALGOR_set0(alg2, OBJ_nid2obj(snid), V_ASN1_UNDEF, NULL)) {
+        return 0;
+      }
+      break;
     }
     case EVP_PKEY_RSA:
     case EVP_PKEY_RSA_PSS: {
-        X509_ALGOR *alg = NULL;
-        PKCS7_SIGNER_INFO_get0_algs(p7i, NULL, NULL, &alg);
-        if (alg != NULL) {
-            return X509_ALGOR_set0(alg, OBJ_nid2obj(NID_rsaEncryption),
-                                   V_ASN1_NULL, NULL);
-        }
-        break;
+      X509_ALGOR *alg = NULL;
+      PKCS7_SIGNER_INFO_get0_algs(p7i, NULL, NULL, &alg);
+      if (alg != NULL) {
+        return X509_ALGOR_set0(alg, OBJ_nid2obj(NID_rsaEncryption), V_ASN1_NULL,
+                               NULL);
+      }
+      break;
     }
     default:
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_SIGNING_NOT_SUPPORTED_FOR_THIS_KEY_TYPE);
-        return 0;
-    }
+      OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_SIGNING_NOT_SUPPORTED_FOR_THIS_KEY_TYPE);
+      return 0;
+  }
 
-    return 1;
+  return 1;
 }
 
 int PKCS7_RECIP_INFO_set(PKCS7_RECIP_INFO *p7i, X509 *x509) {
-    if (!p7i || !x509) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
-    if (!ASN1_INTEGER_set(p7i->version, 0)) {
-        return 0;
-    } else if (!X509_NAME_set(&p7i->issuer_and_serial->issuer,
-                       X509_get_issuer_name(x509))) {
-        return 0;
-    }
+  if (!p7i || !x509) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  }
+  if (!ASN1_INTEGER_set(p7i->version, 0)) {
+    return 0;
+  } else if (!X509_NAME_set(&p7i->issuer_and_serial->issuer,
+                            X509_get_issuer_name(x509))) {
+    return 0;
+  }
 
-    ASN1_INTEGER_free(p7i->issuer_and_serial->serial);
-    if (!(p7i->issuer_and_serial->serial =
-          ASN1_INTEGER_dup(X509_get0_serialNumber(x509)))) {
-        return 0;
+  ASN1_INTEGER_free(p7i->issuer_and_serial->serial);
+  if (!(p7i->issuer_and_serial->serial =
+            ASN1_INTEGER_dup(X509_get0_serialNumber(x509)))) {
+    return 0;
+  }
+
+  EVP_PKEY *pkey = X509_get0_pubkey(x509);
+  if (pkey == NULL) {
+    return 0;
+  }
+
+  if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA_PSS) {
+    return 0;
+  } else if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA) {
+    X509_ALGOR *alg;
+    PKCS7_RECIP_INFO_get0_alg(p7i, &alg);
+    if (!X509_ALGOR_set0(alg, OBJ_nid2obj(NID_rsaEncryption), V_ASN1_NULL,
+                         NULL)) {
+      return 0;
     }
+  }
 
-    EVP_PKEY *pkey = X509_get0_pubkey(x509);
-    if (pkey == NULL) {
-        return 0;
-    }
+  // NOTE: OpenSSL does not free |p7i->cert| before setting it. we do so here
+  // to avoid potential memory leaks.
+  X509_free(p7i->cert);
+  X509_up_ref(x509);
+  p7i->cert = x509;
 
-    if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA_PSS) {
-        return 0;
-    } else if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA) {
-        X509_ALGOR *alg;
-        PKCS7_RECIP_INFO_get0_alg(p7i, &alg);
-        if (!X509_ALGOR_set0(alg, OBJ_nid2obj(NID_rsaEncryption),
-                                   V_ASN1_NULL, NULL)) {
-            return 0;
-        }
-    }
-
-    // NOTE: OpenSSL does not free |p7i->cert| before setting it. we do so here
-    // to avoid potential memory leaks.
-    X509_free(p7i->cert);
-    X509_up_ref(x509);
-    p7i->cert = x509;
-
-    return 1;
+  return 1;
 }
 
 void PKCS7_SIGNER_INFO_get0_algs(PKCS7_SIGNER_INFO *si, EVP_PKEY **pk,
-                                 X509_ALGOR **pdig, X509_ALGOR **psig)
-{
-    if (!si) {
-        return;
-    }
-    if (pk) {
-        *pk = si->pkey;
-    }
-    if (pdig) {
-        *pdig = si->digest_alg;
-    }
-    if (psig) {
-        *psig = si->digest_enc_alg;
-    }
+                                 X509_ALGOR **pdig, X509_ALGOR **psig) {
+  if (!si) {
+    return;
+  }
+  if (pk) {
+    *pk = si->pkey;
+  }
+  if (pdig) {
+    *pdig = si->digest_alg;
+  }
+  if (psig) {
+    *psig = si->digest_enc_alg;
+  }
 }
 
-void PKCS7_RECIP_INFO_get0_alg(PKCS7_RECIP_INFO *ri, X509_ALGOR **penc)
-{
-    if (!ri) {
-        return;
-    }
-    if (penc) {
-        *penc = ri->key_enc_algor;
-    }
+void PKCS7_RECIP_INFO_get0_alg(PKCS7_RECIP_INFO *ri, X509_ALGOR **penc) {
+  if (!ri) {
+    return;
+  }
+  if (penc) {
+    *penc = ri->key_enc_algor;
+  }
 }

--- a/crypto/pkcs7/pkcs7.c
+++ b/crypto/pkcs7/pkcs7.c
@@ -409,7 +409,7 @@ int PKCS7_add_signer(PKCS7 *p7, PKCS7_SIGNER_INFO *p7i) {
 
 
   obj = p7i->digest_alg->algorithm;
-  /* If the digest is not currently listed, add it */
+  // If the digest is not currently listed, add it
   int alg_found = 0;
   for (size_t i = 0; i < sk_X509_ALGOR_num(md_sk); i++) {
     alg = sk_X509_ALGOR_value(md_sk, i);
@@ -425,10 +425,8 @@ int PKCS7_add_signer(PKCS7 *p7, PKCS7_SIGNER_INFO *p7i) {
       OPENSSL_PUT_ERROR(PKCS7, ERR_R_ASN1_LIB);
       return 0;
     }
-    /*
-     * If there is a constant copy of the ASN1 OBJECT in libcrypto, then
-     * use that.  Otherwise, use a dynamically duplicated copy
-     */
+    // If there is a constant copy of the ASN1 OBJECT in libcrypto, then
+    // use that.  Otherwise, use a dynamically duplicated copy.
     int nid = OBJ_obj2nid(obj);
     if (nid != NID_undef) {
       alg->algorithm = OBJ_nid2obj(nid);
@@ -481,7 +479,6 @@ STACK_OF(PKCS7_SIGNER_INFO) *PKCS7_get_signer_info(PKCS7 *p7) {
 
 int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
                           const EVP_MD *dgst) {
-  /* We now need to add another PKCS7_SIGNER_INFO entry */
   if (!p7i || !x509 || !pkey || !dgst) {
     OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
     return 0;
@@ -492,10 +489,6 @@ int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
     return 0;
   }
 
-  /*
-   * because ASN1_INTEGER_set is used to set a 'long' we will do things the
-   * ugly way.
-   */
   ASN1_INTEGER_free(p7i->issuer_and_serial->serial);
   if (!(p7i->issuer_and_serial->serial =
             ASN1_INTEGER_dup(X509_get0_serialNumber(x509)))) {
@@ -507,8 +500,6 @@ int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
   EVP_PKEY_free(p7i->pkey);
   EVP_PKEY_up_ref(pkey);
   p7i->pkey = pkey;
-
-  /* Set the algorithms */
 
   if (!X509_ALGOR_set0(p7i->digest_alg, OBJ_nid2obj(EVP_MD_type(dgst)),
                        V_ASN1_NULL, NULL)) {

--- a/crypto/pkcs7/pkcs7_asn1.c
+++ b/crypto/pkcs7/pkcs7_asn1.c
@@ -131,11 +131,9 @@ ASN1_SEQUENCE_cb(PKCS7_SIGNER_INFO, signer_info_cb) = {
     ASN1_SIMPLE(PKCS7_SIGNER_INFO, version, ASN1_INTEGER),
     ASN1_SIMPLE(PKCS7_SIGNER_INFO, issuer_and_serial, PKCS7_ISSUER_AND_SERIAL),
     ASN1_SIMPLE(PKCS7_SIGNER_INFO, digest_alg, X509_ALGOR),
-    /* NB this should be a SET OF but we use a SEQUENCE OF so the
-     * original order * is retained when the structure is reencoded.
-     * Since the attributes are implicitly tagged this will not affect
-     * the encoding.
-     */
+    // NB this should be a SET OF but we use a SEQUENCE OF so the original
+    // order is retained when the structure is reencoded. Since the attributes
+    // are implicitly tagged this will not affect the encoding.
     ASN1_IMP_SEQUENCE_OF_OPT(PKCS7_SIGNER_INFO, auth_attr, X509_ATTRIBUTE, 0),
     ASN1_SIMPLE(PKCS7_SIGNER_INFO, digest_enc_alg, X509_ALGOR),
     ASN1_SIMPLE(PKCS7_SIGNER_INFO, enc_digest, ASN1_OCTET_STRING),

--- a/crypto/pkcs7/pkcs7_asn1.c
+++ b/crypto/pkcs7/pkcs7_asn1.c
@@ -6,25 +6,29 @@
 #include <openssl/asn1t.h>
 #include <openssl/pem.h>
 
-#include "internal.h"
-#include "../internal.h"
 #include "../bytestring/internal.h"
+#include "../internal.h"
+#include "internal.h"
 
 ASN1_ADB_TEMPLATE(p7default) = ASN1_EXP_OPT(PKCS7, d.other, ASN1_ANY, 0);
 
 ASN1_ADB(PKCS7) = {
-        ADB_ENTRY(NID_pkcs7_data, ASN1_EXP_OPT(PKCS7, d.data, ASN1_OCTET_STRING, 0)),
-        ADB_ENTRY(NID_pkcs7_signed, ASN1_EXP_OPT(PKCS7, d.sign, PKCS7_SIGNED, 0)),
-        ADB_ENTRY(NID_pkcs7_enveloped, ASN1_EXP_OPT(PKCS7, d.enveloped, PKCS7_ENVELOPE, 0)),
-        ADB_ENTRY(NID_pkcs7_signedAndEnveloped, ASN1_EXP_OPT(PKCS7, d.signed_and_enveloped, PKCS7_SIGN_ENVELOPE, 0)),
-        ADB_ENTRY(NID_pkcs7_digest, ASN1_EXP_OPT(PKCS7, d.digest, PKCS7_DIGEST, 0)),
-        ADB_ENTRY(NID_pkcs7_encrypted, ASN1_EXP_OPT(PKCS7, d.encrypted, PKCS7_ENCRYPT, 0))
-} ASN1_ADB_END(PKCS7, 0, type, 0, &p7default_tt, NULL);
+    ADB_ENTRY(NID_pkcs7_data,
+              ASN1_EXP_OPT(PKCS7, d.data, ASN1_OCTET_STRING, 0)),
+    ADB_ENTRY(NID_pkcs7_signed, ASN1_EXP_OPT(PKCS7, d.sign, PKCS7_SIGNED, 0)),
+    ADB_ENTRY(NID_pkcs7_enveloped,
+              ASN1_EXP_OPT(PKCS7, d.enveloped, PKCS7_ENVELOPE, 0)),
+    ADB_ENTRY(NID_pkcs7_signedAndEnveloped,
+              ASN1_EXP_OPT(PKCS7, d.signed_and_enveloped, PKCS7_SIGN_ENVELOPE,
+                           0)),
+    ADB_ENTRY(NID_pkcs7_digest, ASN1_EXP_OPT(PKCS7, d.digest, PKCS7_DIGEST, 0)),
+    ADB_ENTRY(
+        NID_pkcs7_encrypted,
+        ASN1_EXP_OPT(PKCS7, d.encrypted, PKCS7_ENCRYPT,
+                     0))} ASN1_ADB_END(PKCS7, 0, type, 0, &p7default_tt, NULL);
 
-ASN1_SEQUENCE(PKCS7) = {
-    ASN1_SIMPLE(PKCS7, type, ASN1_OBJECT),
-    ASN1_ADB_OBJECT(PKCS7)
-} ASN1_SEQUENCE_END(PKCS7)
+ASN1_SEQUENCE(PKCS7) = {ASN1_SIMPLE(PKCS7, type, ASN1_OBJECT),
+                        ASN1_ADB_OBJECT(PKCS7)} ASN1_SEQUENCE_END(PKCS7)
 
 IMPLEMENT_ASN1_ALLOC_FUNCTIONS(PKCS7)
 
@@ -41,26 +45,23 @@ PKCS7 *d2i_PKCS7(PKCS7 **a, const unsigned char **in, long len) {
   // |CBS_asn1_ber_to_der| will allocate memory and point |der_bytes| to it.
   // we're responsible for freeing this below.
   if (!CBS_asn1_ber_to_der(&cbs, &cbs_der, &der_bytes)) {
-      goto err;
+    goto err;
   }
 
   // |CBS_asn1_ber_to_der| will set |der_bytes| to NULL if it doesn't detect
   // any convertible BER elements in |in|.
   if (der_bytes == NULL) {
-    ret = (PKCS7 *) ASN1_item_d2i(
-        (ASN1_VALUE **) a, in, len,
-        ASN1_ITEM_rptr(PKCS7)
-    );
+    ret = (PKCS7 *)ASN1_item_d2i((ASN1_VALUE **)a, in, len,
+                                 ASN1_ITEM_rptr(PKCS7));
   } else {
     // |ASN1_item_d2i| will increment the input pointer by |der_len| length, so
     // save off another pointer so we can free |der_bytes| at the end of this
     // function.
     uint8_t *der_bytes_ptr = der_bytes;
     size_t der_len = CBS_len(&cbs_der);
-    ret = (PKCS7 *) ASN1_item_d2i(
-        (ASN1_VALUE **) a, (const uint8_t**) &der_bytes_ptr,
-        der_len, ASN1_ITEM_rptr(PKCS7)
-    );
+    ret = (PKCS7 *)ASN1_item_d2i((ASN1_VALUE **)a,
+                                 (const uint8_t **)&der_bytes_ptr, der_len,
+                                 ASN1_ITEM_rptr(PKCS7));
     // Advance |*in| by however many bytes |ASN1_item_d2i| advanced
     // |der_bytes_ptr|
     *in += der_bytes_ptr - der_bytes;
@@ -73,117 +74,117 @@ err:
 }
 
 int i2d_PKCS7(PKCS7 *a, unsigned char **out) {
-    return ASN1_item_i2d((ASN1_VALUE *)a, out, ASN1_ITEM_rptr(PKCS7));
+  return ASN1_item_i2d((ASN1_VALUE *)a, out, ASN1_ITEM_rptr(PKCS7));
 }
 
 IMPLEMENT_ASN1_DUP_FUNCTION(PKCS7)
 
 ASN1_SEQUENCE(PKCS7_SIGNED) = {
-        ASN1_SIMPLE(PKCS7_SIGNED, version, ASN1_INTEGER),
-        ASN1_SET_OF(PKCS7_SIGNED, md_algs, X509_ALGOR),
-        ASN1_SIMPLE(PKCS7_SIGNED, contents, PKCS7),
-        ASN1_IMP_SEQUENCE_OF_OPT(PKCS7_SIGNED, cert, X509, 0),
-        ASN1_IMP_SET_OF_OPT(PKCS7_SIGNED, crl, X509_CRL, 1),
-        ASN1_SET_OF(PKCS7_SIGNED, signer_info, PKCS7_SIGNER_INFO)
-} ASN1_SEQUENCE_END(PKCS7_SIGNED)
+    ASN1_SIMPLE(PKCS7_SIGNED, version, ASN1_INTEGER),
+    ASN1_SET_OF(PKCS7_SIGNED, md_algs, X509_ALGOR),
+    ASN1_SIMPLE(PKCS7_SIGNED, contents, PKCS7),
+    ASN1_IMP_SEQUENCE_OF_OPT(PKCS7_SIGNED, cert, X509, 0),
+    ASN1_IMP_SET_OF_OPT(PKCS7_SIGNED, crl, X509_CRL, 1),
+    ASN1_SET_OF(PKCS7_SIGNED, signer_info,
+                PKCS7_SIGNER_INFO)} ASN1_SEQUENCE_END(PKCS7_SIGNED)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_SIGNED)
 
 ASN1_SEQUENCE(PKCS7_ISSUER_AND_SERIAL) = {
-        ASN1_SIMPLE(PKCS7_ISSUER_AND_SERIAL, issuer, X509_NAME),
-        ASN1_SIMPLE(PKCS7_ISSUER_AND_SERIAL, serial, ASN1_INTEGER)
-} ASN1_SEQUENCE_END(PKCS7_ISSUER_AND_SERIAL)
+    ASN1_SIMPLE(PKCS7_ISSUER_AND_SERIAL, issuer, X509_NAME),
+    ASN1_SIMPLE(PKCS7_ISSUER_AND_SERIAL, serial,
+                ASN1_INTEGER)} ASN1_SEQUENCE_END(PKCS7_ISSUER_AND_SERIAL)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_ISSUER_AND_SERIAL)
 
 // Minor tweak to operation: free up X509.
 static int recip_info_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                 void *exarg)
-{
-    if (operation == ASN1_OP_FREE_POST) {
-        PKCS7_RECIP_INFO *ri = (PKCS7_RECIP_INFO *)*pval;
-        X509_free(ri->cert);
-    }
-    return 1;
+                         void *exarg) {
+  if (operation == ASN1_OP_FREE_POST) {
+    PKCS7_RECIP_INFO *ri = (PKCS7_RECIP_INFO *)*pval;
+    X509_free(ri->cert);
+  }
+  return 1;
 }
 
-ASN1_SEQUENCE_cb(PKCS7_RECIP_INFO, recip_info_cb) = {
-        ASN1_SIMPLE(PKCS7_RECIP_INFO, version, ASN1_INTEGER),
-        ASN1_SIMPLE(PKCS7_RECIP_INFO, issuer_and_serial, PKCS7_ISSUER_AND_SERIAL),
-        ASN1_SIMPLE(PKCS7_RECIP_INFO, key_enc_algor, X509_ALGOR),
-        ASN1_SIMPLE(PKCS7_RECIP_INFO, enc_key, ASN1_OCTET_STRING)
-} ASN1_SEQUENCE_END_cb(PKCS7_RECIP_INFO, PKCS7_RECIP_INFO)
+ASN1_SEQUENCE_cb(PKCS7_RECIP_INFO, recip_info_cb) =
+    {ASN1_SIMPLE(PKCS7_RECIP_INFO, version, ASN1_INTEGER),
+     ASN1_SIMPLE(PKCS7_RECIP_INFO, issuer_and_serial, PKCS7_ISSUER_AND_SERIAL),
+     ASN1_SIMPLE(PKCS7_RECIP_INFO, key_enc_algor, X509_ALGOR),
+     ASN1_SIMPLE(PKCS7_RECIP_INFO, enc_key,
+                 ASN1_OCTET_STRING)} ASN1_SEQUENCE_END_cb(PKCS7_RECIP_INFO,
+                                                          PKCS7_RECIP_INFO)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_RECIP_INFO)
 
 // Minor tweak to operation: free up EVP_PKEY.
 static int signer_info_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                 void *exarg)
-{
-    PKCS7_SIGNER_INFO *si = (PKCS7_SIGNER_INFO *)*pval;
-    if (operation == ASN1_OP_FREE_POST) {
-        EVP_PKEY_free(si->pkey);
-    }
-    return 1;
+                          void *exarg) {
+  PKCS7_SIGNER_INFO *si = (PKCS7_SIGNER_INFO *)*pval;
+  if (operation == ASN1_OP_FREE_POST) {
+    EVP_PKEY_free(si->pkey);
+  }
+  return 1;
 }
 
 ASN1_SEQUENCE_cb(PKCS7_SIGNER_INFO, signer_info_cb) = {
-        ASN1_SIMPLE(PKCS7_SIGNER_INFO, version, ASN1_INTEGER),
-        ASN1_SIMPLE(PKCS7_SIGNER_INFO, issuer_and_serial, PKCS7_ISSUER_AND_SERIAL),
-        ASN1_SIMPLE(PKCS7_SIGNER_INFO, digest_alg, X509_ALGOR),
-        /* NB this should be a SET OF but we use a SEQUENCE OF so the
-         * original order * is retained when the structure is reencoded.
-         * Since the attributes are implicitly tagged this will not affect
-         * the encoding.
-         */
-        ASN1_IMP_SEQUENCE_OF_OPT(PKCS7_SIGNER_INFO, auth_attr, X509_ATTRIBUTE, 0),
-        ASN1_SIMPLE(PKCS7_SIGNER_INFO, digest_enc_alg, X509_ALGOR),
-        ASN1_SIMPLE(PKCS7_SIGNER_INFO, enc_digest, ASN1_OCTET_STRING),
-        ASN1_IMP_SET_OF_OPT(PKCS7_SIGNER_INFO, unauth_attr, X509_ATTRIBUTE, 1)
-} ASN1_SEQUENCE_END_cb(PKCS7_SIGNER_INFO, PKCS7_SIGNER_INFO)
+    ASN1_SIMPLE(PKCS7_SIGNER_INFO, version, ASN1_INTEGER),
+    ASN1_SIMPLE(PKCS7_SIGNER_INFO, issuer_and_serial, PKCS7_ISSUER_AND_SERIAL),
+    ASN1_SIMPLE(PKCS7_SIGNER_INFO, digest_alg, X509_ALGOR),
+    /* NB this should be a SET OF but we use a SEQUENCE OF so the
+     * original order * is retained when the structure is reencoded.
+     * Since the attributes are implicitly tagged this will not affect
+     * the encoding.
+     */
+    ASN1_IMP_SEQUENCE_OF_OPT(PKCS7_SIGNER_INFO, auth_attr, X509_ATTRIBUTE, 0),
+    ASN1_SIMPLE(PKCS7_SIGNER_INFO, digest_enc_alg, X509_ALGOR),
+    ASN1_SIMPLE(PKCS7_SIGNER_INFO, enc_digest, ASN1_OCTET_STRING),
+    ASN1_IMP_SET_OF_OPT(
+        PKCS7_SIGNER_INFO, unauth_attr, X509_ATTRIBUTE,
+        1)} ASN1_SEQUENCE_END_cb(PKCS7_SIGNER_INFO, PKCS7_SIGNER_INFO)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_SIGNER_INFO)
 
 ASN1_SEQUENCE(PKCS7_ENC_CONTENT) = {
-        ASN1_SIMPLE(PKCS7_ENC_CONTENT, content_type, ASN1_OBJECT),
-        ASN1_SIMPLE(PKCS7_ENC_CONTENT, algorithm, X509_ALGOR),
-        ASN1_IMP_OPT(PKCS7_ENC_CONTENT, enc_data, ASN1_OCTET_STRING, 0)
-} ASN1_SEQUENCE_END(PKCS7_ENC_CONTENT)
+    ASN1_SIMPLE(PKCS7_ENC_CONTENT, content_type, ASN1_OBJECT),
+    ASN1_SIMPLE(PKCS7_ENC_CONTENT, algorithm, X509_ALGOR),
+    ASN1_IMP_OPT(PKCS7_ENC_CONTENT, enc_data, ASN1_OCTET_STRING,
+                 0)} ASN1_SEQUENCE_END(PKCS7_ENC_CONTENT)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_ENC_CONTENT)
 
 ASN1_SEQUENCE(PKCS7_SIGN_ENVELOPE) = {
-        ASN1_SIMPLE(PKCS7_SIGN_ENVELOPE, version, ASN1_INTEGER),
-        ASN1_SET_OF(PKCS7_SIGN_ENVELOPE, recipientinfo, PKCS7_RECIP_INFO),
-        ASN1_SET_OF(PKCS7_SIGN_ENVELOPE, md_algs, X509_ALGOR),
-        ASN1_SIMPLE(PKCS7_SIGN_ENVELOPE, enc_data, PKCS7_ENC_CONTENT),
-        ASN1_IMP_SET_OF_OPT(PKCS7_SIGN_ENVELOPE, cert, X509, 0),
-        ASN1_IMP_SET_OF_OPT(PKCS7_SIGN_ENVELOPE, crl, X509_CRL, 1),
-        ASN1_SET_OF(PKCS7_SIGN_ENVELOPE, signer_info, PKCS7_SIGNER_INFO)
-} ASN1_SEQUENCE_END(PKCS7_SIGN_ENVELOPE)
+    ASN1_SIMPLE(PKCS7_SIGN_ENVELOPE, version, ASN1_INTEGER),
+    ASN1_SET_OF(PKCS7_SIGN_ENVELOPE, recipientinfo, PKCS7_RECIP_INFO),
+    ASN1_SET_OF(PKCS7_SIGN_ENVELOPE, md_algs, X509_ALGOR),
+    ASN1_SIMPLE(PKCS7_SIGN_ENVELOPE, enc_data, PKCS7_ENC_CONTENT),
+    ASN1_IMP_SET_OF_OPT(PKCS7_SIGN_ENVELOPE, cert, X509, 0),
+    ASN1_IMP_SET_OF_OPT(PKCS7_SIGN_ENVELOPE, crl, X509_CRL, 1),
+    ASN1_SET_OF(PKCS7_SIGN_ENVELOPE, signer_info,
+                PKCS7_SIGNER_INFO)} ASN1_SEQUENCE_END(PKCS7_SIGN_ENVELOPE)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_SIGN_ENVELOPE)
 
 ASN1_SEQUENCE(PKCS7_ENCRYPT) = {
-        ASN1_SIMPLE(PKCS7_ENCRYPT, version, ASN1_INTEGER),
-        ASN1_SIMPLE(PKCS7_ENCRYPT, enc_data, PKCS7_ENC_CONTENT)
-} ASN1_SEQUENCE_END(PKCS7_ENCRYPT)
+    ASN1_SIMPLE(PKCS7_ENCRYPT, version, ASN1_INTEGER),
+    ASN1_SIMPLE(PKCS7_ENCRYPT, enc_data,
+                PKCS7_ENC_CONTENT)} ASN1_SEQUENCE_END(PKCS7_ENCRYPT)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_ENCRYPT)
 
 ASN1_SEQUENCE(PKCS7_DIGEST) = {
-        ASN1_SIMPLE(PKCS7_DIGEST, version, ASN1_INTEGER),
-        ASN1_SIMPLE(PKCS7_DIGEST, md, X509_ALGOR),
-        ASN1_SIMPLE(PKCS7_DIGEST, contents, PKCS7),
-        ASN1_SIMPLE(PKCS7_DIGEST, digest, ASN1_OCTET_STRING)
-} ASN1_SEQUENCE_END(PKCS7_DIGEST)
+    ASN1_SIMPLE(PKCS7_DIGEST, version, ASN1_INTEGER),
+    ASN1_SIMPLE(PKCS7_DIGEST, md, X509_ALGOR),
+    ASN1_SIMPLE(PKCS7_DIGEST, contents, PKCS7),
+    ASN1_SIMPLE(PKCS7_DIGEST, digest,
+                ASN1_OCTET_STRING)} ASN1_SEQUENCE_END(PKCS7_DIGEST)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_DIGEST)
 
 ASN1_SEQUENCE(PKCS7_ENVELOPE) = {
-        ASN1_SIMPLE(PKCS7_ENVELOPE, version, ASN1_INTEGER),
-        ASN1_SET_OF(PKCS7_ENVELOPE, recipientinfo, PKCS7_RECIP_INFO),
-        ASN1_SIMPLE(PKCS7_ENVELOPE, enc_data, PKCS7_ENC_CONTENT)
-} ASN1_SEQUENCE_END(PKCS7_ENVELOPE)
+    ASN1_SIMPLE(PKCS7_ENVELOPE, version, ASN1_INTEGER),
+    ASN1_SET_OF(PKCS7_ENVELOPE, recipientinfo, PKCS7_RECIP_INFO),
+    ASN1_SIMPLE(PKCS7_ENVELOPE, enc_data,
+                PKCS7_ENC_CONTENT)} ASN1_SEQUENCE_END(PKCS7_ENVELOPE)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_ENVELOPE)

--- a/crypto/pkcs7/pkcs7_test.cc
+++ b/crypto/pkcs7/pkcs7_test.cc
@@ -524,8 +524,8 @@ static const char kPEMCert[] =
     "0T8rIMUNwC4Beh4JVjEA\n"
     "-----END PKCS7-----\n";
 
-/* kPEMCRL is the result of downloading the Equifax CRL and running:
-     openssl crl2pkcs7 -inform DER -in secureca.crl  */
+// kPEMCRL is the result of downloading the Equifax CRL and running:
+//   openssl crl2pkcs7 -inform DER -in secureca.crl  */
 static const char kPEMCRL[] =
     "-----BEGIN PKCS7-----\n"
     "MIIDhQYJKoZIhvcNAQcCoIIDdjCCA3ICAQExADALBgkqhkiG9w0BBwGgAKGCA1gw\n"

--- a/crypto/pkcs7/pkcs7_test.cc
+++ b/crypto/pkcs7/pkcs7_test.cc
@@ -339,7 +339,7 @@ static const uint8_t kPKCS7Windows[] = {
 
 // kPKCS7SignedWithSignerInfo has content SignedData, but unlike other test
 // objects, it contains SignerInfos as well.
-static const uint8_t kPKCS7SignedWithSignerInfo[] {
+static const uint8_t kPKCS7SignedWithSignerInfo[]{
     0x30, 0x82, 0x03, 0x54, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d,
     0x01, 0x07, 0x02, 0xa0, 0x82, 0x03, 0x45, 0x30, 0x82, 0x03, 0x41, 0x02,
     0x01, 0x01, 0x31, 0x0f, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01,
@@ -608,7 +608,8 @@ static void TestCertReparse(const uint8_t *der_bytes, size_t der_len) {
   }
   bssl::UniquePtr<PKCS7> pkcs7_dup(PKCS7_dup(pkcs7_obj.get()));
   ASSERT_TRUE(pkcs7_dup);
-  EXPECT_EQ(OBJ_obj2nid(pkcs7_obj.get()->type), OBJ_obj2nid(pkcs7_dup.get()->type));
+  EXPECT_EQ(OBJ_obj2nid(pkcs7_obj.get()->type),
+            OBJ_obj2nid(pkcs7_dup.get()->type));
 
   ASSERT_TRUE(PKCS7_type_is_signed(pkcs7_obj.get()));
   const STACK_OF(X509) *certs3 = pkcs7_obj->d.sign->cert;
@@ -626,10 +627,8 @@ static void TestCertReparse(const uint8_t *der_bytes, size_t der_len) {
   ASSERT_GT(result3_len, 0);
   bssl::UniquePtr<uint8_t> free_result3_data(result3_data);
   if (is_ber) {
-    EXPECT_EQ(
-        Bytes(der_conv, CBS_len(&der_conv_out)),
-        Bytes(result3_data, result3_len)
-    );
+    EXPECT_EQ(Bytes(der_conv, CBS_len(&der_conv_out)),
+              Bytes(result3_data, result3_len));
   } else {
     EXPECT_EQ(Bytes(der_bytes, der_len), Bytes(result3_data, result3_len));
   }
@@ -755,20 +754,17 @@ TEST(PKCS7Test, CertReparseWindows) {
 }
 
 TEST(PKCS7Test, CertSignedWithSignerInfos) {
-  TestCertReparse(kPKCS7SignedWithSignerInfo, sizeof(kPKCS7SignedWithSignerInfo));
+  TestCertReparse(kPKCS7SignedWithSignerInfo,
+                  sizeof(kPKCS7SignedWithSignerInfo));
 }
 
 TEST(PKCS7Test, CrlReparse) {
   TestCRLReparse(kOpenSSLCRL, sizeof(kOpenSSLCRL));
 }
 
-TEST(PKCS7Test, PEMCerts) {
-  TestPEMCerts(kPEMCert);
-}
+TEST(PKCS7Test, PEMCerts) { TestPEMCerts(kPEMCert); }
 
-TEST(PKCS7Test, PEMCRLs) {
-  TestPEMCRLs(kPEMCRL);
-}
+TEST(PKCS7Test, PEMCRLs) { TestPEMCRLs(kPEMCRL); }
 
 // Test that we output certificates in the canonical DER order.
 TEST(PKCS7Test, SortCerts) {
@@ -1114,247 +1110,252 @@ hJTbHtjEDJ7BHLC/CNUhXbpyyu1y
             Bytes(kExpectedOutput, sizeof(kExpectedOutput)));
 
   // Other option combinations should fail.
-  EXPECT_FALSE(
-      PKCS7_sign(cert.get(), key.get(), /*certs=*/nullptr, data_bio.get(),
-                 PKCS7_NOATTR | PKCS7_BINARY | PKCS7_NOCERTS));
-  EXPECT_FALSE(
-      PKCS7_sign(cert.get(), key.get(), /*certs=*/nullptr, data_bio.get(),
-                 PKCS7_BINARY | PKCS7_NOCERTS | PKCS7_DETACHED));
+  EXPECT_FALSE(PKCS7_sign(cert.get(), key.get(), /*certs=*/nullptr,
+                          data_bio.get(),
+                          PKCS7_NOATTR | PKCS7_BINARY | PKCS7_NOCERTS));
+  EXPECT_FALSE(PKCS7_sign(cert.get(), key.get(), /*certs=*/nullptr,
+                          data_bio.get(),
+                          PKCS7_BINARY | PKCS7_NOCERTS | PKCS7_DETACHED));
   EXPECT_FALSE(
       PKCS7_sign(cert.get(), key.get(), /*certs=*/nullptr, data_bio.get(),
                  PKCS7_NOATTR | PKCS7_TEXT | PKCS7_NOCERTS | PKCS7_DETACHED));
-  EXPECT_FALSE(
-      PKCS7_sign(cert.get(), key.get(), /*certs=*/nullptr, data_bio.get(),
-                 PKCS7_NOATTR | PKCS7_BINARY | PKCS7_DETACHED));
+  EXPECT_FALSE(PKCS7_sign(cert.get(), key.get(), /*certs=*/nullptr,
+                          data_bio.get(),
+                          PKCS7_NOATTR | PKCS7_BINARY | PKCS7_DETACHED));
 
   ERR_clear_error();
 }
 
 TEST(PKCS7Test, GettersSetters) {
-    bssl::UniquePtr<PKCS7> p7;
+  bssl::UniquePtr<PKCS7> p7;
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    EXPECT_FALSE(PKCS7_set_type(p7.get(), NID_undef));
-    EXPECT_FALSE(PKCS7_content_new(p7.get(), NID_undef));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  EXPECT_FALSE(PKCS7_set_type(p7.get(), NID_undef));
+  EXPECT_FALSE(PKCS7_content_new(p7.get(), NID_undef));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
-    // set type redundantly to ensure we're properly freeing up existing
-    // resources on subsequent set.
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
-    EXPECT_TRUE(PKCS7_type_is_signed(p7.get()));
-    EXPECT_TRUE(PKCS7_content_new(p7.get(), NID_pkcs7_signed));
-    EXPECT_FALSE(PKCS7_set_cipher(p7.get(), EVP_aes_128_gcm()));
-    EXPECT_FALSE(PKCS7_add_recipient_info(p7.get(), nullptr));
-    EXPECT_FALSE(PKCS7_get_signer_info(nullptr));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
+  // set type redundantly to ensure we're properly freeing up existing
+  // resources on subsequent set.
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
+  EXPECT_TRUE(PKCS7_type_is_signed(p7.get()));
+  EXPECT_TRUE(PKCS7_content_new(p7.get(), NID_pkcs7_signed));
+  EXPECT_FALSE(PKCS7_set_cipher(p7.get(), EVP_aes_128_gcm()));
+  EXPECT_FALSE(PKCS7_add_recipient_info(p7.get(), nullptr));
+  EXPECT_FALSE(PKCS7_get_signer_info(nullptr));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_digest));
-    // set type redundantly to ensure we're properly freeing up existing
-    // resources on subsequent set.
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_digest));
-    EXPECT_TRUE(PKCS7_type_is_digest(p7.get()));
-    EXPECT_TRUE(PKCS7_content_new(p7.get(), NID_pkcs7_digest));
-    EXPECT_FALSE(PKCS7_add_certificate(p7.get(), nullptr));
-    EXPECT_FALSE(PKCS7_add_crl(p7.get(), nullptr));
-    EXPECT_FALSE(PKCS7_add_signer(p7.get(), nullptr));
-    EXPECT_FALSE(PKCS7_get_signer_info(p7.get()));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_digest));
+  // set type redundantly to ensure we're properly freeing up existing
+  // resources on subsequent set.
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_digest));
+  EXPECT_TRUE(PKCS7_type_is_digest(p7.get()));
+  EXPECT_TRUE(PKCS7_content_new(p7.get(), NID_pkcs7_digest));
+  EXPECT_FALSE(PKCS7_add_certificate(p7.get(), nullptr));
+  EXPECT_FALSE(PKCS7_add_crl(p7.get(), nullptr));
+  EXPECT_FALSE(PKCS7_add_signer(p7.get(), nullptr));
+  EXPECT_FALSE(PKCS7_get_signer_info(p7.get()));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7.get());
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_data));
-    // set type redundantly to ensure we're properly freeing up existing
-    // resources on subsequent set.
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_data));
-    EXPECT_TRUE(PKCS7_type_is_data(p7.get()));
-    EXPECT_FALSE(PKCS7_set_content(p7.get(), p7.get()));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7.get());
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_data));
+  // set type redundantly to ensure we're properly freeing up existing
+  // resources on subsequent set.
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_data));
+  EXPECT_TRUE(PKCS7_type_is_data(p7.get()));
+  EXPECT_FALSE(PKCS7_set_content(p7.get(), p7.get()));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7.get());
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
-    // set type redundantly to ensure we're properly freeing up existing
-    // resources on subsequent set.
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
-    EXPECT_TRUE(PKCS7_type_is_signedAndEnveloped(p7.get()));
-    EXPECT_TRUE(PKCS7_set_cipher(p7.get(), EVP_aes_128_gcm()));
-    EXPECT_FALSE(PKCS7_set_content(p7.get(), p7.get()));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7.get());
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
+  // set type redundantly to ensure we're properly freeing up existing
+  // resources on subsequent set.
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
+  EXPECT_TRUE(PKCS7_type_is_signedAndEnveloped(p7.get()));
+  EXPECT_TRUE(PKCS7_set_cipher(p7.get(), EVP_aes_128_gcm()));
+  EXPECT_FALSE(PKCS7_set_content(p7.get(), p7.get()));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7.get());
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_enveloped));
-    // set type redundantly to ensure we're properly freeing up existing
-    // resources on subsequent set.
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_enveloped));
-    EXPECT_TRUE(PKCS7_type_is_enveloped(p7.get()));
-    EXPECT_TRUE(PKCS7_set_cipher(p7.get(), EVP_aes_128_gcm()));
-    EXPECT_FALSE(PKCS7_set_content(p7.get(), p7.get()));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7.get());
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_enveloped));
+  // set type redundantly to ensure we're properly freeing up existing
+  // resources on subsequent set.
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_enveloped));
+  EXPECT_TRUE(PKCS7_type_is_enveloped(p7.get()));
+  EXPECT_TRUE(PKCS7_set_cipher(p7.get(), EVP_aes_128_gcm()));
+  EXPECT_FALSE(PKCS7_set_content(p7.get(), p7.get()));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7.get());
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_encrypted));
-    // set type redundantly to ensure we're properly freeing up existing
-    // resources on subsequent set.
-    EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_encrypted));
-    EXPECT_TRUE(PKCS7_type_is_encrypted(p7.get()));
-    EXPECT_FALSE(PKCS7_set_content(p7.get(), p7.get()));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7.get());
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_encrypted));
+  // set type redundantly to ensure we're properly freeing up existing
+  // resources on subsequent set.
+  EXPECT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_encrypted));
+  EXPECT_TRUE(PKCS7_type_is_encrypted(p7.get()));
+  EXPECT_FALSE(PKCS7_set_content(p7.get(), p7.get()));
 
-    // |d2i_*| functions advance the input reference by number of bytes parsed,
-    // so save off a local reference and reset it for each test case.
-    const uint8_t *p7_der = kPKCS7SignedWithSignerInfo;
-    const size_t p7_der_len = sizeof(kPKCS7SignedWithSignerInfo);
-    p7.reset(d2i_PKCS7(nullptr, &p7_der, p7_der_len));
-    ASSERT_TRUE(p7);
-    ASSERT_TRUE(PKCS7_type_is_signed(p7.get()));
-    STACK_OF(PKCS7_SIGNER_INFO) *sk_p7si_signed = PKCS7_get_signer_info(p7.get());
-    ASSERT_TRUE(sk_p7si_signed);
-    ASSERT_GT(sk_PKCS7_SIGNER_INFO_num(sk_p7si_signed), 0UL);
-    PKCS7_SIGNER_INFO *p7si = sk_PKCS7_SIGNER_INFO_value(sk_p7si_signed, 0);
-    ASSERT_TRUE(p7si);
-    EXPECT_FALSE(PKCS7_get_signed_attribute(p7si, NID_md5));    // hash nid not valid x509 attr
-    ASN1_TYPE *signing_time = PKCS7_get_signed_attribute(p7si, NID_pkcs9_signingTime);
-    ASSERT_TRUE(signing_time);
-    EVP_PKEY *pkey;
-    X509_ALGOR *pdig;
-    X509_ALGOR *psig;
-    PKCS7_SIGNER_INFO_get0_algs(p7si, &pkey, &pdig, &psig);
-    ASSERT_FALSE(pkey); // no attached pkey
-    ASSERT_TRUE(psig);
-    ASSERT_TRUE(pdig);
+  // |d2i_*| functions advance the input reference by number of bytes parsed,
+  // so save off a local reference and reset it for each test case.
+  const uint8_t *p7_der = kPKCS7SignedWithSignerInfo;
+  const size_t p7_der_len = sizeof(kPKCS7SignedWithSignerInfo);
+  p7.reset(d2i_PKCS7(nullptr, &p7_der, p7_der_len));
+  ASSERT_TRUE(p7);
+  ASSERT_TRUE(PKCS7_type_is_signed(p7.get()));
+  STACK_OF(PKCS7_SIGNER_INFO) *sk_p7si_signed = PKCS7_get_signer_info(p7.get());
+  ASSERT_TRUE(sk_p7si_signed);
+  ASSERT_GT(sk_PKCS7_SIGNER_INFO_num(sk_p7si_signed), 0UL);
+  PKCS7_SIGNER_INFO *p7si = sk_PKCS7_SIGNER_INFO_value(sk_p7si_signed, 0);
+  ASSERT_TRUE(p7si);
+  EXPECT_FALSE(PKCS7_get_signed_attribute(
+      p7si, NID_md5));  // hash nid not valid x509 attr
+  ASN1_TYPE *signing_time =
+      PKCS7_get_signed_attribute(p7si, NID_pkcs9_signingTime);
+  ASSERT_TRUE(signing_time);
+  EVP_PKEY *pkey;
+  X509_ALGOR *pdig;
+  X509_ALGOR *psig;
+  PKCS7_SIGNER_INFO_get0_algs(p7si, &pkey, &pdig, &psig);
+  ASSERT_FALSE(pkey);  // no attached pkey
+  ASSERT_TRUE(psig);
+  ASSERT_TRUE(pdig);
 
-    bssl::UniquePtr<PKCS7> p7_dup(PKCS7_dup(p7.get()));
-    ASSERT_TRUE(p7_dup);
-    EXPECT_TRUE(PKCS7_type_is_signed(p7_dup.get()));
+  bssl::UniquePtr<PKCS7> p7_dup(PKCS7_dup(p7.get()));
+  ASSERT_TRUE(p7_dup);
+  EXPECT_TRUE(PKCS7_type_is_signed(p7_dup.get()));
 
-    p7_der = kPKCS7SignedWithSignerInfo;
-    PKCS7 *p7_ptr = nullptr;
-    bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(p7_der, p7_der_len));
-    ASSERT_FALSE(d2i_PKCS7_bio(bio.get(), nullptr));
-    p7.reset(d2i_PKCS7_bio(bio.get(), &p7_ptr));
-    ASSERT_TRUE(p7);
-    ASSERT_TRUE(PKCS7_type_is_signed(p7.get()));
-    bio.reset(BIO_new(BIO_s_mem()));
-    ASSERT_TRUE(i2d_PKCS7_bio(bio.get(), p7.get()));
+  p7_der = kPKCS7SignedWithSignerInfo;
+  PKCS7 *p7_ptr = nullptr;
+  bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(p7_der, p7_der_len));
+  ASSERT_FALSE(d2i_PKCS7_bio(bio.get(), nullptr));
+  p7.reset(d2i_PKCS7_bio(bio.get(), &p7_ptr));
+  ASSERT_TRUE(p7);
+  ASSERT_TRUE(PKCS7_type_is_signed(p7.get()));
+  bio.reset(BIO_new(BIO_s_mem()));
+  ASSERT_TRUE(i2d_PKCS7_bio(bio.get(), p7.get()));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
-    bio.reset(BIO_new_mem_buf(kPEMCert, strlen(kPEMCert)));
-    ASSERT_TRUE(bio);
-    bssl::UniquePtr<STACK_OF(X509)> certs(sk_X509_new_null());
-    ASSERT_TRUE(certs);
-    ASSERT_TRUE(PKCS7_get_PEM_certificates(certs.get(), bio.get()));
-    ASSERT_EQ(1U, sk_X509_num(certs.get()));
-    EXPECT_TRUE(PKCS7_add_certificate(p7.get(), sk_X509_value(certs.get(), 0U)));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
+  bio.reset(BIO_new_mem_buf(kPEMCert, strlen(kPEMCert)));
+  ASSERT_TRUE(bio);
+  bssl::UniquePtr<STACK_OF(X509)> certs(sk_X509_new_null());
+  ASSERT_TRUE(certs);
+  ASSERT_TRUE(PKCS7_get_PEM_certificates(certs.get(), bio.get()));
+  ASSERT_EQ(1U, sk_X509_num(certs.get()));
+  EXPECT_TRUE(PKCS7_add_certificate(p7.get(), sk_X509_value(certs.get(), 0U)));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
-    bio.reset(BIO_new_mem_buf(kPEMCRL, strlen(kPEMCRL)));
-    ASSERT_TRUE(bio);
-    bssl::UniquePtr<STACK_OF(X509_CRL)> crls(sk_X509_CRL_new_null());
-    ASSERT_TRUE(crls);
-    ASSERT_TRUE(PKCS7_get_PEM_CRLs(crls.get(), bio.get()));
-    ASSERT_EQ(1U, sk_X509_CRL_num(crls.get()));
-    EXPECT_TRUE(PKCS7_add_crl(p7.get(), sk_X509_CRL_value(crls.get(), 0U)));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
+  bio.reset(BIO_new_mem_buf(kPEMCRL, strlen(kPEMCRL)));
+  ASSERT_TRUE(bio);
+  bssl::UniquePtr<STACK_OF(X509_CRL)> crls(sk_X509_CRL_new_null());
+  ASSERT_TRUE(crls);
+  ASSERT_TRUE(PKCS7_get_PEM_CRLs(crls.get(), bio.get()));
+  ASSERT_EQ(1U, sk_X509_CRL_num(crls.get()));
+  EXPECT_TRUE(PKCS7_add_crl(p7.get(), sk_X509_CRL_value(crls.get(), 0U)));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
-    bio.reset(BIO_new_mem_buf(kPEMCert, strlen(kPEMCert)));
-    ASSERT_TRUE(bio);
-    certs.reset(sk_X509_new_null());
-    ASSERT_TRUE(certs);
-    ASSERT_TRUE(PKCS7_get_PEM_certificates(certs.get(), bio.get()));
-    ASSERT_EQ(1U, sk_X509_num(certs.get()));
-    EXPECT_TRUE(PKCS7_add_certificate(p7.get(), sk_X509_value(certs.get(), 0U)));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
+  bio.reset(BIO_new_mem_buf(kPEMCert, strlen(kPEMCert)));
+  ASSERT_TRUE(bio);
+  certs.reset(sk_X509_new_null());
+  ASSERT_TRUE(certs);
+  ASSERT_TRUE(PKCS7_get_PEM_certificates(certs.get(), bio.get()));
+  ASSERT_EQ(1U, sk_X509_num(certs.get()));
+  EXPECT_TRUE(PKCS7_add_certificate(p7.get(), sk_X509_value(certs.get(), 0U)));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
-    bio.reset(BIO_new_mem_buf(kPEMCRL, strlen(kPEMCRL)));
-    ASSERT_TRUE(bio);
-    crls.reset(sk_X509_CRL_new_null());
-    ASSERT_TRUE(crls);
-    ASSERT_TRUE(PKCS7_get_PEM_CRLs(crls.get(), bio.get()));
-    ASSERT_EQ(1U, sk_X509_CRL_num(crls.get()));
-    EXPECT_TRUE(PKCS7_add_crl(p7.get(), sk_X509_CRL_value(crls.get(), 0U)));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
+  bio.reset(BIO_new_mem_buf(kPEMCRL, strlen(kPEMCRL)));
+  ASSERT_TRUE(bio);
+  crls.reset(sk_X509_CRL_new_null());
+  ASSERT_TRUE(crls);
+  ASSERT_TRUE(PKCS7_get_PEM_CRLs(crls.get(), bio.get()));
+  ASSERT_EQ(1U, sk_X509_CRL_num(crls.get()));
+  EXPECT_TRUE(PKCS7_add_crl(p7.get(), sk_X509_CRL_value(crls.get(), 0U)));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
-    bssl::UniquePtr<RSA> rsa(RSA_new());
-    ASSERT_TRUE(rsa);
-    ASSERT_TRUE(RSA_generate_key_fips(rsa.get(), 2048, nullptr));
-    bssl::UniquePtr<EVP_PKEY> rsa_pkey(EVP_PKEY_new());
-    ASSERT_TRUE(rsa_pkey);
-    ASSERT_TRUE(EVP_PKEY_set1_RSA(rsa_pkey.get(), rsa.get()));
-    bssl::UniquePtr<X509> rsa_x509(sk_X509_pop(certs.get()));
-    ASSERT_EQ(0U, sk_X509_num(certs.get()));
-    ASSERT_TRUE(rsa_x509);
-    p7si = PKCS7_SIGNER_INFO_new();
-    ASSERT_TRUE(p7si);
-    EXPECT_TRUE(PKCS7_SIGNER_INFO_set(p7si, rsa_x509.get(), rsa_pkey.get(), EVP_sha256()));
-    EXPECT_FALSE(PKCS7_SIGNER_INFO_set(p7si, nullptr, nullptr, nullptr));
-    EXPECT_TRUE(PKCS7_add_signer(p7.get(), p7si));
-    EXPECT_TRUE(PKCS7_get_signer_info(p7.get()));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
+  bssl::UniquePtr<RSA> rsa(RSA_new());
+  ASSERT_TRUE(rsa);
+  ASSERT_TRUE(RSA_generate_key_fips(rsa.get(), 2048, nullptr));
+  bssl::UniquePtr<EVP_PKEY> rsa_pkey(EVP_PKEY_new());
+  ASSERT_TRUE(rsa_pkey);
+  ASSERT_TRUE(EVP_PKEY_set1_RSA(rsa_pkey.get(), rsa.get()));
+  bssl::UniquePtr<X509> rsa_x509(sk_X509_pop(certs.get()));
+  ASSERT_EQ(0U, sk_X509_num(certs.get()));
+  ASSERT_TRUE(rsa_x509);
+  p7si = PKCS7_SIGNER_INFO_new();
+  ASSERT_TRUE(p7si);
+  EXPECT_TRUE(PKCS7_SIGNER_INFO_set(p7si, rsa_x509.get(), rsa_pkey.get(),
+                                    EVP_sha256()));
+  EXPECT_FALSE(PKCS7_SIGNER_INFO_set(p7si, nullptr, nullptr, nullptr));
+  EXPECT_TRUE(PKCS7_add_signer(p7.get(), p7si));
+  EXPECT_TRUE(PKCS7_get_signer_info(p7.get()));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7.get());
-    ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
-    p7si = PKCS7_SIGNER_INFO_new();
-    ASSERT_TRUE(p7si);
-    bssl::UniquePtr<X509> ecdsa_x509(X509_new());
-    ASSERT_TRUE(ecdsa_x509);
-    bssl::UniquePtr<EVP_PKEY_CTX> ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_EC, nullptr));
-    ASSERT_TRUE(ctx);
-    ASSERT_TRUE(EVP_PKEY_keygen_init(ctx.get()));
-    ASSERT_TRUE(
-        EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx.get(), NID_X9_62_prime256v1));
-    bssl::UniquePtr<EVP_PKEY> ecdsa_pkey(EVP_PKEY_new());
-    EVP_PKEY *ecdsa_pkey_ptr = ecdsa_pkey.get();
-    ASSERT_TRUE(EVP_PKEY_keygen(ctx.get(), &ecdsa_pkey_ptr));
-    EXPECT_TRUE(PKCS7_SIGNER_INFO_set(p7si, ecdsa_x509.get(), ecdsa_pkey.get(), EVP_sha256()));
-    EXPECT_TRUE(PKCS7_add_signer(p7.get(), p7si));
-    EXPECT_TRUE(PKCS7_get_signer_info(p7.get()));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7.get());
+  ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
+  p7si = PKCS7_SIGNER_INFO_new();
+  ASSERT_TRUE(p7si);
+  bssl::UniquePtr<X509> ecdsa_x509(X509_new());
+  ASSERT_TRUE(ecdsa_x509);
+  bssl::UniquePtr<EVP_PKEY_CTX> ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_EC, nullptr));
+  ASSERT_TRUE(ctx);
+  ASSERT_TRUE(EVP_PKEY_keygen_init(ctx.get()));
+  ASSERT_TRUE(
+      EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx.get(), NID_X9_62_prime256v1));
+  bssl::UniquePtr<EVP_PKEY> ecdsa_pkey(EVP_PKEY_new());
+  EVP_PKEY *ecdsa_pkey_ptr = ecdsa_pkey.get();
+  ASSERT_TRUE(EVP_PKEY_keygen(ctx.get(), &ecdsa_pkey_ptr));
+  EXPECT_TRUE(PKCS7_SIGNER_INFO_set(p7si, ecdsa_x509.get(), ecdsa_pkey.get(),
+                                    EVP_sha256()));
+  EXPECT_TRUE(PKCS7_add_signer(p7.get(), p7si));
+  EXPECT_TRUE(PKCS7_get_signer_info(p7.get()));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7.get());
-    ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
-    p7si = PKCS7_SIGNER_INFO_new();
-    ASSERT_TRUE(p7si);
-    ecdsa_x509.reset(X509_new());
-    ASSERT_TRUE(ecdsa_x509);
-    ctx.reset(EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, nullptr));
-    ASSERT_TRUE(ctx);
-    ASSERT_TRUE(EVP_PKEY_keygen_init(ctx.get()));
-    ecdsa_pkey.reset(EVP_PKEY_new());
-    ecdsa_pkey_ptr = ecdsa_pkey.get();
-    ASSERT_TRUE(EVP_PKEY_keygen(ctx.get(), &ecdsa_pkey_ptr));
-    EXPECT_FALSE(PKCS7_SIGNER_INFO_set(p7si, ecdsa_x509.get(), ecdsa_pkey.get(), EVP_sha256()));
-    PKCS7_SIGNER_INFO_free(p7si);
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7.get());
+  ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signed));
+  p7si = PKCS7_SIGNER_INFO_new();
+  ASSERT_TRUE(p7si);
+  ecdsa_x509.reset(X509_new());
+  ASSERT_TRUE(ecdsa_x509);
+  ctx.reset(EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, nullptr));
+  ASSERT_TRUE(ctx);
+  ASSERT_TRUE(EVP_PKEY_keygen_init(ctx.get()));
+  ecdsa_pkey.reset(EVP_PKEY_new());
+  ecdsa_pkey_ptr = ecdsa_pkey.get();
+  ASSERT_TRUE(EVP_PKEY_keygen(ctx.get(), &ecdsa_pkey_ptr));
+  EXPECT_FALSE(PKCS7_SIGNER_INFO_set(p7si, ecdsa_x509.get(), ecdsa_pkey.get(),
+                                     EVP_sha256()));
+  PKCS7_SIGNER_INFO_free(p7si);
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
-    ASSERT_TRUE(X509_set_pubkey(rsa_x509.get(), rsa_pkey.get()));
-    PKCS7_RECIP_INFO *p7ri = PKCS7_RECIP_INFO_new();
-    EXPECT_TRUE(PKCS7_RECIP_INFO_set(p7ri, rsa_x509.get()));
-    EXPECT_FALSE(PKCS7_RECIP_INFO_set(p7ri, nullptr));
-    X509_ALGOR *penc = NULL;
-    PKCS7_RECIP_INFO_get0_alg(p7ri, &penc);
-    ASSERT_TRUE(penc);
-    EXPECT_TRUE(PKCS7_add_recipient_info(p7.get(), p7ri));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_signedAndEnveloped));
+  ASSERT_TRUE(X509_set_pubkey(rsa_x509.get(), rsa_pkey.get()));
+  PKCS7_RECIP_INFO *p7ri = PKCS7_RECIP_INFO_new();
+  EXPECT_TRUE(PKCS7_RECIP_INFO_set(p7ri, rsa_x509.get()));
+  EXPECT_FALSE(PKCS7_RECIP_INFO_set(p7ri, nullptr));
+  X509_ALGOR *penc = NULL;
+  PKCS7_RECIP_INFO_get0_alg(p7ri, &penc);
+  ASSERT_TRUE(penc);
+  EXPECT_TRUE(PKCS7_add_recipient_info(p7.get(), p7ri));
 
-    p7.reset(PKCS7_new());
-    ASSERT_TRUE(p7);
-    ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_enveloped));
-    ASSERT_TRUE(X509_set_pubkey(rsa_x509.get(), rsa_pkey.get()));
-    p7ri = PKCS7_RECIP_INFO_new();
-    EXPECT_TRUE(PKCS7_RECIP_INFO_set(p7ri, rsa_x509.get()));
-    PKCS7_RECIP_INFO_get0_alg(p7ri, &penc);
-    ASSERT_TRUE(penc);
-    EXPECT_TRUE(PKCS7_add_recipient_info(p7.get(), p7ri));
+  p7.reset(PKCS7_new());
+  ASSERT_TRUE(p7);
+  ASSERT_TRUE(PKCS7_set_type(p7.get(), NID_pkcs7_enveloped));
+  ASSERT_TRUE(X509_set_pubkey(rsa_x509.get(), rsa_pkey.get()));
+  p7ri = PKCS7_RECIP_INFO_new();
+  EXPECT_TRUE(PKCS7_RECIP_INFO_set(p7ri, rsa_x509.get()));
+  PKCS7_RECIP_INFO_get0_alg(p7ri, &penc);
+  ASSERT_TRUE(penc);
+  EXPECT_TRUE(PKCS7_add_recipient_info(p7.get(), p7ri));
 }

--- a/crypto/pkcs7/pkcs7_x509.c
+++ b/crypto/pkcs7/pkcs7_x509.c
@@ -26,24 +26,22 @@
 #include <openssl/stack.h>
 #include <openssl/x509.h>
 
-#include "internal.h"
 #include "../internal.h"
+#include "internal.h"
 
 
 int PKCS7_get_certificates(STACK_OF(X509) *out_certs, CBS *cbs) {
   int ret = 0;
   const size_t initial_certs_len = sk_X509_num(out_certs);
   STACK_OF(CRYPTO_BUFFER) *raw = sk_CRYPTO_BUFFER_new_null();
-  if (raw == NULL ||
-      !PKCS7_get_raw_certificates(raw, cbs, NULL)) {
+  if (raw == NULL || !PKCS7_get_raw_certificates(raw, cbs, NULL)) {
     goto err;
   }
 
   for (size_t i = 0; i < sk_CRYPTO_BUFFER_num(raw); i++) {
     CRYPTO_BUFFER *buf = sk_CRYPTO_BUFFER_value(raw, i);
     X509 *x509 = X509_parse_from_buffer(buf);
-    if (x509 == NULL ||
-        !sk_X509_push(out_certs, x509)) {
+    if (x509 == NULL || !sk_X509_push(out_certs, x509)) {
       X509_free(x509);
       goto err;
     }
@@ -186,8 +184,7 @@ static int pkcs7_bundle_certificates_cb(CBB *out, const void *arg) {
     uint8_t *buf;
     int len = i2d_X509(x509, NULL);
 
-    if (len < 0 ||
-        !CBB_add_space(&certificates, &buf, len) ||
+    if (len < 0 || !CBB_add_space(&certificates, &buf, len) ||
         i2d_X509(x509, &buf) < 0) {
       return 0;
     }
@@ -219,8 +216,7 @@ static int pkcs7_bundle_crls_cb(CBB *out, const void *arg) {
     uint8_t *buf;
     int len = i2d_X509_CRL(crl, NULL);
 
-    if (len < 0 ||
-        !CBB_add_space(&crl_data, &buf, len) ||
+    if (len < 0 || !CBB_add_space(&crl_data, &buf, len) ||
         i2d_X509_CRL(crl, &buf) < 0) {
       return 0;
     }
@@ -238,39 +234,39 @@ int PKCS7_bundle_CRLs(CBB *out, const STACK_OF(X509_CRL) *crls) {
 
 PKCS7 *d2i_PKCS7_bio(BIO *bio, PKCS7 **out) {
   if (out == NULL) {
-      OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-      return NULL;
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return NULL;
   }
 
   return ASN1_item_d2i_bio(ASN1_ITEM_rptr(PKCS7), bio, *out);
 }
 
 int i2d_PKCS7_bio(BIO *bio, const PKCS7 *p7) {
-  return ASN1_item_i2d_bio(ASN1_ITEM_rptr(PKCS7), bio, (void *) p7);
+  return ASN1_item_i2d_bio(ASN1_ITEM_rptr(PKCS7), bio, (void *)p7);
 }
 
 int PKCS7_type_is_data(const PKCS7 *p7) {
-    return OBJ_obj2nid(p7->type) == NID_pkcs7_data;
+  return OBJ_obj2nid(p7->type) == NID_pkcs7_data;
 }
 
 int PKCS7_type_is_digest(const PKCS7 *p7) {
-    return OBJ_obj2nid(p7->type) == NID_pkcs7_digest;
+  return OBJ_obj2nid(p7->type) == NID_pkcs7_digest;
 }
 
 int PKCS7_type_is_encrypted(const PKCS7 *p7) {
-    return OBJ_obj2nid(p7->type) == NID_pkcs7_encrypted;
+  return OBJ_obj2nid(p7->type) == NID_pkcs7_encrypted;
 }
 
 int PKCS7_type_is_enveloped(const PKCS7 *p7) {
-    return OBJ_obj2nid(p7->type) == NID_pkcs7_enveloped;
+  return OBJ_obj2nid(p7->type) == NID_pkcs7_enveloped;
 }
 
 int PKCS7_type_is_signed(const PKCS7 *p7) {
-    return OBJ_obj2nid(p7->type) == NID_pkcs7_signed;
+  return OBJ_obj2nid(p7->type) == NID_pkcs7_signed;
 }
 
 int PKCS7_type_is_signedAndEnveloped(const PKCS7 *p7) {
-    return OBJ_obj2nid(p7->type) == NID_pkcs7_signedAndEnveloped;
+  return OBJ_obj2nid(p7->type) == NID_pkcs7_signedAndEnveloped;
 }
 
 // write_sha256_ai writes an AlgorithmIdentifier for SHA-256 to
@@ -349,8 +345,7 @@ static int write_signer_info(CBB *out, const void *arg) {
       &serial_bytes);
 
   CBB seq, issuer_and_serial, signing_algo, null, signature;
-  if (subject_len < 0 ||
-      serial_len < 0 ||
+  if (subject_len < 0 || serial_len < 0 ||
       !CBB_add_asn1(out, &seq, CBS_ASN1_SEQUENCE) ||
       // version
       !CBB_add_asn1_uint64(&seq, 1) ||
@@ -399,8 +394,8 @@ PKCS7 *PKCS7_sign(X509 *sign_cert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
     // sign-file.c from the Linux kernel.
     const size_t signature_max_len = EVP_PKEY_size(pkey);
     struct signer_info_data si_data = {
-      .sign_cert = sign_cert,
-      .signature = OPENSSL_malloc(signature_max_len),
+        .sign_cert = sign_cert,
+        .signature = OPENSSL_malloc(signature_max_len),
     };
 
     if (!si_data.signature ||
@@ -430,75 +425,72 @@ out:
   return ret;
 }
 
-int PKCS7_add_certificate(PKCS7 *p7, X509 *x509)
-{
-    STACK_OF(X509) **sk;
+int PKCS7_add_certificate(PKCS7 *p7, X509 *x509) {
+  STACK_OF(X509) **sk;
 
-    if (p7 == NULL || x509 == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
+  if (p7 == NULL || x509 == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  }
 
-    switch (OBJ_obj2nid(p7->type)) {
+  switch (OBJ_obj2nid(p7->type)) {
     case NID_pkcs7_signed:
-        sk = &(p7->d.sign->cert);
-        break;
+      sk = &(p7->d.sign->cert);
+      break;
     case NID_pkcs7_signedAndEnveloped:
-        sk = &(p7->d.signed_and_enveloped->cert);
-        break;
+      sk = &(p7->d.signed_and_enveloped->cert);
+      break;
     default:
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
-        return 0;
-    }
+      OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
+      return 0;
+  }
 
-    if (*sk == NULL) {
-        *sk = sk_X509_new_null();
-    }
-    if (*sk == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_CRYPTO_LIB);
-        return 0;
-    }
+  if (*sk == NULL) {
+    *sk = sk_X509_new_null();
+  }
+  if (*sk == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_CRYPTO_LIB);
+    return 0;
+  }
 
-    if (!sk_X509_push(*sk, x509)) {
-        return 0;
-    }
-    X509_up_ref(x509);
-    return 1;
-
+  if (!sk_X509_push(*sk, x509)) {
+    return 0;
+  }
+  X509_up_ref(x509);
+  return 1;
 }
 
-int PKCS7_add_crl(PKCS7 *p7, X509_CRL *crl)
-{
-    STACK_OF(X509_CRL) **sk;
+int PKCS7_add_crl(PKCS7 *p7, X509_CRL *crl) {
+  STACK_OF(X509_CRL) **sk;
 
-    if (p7 == NULL || crl == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
+  if (p7 == NULL || crl == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  }
 
-    switch (OBJ_obj2nid(p7->type)) {
+  switch (OBJ_obj2nid(p7->type)) {
     case NID_pkcs7_signed:
-        sk = &(p7->d.sign->crl);
-        break;
+      sk = &(p7->d.sign->crl);
+      break;
     case NID_pkcs7_signedAndEnveloped:
-        sk = &(p7->d.signed_and_enveloped->crl);
-        break;
+      sk = &(p7->d.signed_and_enveloped->crl);
+      break;
     default:
-        OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
-        return 0;
-    }
+      OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_WRONG_CONTENT_TYPE);
+      return 0;
+  }
 
-    if (*sk == NULL) {
-        *sk = sk_X509_CRL_new_null();
-    }
-    if (*sk == NULL) {
-        OPENSSL_PUT_ERROR(PKCS7, ERR_R_CRYPTO_LIB);
-        return 0;
-    }
+  if (*sk == NULL) {
+    *sk = sk_X509_CRL_new_null();
+  }
+  if (*sk == NULL) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_CRYPTO_LIB);
+    return 0;
+  }
 
-    if (!sk_X509_CRL_push(*sk, crl)) {
-        return 0;
-    }
-    X509_CRL_up_ref(crl);
-    return 1;
+  if (!sk_X509_CRL_push(*sk, crl)) {
+    return 0;
+  }
+  X509_CRL_up_ref(crl);
+  return 1;
 }


### PR DESCRIPTION
### Issues:
Resolves n/a
Addresses n/a

### Description of changes: 

Other than some manual comment cleanups, this PR's diff is generated with `clang-format`. Run clang-format on pkcs7 code. Commands run:

```
$ clang-format -i crypto/pkcs7/*; echo $?
0

$ clang-format --version
Ubuntu clang-format version 14.0.0-1ubuntu1.1
```


### Call-outs:

n/a

### Testing:
- CI
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
