### PR TITLE
fix socat integration CI

### DIFF
--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -24,6 +24,10 @@ function build_and_test_socat() {
   autoconf
   ./configure --enable-openssl-base="$AWS_LC_INSTALL_FOLDER"
   make -j "$NUM_CPU_THREADS"
+  # See: t/V1497389456.
+  # socat decreased the test wait time to 3 milliseconds, which causes failures when additional warnings/logs are written.
+  # Extending the wait time to 50 milliseconds is just right for us.
+  sed -i 's/MILLIs=\$((3/MILLIs=\$((50/' ./test.sh
   # test 146 OPENSSLLISTENDSA: fails because AWS-LC doesn't support FFDH ciphersuites which are needed for DSA
   # test 216 UDP6MULTICAST_UNIDIR: known flaky test in socat with newer kernels
   # test 309 OPENSSLRENEG1: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode


### PR DESCRIPTION
socat started cutting off the tests prematurely if the test hadn't finished yet with these commits:
* https://repo.or.cz/socat.git/commitdiff/74d03b37da1226f5d76d1503487d7cd8b90c4d80
* https://repo.or.cz/socat.git/commitdiff/b5b9ee0031eb0f38a71b44a45723d728265ee1bd 
```
+if [ -z "$val_t" ]; then
+    # Determine the time Socat needs for an empty run
+    $SOCAT /dev/null /dev/null         # populate caches
+    MILLIs=$(bash -c 'time socat /dev/null /dev/null' 2>&1 |grep ^real |sed 's/.*m\(.*\)s.*/\1/' |tr -d ,.)
+    while [ "${MILLIs:0:1}" = '0' ]; do MILLIs=${MILLIs##0}; done      # strip leading '0' to avoid octal
+    [ -z "$MILLIs" ] && MILLIs=1
+    [ "$DEFS" ] && echo "MILLIs=\"$MILLIs\" (1)" >&2
+
+    # On my idle development computer this value flaps from 0.001 to 0.004
+    # 0.001 lets many tests fail, so we triple the result
+    MILLIs=$((3*MILLIs))
+    [ "$DEFS" ] && echo "MILLIs=\"$MILLIs\" (2)" >&2
+    MICROS=${MILLIs}000
```
A lot of tests are related to specific warnings that socat emits based on the openssl version not supporting certain things. My suspicion is that the additional time when writing to the logs breaks the 3 millisecond threshold and socat determines that we've failed the test. Extending this time threshold to  50 milliseconds gets past things.
  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
