### PR TITLE
Create mutable EC_GROUP API for OpenSSL compatibility

### DIFF
--- a/crypto/fipsmodule/ec/ec.c
+++ b/crypto/fipsmodule/ec/ec.c
@@ -496,11 +496,13 @@ int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ignored) {
     if (a == b) {
       return 0;
     }
+    // Built-in static curves may be compared by curve name alone.
     if (a->curve_name != b->curve_name) {
       return 1;
     }
     if (a->curve_name != NID_undef) {
-      // Built-in curves may be compared by curve name alone.
+      // |NID_undef| indicates a custom curve. If we're comparing custom curves
+      // we fall through and compare the entire curve structure below.
       return 0;
     }
   }

--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -279,12 +279,12 @@ point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key) {
 }
 
 void EC_KEY_set_conv_form(EC_KEY *key, point_conversion_form_t cform) {
-  if (key == NULL || key->group == NULL) {
+  if (key == NULL) {
     OPENSSL_PUT_ERROR(EC, ERR_R_PASSED_NULL_PARAMETER);
     return;
   }
   key->conv_form = cform;
-  if (key->group->mutable_ec_group) {
+  if (key->group != NULL && key->group->mutable_ec_group) {
     key->group->conv_form = cform;
   }
 }

--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -279,6 +279,10 @@ point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key) {
 }
 
 void EC_KEY_set_conv_form(EC_KEY *key, point_conversion_form_t cform) {
+  if (key == NULL || key->group == NULL) {
+    OPENSSL_PUT_ERROR(EC, ERR_R_PASSED_NULL_PARAMETER);
+    return;
+  }
   key->conv_form = cform;
   if (key->group->mutable_ec_group) {
     key->group->conv_form = cform;

--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -280,6 +280,9 @@ point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key) {
 
 void EC_KEY_set_conv_form(EC_KEY *key, point_conversion_form_t cform) {
   key->conv_form = cform;
+  if (key->group->mutable_ec_group) {
+    key->group->conv_form = cform;
+  }
 }
 
 int EC_KEY_check_key(const EC_KEY *eckey) {

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1926,11 +1926,8 @@ static std::vector<CurveParam> AllCurves() {
   EC_get_builtin_curves(curves.data(), num_curves);
   std::vector<CurveParam> nids;
   for (const auto &curve : curves) {
-    CurveParam curve_param{};
-    curve_param.nid = curve.nid;
-
     // Curve test parameter to use static groups.
-    curve_param.mutable_group = false;
+    CurveParam curve_param = { curve.nid, false };
     nids.push_back(curve_param);
 
     // Curve test parameter to use mutable groups.

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -718,6 +718,28 @@ TEST_P(ECPublicKeyTest, DecodeAndEncode) {
   OPENSSL_free(p);
 }
 
+TEST_P(ECPublicKeyTest, MutableECGroup) {
+  const auto &param = GetParam();
+
+  bssl::UniquePtr<EC_GROUP> group(
+      EC_GROUP_new_by_curve_name_mutable(param.nid));
+  ASSERT_TRUE(group);
+
+  bssl::UniquePtr<EC_POINT> point(EC_POINT_new(group.get()));
+  ASSERT_TRUE(EC_POINT_oct2point(group.get(), point.get(), param.input_key,
+                                 param.input_key_len, nullptr));
+
+  EC_GROUP_set_point_conversion_form(group.get(), param.encode_conv_form);
+
+  // Use the saved conversion form in |group|. This should only work with
+  // |EC_GROUP_new_by_curve_name_mutable|.
+  std::vector<uint8_t> serialized;
+  ASSERT_TRUE(EncodeECPoint(&serialized, group.get(), point.get(),
+                            EC_GROUP_get_point_conversion_form(group.get())));
+  EXPECT_EQ(Bytes(param.expected_output_key, param.expected_output_key_len),
+            Bytes(serialized));
+}
+
 INSTANTIATE_TEST_SUITE_P(All, ECPublicKeyTest,
                          testing::ValuesIn(kDecodeAndEncodeInputs));
 
@@ -1407,22 +1429,32 @@ TEST(ECDeathTest, SmallGroupOrderAndDie) {
 #endif
 #endif
 
-class ECCurveTest : public testing::TestWithParam<int> {
+struct CurveParam {
+  int nid;
+  bool mutable_group;
+};
+
+class ECCurveTest : public testing::TestWithParam<CurveParam> {
  public:
-  const EC_GROUP *group() const { return group_; }
+  EC_GROUP *group() const { return group_.get(); }
 
   void SetUp() override {
-    group_ = EC_GROUP_new_by_curve_name(GetParam());
-    ASSERT_TRUE(group_);
+    if(GetParam().mutable_group) {
+      group_.reset(EC_GROUP_new_by_curve_name_mutable(GetParam().nid));
+      ASSERT_TRUE(group_);
+    } else {
+      group_.reset(EC_GROUP_new_by_curve_name(GetParam().nid));
+      ASSERT_TRUE(group_);
+    }
   }
 
  private:
-  const EC_GROUP *group_{};
+  bssl::UniquePtr<EC_GROUP> group_{};
 };
 
 TEST_P(ECCurveTest, SetAffine) {
   // Generate an EC_KEY.
-  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam()));
+  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam().nid));
   ASSERT_TRUE(key);
   ASSERT_TRUE(EC_KEY_generate_key(key.get()));
 
@@ -1464,7 +1496,7 @@ TEST_P(ECCurveTest, SetAffine) {
 }
 
 TEST_P(ECCurveTest, IsOnCurve) {
-  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam()));
+  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam().nid));
   ASSERT_TRUE(key);
   ASSERT_TRUE(EC_KEY_generate_key(key.get()));
 
@@ -1488,12 +1520,12 @@ TEST_P(ECCurveTest, IsOnCurve) {
 }
 
 TEST_P(ECCurveTest, Compare) {
-  bssl::UniquePtr<EC_KEY> key1(EC_KEY_new_by_curve_name(GetParam()));
+  bssl::UniquePtr<EC_KEY> key1(EC_KEY_new_by_curve_name(GetParam().nid));
   ASSERT_TRUE(key1);
   ASSERT_TRUE(EC_KEY_generate_key(key1.get()));
   const EC_POINT *pub1 = EC_KEY_get0_public_key(key1.get());
 
-  bssl::UniquePtr<EC_KEY> key2(EC_KEY_new_by_curve_name(GetParam()));
+  bssl::UniquePtr<EC_KEY> key2(EC_KEY_new_by_curve_name(GetParam().nid));
   ASSERT_TRUE(key2);
   ASSERT_TRUE(EC_KEY_generate_key(key2.get()));
   const EC_POINT *pub2 = EC_KEY_get0_public_key(key2.get());
@@ -1544,13 +1576,13 @@ TEST_P(ECCurveTest, Compare) {
 
 TEST_P(ECCurveTest, GenerateFIPS) {
   // Generate an EC_KEY.
-  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam()));
+  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam().nid));
   ASSERT_TRUE(key);
   ASSERT_TRUE(EC_KEY_generate_key_fips(key.get()));
 }
 
 TEST_P(ECCurveTest, AddingEqualPoints) {
-  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam()));
+  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam().nid));
   ASSERT_TRUE(key);
   ASSERT_TRUE(EC_KEY_generate_key(key.get()));
 
