### PR TITLE
preparing for v1.35.1 release

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4735,7 +4735,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.35.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.35.1");
 }
 
 #else
@@ -4778,6 +4778,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.35.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.35.1");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.35.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.35.1"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* More tweaks for Ruby integration by @samuel40791765 in https://github.com/aws/aws-lc/pull/1852
* Implementation of EVP_PKEY_CTX_ctrl_str for various key types by @justsmth in https://github.com/aws/aws-lc/pull/1850
* Add MLKEM768 Hybrid Groups to libssl by @alexw91 in https://github.com/aws/aws-lc/pull/1849
* add support for PEM_write_bio_PrivateKey_traditional by @samuel40791765 in https://github.com/aws/aws-lc/pull/1845
* Update s2n-bignum subtree  by @torben-hansen in https://github.com/aws/aws-lc/pull/1861
* Add asserts in testing to fix Coverity alert by @smittals2 in https://github.com/aws/aws-lc/pull/1864
* Disable CRYPTO_is_AVX512IFMA_capable by @justsmth in https://github.com/aws/aws-lc/pull/1858


**Full Changelog**: https://github.com/aws/aws-lc/compare/v1.35.0...v1.35.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
