### PR TITLE
Add docker image for gcc 7.2

### DIFF
--- a/tests/docker_images/gcc/7.2/Dockerfile
+++ b/tests/docker_images/gcc/7.2/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+FROM --platform=linux/amd64 gcc:7.2
+
+SHELL ["/bin/bash", "-c"]
+
+COPY cmake-3.6.3-Linux-x86_64.tar.gz /
+COPY go1.18.10.linux-amd64.tar.gz /
+RUN tar -C /usr/local -xzf cmake-3.6.3-Linux-x86_64.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.10.linux-amd64.tar.gz
+RUN rm cmake-3.6.3-Linux-x86_64.tar.gz
+RUN rm go1.18.10.linux-amd64.tar.gz
+RUN curl --proto '=https' -sSf https://sh.rustup.rs > ./rust_install.sh && \
+    chmod +x ./rust_install.sh && \
+    ./rust_install.sh -y
+ENV PATH="${PATH}:/usr/local/cmake-3.6.3-Linux-x86_64/bin:/usr/local/go/bin"
+
+CMD ["/bin/bash"]

--- a/tests/docker_images/gcc/build_images.sh
+++ b/tests/docker_images/gcc/build_images.sh
@@ -24,5 +24,12 @@ docker buildx build -t aws-lc:gcc-4.8 "${SCRIPT_DIR}"/4.8 --load
 rm "${SCRIPT_DIR}"/4.8/go1.18.10.linux-amd64.tar.gz
 rm "${SCRIPT_DIR}"/4.8/cmake-3.6.3-Linux-x86_64.tar.gz
 
+## GCC-7.2
+curl --output-dir "${SCRIPT_DIR}"/7.2 -LO https://go.dev/dl/go1.18.10.linux-amd64.tar.gz
+curl --output-dir "${SCRIPT_DIR}"/7.2 -LO https://github.com/Kitware/CMake/releases/download/v3.6.3/cmake-3.6.3-Linux-x86_64.tar.gz
+docker buildx build -t aws-lc:gcc-7.2 "${SCRIPT_DIR}"/7.2 --load
+rm "${SCRIPT_DIR}"/7.2/go1.18.10.linux-amd64.tar.gz
+rm "${SCRIPT_DIR}"/7.2/cmake-3.6.3-Linux-x86_64.tar.gz
+
 docker buildx rm ${BUILDER_NAME}
 


### PR DESCRIPTION
### Description of changes: 
Provides an easy way to create docker image w/ GCC 7.2 for local testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
