### PR TITLE
Implement more EVP_PKEY_DH functionality

### DIFF
--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -1815,6 +1815,29 @@ TEST(EVPExtraTest, DHKeygen) {
   }
 }
 
+TEST(EVPExtraTest, DHParamgen) {
+  std::vector<std::pair<int, int>> test_data({ {1024, 3}, {512, 2}});
+
+  for (std::pair<int, int> plgen : test_data) {
+    const int prime_len = plgen.first;
+    const int generator = plgen.second;
+    // Construct a EVP_PKEY_CTX
+    bssl::UniquePtr<EVP_PKEY_CTX> ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_DH, nullptr));
+    ASSERT_TRUE(ctx);
+    // Initialize for paramgen
+    ASSERT_TRUE(EVP_PKEY_paramgen_init(ctx.get()));
+    // Set the prime length
+    ASSERT_TRUE(EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx.get(), prime_len));
+    // Set the generator
+    ASSERT_TRUE(EVP_PKEY_CTX_set_dh_paramgen_generator(ctx.get(), generator));
+
+    EVP_PKEY *raw_pkey = NULL;
+    // Generate the parameters
+    ASSERT_TRUE(EVP_PKEY_paramgen(ctx.get(), &raw_pkey));
+    EVP_PKEY_free(raw_pkey);
+  }
+}
+
 // Test that |EVP_PKEY_keygen| works for Ed25519.
 TEST(EVPExtraTest, Ed25519Keygen) {
   bssl::UniquePtr<EVP_PKEY_CTX> pctx(

--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -1836,7 +1836,13 @@ TEST(EVPExtraTest, DHParamgen) {
     EVP_PKEY *raw_pkey = NULL;
     // Generate the parameters
     ASSERT_TRUE(EVP_PKEY_paramgen(ctx.get(), &raw_pkey));
-    EVP_PKEY_free(raw_pkey);
+    bssl::UniquePtr<EVP_PKEY> pkey(raw_pkey);
+    ASSERT_TRUE(raw_pkey);
+
+    const DH* dh = EVP_PKEY_get0_DH(pkey.get());
+    const BIGNUM* p = DH_get0_p(dh);
+    unsigned p_size = BN_num_bits(p);
+    ASSERT_EQ(p_size, (unsigned)prime_len);
   }
 
   // Test error conditions

--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -1816,13 +1816,15 @@ TEST(EVPExtraTest, DHKeygen) {
 }
 
 TEST(EVPExtraTest, DHParamgen) {
-  std::vector<std::pair<int, int>> test_data({ {1024, 3}, {512, 2}});
+  std::vector<std::pair<int, int>> test_data(
+      {{768, 3}, {512, DH_GENERATOR_2}, {256, DH_GENERATOR_5}});
 
   for (std::pair<int, int> plgen : test_data) {
     const int prime_len = plgen.first;
     const int generator = plgen.second;
     // Construct a EVP_PKEY_CTX
-    bssl::UniquePtr<EVP_PKEY_CTX> ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_DH, nullptr));
+    bssl::UniquePtr<EVP_PKEY_CTX> ctx(
+        EVP_PKEY_CTX_new_id(EVP_PKEY_DH, nullptr));
     ASSERT_TRUE(ctx);
     // Initialize for paramgen
     ASSERT_TRUE(EVP_PKEY_paramgen_init(ctx.get()));
@@ -1836,6 +1838,19 @@ TEST(EVPExtraTest, DHParamgen) {
     ASSERT_TRUE(EVP_PKEY_paramgen(ctx.get(), &raw_pkey));
     EVP_PKEY_free(raw_pkey);
   }
+
+  // Test error conditions
+  const int prime_len = 255;
+  const int generator = 1;
+  // Construct a EVP_PKEY_CTX
+  bssl::UniquePtr<EVP_PKEY_CTX> ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_DH, nullptr));
+  ASSERT_TRUE(ctx);
+  // Initialize for paramgen
+  ASSERT_TRUE(EVP_PKEY_paramgen_init(ctx.get()));
+  // Set the prime length
+  ASSERT_NE(EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx.get(), prime_len), 1);
+  // Set the generator
+  ASSERT_NE(EVP_PKEY_CTX_set_dh_paramgen_generator(ctx.get(), generator), 1);
 }
 
 // Test that |EVP_PKEY_keygen| works for Ed25519.

