### PR TITLE
Pin the version of aws-lc-verification to a known working version

### DIFF
--- a/tests/ci/run_formal_verification.sh
+++ b/tests/ci/run_formal_verification.sh
@@ -13,6 +13,8 @@ rm -rf aws-lc-verification-build
 git clone https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
 
 cd aws-lc-verification-build
+# Checkout a version of the formal verification repo that works with this version of AWS-LC
+git checkout b19e155db93518ea1bf23eb40c38ad27c8899c7a
 git submodule update --init
 
 # aws-lc-verification has aws-lc as one submodule under 'src' dir.


### PR DESCRIPTION
### Description of changes: 

Previously this script always used the head of aws-lc-verification which will have diverged from this branch since the code on the FIPS 2024 branch is a snapshot of AWS-LC. I picked https://github.com/awslabs/aws-lc-verification/commit/b19e155db93518ea1bf23eb40c38ad27c8899c7a since it's the most recent commit and known to be working.

### Testing:

This will hopefully get the CI to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
