### PR TITLE
Add EC_GROUP mutablility to custom curves

### DIFF
--- a/crypto/fipsmodule/ec/ec.c
+++ b/crypto/fipsmodule/ec/ec.c
@@ -478,6 +478,10 @@ EC_GROUP *EC_GROUP_dup(const EC_GROUP *a) {
 }
 
 int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ignored) {
+  // Note this function returns 0 if equal and non-zero otherwise.
+  if (a == b) {
+    return 0;
+  }
   // Built-in static curves may be compared by curve name alone.
   if (a->curve_name != b->curve_name) {
     return 1;
@@ -500,7 +504,8 @@ int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ignored) {
            !ec_felem_equal(a, &a->b, &b->b) ||
            !ec_GFp_simple_points_equal(a, &a->generator.raw, &b->generator.raw);
   } else {
-    return a->meth != b->meth || BN_cmp(&a->field.N, &b->field.N) != 0 ||
+    return a->meth != b->meth || a->has_order != b->has_order ||
+           BN_cmp(&a->field.N, &b->field.N) != 0 ||
            !ec_felem_equal(a, &a->a, &b->a) || !ec_felem_equal(a, &a->b, &b->b);
   }
 }

--- a/crypto/fipsmodule/ec/ec.c
+++ b/crypto/fipsmodule/ec/ec.c
@@ -490,8 +490,9 @@ int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ignored) {
 
   // |a| and |b| are both custom curves. We compare the entire curve structure
   // if both |a| and |b| are complete. If either are incomplete (due to legacy
-  // OpenSSL mistakes, custom curve construction is sadly done in two parts), we
-  // only compare the parts that are available.
+  // OpenSSL mistakes, custom curve construction is sadly done in two parts
+  // |EC_GROUP_new_curve_GFp| -> |EC_GROUP_set_generator|), we only compare
+  // the parts that are available.
   if (a->has_order && b->has_order) {
     return a->meth != b->meth || BN_cmp(&a->order.N, &b->order.N) != 0 ||
            BN_cmp(&a->field.N, &b->field.N) != 0 ||

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1209,11 +1209,11 @@ TEST(ECTest, BIGNUMConvert) {
   // Convert |EC_POINT| to |BIGNUM| in uncompressed format with
   // |EC_POINT_point2bn| and ensure results are the same.
   bssl::UniquePtr<BIGNUM> converted_bignum(
-      EC_POINT_point2bn(group.get(), generator.get(),
+      EC_POINT_point2bn(group.get(), EC_GROUP_get0_generator(group.get()),
                         POINT_CONVERSION_UNCOMPRESSED, nullptr, nullptr));
   ASSERT_TRUE(converted_bignum);
   bssl::UniquePtr<BIGNUM> converted_bignum2(
-      EC_POINT_point2bn(group2.get(), generator2.get(),
+      EC_POINT_point2bn(group2.get(), EC_GROUP_get0_generator(group2.get()),
                         POINT_CONVERSION_UNCOMPRESSED, nullptr, nullptr));
   ASSERT_TRUE(converted_bignum2);
   EXPECT_EQ(0, BN_cmp(converted_bignum.get(), converted_bignum2.get()));
@@ -1223,23 +1223,23 @@ TEST(ECTest, BIGNUMConvert) {
   bssl::UniquePtr<EC_POINT> converted_generator(
       EC_POINT_bn2point(group.get(), converted_bignum.get(), nullptr, nullptr));
   ASSERT_TRUE(converted_generator);
-  EXPECT_EQ(0, EC_POINT_cmp(group.get(), generator.get(),
+  EXPECT_EQ(0, EC_POINT_cmp(group.get(), EC_GROUP_get0_generator(group.get()),
                             converted_generator.get(), nullptr));
   bssl::UniquePtr<EC_POINT> converted_generator2(EC_POINT_bn2point(
       group2.get(), converted_bignum2.get(), nullptr, nullptr));
   ASSERT_TRUE(converted_generator2);
-  EXPECT_EQ(0, EC_POINT_cmp(group2.get(), generator2.get(),
+  EXPECT_EQ(0, EC_POINT_cmp(group2.get(), EC_GROUP_get0_generator(group2.get()),
                             converted_generator2.get(), nullptr));
 
   // Convert |EC_POINT|s in compressed format with |EC_POINT_point2bn| and
   // ensure results are the same.
-  converted_bignum.reset(EC_POINT_point2bn(group.get(), generator.get(),
-                                           POINT_CONVERSION_COMPRESSED, nullptr,
-                                           nullptr));
+  converted_bignum.reset(
+      EC_POINT_point2bn(group.get(), EC_GROUP_get0_generator(group.get()),
+                        POINT_CONVERSION_COMPRESSED, nullptr, nullptr));
   ASSERT_TRUE(converted_bignum);
-  converted_bignum2.reset(EC_POINT_point2bn(group2.get(), generator2.get(),
-                                            POINT_CONVERSION_COMPRESSED,
-                                            nullptr, nullptr));
+  converted_bignum2.reset(
+      EC_POINT_point2bn(group2.get(), EC_GROUP_get0_generator(group2.get()),
+                        POINT_CONVERSION_COMPRESSED, nullptr, nullptr));
   ASSERT_TRUE(converted_bignum2);
   EXPECT_EQ(0, BN_cmp(converted_bignum.get(), converted_bignum2.get()));
 
@@ -1248,12 +1248,12 @@ TEST(ECTest, BIGNUMConvert) {
   converted_generator.reset(
       EC_POINT_bn2point(group.get(), converted_bignum.get(), nullptr, nullptr));
   ASSERT_TRUE(converted_generator);
-  EXPECT_EQ(0, EC_POINT_cmp(group.get(), generator.get(),
+  EXPECT_EQ(0, EC_POINT_cmp(group.get(), EC_GROUP_get0_generator(group.get()),
                             converted_generator.get(), nullptr));
   converted_generator2.reset(EC_POINT_bn2point(
       group2.get(), converted_bignum2.get(), nullptr, nullptr));
   ASSERT_TRUE(converted_generator2);
-  EXPECT_EQ(0, EC_POINT_cmp(group2.get(), generator2.get(),
+  EXPECT_EQ(0, EC_POINT_cmp(group2.get(), EC_GROUP_get0_generator(group2.get()),
                             converted_generator2.get(), nullptr));
 
   // Test specific openssl/openssl#10258 case for |BN_zero|.

--- a/crypto/fipsmodule/ec/internal.h
+++ b/crypto/fipsmodule/ec/internal.h
@@ -660,8 +660,6 @@ struct ec_group_st {
   // with |EC_GROUP_new_by_curve_name_mutable|. The default is zero to indicate
   // our built-in static curves.
   int mutable_ec_group;
-
-  CRYPTO_refcount_t references;
 } /* EC_GROUP */;
 
 EC_GROUP *ec_group_new(const EC_METHOD *meth, const BIGNUM *p, const BIGNUM *a,

--- a/crypto/fipsmodule/ec/internal.h
+++ b/crypto/fipsmodule/ec/internal.h
@@ -635,7 +635,11 @@ struct ec_group_st {
   // comment is a human-readable string describing the curve.
   const char *comment;
 
-  int curve_name;  // optional NID for named curve
+  // curve_name is the optional NID for named curves. |oid| and |oid_len| are
+  // populated with values corresponding to the named curve's NID.
+  // |NID_undef| is used to imply that the curve is a custom explicit curve and
+  // the oid values are empty if so.
+  int curve_name;
   uint8_t oid[9];
   uint8_t oid_len;
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -456,9 +456,6 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED EC_POINT *EC_POINT_bn2point(
 OPENSSL_EXPORT int EC_GROUP_get_order(const EC_GROUP *group, BIGNUM *order,
                                       BN_CTX *ctx);
 
-#define OPENSSL_EC_EXPLICIT_CURVE 0
-#define OPENSSL_EC_NAMED_CURVE 1
-
 // EC_builtin_curve describes a supported elliptic curve.
 typedef struct {
   int nid;
@@ -509,7 +506,22 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int ECPKParameters_print(
 // functions undermines the assumption that our curves are static. Consider
 // using the listed alternatives.
 
-// EC_GROUP_set_asn1_flag does nothing.
+// OPENSSL_EC_EXPLICIT_CURVE lets OpenSSL encode the curve as explicitly
+// encoded curve parameters. AWS-LC does not support this.
+//
+// Note: Sadly, this was the default prior to OpenSSL 1.1.0.
+#define OPENSSL_EC_EXPLICIT_CURVE 0
+
+// OPENSSL_EC_NAMED_CURVE lets OpenSSL encode a named curve form with its
+// corresponding NID. This is the only ASN1 encoding method for |EC_GROUP| that
+// AWS-LC supports.
+#define OPENSSL_EC_NAMED_CURVE 1
+
+// EC_GROUP_set_asn1_flag does nothing. In OpenSSL, |flag| is used  to determine
+// whether the curve encoding uses explicit parameters or a named curve using an
+// ASN1 OID. AWS-LC does not support serialization of explicit curve parameters.
+// This behavior is only intended for custom curves. We encourage the use of
+// named curves instead.
 OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_asn1_flag(EC_GROUP *group,
                                                               int flag);
 
@@ -524,7 +536,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int EC_GROUP_get_asn1_flag(
 // |EC_GROUP_new_by_curve_name_mutable| for the encoding format to change.
 //
 // Note: Use |EC_KEY_set_conv_form| / |EC_KEY_get_conv_form| to set and return
-// the  desired compression format.
+// the desired compression format.
 OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_point_conversion_form(
     EC_GROUP *group, point_conversion_form_t form);
 
@@ -532,7 +544,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED void EC_GROUP_set_point_conversion_form(
 // (the default compression format).
 //
 // Note: Use |EC_KEY_set_conv_form| / |EC_KEY_get_conv_form| to set and return
-// the  desired compression format.
+// the desired compression format.
 OPENSSL_EXPORT OPENSSL_DEPRECATED point_conversion_form_t
 EC_GROUP_get_point_conversion_form(const EC_GROUP *group);
 


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2547`

### Description of changes: 
Following up on https://github.com/aws/aws-lc/pull/1860 which introduces an API to return a mutable `EC_GROUP`, this commit applies the same concept for custom curves. Custom curves are already dynamically allocated, but were logically immutable due to the strict enforcement of calling `EC_GROUP_new_curve_GFp` -> `EC_GROUP_set_generator`.
The reference call in `EC_GROUP` that was used for custom curves is no longer needed. We actually duplicate the structure instead.

### Call-outs:
N/A


### Testing:
Test using a custom generator identical to P-256.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