--- a/crypto/evp_extra/p_dh.c
+++ b/crypto/evp_extra/p_dh.c
@@ -31,6 +31,8 @@ static int pkey_dh_init(EVP_PKEY_CTX *ctx) {
   if (dctx == NULL) {
     return 0;
   }
+  dctx->prime_len = 2048;
+  dctx->generator = 2;
 
   ctx->data = dctx;
   return 1;

--- a/crypto/evp_extra/p_dh.c
+++ b/crypto/evp_extra/p_dh.c
@@ -31,8 +31,9 @@ static int pkey_dh_init(EVP_PKEY_CTX *ctx) {
   if (dctx == NULL) {
     return 0;
   }
+  // Default parameters
   dctx->prime_len = 2048;
-  dctx->generator = 2;
+  dctx->generator = DH_GENERATOR_2;
 
   ctx->data = dctx;
   return 1;
@@ -129,6 +130,9 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *_p2) {
       return 1;
 
     case EVP_PKEY_CTRL_DH_PARAMGEN_GENERATOR:
+      if(p1 < 2) {
+        return -2;
+      }
       dctx->generator = p1;
       return 1;
 
@@ -140,15 +144,15 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *_p2) {
 
 static int pkey_dh_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey) {
   DH_PKEY_CTX *dctx = ctx->data;
-
   DH *dh = DH_new();
   if (dh == NULL) {
     return 0;
   }
   int ret = DH_generate_parameters_ex(dh, dctx->prime_len, dctx->generator, NULL);
-  if (ret) {
+  if (ret == 1) {
     EVP_PKEY_assign_DH(pkey, dh);
   } else {
+    ret = 0;
     DH_free(dh);
   }
   return ret;

--- a/crypto/fipsmodule/evp/evp_ctx_test.cc
+++ b/crypto/fipsmodule/evp/evp_ctx_test.cc
@@ -4,6 +4,7 @@
 #include "internal.h"
 
 #include <gtest/gtest.h>
+#include <openssl/dh.h>
 #include <openssl/ec_key.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -237,6 +238,31 @@ TEST_F(EvpPkeyCtxCtrlStrTest, DhPad) {
   ASSERT_EQ(EVP_PKEY_CTX_ctrl_str(ctx.get(), "dh_pad", "17"), 1);
 
   // There is no function to retrieve the DH pad value.
+}
+
+TEST_F(EvpPkeyCtxCtrlStrTest, DhParamGen) {
+  // Create a EVP_PKEY_CTX with a newly generated DH
+  bssl::UniquePtr<EVP_PKEY_CTX> ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_DH, nullptr));
+  ASSERT_TRUE(ctx);
+  ASSERT_TRUE(EVP_PKEY_paramgen_init(ctx.get()));
+
+  ASSERT_EQ(EVP_PKEY_CTX_ctrl_str(ctx.get(), "dh_paramgen_prime_len", "256"), 1);
+  ASSERT_NE(EVP_PKEY_CTX_ctrl_str(ctx.get(), "dh_paramgen_prime_len", "gg"), 1);
+  ASSERT_NE(EVP_PKEY_CTX_ctrl_str(ctx.get(), "dh_paramgen_prime_len", "255"), 1);
+
+  ASSERT_EQ(EVP_PKEY_CTX_ctrl_str(ctx.get(), "dh_paramgen_generator", "5"), 1);
+  ASSERT_NE(EVP_PKEY_CTX_ctrl_str(ctx.get(), "dh_paramgen_prime_len", "gg"), 1);
+  ASSERT_NE(EVP_PKEY_CTX_ctrl_str(ctx.get(), "dh_paramgen_prime_len", "1"), 1);
+
+  EVP_PKEY* raw = nullptr;
+  ASSERT_EQ(EVP_PKEY_paramgen(ctx.get(), &raw), 1);
+  bssl::UniquePtr<EVP_PKEY> pkey(raw);
+  ASSERT_TRUE(raw);
+
+  const DH* dh = EVP_PKEY_get0_DH(pkey.get());
+  const BIGNUM* p = DH_get0_p(dh);
+  unsigned p_size = BN_num_bits(p);
+  ASSERT_EQ(p_size, 256u);
 }
 
 static const char *hkdf_hexsalt = "000102030405060708090a0b0c";

