### PR TITLE
Default entropy source

### DIFF
--- a/crypto/fipsmodule/rand/entropy/entropy_sources.c
+++ b/crypto/fipsmodule/rand/entropy/entropy_sources.c
@@ -7,34 +7,52 @@
 #include <openssl/base.h>
 
 #include "internal.h"
+#include "../internal.h"
+#include "../../delocate.h"
 
-static int fake_void(void) {
+static int entropy_default_initialize(void) {
   return 1;
 }
 
-static int fake_rand(uint8_t a[CTR_DRBG_ENTROPY_LEN]) {
-  OPENSSL_cleanse(a, CTR_DRBG_ENTROPY_LEN);
+static void entropy_default_cleanup(void) {
+}
+
+static int entropy_default_get_seed(uint8_t seed[CTR_DRBG_ENTROPY_LEN]) {
+  CRYPTO_sysrand_for_seed(seed, CTR_DRBG_ENTROPY_LEN);
   return 1;
 }
 
-static int fake_rand_(uint8_t a[RAND_PRED_RESISTANCE_LEN]) {
-  OPENSSL_cleanse(a, RAND_PRED_RESISTANCE_LEN);
+static int entropy_default_get_prediction_resistance(
+  uint8_t pred_resistance[RAND_PRED_RESISTANCE_LEN]) {
+  if (have_fast_rdrand() != 1 ||
+      rdrand(pred_resistance, RAND_PRED_RESISTANCE_LEN) != 1) {
+    return 0;
+  }
   return 1;
 }
 
-int get_entropy_source(struct entropy_source *entropy_source) {
-
-  // In the future this function will lazily initialise a global entropy source.
-
-  GUARD_PTR(entropy_source);
-
-  entropy_source->is_initialized = 1;
-  entropy_source->initialize = fake_void;
-  entropy_source->cleanup = fake_void;
-  entropy_source->get_seed = fake_rand;
-  entropy_source->get_personalization_string = fake_rand;
-  entropy_source->get_prediction_resistance = fake_rand_;
-  entropy_source->randomize = fake_void;
-
+static int entropy_default_randomize(void) {
   return 1;
+}
+
+// The default entropy source configuration using
+// - OS randomness source for seeding
+// - Doesn't have a personalization string source
+// - If run-time is on an Intel CPU and it supports rdrand, use it as a source
+//   for prediction resistance. Otherwise, no source.
+DEFINE_LOCAL_DATA(struct entropy_source, default_entropy_source) {
+  out->initialize = entropy_default_initialize;
+  out->cleanup = entropy_default_cleanup;
+  out->get_seed = entropy_default_get_seed;
+  out->get_personalization_string = NULL;
+  if (have_fast_rdrand() == 1) {
+    out->get_prediction_resistance = entropy_default_get_prediction_resistance;
+  } else {
+    out->get_prediction_resistance = NULL;
+  }
+  out->randomize = entropy_default_randomize;
+};
+
+const struct entropy_source * get_entropy_source(void) {
+  return default_entropy_source();
 }

--- a/crypto/fipsmodule/rand/entropy/internal.h
+++ b/crypto/fipsmodule/rand/entropy/internal.h
@@ -14,17 +14,16 @@ extern "C" {
 
 // I could make these array types!
 struct entropy_source {
-  int is_initialized;
   int (*initialize)(void);
-  int (*cleanup)(void);
+  void (*cleanup)(void);
   int (*get_seed)(uint8_t seed[CTR_DRBG_ENTROPY_LEN]);
   int (*get_personalization_string)(uint8_t personalization_string[CTR_DRBG_ENTROPY_LEN]);
   int (*get_prediction_resistance)(uint8_t pred_resistance[RAND_PRED_RESISTANCE_LEN]);
   int (*randomize)(void);
 };
 
-// get_entropy_source will configure an entropy source in |entropy_source|.
-int get_entropy_source(struct entropy_source *entropy_source);
+// get_entropy_source will return an entropy source configured for the platform.
+const struct entropy_source * get_entropy_source(void);
 
 #if defined(__cplusplus)
 }  // extern C

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -97,6 +97,8 @@ OPENSSL_EXPORT int CTR_DRBG_init(CTR_DRBG_STATE *drbg,
                                  const uint8_t *personalization,
                                  size_t personalization_len);
 
+int rdrand(uint8_t *buf, const size_t len);
+
 #if defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM)
 
 OPENSSL_INLINE int have_rdrand(void) {

--- a/crypto/fipsmodule/rand/new_rand.c
+++ b/crypto/fipsmodule/rand/new_rand.c
@@ -23,7 +23,7 @@ struct rand_thread_local_state {
   uint64_t generate_calls_since_seed;
 
   // Entropy source. UBE volatile state.
-  struct entropy_source entropy_source;
+  const struct entropy_source *entropy_source;
 };
 
 // rand_thread_local_state frees a |rand_thread_local_state|. This is called
@@ -33,6 +33,10 @@ static void rand_thread_local_state_free(void *state_in) {
   struct rand_thread_local_state *state = state_in;
   if (state_in == NULL) {
     return;
+  }
+
+  if (state->entropy_source != NULL) {
+    state->entropy_source->cleanup();
   }
 
   OPENSSL_free(state);
@@ -60,7 +64,7 @@ static int rand_ensure_ctr_drbg_uniquness(struct rand_thread_local_state *state,
 // |*pred_resistance_len| is set to 0 if no prediction resistance source is
 // available and |RAND_PRED_RESISTANCE_LEN| otherwise.
 static void rand_maybe_get_ctr_drbg_pred_resistance(
-  struct entropy_source *entropy_source,
+  const struct entropy_source *entropy_source,
   uint8_t pred_resistance[RAND_PRED_RESISTANCE_LEN],
   size_t *pred_resistance_len) {
 
@@ -83,7 +87,8 @@ static void rand_maybe_get_ctr_drbg_pred_resistance(
 //
 // |*personalization_string_len| is set to 0 if no personalization string source
 // is available and |CTR_DRBG_ENTROPY_LEN| otherwise.
-static void rand_get_ctr_drbg_seed_entropy(struct entropy_source *entropy_source,
+static void rand_get_ctr_drbg_seed_entropy(
+  const struct entropy_source *entropy_source,
   uint8_t seed[CTR_DRBG_ENTROPY_LEN],
   uint8_t personalization_string[CTR_DRBG_ENTROPY_LEN],
   size_t *personalization_string_len) {
@@ -93,10 +98,8 @@ static void rand_get_ctr_drbg_seed_entropy(struct entropy_source *entropy_source
 
   *personalization_string_len = 0;
 
-  // If not initialized or the seed source is missing it is impossible to source
-  // any entropy.
-  if (entropy_source->is_initialized == 0 ||
-      entropy_source->get_seed(seed) != 1) {
+  // If the seed source is missing it is impossible to source any entropy.
+  if (entropy_source->get_seed(seed) != 1) {
     abort();
   }
 
@@ -118,7 +121,7 @@ static void rand_ctr_drbg_reseed(struct rand_thread_local_state *state) {
   uint8_t seed[CTR_DRBG_ENTROPY_LEN];
   uint8_t personalization_string[CTR_DRBG_ENTROPY_LEN];
   size_t personalization_string_len = 0;
-  rand_get_ctr_drbg_seed_entropy(&(state->entropy_source), seed,
+  rand_get_ctr_drbg_seed_entropy(state->entropy_source, seed,
     personalization_string, &personalization_string_len);
 
   assert(personalization_string_len == 0 ||
@@ -141,14 +144,15 @@ static void rand_state_initialize(struct rand_thread_local_state *state) {
 
   GUARD_PTR_ABORT(state);
 
-  if (get_entropy_source(&(state->entropy_source)) != 1) {
+  state->entropy_source = get_entropy_source();
+  if (state->entropy_source == NULL) {
     abort();
   }
 
   uint8_t seed[CTR_DRBG_ENTROPY_LEN];
   uint8_t personalization_string[CTR_DRBG_ENTROPY_LEN];
   size_t personalization_string_len = 0;
-  rand_get_ctr_drbg_seed_entropy(&(state->entropy_source), seed,
+  rand_get_ctr_drbg_seed_entropy(state->entropy_source, seed,
     personalization_string, &personalization_string_len);
 
   assert(personalization_string_len == 0 ||
@@ -192,7 +196,7 @@ static void RAND_bytes_core(
   // ensuring that its state is randomized before generating output.
   size_t first_pred_resistance_len = 0;
   uint8_t pred_resistance[RAND_PRED_RESISTANCE_LEN] = {0};
-  rand_maybe_get_ctr_drbg_pred_resistance(&(state->entropy_source),
+  rand_maybe_get_ctr_drbg_pred_resistance(state->entropy_source,
     pred_resistance, &first_pred_resistance_len);
 
   // If caller input user-controlled prediction resistance, use it.

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -301,7 +301,7 @@ OPENSSL_STATIC_ASSERT(RDRAND_MAX_RETRIES > 0, rdrand_max_retries_must_be_positiv
 
 // rdrand should only be called if either |have_rdrand| or |have_fast_rdrand|
 // returned true.
-static int rdrand(uint8_t *buf, const size_t len) {
+int rdrand(uint8_t *buf, const size_t len) {
   const size_t len_multiple8 = len & ~7;
   CALL_RDRAND_WITH_RETRY(CRYPTO_rdrand_multiple8_buf(buf, len_multiple8), 0)
   const size_t remainder = len - len_multiple8;
@@ -319,7 +319,7 @@ static int rdrand(uint8_t *buf, const size_t len) {
 
 #else
 
-static int rdrand(uint8_t *buf, size_t len) {
+int rdrand(uint8_t *buf, size_t len) {
   return 0;
 }
 


### PR DESCRIPTION
### Description of changes: 

This PR implements a default entropy source object for the randomness generation. This is done by defining the function table that is already assumed by the randomness generation code in `new_rand.c`. The configuration is similar to the one already being used but simplified. It's now assumed that an entropy source can never not be initialised which seems reasonable...

Since the entropy source method table is a const object, `get_entropy_source()` is changed to return a reference to it. Related code is also changed to take this into account.

Finally, the entropy source object "cleanup" function is changed to not return anything. It's called at thread exit and if it fails there is no way to recover anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
