### PR TITLE
support building on illumos systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
   endif()
 endif()
 
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL "SunOS")
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "SunOS" AND NOT CMAKE_CROSSCOMPILING)
   # Determine if the host is running an illumos distribution:
   execute_process(COMMAND /usr/bin/uname -o OUTPUT_VARIABLE UNAME_O
     OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,28 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
   endif()
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
+  # Determine if the host is running an illumos distribution:
+  execute_process(COMMAND /usr/bin/uname -o OUTPUT_VARIABLE UNAME_O
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if (UNAME_O STREQUAL "illumos")
+    set(ILLUMOS 1)
+  endif()
+
+  if (ILLUMOS)
+    #
+    # illumos systems require linking libsocket and libnsl to get various
+    # networking routines sometimes found in libc on other platforms:
+    #
+    if(NOT BUILD_SHARED_LIBS)
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lsocket -lnsl")
+    else()
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lsocket -lnsl")
+    endif()
+  endif()
+endif()
+
 # Tests and libssl both require the CXX language to be enabled. If a consumer
 # chooses to disable building the tests and libssl, do not enable CXX
 if(BUILD_TESTING OR BUILD_LIBSSL)
@@ -789,9 +811,20 @@ if(OPENSSL_NO_SSE2_FOR_TESTING)
   add_definitions(-DOPENSSL_NO_SSE2_FOR_TESTING)
 endif()
 
-# Some consumers might use upper-case (e.g.) "X86" or "X86_64".
-# Matching below is based on lower-case.
-string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" CMAKE_SYSTEM_PROCESSOR_LOWER)
+if(ILLUMOS)
+  #
+  # CMAKE_SYSTEM_PROCESSOR unfortunately comes from the output of "uname -p",
+  # which on illumos systems emits "i386".  Instead, use the value from
+  # "isainfo -n", which prints "the name of the native instruction set used by
+  # portable applications"; e.g., "amd64".
+  #
+  execute_process(COMMAND /usr/bin/isainfo -n OUTPUT_VARIABLE
+    CMAKE_SYSTEM_PROCESSOR_LOWER OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  # Some consumers might use upper-case (e.g.) "X86" or "X86_64".
+  # Matching below is based on lower-case.
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" CMAKE_SYSTEM_PROCESSOR_LOWER)
+endif()
 
 if(OPENSSL_NO_ASM)
   add_definitions(-DOPENSSL_NO_ASM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,16 +61,16 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
   endif()
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "SunOS")
   # Determine if the host is running an illumos distribution:
   execute_process(COMMAND /usr/bin/uname -o OUTPUT_VARIABLE UNAME_O
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   if (UNAME_O STREQUAL "illumos")
-    set(ILLUMOS 1)
+    set(HOST_ILLUMOS 1)
   endif()
 
-  if (ILLUMOS)
+  if (HOST_ILLUMOS)
     #
     # illumos systems require linking libsocket and libnsl to get various
     # networking routines sometimes found in libc on other platforms:
@@ -811,7 +811,7 @@ if(OPENSSL_NO_SSE2_FOR_TESTING)
   add_definitions(-DOPENSSL_NO_SSE2_FOR_TESTING)
 endif()
 
-if(ILLUMOS)
+if(HOST_ILLUMOS)
   #
   # CMAKE_SYSTEM_PROCESSOR unfortunately comes from the output of "uname -p",
   # which on illumos systems emits "i386".  Instead, use the value from


### PR DESCRIPTION
### Issues:
n/a

### Description of changes: 
The team that works on [awslabs/tough](https://github.com/awslabs/tough) wants to support using the aws-lc-rs Rust crate (https://github.com/awslabs/tough/issues/824). As one of several downstream consumers of tough outside of AWS, we were asked for feedback. Oxide uses tough as part of our product which runs on the illumos operating system.

When linking Rust code using aws-lc-rs, the linker cannot find several `aws_lc_*` symbols:

```
Undefined            first referenced
 symbol                  in file
aws_lc_0_21_1_bn_gather5            /home/iliana/git/omicron/target/debug/deps/libaws_lc_sys-ff0ab07b18206e1f.rlib(bcm.c.o)
aws_lc_0_21_1_rsaz_1024_red2norm_avx2 /home/iliana/git/omicron/target/debug/deps/libaws_lc_sys-ff0ab07b18206e1f.rlib(bcm.c.o)
aws_lc_0_21_1_aesni_gcm_encrypt     /home/iliana/git/omicron/target/debug/deps/libaws_lc_sys-ff0ab07b18206e1f.rlib(bcm.c.o)
aws_lc_0_21_1_chacha20_poly1305_seal /home/iliana/git/omicron/target/debug/deps/libaws_lc_sys-ff0ab07b18206e1f.rlib(e_chacha20poly1305.c.o)
aws_lc_0_21_1_chacha20_poly1305_open /home/iliana/git/omicron/target/debug/deps/libaws_lc_sys-ff0ab07b18206e1f.rlib(e_chacha20poly1305.c.o)
[ ... this goes on for some hundreds of lines ... ]
```

`uname -p` on illumos systems returns `i386` on 64-bit machines. This resulted in assembly code not being linked into the AWS-LC library due to architecture misdetection. To determine the native instruction set, `isainfo -n` is used instead.

Once these cryptic errors were out of the way, we got a more normal linking error indicating some missing libraries; symbols that are in the libc on other platforms are in separate libraries on illumos.

I'm sending this PR on behalf of my coworker, @jclulow, but I can help handle any requested changes.

### Call-outs:
n/a

### Testing:
Tested on an illumos system via aws-lc-rs by patching the crate in Cargo.toml with:

```
[patch.crates-io.aws-lc-sys]
git = "https://github.com/oxidecomputer/aws-lc-rs"
branch = "illumos/aws-lc-sys/v0.21.1"
```

which updates the AWS-LC submodule to this commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
