### PR TITLE
Integrate ube for rand engine

### DIFF
--- a/crypto/fipsmodule/rand/new_rand.c
+++ b/crypto/fipsmodule/rand/new_rand.c
@@ -27,7 +27,7 @@ struct rand_thread_local_state {
   // |drbg| since its initialization.
   uint64_t reseed_calls_since_initialization;
 
-  // generate_number caches the UBE generation number.
+  // generation_number caches the UBE generation number.
   uint64_t generation_number;
 
   // Entropy source. UBE volatile state.
@@ -71,17 +71,17 @@ static int rand_ensure_valid_state(struct rand_thread_local_state *state) {
   return 1;
 }
 
-// rand_ensure_ctr_drbg_uniquness computes whether |state| must be randomized to
-// ensure uniqueness.
+// rand_ensure_ctr_drbg_uniqueness computes whether |state| must be randomized
+// to ensure uniqueness.
 //
-// Note: If |rand_ensure_ctr_drbg_uniquness| returns 1 it does not necessarily
+// Note: If |rand_ensure_ctr_drbg_uniqueness| returns 1 it does not necessarily
 // imply that an UBE occurred. It can also mean that no UBE detection is
 // supported or that UBE detection failed. In these cases, |state| must also be
 // randomized to ensure uniqueness. Any special future cases can be handled in
 // this function. 
 //
 // Return 1 if |state| must be randomized. 0 otherwise.
-static int rand_ensure_ctr_drbg_uniquness(struct rand_thread_local_state *state) {
+static int rand_ensure_ctr_drbg_uniqueness(struct rand_thread_local_state *state) {
 
   uint64_t current_generation_number = 0;
   if (CRYPTO_get_ube_generation_number(&current_generation_number) != 1) {
@@ -358,7 +358,7 @@ int NR_PREFIX(RAND_pseudo_bytes)(uint8_t *out, size_t out_len) {
   return NR_PREFIX(RAND_bytes)(out, out_len);
 }
 
-// Returns the number of generate calls made using the thread-local state since
+// Returns the number of generate calls made on the thread-local state since
 // last seed/reseed. Returns 0 if thread-local state has not been initialized.
 uint64_t get_thread_generate_calls_since_seed(void) {
 
@@ -371,8 +371,8 @@ uint64_t get_thread_generate_calls_since_seed(void) {
   return state->generate_calls_since_seed;
 }
 
-// Returns the number of generate calls made using the thread-local state since
-// last seed/reseed. Returns 0 if thread-local state has not been initialized.
+// Returns the number of reseed calls made on the thread-local state since
+// initialization. Returns 0 if thread-local state has not been initialized.
 uint64_t get_thread_reseed_calls_since_initialization(void) {
 
   struct rand_thread_local_state *state =

--- a/crypto/fipsmodule/rand/new_rand.c
+++ b/crypto/fipsmodule/rand/new_rand.c
@@ -232,7 +232,7 @@ static void RAND_bytes_core(
   GUARD_PTR_ABORT(out);
 
   // Ensure the CTR-DRBG state is unique.
-  if (rand_ensure_ctr_drbg_uniquness(state) == 1) {
+  if (rand_ensure_ctr_drbg_uniqueness(state) == 1) {
     rand_ctr_drbg_reseed(state);
   }
 

--- a/crypto/fipsmodule/rand/new_rand.c
+++ b/crypto/fipsmodule/rand/new_rand.c
@@ -23,6 +23,7 @@ struct rand_thread_local_state {
   // since it was last (re)seeded. Must be bounded by |kReseedInterval|.
   uint64_t generate_calls_since_seed;
 
+  // generate_number caches the UBE generation number.
   uint64_t generation_number;
 
   // Entropy source. UBE volatile state.
@@ -53,8 +54,16 @@ static int rand_ensure_valid_state(void) {
   return 1;
 }
 
-// TODO
-// For UBE.
+// rand_ensure_ctr_drbg_uniquness computes whether |state| must be randomized to
+// ensure uniqueness.
+//
+// Note: If |rand_ensure_ctr_drbg_uniquness| returns 0 it does not necessarily
+// imply that an UBE occurred. It can also mean that no UBE detection is
+// supported or that UBE detection failed. In these cases, |state| must also be
+// randomized to ensure uniqueness. Any special future cases can be handled in
+// this function. 
+//
+// Return 1 if |state| must be randomized. 0 otherwise.
 static int rand_ensure_ctr_drbg_uniquness(struct rand_thread_local_state *state) {
 
   uint64_t current_generation_number = 0;

--- a/crypto/fipsmodule/rand/new_rand_internal.h
+++ b/crypto/fipsmodule/rand/new_rand_internal.h
@@ -29,6 +29,9 @@ OPENSSL_EXPORT int NR_PREFIX(RAND_pseudo_bytes)(uint8_t *out, size_t out_len);
 OPENSSL_EXPORT int RAND_bytes_with_user_prediction_resistance(uint8_t *out,
   size_t out_len, const uint8_t user_pred_resistance[RAND_PRED_RESISTANCE_LEN]);
 
+OPENSSL_EXPORT uint64_t get_thread_generate_calls_since_seed(void);
+OPENSSL_EXPORT uint64_t get_thread_reseed_calls_since_initialization(void);
+
 #if defined(__cplusplus)
 }  // extern C
 #endif

--- a/crypto/ube/ube.c
+++ b/crypto/ube/ube.c
@@ -209,7 +209,7 @@ int CRYPTO_get_ube_generation_number(uint64_t *current_generation_number) {
   // synchronize an update to the UBE generation number. To avoid redundant
   // reseeds, we must ensure the generation number is only incremented once for
   // all UBE's that might have happened. Therefore, first take a write lock but
-  // before mutation the state, check for an UBE again. Checking again ensures
+  // before mutating the state, check for an UBE again. Checking again ensures
   // that only one thread increments the UBE generation number, because the
   // cached detection method generation numbers have been updated by the thread
   // that had the first entry.


### PR DESCRIPTION
### Description of changes: 

This PR integrates protection of the thread-local state into the new randomness generation implementation. `rand_ensure_ctr_drbg_uniquness()` is the function that determines whether a randomization of the thread-local state is necessary. `rand_ensure_ctr_drbg_uniquness()` is called inline in the core randomness generation code path (in `RAND_bytes_core()` and invoked on every entry.

The only mechanism currently implemented that can force a randomization is the UBE mechanism implemented in https://github.com/aws/aws-lc/commit/bc7aeff2f5c12c62f17df71abdd0c7b55c3eb984. Note that if UBE is "unavailable" then a randomization is forced every time.

### Testing:

Some additional support code is implemented to mock the UBE detection and determine if correct behaviour occurred.

The failing tests are because the target branch is `randomness_generation` that haven't been rebased on `main` branch with fixes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
