### PR TITLE
Update Service Indicator to handle custom crypto through *_METHOD structs

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -221,26 +221,38 @@ static int is_md_fips_approved_for_verifying(int md_type, int pkey_type) {
 // or |eckey_method| fields for a given |RSA| or |EC_KEY| respectively. For
 // |RSA| keys, custom verify and sign functionality is supported. For |EC_KEY|
 // keys, only custom sign functionality is supported.
-// Returns one if no custom crypto was invoked and zero otherwise.
-static int no_custom_meth_invoked(const EVP_PKEY_CTX *ctx) {
+// Returns one if custom crypto was invoked and zero otherwise.
+static int custom_meth_invoked(const EVP_PKEY_CTX *ctx) {
   const int pkey_type = EVP_PKEY_id(ctx->pkey);
-  if(pkey_type == EVP_PKEY_RSA || pkey_type == EVP_PKEY_RSA_PSS) {
-    const RSA_METHOD *meth = ctx->pkey->pkey.rsa->meth;
-    // Must be either |EVP_PKEY_OP_VERIFY| or |EVP_PKEY_OP_SIGN|
-    if(ctx->operation == EVP_PKEY_OP_VERIFY) {
-      return meth->verify_raw ? 0 : 1;
-    } else { // EVP_PKEY_OP_SIGN
-      // There are cases where custom |sign| functionality may be set but not
-      // |sign_raw|. However, this check is more conservative and fails if
-      // custom functionality is provided for either function pointer.
-      return (meth->sign || meth->sign_raw) ? 0 : 1;
-    }
-  } else if (pkey_type == EVP_PKEY_EC) {
-    const EC_KEY_METHOD *meth = ctx->pkey->pkey.ec->eckey_method;
-    return (meth->sign || meth->sign_sig) ? 0 : 1;
-  }
+  switch (pkey_type) {
+    case EVP_PKEY_RSA:
+    case EVP_PKEY_RSA_PSS: {
+      const RSA_METHOD *meth = ctx->pkey->pkey.rsa->meth;
+      // Must be either |EVP_PKEY_OP_VERIFY| or |EVP_PKEY_OP_SIGN|
+      switch (ctx->operation) {
+        case EVP_PKEY_OP_VERIFY:
+          return meth->verify_raw ? 1 : 0;
 
-  return 0;
+        case EVP_PKEY_OP_SIGN:
+          // There are cases where custom |sign| functionality may be set but
+          // not |sign_raw|. This check is more conservative and fails if
+          // custom functionality is provided for either function pointer.
+          return (meth->sign || meth->sign_raw) ? 1 : 0;
+
+        default:
+          return 0;  // custom crypto can't be invoked for unsupported ops
+      }
+    }
+
+    case EVP_PKEY_EC: {
+      const EC_KEY_METHOD *meth = ctx->pkey->pkey.ec->eckey_method;
+      return (meth->sign || meth->sign_sig) ? 1 : 0;
+    }
+
+    default:
+      // custom crypto can't be invoked for unsupported key types
+      return 0;
+  }
 }
 
 static void evp_md_ctx_verify_service_indicator(const EVP_MD_CTX *ctx,
@@ -300,7 +312,7 @@ static void evp_md_ctx_verify_service_indicator(const EVP_MD_CTX *ctx,
     // custom operations from |pkey.rsa->meth| were invoked.
     if (md_ok(md_type, pkey_type) &&
         ((rsa_1024_ok && n_bits == 1024) || (n_bits >= 2048 && n_bits % 2 == 0))
-        && no_custom_meth_invoked(pctx)) {
+        && !custom_meth_invoked(pctx)) {
       FIPS_service_indicator_update_state();
     }
   } else if (pkey_type == EVP_PKEY_EC) {
@@ -308,7 +320,7 @@ static void evp_md_ctx_verify_service_indicator(const EVP_MD_CTX *ctx,
     // if custom operations from |pkey.ec->eckey_method| were invoked.
     int curve_nid = EC_GROUP_get_curve_name(pkey->pkey.ec->group);
     if (md_ok(md_type, pkey_type) && is_ec_fips_approved(curve_nid) &&
-        no_custom_meth_invoked(pctx)) {
+        !custom_meth_invoked(pctx)) {
       FIPS_service_indicator_update_state();
     }
   }

--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -226,9 +226,6 @@ static int no_custom_meth_invoked(const EVP_PKEY_CTX *ctx) {
   const int pkey_type = EVP_PKEY_id(ctx->pkey);
   if(pkey_type == EVP_PKEY_RSA || pkey_type == EVP_PKEY_RSA_PSS) {
     const RSA_METHOD *meth = ctx->pkey->pkey.rsa->meth;
-    if (meth == NULL) {
-      return 0;
-    }
     // Must be either |EVP_PKEY_OP_VERIFY| or |EVP_PKEY_OP_SIGN|
     if(ctx->operation == EVP_PKEY_OP_VERIFY) {
       return meth->verify_raw ? 0 : 1;
@@ -240,10 +237,6 @@ static int no_custom_meth_invoked(const EVP_PKEY_CTX *ctx) {
     }
   } else if (pkey_type == EVP_PKEY_EC) {
     const EC_KEY_METHOD *meth = ctx->pkey->pkey.ec->eckey_method;
-    if(meth == NULL) {
-      return 0;
-    }
-
     return (meth->sign || meth->sign_sig) ? 0 : 1;
   }
 

--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -232,7 +232,10 @@ static int no_custom_meth_invoked(const EVP_PKEY_CTX *ctx) {
     // Must be either |EVP_PKEY_OP_VERIFY| or |EVP_PKEY_OP_SIGN|
     if(ctx->operation == EVP_PKEY_OP_VERIFY) {
       return meth->verify_raw ? 0 : 1;
-    } else {
+    } else { // EVP_PKEY_OP_SIGN
+      // There are cases where custom |sign| functionality may be set but not
+      // |sign_raw|. However, this check is more conservative and fails if
+      // custom functionality is provided for either function pointer.
       return (meth->sign || meth->sign_raw) ? 0 : 1;
     }
   } else if (pkey_type == EVP_PKEY_EC) {

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2545,7 +2545,7 @@ TEST_P(RSAServiceIndicatorTest, RSAMethod) {
 
   RSA_METHOD *meth = RSA_meth_new(NULL, 0);
   RSA_meth_set_priv_enc(meth, custom_sign);
-  RSA_set_method(rsa, meth);
+  RSA_set_method(EVP_PKEY_get0_RSA(pkey.get()), meth);
 
   bssl::ScopedEVP_MD_CTX ctx;
   ASSERT_TRUE(EVP_DigestInit(ctx.get(), test.func()));
@@ -3026,7 +3026,7 @@ TEST_P(ECDSAServiceIndicatorTest, ECKeyMethod) {
   EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
 
   // Test using the one-shot |EVP_DigestSign| function for approval. It should
-  // not return an approval because custom sign functionality is defined. 
+  // not return an approval because custom sign functionality is defined.
   md_ctx.Reset();
   CALL_SERVICE_AND_CHECK_APPROVED(approved,
                                   ASSERT_TRUE(EVP_DigestSignInit(md_ctx.get(),

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2527,6 +2527,12 @@ static int custom_sign(int max_out, const uint8_t *in, uint8_t *out, RSA *rsa,
   return 0;
 }
 
+static int custom_finish(RSA *rsa) {
+  const RSA_METHOD *meth = RSA_get_method(rsa);
+  RSA_meth_free((RSA_METHOD *) meth);
+  return 1;
+}
+
 TEST_P(RSAServiceIndicatorTest, RSAMethod) {
   const RSATestVector &test = GetParam();
 
@@ -2545,6 +2551,7 @@ TEST_P(RSAServiceIndicatorTest, RSAMethod) {
 
   RSA_METHOD *meth = RSA_meth_new(NULL, 0);
   RSA_meth_set_priv_enc(meth, custom_sign);
+  RSA_meth_set_finish(meth, custom_finish);
   RSA_set_method(EVP_PKEY_get0_RSA(pkey.get()), meth);
 
   bssl::ScopedEVP_MD_CTX ctx;
@@ -2575,8 +2582,6 @@ TEST_P(RSAServiceIndicatorTest, RSAMethod) {
 
   ASSERT_EQ(approved, AWSLC_NOT_APPROVED);
   sig.resize(sig_len);
-
-  RSA_meth_free(meth);
 }
 
 struct ECDSATestVector {

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2524,7 +2524,6 @@ TEST_P(RSAServiceIndicatorTest, ManualRSASignVerify) {
 
 static int custom_sign(int max_out, const uint8_t *in, uint8_t *out, RSA *rsa,
                        int padding) {
-  RSA_set_ex_data((RSA*)rsa, 0, (void*)"custom sign");
   return 0;
 }
 
@@ -2574,7 +2573,6 @@ TEST_P(RSAServiceIndicatorTest, RSAMethod) {
   CALL_SERVICE_AND_CHECK_APPROVED(approved,
                                   EVP_DigestSignFinal(ctx.get(), sig.data(), &sig_len));
 
-  ASSERT_STREQ(static_cast<const char*>(RSA_get_ex_data(rsa, 0)), "custom sign");
   ASSERT_EQ(approved, AWSLC_NOT_APPROVED);
   sig.resize(sig_len);
 

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2530,7 +2530,6 @@ static int custom_sign(int max_out, const uint8_t *in, uint8_t *out, RSA *rsa,
 static int custom_finish(RSA *rsa) {
   const RSA_METHOD *meth = RSA_get_method(rsa);
   RSA_meth_free((RSA_METHOD *) meth);
-  rsa->meth = RSA_get_default_method();
   return 1;
 }
 
@@ -2550,8 +2549,8 @@ TEST_P(RSAServiceIndicatorTest, RSAMethod) {
     ASSERT_TRUE(EVP_PKEY_set1_RSA(pkey.get(), rsa));
   }
 
-  // If meth is not previously set
-  if (!EVP_PKEY_get0_RSA(pkey.get())->meth->sign) {
+  // If meth is previously set, avoid overwriting cached RSA key
+  if (!EVP_PKEY_get0_RSA(pkey.get())->meth->sign_raw) {
     RSA_METHOD *meth = RSA_meth_new(NULL, 0);
     RSA_meth_set_priv_enc(meth, custom_sign);
     RSA_meth_set_finish(meth, custom_finish);

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2966,6 +2966,12 @@ static int ecdsa_sign(int type, const unsigned char *dgst, int dgstlen,
   return 1;
 }
 
+static void ecdsa_finish(EC_KEY *ec)
+{
+  const EC_KEY_METHOD *ec_meth = EC_KEY_get_method(ec);
+  EC_KEY_METHOD_free((EC_KEY_METHOD *) ec_meth);
+}
+
 TEST_P(ECDSAServiceIndicatorTest, ECKeyMethod) {
   const ECDSATestVector &test = GetParam();
   if (test.nid == NID_secp256k1 && !kCurveSecp256k1Supported) {
@@ -2983,6 +2989,7 @@ TEST_P(ECDSAServiceIndicatorTest, ECKeyMethod) {
 
   EC_KEY_METHOD *meth = EC_KEY_METHOD_new(NULL);
   EC_KEY_METHOD_set_sign(meth, ecdsa_sign, NULL, NULL);
+  EC_KEY_METHOD_set_init(meth, NULL, ecdsa_finish, NULL, NULL, NULL, NULL);
   EC_KEY_set_method(eckey.get(), meth);
 
   // Generate an EC key.
@@ -3049,7 +3056,6 @@ TEST_P(ECDSAServiceIndicatorTest, ECKeyMethod) {
 
   ASSERT_LE(sig_len, signature.size());
   EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
-  EC_KEY_METHOD_free(meth);
 }
 
 struct ECDHTestVector {

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2985,7 +2985,7 @@ TEST_P(ECDSAServiceIndicatorTest, ECKeyMethod) {
   EC_KEY_METHOD_set_sign(meth, ecdsa_sign, NULL, NULL);
   EC_KEY_set_method(eckey.get(), meth);
 
-  // Generate a generic EC key.
+  // Generate an EC key.
   ASSERT_TRUE(EC_KEY_generate_key(eckey.get()));
   ASSERT_TRUE(EVP_PKEY_set1_EC_KEY(pkey.get(), eckey.get()));
 
@@ -3013,7 +3013,8 @@ TEST_P(ECDSAServiceIndicatorTest, ECKeyMethod) {
                                                                   &max_sig_len)));
   EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
   std::vector<uint8_t> signature(max_sig_len);
-  // The second call performs the actual operation.
+  // The second call performs the actual operation and should not return an
+  // approval because custom sign functionality is defined.
   size_t sig_len = max_sig_len;
   CALL_SERVICE_AND_CHECK_APPROVED(approved,
                                   ASSERT_TRUE(EVP_DigestSignFinal(md_ctx.get(),
@@ -3024,7 +3025,8 @@ TEST_P(ECDSAServiceIndicatorTest, ECKeyMethod) {
   ASSERT_LE(sig_len, signature.size());
   EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
 
-  // Test using the one-shot |EVP_DigestSign| function for approval.
+  // Test using the one-shot |EVP_DigestSign| function for approval. It should
+  // not return an approval because custom sign functionality is defined. 
   md_ctx.Reset();
   CALL_SERVICE_AND_CHECK_APPROVED(approved,
                                   ASSERT_TRUE(EVP_DigestSignInit(md_ctx.get(),

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -15,6 +15,7 @@
 #include <openssl/dh.h>
 #include <openssl/digest.h>
 #include <openssl/ec.h>
+#include <openssl/ecdsa.h>
 #include <openssl/ecdh.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
@@ -34,6 +35,8 @@
 #include "../hmac/internal.h"
 #include "../rand/internal.h"
 #include "../sha/internal.h"
+#include "../rsa/internal.h"
+#include "../ec/internal.h"
 
 static const uint8_t kAESKey[16] = {
     'A','W','S','-','L','C','C','r','y','p','t','o',' ','K', 'e','y'};
@@ -2519,6 +2522,65 @@ TEST_P(RSAServiceIndicatorTest, ManualRSASignVerify) {
   ASSERT_EQ(approved, test.sig_ver_expect_approved);
 }
 
+static int custom_sign(int max_out, const uint8_t *in, uint8_t *out, RSA *rsa,
+                       int padding) {
+  RSA_set_ex_data((RSA*)rsa, 0, (void*)"custom sign");
+  return 0;
+}
+
+TEST_P(RSAServiceIndicatorTest, RSAMethod) {
+  const RSATestVector &test = GetParam();
+
+  FIPSStatus approved = AWSLC_NOT_APPROVED;
+
+  bssl::UniquePtr<EVP_PKEY> pkey(EVP_PKEY_new());
+  ASSERT_TRUE(pkey);
+
+  RSA *rsa = nullptr;
+  if(test.use_pss) {
+    AssignRSAPSSKey(pkey.get(), test.key_size);
+  } else {
+    rsa = GetRSAKey(test.key_size);
+    ASSERT_TRUE(EVP_PKEY_set1_RSA(pkey.get(), rsa));
+  }
+
+  RSA_METHOD *meth = RSA_meth_new(NULL, 0);
+  RSA_meth_set_priv_enc(meth, custom_sign);
+  RSA_set_method(rsa, meth);
+
+  bssl::ScopedEVP_MD_CTX ctx;
+  ASSERT_TRUE(EVP_DigestInit(ctx.get(), test.func()));
+  ASSERT_TRUE(EVP_DigestUpdate(ctx.get(), kPlaintext, sizeof(kPlaintext)));
+
+  // Manual construction for signing.
+  bssl::UniquePtr<EVP_PKEY_CTX> pctx(EVP_PKEY_CTX_new(pkey.get(), nullptr));
+  ASSERT_TRUE(EVP_PKEY_sign_init(pctx.get()));
+  ASSERT_TRUE(EVP_PKEY_CTX_set_signature_md(pctx.get(), test.func()));
+  if (test.use_pss) {
+    ASSERT_TRUE(EVP_PKEY_CTX_set_rsa_padding(pctx.get(),
+                                             RSA_PKCS1_PSS_PADDING));
+    ASSERT_TRUE(EVP_PKEY_CTX_set_rsa_pss_saltlen(pctx.get(), -1));
+  }
+  EVP_MD_CTX_set_pkey_ctx(ctx.get(), pctx.get());
+  // Determine the size of the signature.
+  size_t sig_len = 0;
+  CALL_SERVICE_AND_CHECK_APPROVED(approved,
+                                  ASSERT_TRUE(EVP_DigestSignFinal(ctx.get(), nullptr, &sig_len)));
+  ASSERT_EQ(approved, AWSLC_NOT_APPROVED);
+
+  std::vector<uint8_t> sig;
+  sig.resize(sig_len);
+  // Custom sign will be called, never approved
+  CALL_SERVICE_AND_CHECK_APPROVED(approved,
+                                  EVP_DigestSignFinal(ctx.get(), sig.data(), &sig_len));
+
+  ASSERT_STREQ(static_cast<const char*>(RSA_get_ex_data(rsa, 0)), "custom sign");
+  ASSERT_EQ(approved, AWSLC_NOT_APPROVED);
+  sig.resize(sig_len);
+
+  RSA_meth_free(meth);
+}
+
 struct ECDSATestVector {
   // nid is the input curve nid.
   const int nid;
@@ -2874,6 +2936,120 @@ TEST_P(ECDSAServiceIndicatorTest, ManualECDSASignVerify) {
   CALL_SERVICE_AND_CHECK_APPROVED(approved,
       ASSERT_TRUE(EVP_DigestVerifyFinal(ctx.get(), sig.data(), sig_len)));
   EXPECT_EQ(approved, test.sig_ver_expect_approved);
+}
+
+static int ecdsa_sign(int type, const unsigned char *dgst, int dgstlen,
+                      unsigned char *sig, unsigned int *siglen,
+                      const BIGNUM *kinv, const BIGNUM *r, EC_KEY *ec) {
+
+  ECDSA_SIG *ret = ECDSA_do_sign(dgst, dgstlen, ec);
+  if (!ret) {
+    *siglen = 0;
+    return 0;
+  }
+
+  CBB cbb;
+  CBB_init_fixed(&cbb, sig, ECDSA_size(ec));
+  size_t len;
+  if (!ECDSA_SIG_marshal(&cbb, ret) ||
+      !CBB_finish(&cbb, nullptr, &len)) {
+    ECDSA_SIG_free(ret);
+    OPENSSL_PUT_ERROR(ECDSA, ECDSA_R_ENCODE_ERROR);
+    *siglen = 0;
+    return 0;
+  }
+
+  *siglen = (unsigned)len;
+
+  // To track whether custom implementation was called
+  EC_KEY_set_ex_data(ec, 0, (void*)"ecdsa_sign");
+
+  ECDSA_SIG_free(ret);
+  return 1;
+}
+
+TEST_P(ECDSAServiceIndicatorTest, ECKeyMethod) {
+  const ECDSATestVector &test = GetParam();
+  if (test.nid == NID_secp256k1 && !kCurveSecp256k1Supported) {
+    GTEST_SKIP();
+  }
+
+  FIPSStatus approved = AWSLC_NOT_APPROVED;
+
+  const EC_GROUP *group = EC_GROUP_new_by_curve_name(test.nid);
+  bssl::UniquePtr<EC_KEY> eckey(EC_KEY_new());
+  bssl::UniquePtr<EVP_PKEY> pkey(EVP_PKEY_new());
+  bssl::ScopedEVP_MD_CTX md_ctx;
+  ASSERT_TRUE(eckey);
+  ASSERT_TRUE(EC_KEY_set_group(eckey.get(), group));
+
+  EC_KEY_METHOD *meth = EC_KEY_METHOD_new(NULL);
+  EC_KEY_METHOD_set_sign(meth, ecdsa_sign, NULL, NULL);
+  EC_KEY_set_method(eckey.get(), meth);
+
+  // Generate a generic EC key.
+  ASSERT_TRUE(EC_KEY_generate_key(eckey.get()));
+  ASSERT_TRUE(EVP_PKEY_set1_EC_KEY(pkey.get(), eckey.get()));
+
+  // Test running the EVP_DigestSign interfaces one by one directly, and check
+  // |EVP_DigestSignFinal| for approval at the end. |EVP_DigestSignInit|,
+  // |EVP_DigestSignUpdate| should not be approved because they do not indicate
+  // an entire service has been done.
+  CALL_SERVICE_AND_CHECK_APPROVED(
+          approved, ASSERT_TRUE(EVP_DigestSignInit(md_ctx.get(), nullptr,
+                                                   test.func(), nullptr,
+                                                   pkey.get())));
+  EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
+  CALL_SERVICE_AND_CHECK_APPROVED(approved,
+                                  ASSERT_TRUE(EVP_DigestSignUpdate(md_ctx.get(),
+                                                                   kPlaintext,
+                                                                   sizeof(kPlaintext))));
+  EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
+  // Determine the size of the signature. The first call of
+  // |EVP_DigestSignFinal| should not return an approval check because no crypto
+  // is being done when |nullptr| is given as the |out_sig| field.
+  size_t max_sig_len;
+  CALL_SERVICE_AND_CHECK_APPROVED(approved,
+                                  ASSERT_TRUE(EVP_DigestSignFinal(md_ctx.get(),
+                                                                  nullptr,
+                                                                  &max_sig_len)));
+  EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
+  std::vector<uint8_t> signature(max_sig_len);
+  // The second call performs the actual operation.
+  size_t sig_len = max_sig_len;
+  CALL_SERVICE_AND_CHECK_APPROVED(approved,
+                                  ASSERT_TRUE(EVP_DigestSignFinal(md_ctx.get(),
+                                                                  signature.data(),
+                                                                  &sig_len)));
+  ASSERT_STREQ(static_cast<const char*>(EC_KEY_get_ex_data(eckey.get(), 0)), "ecdsa_sign");
+
+  ASSERT_LE(sig_len, signature.size());
+  EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
+
+  // Test using the one-shot |EVP_DigestSign| function for approval.
+  md_ctx.Reset();
+  CALL_SERVICE_AND_CHECK_APPROVED(approved,
+                                  ASSERT_TRUE(EVP_DigestSignInit(md_ctx.get(),
+                                                                 nullptr,
+                                                                 test.func(),
+                                                                 nullptr,
+                                                                 pkey.get())));
+  EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
+  sig_len = max_sig_len;
+  EC_KEY_set_ex_data(eckey.get(), 0, (void*) "");
+  ASSERT_STREQ(static_cast<const char*>(EC_KEY_get_ex_data(eckey.get(), 0)), "");
+
+  CALL_SERVICE_AND_CHECK_APPROVED(approved,
+                                  ASSERT_TRUE(EVP_DigestSign(md_ctx.get(),
+                                                             signature.data(),
+                                                             &sig_len,
+                                                             kPlaintext,
+                                                             sizeof(kPlaintext))));
+  ASSERT_STREQ(static_cast<const char*>(EC_KEY_get_ex_data(eckey.get(), 0)), "ecdsa_sign");
+
+  ASSERT_LE(sig_len, signature.size());
+  EXPECT_EQ(approved, AWSLC_NOT_APPROVED);
+  EC_KEY_METHOD_free(meth);
 }
 
 struct ECDHTestVector {


### PR DESCRIPTION
### Issues:
`CryptoAlg-2633`

### Description of changes: 
The service indicator "update" functions were modified to check for the existence of custom crypto in RSA_METHOD and EC_KEY_METHOD structs. If custom crypto is utilized for a given operation, the service indicator should not be updated. The checks are conservative and do not update the service indicator for a signing operation for EC/RSA keys if either custom sign or sign_sig/sign_raw functionality is provided - regardless of whether these may be invoked. 

### Testing:
Tested both EC_KEY_METHOD and RSA_METHOD with custom crypto and ensured the service indicator was not updating. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
