### PR TITLE
Pin the version of aws-lc-verification to a known working version

### DIFF
--- a/tests/ci/run_formal_verification.sh
+++ b/tests/ci/run_formal_verification.sh
@@ -7,11 +7,11 @@ cd ../
 ROOT=$(pwd)
 
 rm -rf aws-lc-verification-build
-git clone https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
+git clone --branch fips-2022-11-02 --depth 1 https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
+
 cd aws-lc-verification-build
-# Checkout a version of the formal verification repo that works with this version of AWS-LC
-git checkout e504944f94b6379eaf95f1146a168feb72ce844f
-git submodule update --init
+git submodule update --init --depth 1
+
 # aws-lc-verification has aws-lc as one submodule under 'src' dir.
 # Below is to copy code of **target** aws-lc to 'src' dir.
 rm -rf ./src/* && cp -r "${ROOT}/${AWS_LC_DIR}/"* ./src

--- a/tests/ci/run_formal_verification.sh
+++ b/tests/ci/run_formal_verification.sh
@@ -10,7 +10,7 @@ rm -rf aws-lc-verification-build
 git clone https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
 cd aws-lc-verification-build
 # Checkout a version of the formal verification repo that works with this version of AWS-LC
-git checkout 076973cc1ae011beab8df6af4f02464158374b24
+git checkout 7d0a46ac0841d1d9f1c078153d38409af056c482
 git submodule update --init
 # aws-lc-verification has aws-lc as one submodule under 'src' dir.
 # Below is to copy code of **target** aws-lc to 'src' dir.

--- a/tests/ci/run_formal_verification.sh
+++ b/tests/ci/run_formal_verification.sh
@@ -10,7 +10,7 @@ rm -rf aws-lc-verification-build
 git clone https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
 cd aws-lc-verification-build
 # Checkout a version of the formal verification repo that works with this version of AWS-LC
-git checkout 7d0a46ac0841d1d9f1c078153d38409af056c482
+git checkout e504944f94b6379eaf95f1146a168feb72ce844f
 git submodule update --init
 # aws-lc-verification has aws-lc as one submodule under 'src' dir.
 # Below is to copy code of **target** aws-lc to 'src' dir.

--- a/tests/ci/run_formal_verification.sh
+++ b/tests/ci/run_formal_verification.sh
@@ -7,8 +7,11 @@ cd ../
 ROOT=$(pwd)
 
 rm -rf aws-lc-verification-build
-git clone --recurse-submodules https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
+git clone https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
 cd aws-lc-verification-build
+# Checkout a version of the formal verification repo that works with this version of AWS-LC
+git checkout 076973cc1ae011beab8df6af4f02464158374b24
+git submodule update --init
 # aws-lc-verification has aws-lc as one submodule under 'src' dir.
 # Below is to copy code of **target** aws-lc to 'src' dir.
 rm -rf ./src/* && cp -r "${ROOT}/${AWS_LC_DIR}/"* ./src


### PR DESCRIPTION
### Description of changes: 
Previously this script always used the head of aws-lc-verification which will have diverged from this branch since the code on the FIPS 2022 branch is a snapshot of AWS-LC. I picked https://github.com/awslabs/aws-lc-verification/commit/076973cc1ae011beab8df6af4f02464158374b24 as one of the last commits before we stopped touching this branch. 

### Testing:
This will hopefully get the CI to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
