### PR TITLE
ML-KEM FIPS 203 destruction of intermediate values

### DIFF
--- a/crypto/fipsmodule/ml_kem/ml_kem_ref/indcpa.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem_ref/indcpa.c
@@ -192,7 +192,7 @@ void gen_matrix(ml_kem_params *params, polyvec *a, const uint8_t seed[KYBER_SYMB
   }
   
   // FIPS 203. Section 3.3 Destruction of intermidiate values.
-  OPENSSL_memset(buf, 0, sizeof(buf));
+  OPENSSL_cleanse(buf, sizeof(buf));
 }
 
 /*************************************************
@@ -249,12 +249,12 @@ void indcpa_keypair_derand(ml_kem_params *params,
   pack_pk(params, pk, &pkpv, publicseed);
 
   // FIPS 203. Section 3.3 Destruction of intermidiate values.
-  OPENSSL_memset(buf, 0, sizeof(buf));
-  OPENSSL_memset(coins_with_domain_separator, 0, sizeof(coins_with_domain_separator));
-  OPENSSL_memset(a, 0, sizeof(a));
-  OPENSSL_memset(&e, 0, sizeof(e));
-  OPENSSL_memset(&pkpv, 0, sizeof(pkpv));
-  OPENSSL_memset(&skpv, 0, sizeof(skpv));
+  OPENSSL_cleanse(buf, sizeof(buf));
+  OPENSSL_cleanse(coins_with_domain_separator, sizeof(coins_with_domain_separator));
+  OPENSSL_cleanse(a, sizeof(a));
+  OPENSSL_cleanse(&e, sizeof(e));
+  OPENSSL_cleanse(&pkpv, sizeof(pkpv));
+  OPENSSL_cleanse(&skpv, sizeof(skpv));
 }
 
 
@@ -316,15 +316,15 @@ void indcpa_enc(ml_kem_params *params,
   pack_ciphertext(params, c, &b, &v);
 
   // FIPS 203. Section 3.3 Destruction of intermidiate values.
-  OPENSSL_memset(seed, 0, sizeof(seed));
-  OPENSSL_memset(&sp, 0, sizeof(sp));
-  OPENSSL_memset(&pkpv, 0, sizeof(pkpv));
-  OPENSSL_memset(&ep, 0, sizeof(ep));
-  OPENSSL_memset(&at, 0, sizeof(at));
-  OPENSSL_memset(&b, 0, sizeof(b));
-  OPENSSL_memset(&v, 0, sizeof(v));
-  OPENSSL_memset(&k, 0, sizeof(k));
-  OPENSSL_memset(&epp, 0, sizeof(epp));
+  OPENSSL_cleanse(seed, sizeof(seed));
+  OPENSSL_cleanse(&sp, sizeof(sp));
+  OPENSSL_cleanse(&pkpv, sizeof(pkpv));
+  OPENSSL_cleanse(&ep, sizeof(ep));
+  OPENSSL_cleanse(at, sizeof(at));
+  OPENSSL_cleanse(&b, sizeof(b));
+  OPENSSL_cleanse(&v, sizeof(v));
+  OPENSSL_cleanse(&k, sizeof(k));
+  OPENSSL_cleanse(&epp, sizeof(epp));
 }
 
 /*************************************************
@@ -365,8 +365,8 @@ void indcpa_dec(ml_kem_params *params,
 
 
   // FIPS 203. Section 3.3 Destruction of intermidiate values.
-  OPENSSL_memset(&b, 0, sizeof(b));
-  OPENSSL_memset(&skpv, 0, sizeof(skpv));
-  OPENSSL_memset(&v, 0, sizeof(v));
-  OPENSSL_memset(&mp, 0, sizeof(mp));
+  OPENSSL_cleanse(&b, sizeof(b));
+  OPENSSL_cleanse(&skpv, sizeof(skpv));
+  OPENSSL_cleanse(&v, sizeof(v));
+  OPENSSL_cleanse(&mp, sizeof(mp));
 }

--- a/crypto/fipsmodule/ml_kem/ml_kem_ref/indcpa.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem_ref/indcpa.c
@@ -191,7 +191,7 @@ void gen_matrix(ml_kem_params *params, polyvec *a, const uint8_t seed[KYBER_SYMB
     }
   }
   
-  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
   OPENSSL_cleanse(buf, sizeof(buf));
 }
 
@@ -248,7 +248,7 @@ void indcpa_keypair_derand(ml_kem_params *params,
   pack_sk(params, sk, &skpv);
   pack_pk(params, pk, &pkpv, publicseed);
 
-  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
   OPENSSL_cleanse(buf, sizeof(buf));
   OPENSSL_cleanse(coins_with_domain_separator, sizeof(coins_with_domain_separator));
   OPENSSL_cleanse(a, sizeof(a));
@@ -315,7 +315,7 @@ void indcpa_enc(ml_kem_params *params,
 
   pack_ciphertext(params, c, &b, &v);
 
-  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
   OPENSSL_cleanse(seed, sizeof(seed));
   OPENSSL_cleanse(&sp, sizeof(sp));
   OPENSSL_cleanse(&pkpv, sizeof(pkpv));
@@ -364,7 +364,7 @@ void indcpa_dec(ml_kem_params *params,
   poly_tomsg(m, &mp);
 
 
-  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
   OPENSSL_cleanse(&b, sizeof(b));
   OPENSSL_cleanse(&skpv, sizeof(skpv));
   OPENSSL_cleanse(&v, sizeof(v));

--- a/crypto/fipsmodule/ml_kem/ml_kem_ref/indcpa.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem_ref/indcpa.c
@@ -190,6 +190,9 @@ void gen_matrix(ml_kem_params *params, polyvec *a, const uint8_t seed[KYBER_SYMB
       }
     }
   }
+  
+  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  OPENSSL_memset(buf, 0, sizeof(buf));
 }
 
 /*************************************************
@@ -244,6 +247,14 @@ void indcpa_keypair_derand(ml_kem_params *params,
 
   pack_sk(params, sk, &skpv);
   pack_pk(params, pk, &pkpv, publicseed);
+
+  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  OPENSSL_memset(buf, 0, sizeof(buf));
+  OPENSSL_memset(coins_with_domain_separator, 0, sizeof(coins_with_domain_separator));
+  OPENSSL_memset(a, 0, sizeof(a));
+  OPENSSL_memset(&e, 0, sizeof(e));
+  OPENSSL_memset(&pkpv, 0, sizeof(pkpv));
+  OPENSSL_memset(&skpv, 0, sizeof(skpv));
 }
 
 
@@ -303,6 +314,17 @@ void indcpa_enc(ml_kem_params *params,
   poly_reduce(&v);
 
   pack_ciphertext(params, c, &b, &v);
+
+  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  OPENSSL_memset(seed, 0, sizeof(seed));
+  OPENSSL_memset(&sp, 0, sizeof(sp));
+  OPENSSL_memset(&pkpv, 0, sizeof(pkpv));
+  OPENSSL_memset(&ep, 0, sizeof(ep));
+  OPENSSL_memset(&at, 0, sizeof(at));
+  OPENSSL_memset(&b, 0, sizeof(b));
+  OPENSSL_memset(&v, 0, sizeof(v));
+  OPENSSL_memset(&k, 0, sizeof(k));
+  OPENSSL_memset(&epp, 0, sizeof(epp));
 }
 
 /*************************************************
@@ -340,4 +362,11 @@ void indcpa_dec(ml_kem_params *params,
   poly_reduce(&mp);
 
   poly_tomsg(m, &mp);
+
+
+  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  OPENSSL_memset(&b, 0, sizeof(b));
+  OPENSSL_memset(&skpv, 0, sizeof(skpv));
+  OPENSSL_memset(&v, 0, sizeof(v));
+  OPENSSL_memset(&mp, 0, sizeof(mp));
 }

--- a/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
@@ -57,6 +57,9 @@ int crypto_kem_keypair(ml_kem_params *params,
   uint8_t coins[2*KYBER_SYMBYTES];
   RAND_bytes(coins, 2*KYBER_SYMBYTES);
   crypto_kem_keypair_derand(params, pk, sk, coins);
+
+  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  OPENSSL_memset(coins, 0, sizeof(coins));
   return 0;
 }
 
@@ -218,6 +221,10 @@ int crypto_kem_enc_derand(ml_kem_params *params,
   indcpa_enc(params, ct, buf, pk, kr+KYBER_SYMBYTES);
 
   memcpy(ss,kr,KYBER_SYMBYTES);
+
+  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  OPENSSL_memset(buf, 0, sizeof(buf));
+  OPENSSL_memset(kr, 0, sizeof(kr));
   return 0;
 }
 
@@ -248,6 +255,9 @@ int crypto_kem_enc(ml_kem_params *params,
   uint8_t coins[KYBER_SYMBYTES];
   RAND_bytes(coins, KYBER_SYMBYTES);
   crypto_kem_enc_derand(params, ct, ss, pk, coins);
+
+  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  OPENSSL_memset(coins, 0, sizeof(coins));
   return 0;
 }
 
@@ -301,5 +311,9 @@ int crypto_kem_dec(ml_kem_params *params,
   /* Copy true key to return buffer if fail is false */
   cmov(ss,kr,KYBER_SYMBYTES,!fail);
 