@@ -1719,7 +1751,7 @@ TEST_P(ECCurveTest, MulNonMinimal) {
 
 // Test that EC_KEY_set_private_key rejects invalid values.
 TEST_P(ECCurveTest, SetInvalidPrivateKey) {
-  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam()));
+  bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(GetParam().nid));
   ASSERT_TRUE(key);
 
   bssl::UniquePtr<BIGNUM> bn(BN_dup(BN_value_one()));
@@ -1855,19 +1887,63 @@ TEST_P(ECCurveTest, EncodeInfinity) {
                              nullptr, 0, nullptr));
 }
 
-static std::vector<int> AllCurves() {
+TEST_P(ECCurveTest, ECGroupConvForm) {
+  bssl::UniquePtr<BIGNUM> one(BN_new());
+  ASSERT_TRUE(one);
+  ASSERT_TRUE(BN_set_word(one.get(), 1));
+
+  // Ruby depends on |EC_GROUP| to save the used compression format, so we
+  // replicate that scenario. This won't work with our default static curves.
+  bssl::UniquePtr<EC_GROUP> group2(EC_GROUP_dup(group()));
+  EC_GROUP_set_point_conversion_form(group2.get(), POINT_CONVERSION_COMPRESSED);
+
+  // Compute g × 1.
+  bssl::UniquePtr<EC_POINT> point(EC_POINT_new(group()));
+  ASSERT_TRUE(point);
+  ASSERT_TRUE(
+      EC_POINT_mul(group(), point.get(), one.get(), nullptr, nullptr, nullptr));
+
+  // Serialize the points.
+  std::vector<uint8_t> group1_serialized;
+  std::vector<uint8_t> group2_serialized;
+  ASSERT_TRUE(EncodeECPoint(&group1_serialized, group(), point.get(),
+                            EC_GROUP_get_point_conversion_form(group())));
+  ASSERT_TRUE(EncodeECPoint(&group2_serialized, group2.get(), point.get(),
+                            EC_GROUP_get_point_conversion_form(group2.get())));
+
+  if (GetParam().mutable_group) {
+    EXPECT_NE(Bytes(group1_serialized), Bytes(group2_serialized));
+  } else {
+    // |EC_GROUP_set_point_conversion_form| is a no-op when using our default
+    // static groups.
+    EXPECT_EQ(Bytes(group1_serialized), Bytes(group2_serialized));
+  }
+}
+
+static std::vector<CurveParam> AllCurves() {
   const size_t num_curves = EC_get_builtin_curves(nullptr, 0);
   std::vector<EC_builtin_curve> curves(num_curves);
   EC_get_builtin_curves(curves.data(), num_curves);
-  std::vector<int> nids;
-  for (const auto& curve : curves) {
-    nids.push_back(curve.nid);
+  std::vector<CurveParam> nids;
+  for (const auto &curve : curves) {
+    CurveParam curve_param{};
+    curve_param.nid = curve.nid;
+
+    // Curve test parameter to use static groups.
+    curve_param.mutable_group = false;
+    nids.push_back(curve_param);
+
+    // Curve test parameter to use mutable groups.
+    curve_param.mutable_group = true;
+    nids.push_back(curve_param);
   }
   return nids;
 }
 
-static std::string CurveToString(const testing::TestParamInfo<int> &params) {
-  return OBJ_nid2sn(params.param);
+static std::string CurveToString(
+    const testing::TestParamInfo<CurveParam> &params) {
+  return std::string(OBJ_nid2sn(params.param.nid)) +
+         std::string(params.param.mutable_group ? "_mutable" : "_static_curve");
 }
 
 INSTANTIATE_TEST_SUITE_P(All, ECCurveTest, testing::ValuesIn(AllCurves()),

--- a/crypto/fipsmodule/ec/internal.h
+++ b/crypto/fipsmodule/ec/internal.h
@@ -650,6 +650,17 @@ struct ec_group_st {
   // otherwise.
   int field_greater_than_order;
 
+  // conv_form represents the encoding format of the elliptic curve point.
+  // The default is |POINT_CONVERSION_UNCOMPRESSED|. This is not changed unless
+  // the user allocates the |EC_GROUP| with |EC_GROUP_new_by_curve_name_mutable|
+  // and customizes |conv_form| with |EC_GROUP_set_point_conversion_form|.
+  point_conversion_form_t conv_form;
+
+  // mutable_ec_group is one if the |EC_GROUP| has been dynamically allocated
+  // with |EC_GROUP_new_by_curve_name_mutable|. The default is zero to indicate
+  // our built-in static curves.
+  int mutable_ec_group;
+
   CRYPTO_refcount_t references;
 } /* EC_GROUP */;
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -147,6 +147,15 @@ OPENSSL_EXPORT const EC_GROUP *EC_group_secp256k1(void);
 // more modern primitives.
 OPENSSL_EXPORT EC_GROUP *EC_GROUP_new_by_curve_name(int nid);
 
+// EC_GROUP_new_by_curve_name_mutable is like |EC_GROUP_new_by_curve_name|, but
+// dynamically allocates a mutable |EC_GROUP| pointer for more OpenSSL
+// compatibility. Although |EC_GROUP_new_by_curve_name| returns a const pointer
+// under the hood, resulting objects returned by this function MUST be freed
+// by |EC_GROUP_free|.
+//
+// Note: Users should use |EC_GROUP_new_by_curve_name| when possible.
+OPENSSL_EXPORT EC_GROUP *EC_GROUP_new_by_curve_name_mutable(int nid);
+
 // EC_GROUP_cmp returns zero if |a| and |b| are the same group and non-zero
 // otherwise.
 OPENSSL_EXPORT int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b,
@@ -357,25 +366,29 @@ OPENSSL_EXPORT int EC_hash_to_curve_p384_xmd_sha384_sswu(
     const EC_GROUP *group, EC_POINT *out, const uint8_t *dst, size_t dst_len,
     const uint8_t *msg, size_t msg_len);
 
-
-// Deprecated functions.
-
 // EC_GROUP_free releases a reference to |group|, if |group| was created by
-// |EC_GROUP_new_curve_GFp|. If |group| is static, it does nothing.
+// |EC_GROUP_new_by_curve_name_mutable| or |EC_GROUP_new_curve_GFp|. If
+// |group| is static, it does nothing.
 //
-// This function exists for OpenSSL compatibilty, and to manage dynamic
-// |EC_GROUP|s constructed by |EC_GROUP_new_curve_GFp|. Callers that do not need
-// either may ignore this function.
+// This function exists for OpenSSL compatibility, and to manage dynamic
+// |EC_GROUP|s constructed by |EC_GROUP_new_by_curve_name_mutable| and
+// |EC_GROUP_new_curve_GFp|. Callers that do not need either may ignore this
+// function.
 OPENSSL_EXPORT void EC_GROUP_free(EC_GROUP *group);
 
 // EC_GROUP_dup increments |group|'s reference count and returns it, if |group|
-// was created by |EC_GROUP_new_curve_GFp|. If |group| is static, it simply
-// returns |group|.
+// was created by |EC_GROUP_new_curve_GFp|. If |group| was created by
+// |EC_GROUP_new_by_curve_name_mutable|, it does a deep copy of |group|. If
+// |group| is static, it simply returns |group|.
 //
-// This function exists for OpenSSL compatibilty, and to manage dynamic
-// |EC_GROUP|s constructed by |EC_GROUP_new_curve_GFp|. Callers that do not need
-// either may ignore this function.
+// This function exists for OpenSSL compatibility, and to manage dynamic
+// |EC_GROUP|s constructed by |EC_GROUP_new_by_curve_name_mutable| and
+// |EC_GROUP_new_curve_GFp|. Callers that do not need either may ignore this
+// function.
 OPENSSL_EXPORT EC_GROUP *EC_GROUP_dup(const EC_GROUP *group);
+
+
+// Deprecated functions.
 
 // EC_GROUP_new_curve_GFp creates a new, arbitrary elliptic curve group based
 // on the equation y² = x³ + a·x + b. It returns the new group or NULL on
@@ -464,21 +477,7 @@ OPENSSL_EXPORT size_t EC_get_builtin_curves(EC_builtin_curve *out_curves,
 OPENSSL_EXPORT void EC_POINT_clear_free(EC_POINT *point);
 
 
-// |EC_GROUP| No-op Functions [Deprecated].
-
-// EC_GROUP_set_asn1_flag does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_asn1_flag(EC_GROUP *group,
-                                                              int flag);
-
-// EC_GROUP_get_asn1_flag returns |OPENSSL_EC_NAMED_CURVE|.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int EC_GROUP_get_asn1_flag(
-    const EC_GROUP *group);
-
-// EC_GROUP_set_point_conversion_form aborts the process if |form| is not
-// |POINT_CONVERSION_UNCOMPRESSED| or |POINT_CONVERSION_COMPRESSED|, and
-// otherwise does nothing.
-OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_point_conversion_form(
-    EC_GROUP *group, point_conversion_form_t form);
+// General No-op Functions [Deprecated].
 
 // EC_GROUP_set_seed does nothing and returns 0.
 //
@@ -500,6 +499,43 @@ EC_GROUP_get_seed_len(const EC_GROUP *group);
 // ECPKParameters_print prints nothing and returns 1.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int ECPKParameters_print(
     BIO *bio, const EC_GROUP *group, int offset);
+
+
+// |EC_GROUP| No-op Functions [Deprecated].
+//
+// Unlike OpenSSL's |EC_GROUP| implementation, our |EC_GROUP|s for named
+// curves are static and immutable. The following functions pertain to
+// the mutable aspects of OpenSSL's |EC_GROUP| structure. Using these
+// functions undermines the assumption that our curves are static. Consider
+// using the listed alternatives.
+
+// EC_GROUP_set_asn1_flag does nothing.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_asn1_flag(EC_GROUP *group,
+                                                              int flag);
+
+// EC_GROUP_get_asn1_flag returns |OPENSSL_EC_NAMED_CURVE|.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int EC_GROUP_get_asn1_flag(
+    const EC_GROUP *group);
+
+// EC_GROUP_set_point_conversion_form aborts the process if |form| is not
+// |POINT_CONVERSION_UNCOMPRESSED| or |POINT_CONVERSION_COMPRESSED|, and
+// otherwise does nothing. This DOES NOT change the encoding format for
+// |EC_GROUP| by default. |group| must be allocated by
+// |EC_GROUP_new_by_curve_name_mutable| for the encoding format to change.
+//
+// Note: Use |EC_KEY_set_conv_form| / |EC_KEY_get_conv_form| to set and return
+// the  desired compression format.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_point_conversion_form(
+    EC_GROUP *group, point_conversion_form_t form);
+
+// EC_GROUP_get_point_conversion_form returns |POINT_CONVERSION_UNCOMPRESSED|
+// (the default compression format).
+//
+// Note: Use |EC_KEY_set_conv_form| / |EC_KEY_get_conv_form| to set and return
+// the  desired compression format.
+OPENSSL_EXPORT OPENSSL_DEPRECATED point_conversion_form_t
+EC_GROUP_get_point_conversion_form(const EC_GROUP *group);
+
 
 // EC_METHOD No-ops [Deprecated].
 //


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2547`

### Description of changes: 
Further investigation led us to discover that Ruby [depends](https://github.com/ruby/ruby/blob/ruby_3_1/ext/openssl/lib/openssl/pkey.rb#L296-L311) on mutable `EC_GROUP`s from OpenSSL. These were made immutable with the introduction of our default static `EC_GROUP` curves, which have been beneficial for us and our existing consumers. This was done by making the mutable portions of `EC_GROUP`s no-ops (`EC_GROUP_set_asn1_flag` and `EC_GROUP_set_point_conversion_form`), which OpenSSL couldn't do due to their more complex use case.
* https://github.com/aws/aws-lc/commit/51073ce05587f413d46f908407b47e884d6d325e
* https://github.com/aws/aws-lc/commit/e166375a20c06155e149c87d4f176f9770abc29a

Ruby (and possibly other dynamic languages) mutates the data being stored in `EC_GROUP` and depends on it for subsequent operations. Since our default groups are static and immutable, this causes issues when integrating with Ruby. We don't want to sacrifice the benefits of static groups and reversing the optional call to `EC_GROUP_free` is a dangerously silent memory leak. 
We've decided to introduce a special API for mutable `EC_GROUP`s for our default curves. This gives us a path forward for Ruby and keeps the benefits of static curves for existing consumers. Custom curves are already dynamically allocated so they don't need another special API, but the additional complexities for maintaining the underlying `generator` warrant another commit separate from this.

### Call-outs:
1. Custom curves aren't mutable just yet, but will be in another PR.
2. It would be nice to get additional verification that the bookkeeping in `EC_GROUP_dup` and `EC_GROUP_cmp` were done right.

### Testing:
Extended against tests using existing `EC_GROUP`s and conversion formats. These were focused on retrieving the `conv_form` from the `EC_GROUP` to use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
