### PR TITLE
Use larger instance for c6g fips

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
@@ -29,7 +29,7 @@ batch:
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
         variables:
           EC2_AMI: "ami-0c29a2c5cf69b5a9c"
-          EC2_INSTANCE_TYPE: "c6g.2xlarge"
+          EC2_INSTANCE_TYPE: "c6g.4xlarge"
           ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"
           TARGET_TEST_SCRIPT: "./tests/ci/run_fips_tests.sh"
 


### PR DESCRIPTION
### Description of changes: 
c6g on the ec2-test-framework has been slowing down considerably with our recent FIPS changes.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
