### PR TITLE
use filepath.Join for file paths

### DIFF
--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -164,7 +164,7 @@ var (
 )
 
 func runTestOnce(test test, mallocNumToFail int64) (passed bool, err error) {
-	prog := path.Join(*buildDir, test.Cmd[0])
+	prog := filepath.Join(*buildDir, test.Cmd[0])
 	args := append([]string{}, test.Cmd[1:]...)
 	if *useSDE {
 		// SDE is neither compatible with the unwind tester nor automatically


### PR DESCRIPTION
### Description of changes: 
To accommodate Windows use `filepath.Join`.

### Call-outs:
[Documentation](https://pkg.go.dev/path/filepath#Join):
> Join joins any number of path elements into a single path, separating them with an OS specific [Separator](https://pkg.go.dev/path/filepath#Separator). Empty elements are ignored. The result is Cleaned. However, if the argument list is empty or all its elements are empty, Join returns an empty string. On Windows, the result will only be a UNC path if the first non-empty element is a UNC path.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
