### PR TITLE
ML-KEM Service Indicator for EVP_PKEY_keygen, EVP_PKEY_encapsulate, EVP_PKEY_decapsulate

### DIFF
--- a/crypto/fipsmodule/evp/digestsign.c
+++ b/crypto/fipsmodule/evp/digestsign.c
@@ -292,7 +292,9 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, uint8_t *out_sig, size_t *out_sig_len,
                                        data_len);
 end:
   FIPS_service_indicator_unlock_state();
-  if (ret > 0) {
+  if (ret > 0 && out_sig != NULL) {
+    // Indicator should only be set if we performed crypto, don't set if we only
+    // performed a size check.
     EVP_DigestSign_verify_service_indicator(ctx);
   }
   return ret;

--- a/crypto/fipsmodule/evp/p_kem.c
+++ b/crypto/fipsmodule/evp/p_kem.c
@@ -95,10 +95,11 @@ static int pkey_kem_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey) {
   if (key == NULL ||
       !KEM_KEY_init(key, kem) ||
       !kem->method->keygen(key->public_key, key->secret_key) ||
-      !EVP_PKEY_assign(pkey, EVP_PKEY_KEM, key)) {
+      !EVP_PKEY_set_type(pkey, EVP_PKEY_KEM)) {
     KEM_KEY_free(key);
     return 0;
   }
+  pkey->pkey.kem_key = key;
 
   return 1;
 }

--- a/crypto/fipsmodule/service_indicator/internal.h
+++ b/crypto/fipsmodule/service_indicator/internal.h
@@ -56,6 +56,8 @@ void TLSKDF_verify_service_indicator(const EVP_MD *dgst, const char *label,
 void SSKDF_digest_verify_service_indicator(const EVP_MD *dgst);
 void SSKDF_hmac_verify_service_indicator(const EVP_MD *dgst);
 void KBKDF_ctr_hmac_verify_service_indicator(const EVP_MD *dgst);
+void EVP_PKEY_encapsulate_verify_service_indicator(const EVP_PKEY_CTX* ctx);
+void EVP_PKEY_decapsulate_verify_service_indicator(const EVP_PKEY_CTX* ctx);
 
 #else
 
@@ -126,6 +128,10 @@ OPENSSL_INLINE void SSKDF_hmac_verify_service_indicator(
     OPENSSL_UNUSED const EVP_MD *dgst) {}
 
 OPENSSL_INLINE void KBKDF_ctr_hmac_verify_service_indicator(OPENSSL_UNUSED const EVP_MD *dgst) {}
+
+OPENSSL_INLINE void EVP_PKEY_encapsulate_verify_service_indicator(OPENSSL_UNUSED const EVP_PKEY_CTX* ctx) {}
+
+OPENSSL_INLINE void EVP_PKEY_decapsulate_verify_service_indicator(OPENSSL_UNUSED const EVP_PKEY_CTX* ctx) {}
 
 #endif // AWSLC_FIPS
 

--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -319,6 +319,17 @@ void EVP_PKEY_keygen_verify_service_indicator(const EVP_PKEY *pkey) {
     if (is_ec_fips_approved(curve_nid)) {
       FIPS_service_indicator_update_state();
     }
+  } else if (pkey->type == EVP_PKEY_KEM) {
+    const KEM *kem = KEM_KEY_get0_kem(pkey->pkey.kem_key);
+    switch (kem->nid) {
+      case NID_MLKEM512:
+      case NID_MLKEM768:
+      case NID_MLKEM1024:
+        FIPS_service_indicator_update_state();
+        break;
+      default:
+        break;
+    }
   }
 }
 
@@ -568,6 +579,36 @@ void KBKDF_ctr_hmac_verify_service_indicator(const EVP_MD *dgst) {
       break;
     default:
       break;
+  }
+}
+
+void EVP_PKEY_encapsulate_verify_service_indicator(const EVP_PKEY_CTX* ctx) {
+  if (ctx->pkey->type == EVP_PKEY_KEM) {
+    const KEM *kem = KEM_KEY_get0_kem(ctx->pkey->pkey.kem_key);
+    switch (kem->nid) {
+      case NID_MLKEM512:
+      case NID_MLKEM768:
+      case NID_MLKEM1024:
+        FIPS_service_indicator_update_state();
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+void EVP_PKEY_decapsulate_verify_service_indicator(const EVP_PKEY_CTX* ctx) {
+  if (ctx->pkey->type == EVP_PKEY_KEM) {
+    const KEM *kem = KEM_KEY_get0_kem(ctx->pkey->pkey.kem_key);
+    switch (kem->nid) {
+      case NID_MLKEM512:
+      case NID_MLKEM768:
+      case NID_MLKEM1024:
+        FIPS_service_indicator_update_state();
+        break;
+      default:
+        break;
+    }
   }
 }
 


### PR DESCRIPTION
### Description of changes:
* Fixes `EVP_DigestSign` to not set the indicator on size checks
* Adds service indicator for ML-KEM-{5127,768,1024} for `EVP_PKEY_keygen`, `EVP_PKEY_encapsulate`, `EVP_PKEY_decapsulate` functions.
* Adjusts the internal `pkey_kem_keygen` function to use `kem_key` union member for consistency when setting the generated keypair on the EVP_PKEY.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
