### PR TITLE
Fix OCSP timebomb in tests

### DIFF
--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -416,6 +416,7 @@ TEST(OCSPTest, TestGoodOCSP) {
   // This will cause the function to fail in two places, once when checking
   // if "(current_time + nsec) > thisupd [Status Not Yet Valid]", and a second
   // time when checking if "nextupd > (current_time - nsec) [Status Expired]".
+  ERR_clear_error();
   EXPECT_FALSE(OCSP_check_validity(thisupd, nextupd, -time(nullptr), -1));
   err = ERR_get_error();
   EXPECT_EQ(OCSP_R_STATUS_NOT_YET_VALID, ERR_GET_REASON(err));


### PR DESCRIPTION
### Issues:
Resolves https://github.com/aws/aws-lc/issues/1889

It turns out the first call to `OCSP_check_validity` in `TestGoodOCSP` will emit two additional errors on to the error stack once the "this update" field is outdated. Clearing the previous additional errors on the stack allows us to check for which specific errors were emitted more accurately. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