--- a/crypto/fipsmodule/evp/internal.h
+++ b/crypto/fipsmodule/evp/internal.h
@@ -241,6 +241,8 @@ int EVP_RSA_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *
 #define EVP_PKEY_CTRL_HKDF_SALT (EVP_PKEY_ALG_CTRL + 17)
 #define EVP_PKEY_CTRL_HKDF_INFO (EVP_PKEY_ALG_CTRL + 18)
 #define EVP_PKEY_CTRL_DH_PAD (EVP_PKEY_ALG_CTRL + 19)
+#define EVP_PKEY_CTRL_DH_PARAMGEN_PRIME_LEN (EVP_PKEY_ALG_CTRL + 20)
+#define EVP_PKEY_CTRL_DH_PARAMGEN_GENERATOR (EVP_PKEY_ALG_CTRL + 21)
 
 struct evp_pkey_ctx_st {
   // Method associated with this operation

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -180,6 +180,8 @@ OPENSSL_EXPORT int EVP_PKEY_set1_DH(EVP_PKEY *pkey, DH *key);
 OPENSSL_EXPORT int EVP_PKEY_assign_DH(EVP_PKEY *pkey, DH *key);
 OPENSSL_EXPORT DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
 OPENSSL_EXPORT DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
+OPENSSL_EXPORT int EVP_PKEY_CTX_set_dh_paramgen_prime_len(EVP_PKEY_CTX *ctx, int pbits);
+OPENSSL_EXPORT int EVP_PKEY_CTX_set_dh_paramgen_generator(EVP_PKEY_CTX *ctx, int gen);
 
 #define EVP_PKEY_NONE NID_undef
 #define EVP_PKEY_RSA NID_rsaEncryption

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -183,11 +183,14 @@ OPENSSL_EXPORT DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
 
 // EVP_PKEY_CTX_set_dh_paramgen_prime_len sets the length of the DH prime
 // parameter p for DH parameter generation. If this function is not called,
-// the default length of 2048 is used.
+// the default length of 2048 is used. |pbits| must be greater than or equal
+// to 256. Returns 1 on success, otherwise returns a non-positive value.
 OPENSSL_EXPORT int EVP_PKEY_CTX_set_dh_paramgen_prime_len(EVP_PKEY_CTX *ctx, int pbits);
 
 // EVP_PKEY_CTX_set_dh_paramgen_generator sets the DH generator for DH parameter
 // generation. If this function is not called, the default value of 2 is used.
+// |gen| must be greater than 1. Returns 1 on success, otherwise returns a
+// non-positive value.
 OPENSSL_EXPORT int EVP_PKEY_CTX_set_dh_paramgen_generator(EVP_PKEY_CTX *ctx, int gen);
 
 #define EVP_PKEY_NONE NID_undef

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -180,7 +180,14 @@ OPENSSL_EXPORT int EVP_PKEY_set1_DH(EVP_PKEY *pkey, DH *key);
 OPENSSL_EXPORT int EVP_PKEY_assign_DH(EVP_PKEY *pkey, DH *key);
 OPENSSL_EXPORT DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
 OPENSSL_EXPORT DH *EVP_PKEY_get1_DH(const EVP_PKEY *pkey);
+
+// EVP_PKEY_CTX_set_dh_paramgen_prime_len sets the length of the DH prime
+// parameter p for DH parameter generation. If this function is not called,
+// the default length of 2048 is used.
 OPENSSL_EXPORT int EVP_PKEY_CTX_set_dh_paramgen_prime_len(EVP_PKEY_CTX *ctx, int pbits);
+
+// EVP_PKEY_CTX_set_dh_paramgen_generator sets the DH generator for DH parameter
+// generation. If this function is not called, the default value of 2 is used.
 OPENSSL_EXPORT int EVP_PKEY_CTX_set_dh_paramgen_generator(EVP_PKEY_CTX *ctx, int gen);
 
 #define EVP_PKEY_NONE NID_undef


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-2363

### Description of changes: 
* Support for EVP_PKEY_DH "paramgen".
* Implentation for `EVP_PKEY_CTX_set_dh_paramgen_prime_len` and `EVP_PKEY_CTX_set_dh_paramgen_generator`
   * Support of these operations via `EVP_PKEY_CTX_ctrl` and `EVP_PKEY_CTX_ctrl_str`

### Testing:
* New test added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