+  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  OPENSSL_memset(buf, 0, sizeof(buf));
+  OPENSSL_memset(kr, 0, sizeof(kr));
+  OPENSSL_memset(cmp, 0, sizeof(cmp));
   return 0;
 }

--- a/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
@@ -58,7 +58,7 @@ int crypto_kem_keypair(ml_kem_params *params,
   RAND_bytes(coins, 2*KYBER_SYMBYTES);
   crypto_kem_keypair_derand(params, pk, sk, coins);
 
-  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
   OPENSSL_cleanse(coins, sizeof(coins));
   return 0;
 }
@@ -222,7 +222,7 @@ int crypto_kem_enc_derand(ml_kem_params *params,
 
   memcpy(ss,kr,KYBER_SYMBYTES);
 
-  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
   OPENSSL_cleanse(buf, sizeof(buf));
   OPENSSL_cleanse(kr, sizeof(kr));
   return 0;
@@ -256,7 +256,7 @@ int crypto_kem_enc(ml_kem_params *params,
   RAND_bytes(coins, KYBER_SYMBYTES);
   crypto_kem_enc_derand(params, ct, ss, pk, coins);
 
-  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
   OPENSSL_cleanse(coins, sizeof(coins));
   return 0;
 }
@@ -311,7 +311,7 @@ int crypto_kem_dec(ml_kem_params *params,
   /* Copy true key to return buffer if fail is false */
   cmov(ss,kr,KYBER_SYMBYTES,!fail);
 
-  // FIPS 203. Section 3.3 Destruction of intermidiate values.
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
   OPENSSL_cleanse(buf, sizeof(buf));
   OPENSSL_cleanse(kr, sizeof(kr));
   OPENSSL_cleanse(cmp, sizeof(cmp));

--- a/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
@@ -59,7 +59,7 @@ int crypto_kem_keypair(ml_kem_params *params,
   crypto_kem_keypair_derand(params, pk, sk, coins);
 
   // FIPS 203. Section 3.3 Destruction of intermidiate values.
-  OPENSSL_memset(coins, 0, sizeof(coins));
+  OPENSSL_cleanse(coins, sizeof(coins));
   return 0;
 }
 
@@ -223,8 +223,8 @@ int crypto_kem_enc_derand(ml_kem_params *params,
   memcpy(ss,kr,KYBER_SYMBYTES);
 
   // FIPS 203. Section 3.3 Destruction of intermidiate values.
-  OPENSSL_memset(buf, 0, sizeof(buf));
-  OPENSSL_memset(kr, 0, sizeof(kr));
+  OPENSSL_cleanse(buf, sizeof(buf));
+  OPENSSL_cleanse(kr, sizeof(kr));
   return 0;
 }
 
@@ -257,7 +257,7 @@ int crypto_kem_enc(ml_kem_params *params,
   crypto_kem_enc_derand(params, ct, ss, pk, coins);
 
   // FIPS 203. Section 3.3 Destruction of intermidiate values.
-  OPENSSL_memset(coins, 0, sizeof(coins));
+  OPENSSL_cleanse(coins, sizeof(coins));
   return 0;
 }
 
@@ -312,8 +312,8 @@ int crypto_kem_dec(ml_kem_params *params,
   cmov(ss,kr,KYBER_SYMBYTES,!fail);
 
   // FIPS 203. Section 3.3 Destruction of intermidiate values.
-  OPENSSL_memset(buf, 0, sizeof(buf));
-  OPENSSL_memset(kr, 0, sizeof(kr));
-  OPENSSL_memset(cmp, 0, sizeof(cmp));
+  OPENSSL_cleanse(buf, sizeof(buf));
+  OPENSSL_cleanse(kr, sizeof(kr));
+  OPENSSL_cleanse(cmp, sizeof(cmp));
   return 0;
 }


### PR DESCRIPTION
### Issues:
CryptoAlg-2616

### Description of changes: 
FIPS 203 Section 3.3 requires destruction of intermediate values.
AWS-LC ML-KEM implementation allocates intermediate values
only on stack, so this destruction seems a bit silly, but we do it
anyway for compliance.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
