### PR TITLE
Check for null return pointers in pem_test.cc

### DIFF
--- a/crypto/pem/pem_test.cc
+++ b/crypto/pem/pem_test.cc
@@ -292,8 +292,11 @@ TEST(ParametersTest, PEMReadwrite) {
   ASSERT_TRUE(pkey_read);
 
   EC_KEY *pkey_eckey = EVP_PKEY_get0_EC_KEY(pkey.get());
+  ASSERT_TRUE(pkey_eckey);
   const EC_GROUP *orig_params = EC_KEY_get0_group(pkey_eckey);
+  ASSERT_TRUE(orig_params);
   const EC_GROUP *read_params = EC_KEY_get0_group(pkey_eckey);
+  ASSERT_TRUE(read_params);
   ASSERT_EQ(0, EC_GROUP_cmp(orig_params, read_params, nullptr));
 
   // Test |PEM_read/write_bio_Parameters| with |DH|.
@@ -317,6 +320,7 @@ TEST(ParametersTest, PEMReadwrite) {
   ASSERT_TRUE(pkey_read);
 
   DH *pkey_dh = EVP_PKEY_get0_DH(pkey.get());
+  ASSERT_TRUE(pkey_dh);
   EXPECT_EQ(0, BN_cmp(DH_get0_p(pkey_dh), DH_get0_p(dh.get())));
   EXPECT_EQ(0, BN_cmp(DH_get0_g(pkey_dh), DH_get0_g(dh.get())));
 


### PR DESCRIPTION
### Issues:
Resolves P154590111

### Description of changes: 
Static analysis found a few cases where these tests could fail due to dereferencing null, if a null pointer ever shows up here the test will still fail, but now more gracefully. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
