### PR TITLE
prepare for v1.35.0 release

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4561,7 +4561,7 @@ TEST_P(KBKDFCtrHmacIndicatorTest, KBKDF) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.34.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.35.0");
 }
 
 #else
@@ -4604,6 +4604,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.34.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.35.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.34.2"
+#define AWSLC_VERSION_NUMBER_STRING "1.35.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Use OPENSSL_STATIC_ASSERT which handles all the platform/compiler/C s… by @andrewhop in https://github.com/aws/aws-lc/pull/1791
* ML-KEM refactor by @dkostic in https://github.com/aws/aws-lc/pull/1763
* ML-KEM-IPD to ML-KEM as defined in FIPS 203 by @dkostic in https://github.com/aws/aws-lc/pull/1796
* Add KDA OneStep testing to ACVP by @skmcgrail in https://github.com/aws/aws-lc/pull/1792
* Updating erroneous documentation for BIO_get_mem_data and subsequent usage by @smittals2 in https://github.com/aws/aws-lc/pull/1752
* No-op impls for several EVP_PKEY_CTX functions by @justsmth in https://github.com/aws/aws-lc/pull/1759
* Drop "ipd" suffix from ML-KEM related code by @dkostic in https://github.com/aws/aws-lc/pull/1797
* Upstream merge 2024 08 19 by @skmcgrail in https://github.com/aws/aws-lc/pull/1781
* ML-KEM move to the FIPS module by @dkostic in https://github.com/aws/aws-lc/pull/1802
* Reduce collision probability for variable names by @torben-hansen in https://github.com/aws/aws-lc/pull/1804
* Refactor ENGINE API and memory around METHOD structs by @smittals2 in https://github.com/aws/aws-lc/pull/1776
* bn: Move x86-64 argument-based dispatching of bn_mul_mont to C. by @justsmth in https://github.com/aws/aws-lc/pull/1795
* Check at runtime that the tool is loading the same libcrypto it was built with by @andrewhop in https://github.com/aws/aws-lc/pull/1716
* Avoid matching prefixes of a symbol as arm registers by @torben-hansen in https://github.com/aws/aws-lc/pull/1807
* Add CI for FreeBSD by @justsmth in https://github.com/aws/aws-lc/pull/1787
* Move curve25519 implementations to fips module except spake25519 by @torben-hansen in https://github.com/aws/aws-lc/pull/1809
* Add CAST for SP 800-56Cr2 One-Step function by @skmcgrail in https://github.com/aws/aws-lc/pull/1803
* Remove custom PKCS7 ASN1 functions, add new structs by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1726
* NASM use default debug format by @justsmth in https://github.com/aws/aws-lc/pull/1747
* Add KDF in counter mode ACVP Testing by @skmcgrail in https://github.com/aws/aws-lc/pull/1810
* add support for OCSP_request_verify by @samuel40791765 in https://github.com/aws/aws-lc/pull/1778
* Fix GitHub/CodeBuild Purge Lambda by @justsmth in https://github.com/aws/aws-lc/pull/1808
* KBKDF_ctr_hmac FIPS Service Indicator by @skmcgrail in https://github.com/aws/aws-lc/pull/1798
* Update x509 tool to write all output to common BIO which is a file or stdout by @andrewhop in https://github.com/aws/aws-lc/pull/1800
* Add ML-KEM to speed.cc, bump AWSLC_API_VERSION to 30 by @andrewhop in https://github.com/aws/aws-lc/pull/1817
* Add EVP_PKEY_asn1_* functions by @justsmth in https://github.com/aws/aws-lc/pull/1751
* Improve portability of CI integration script by @torben-hansen in https://github.com/aws/aws-lc/pull/1815
* Upstream merge 2024 08 23 by @justsmth in https://github.com/aws/aws-lc/pull/1799
* Replace ECDSA_METHOD with EC_KEY_METHOD and add the associated API by @smittals2 in https://github.com/aws/aws-lc/pull/1785
* Cherrypick "Add some barebones support for DH in EVP"  by @samuel40791765 in https://github.com/aws/aws-lc/pull/1813
* Add KDA OneStep (SSKDF_digest and SSKDF_hmac) to FIPS indicator by @skmcgrail in https://github.com/aws/aws-lc/pull/1793
* Add EVP_Digest one-shot test XOFs by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1820
* Wire-up ACVP Testing for SHA3 Signatures with RSA by @skmcgrail in https://github.com/aws/aws-lc/pull/1805
* Make SHA3 (not SHAKE) Approved for EVP_DigestSign/Verify, RSA and ECDSA. by @nebeid in https://github.com/aws/aws-lc/pull/1821
* Begin tracking RelWithDebInfo library statistics by @andrewhop in https://github.com/aws/aws-lc/pull/1822
* Move EVP ed25519 function table under FIPS module by @torben-hansen in https://github.com/aws/aws-lc/pull/1826
* Avoid C11 Atomics on Windows by @justsmth in https://github.com/aws/aws-lc/pull/1824
* Improve pre-sandbox setup by @torben-hansen in https://github.com/aws/aws-lc/pull/1825
* Add OCSP round trip integration test with minor fixes by @samuel40791765 in https://github.com/aws/aws-lc/pull/1811
* Add various PKCS7 getters and setters by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1780
* Run clang-format on pkcs7 code by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1830
* Move KEM API and ML-KEM definitions to FIPS module by @torben-hansen in https://github.com/aws/aws-lc/pull/1828
* fix socat integration CI by @samuel40791765 in https://github.com/aws/aws-lc/pull/1833
* Retire out-of-module KEM folder by @torben-hansen in https://github.com/aws/aws-lc/pull/1832
* Refactor RSA_METHOD and expand API by @smittals2 in https://github.com/aws/aws-lc/pull/1790
* Update benchmark documentation in tool/readme.md by @andrewhop in https://github.com/aws/aws-lc/pull/1812
* Pre jail unit test by @torben-hansen in https://github.com/aws/aws-lc/pull/1835
* Move EVP KEM implementation to in-module and correct OID by @torben-hansen in https://github.com/aws/aws-lc/pull/1838
* More minor symbols Ruby depends on by @samuel40791765 in https://github.com/aws/aws-lc/pull/1837
* ED25519 Power-on Self Test / CAST / KAT by @skmcgrail in https://github.com/aws/aws-lc/pull/1834
* ACVP ML-KEM testing by @skmcgrail in https://github.com/aws/aws-lc/pull/1840
* ACVP ECDSA SHA3 Digest Testing by @skmcgrail in https://github.com/aws/aws-lc/pull/1819
* ML-KEM Service Indicator for EVP_PKEY_keygen, EVP_PKEY_encapsulate, EVP_PKEY_decapsulate by @skmcgrail in https://github.com/aws/aws-lc/pull/1844
* Add ML-KEM CAST for KeyGen, Encaps, and Decaps by @skmcgrail in https://github.com/aws/aws-lc/pull/1846
* ED25519 Service Indicator by @skmcgrail in https://github.com/aws/aws-lc/pull/1829
* Update Allowed RSA KeySize Generation to FIPS 186-5 specification by @skmcgrail in https://github.com/aws/aws-lc/pull/1823
* Add ED25519 ACVP Testing by @skmcgrail in https://github.com/aws/aws-lc/pull/1818
* Make EDDSA/Ed25519 POST lazy initalized by @skmcgrail in https://github.com/aws/aws-lc/pull/1848
* add support for PEM Parameters without ASN1 hooks by @samuel40791765 in https://github.com/aws/aws-lc/pull/1831
* Add OpenVPN tip of main to CI by @smittals2 in https://github.com/aws/aws-lc/pull/1843
* Ensure SSE2 is enabled when using optimized assembly for 32-bit x86 by @graebm in https://github.com/aws/aws-lc/pull/1841
* Add support for `EVP_PKEY_CTX_ctrl_str` - Step #1 by @justsmth in https://github.com/aws/aws-lc/pull/1842
* Added SHA3/SHAKE XOF functionality by @jakemas in https://github.com/aws/aws-lc/pull/1839
* Migrated ML-KEM SHA3/SHAKE usage to fipsmodule by @jakemas in https://github.com/aws/aws-lc/pull/1851
* AVX-512 support for RSA Signing by @pittma in https://github.com/aws/aws-lc/pull/1273
