### PR TITLE
Remove special s2n-bignum symbol handling sauce from build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,15 +215,6 @@ if(BORINGSSL_PREFIX AND BORINGSSL_PREFIX_SYMBOLS AND GO_EXECUTABLE)
            symbol_prefix_include/openssl/boringssl_prefix_symbols_nasm.inc
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl
     COMMAND ${GO_EXECUTABLE} run ${CMAKE_CURRENT_SOURCE_DIR}/util/make_prefix_headers.go -out ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl -prefix ${BORINGSSL_PREFIX} ${BORINGSSL_PREFIX_SYMBOLS_PATH}
-    COMMAND sed -i.bak '/ bignum_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h
-    COMMAND sed -i.bak '/ bignum_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h
-    COMMAND sed -i.bak '/ bignum_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_nasm.inc
-    COMMAND sed -i.bak '/ curve25519_x25519/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h
-    COMMAND sed -i.bak '/ curve25519_x25519/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h
-    COMMAND sed -i.bak '/ curve25519_x25519/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_nasm.inc
-    COMMAND sed -i.bak '/ edwards25519_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h
-    COMMAND sed -i.bak '/ edwards25519_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h
-    COMMAND sed -i.bak '/ edwards25519_/d' ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_nasm.inc
     COMMAND ${CMAKE_COMMAND} -E remove
           ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h.bak
           ${CMAKE_CURRENT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h.bak

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -305,14 +305,19 @@ function(s2n_asm_cpreprocess dest src)
 
   string(REGEX REPLACE "[ ]+" ";" CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS}")
 
+  #if(BORINGSSL_PREFIX)
+    set(S2N_BIGNUM_PREFIX_INCLUDE "-I${PROJECT_BINARY_DIR}/symbol_prefix_include")
+    set(S2N_BIGNUM_PREFIX_FLAG "-DAWSLC_PRIVATE_BUILD")
+  #endif()
+
   add_custom_command(
           OUTPUT ${dest}
           COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
-          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${S2N_BIGNUM_DIR}/${src} -I${S2N_BIGNUM_INCLUDE_DIR} -DS2N_BN_HIDE_SYMBOLS| tr \"\;\" \"\\n\" > ${dest}
+          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${S2N_BIGNUM_DIR}/${src} -I${S2N_BIGNUM_INCLUDE_DIR} ${S2N_BIGNUM_PREFIX_INCLUDE} ${S2N_BIGNUM_PREFIX_FLAG} -DS2N_BN_HIDE_SYMBOLS | tr \"\;\" \"\\n\" > ${dest}
           DEPENDS
           ${S2N_BIGNUM_DIR}/${src}
           WORKING_DIRECTORY .
-)
+  )
 endfunction()
 
 if(S2N_BIGNUM_ASM_SOURCES)

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -305,10 +305,10 @@ function(s2n_asm_cpreprocess dest src)
 
   string(REGEX REPLACE "[ ]+" ";" CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS}")
 
-  #if(BORINGSSL_PREFIX)
+  if(BORINGSSL_PREFIX)
     set(S2N_BIGNUM_PREFIX_INCLUDE "-I${PROJECT_BINARY_DIR}/symbol_prefix_include")
     set(S2N_BIGNUM_PREFIX_FLAG "-DAWSLC_PRIVATE_BUILD")
-  #endif()
+  endif()
 
   add_custom_command(
           OUTPUT ${dest}

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -306,14 +306,13 @@ function(s2n_asm_cpreprocess dest src)
   string(REGEX REPLACE "[ ]+" ";" CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS}")
 
   if(BORINGSSL_PREFIX)
-    set(S2N_BIGNUM_PREFIX_INCLUDE "-I${PROJECT_BINARY_DIR}/symbol_prefix_include")
-    set(S2N_BIGNUM_PREFIX_FLAG "-DAWSLC_PRIVATE_BUILD")
+    set(S2N_BIGNUM_PREFIX_INCLUDE "--include=${PROJECT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h")
   endif()
 
   add_custom_command(
           OUTPUT ${dest}
           COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
-          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${S2N_BIGNUM_DIR}/${src} -I${S2N_BIGNUM_INCLUDE_DIR} ${S2N_BIGNUM_PREFIX_INCLUDE} ${S2N_BIGNUM_PREFIX_FLAG} -DS2N_BN_HIDE_SYMBOLS | tr \"\;\" \"\\n\" > ${dest}
+          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${S2N_BIGNUM_DIR}/${src} -I${S2N_BIGNUM_INCLUDE_DIR} ${S2N_BIGNUM_PREFIX_INCLUDE} ${S2N_BIGNUM_PREFIX_INCLUDE} -DS2N_BN_HIDE_SYMBOLS | tr \"\;\" \"\\n\" > ${dest}
           DEPENDS
           ${S2N_BIGNUM_DIR}/${src}
           WORKING_DIRECTORY .

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -94,16 +94,7 @@ function generate_symbols_file {
 function verify_symbols_prefixed {
   go run "$SRC_ROOT"/util/read_symbols.go -out "$BUILD_ROOT"/symbols_final_crypto.txt "$BUILD_ROOT"/crypto/libcrypto.a
   go run "$SRC_ROOT"/util/read_symbols.go -out "$BUILD_ROOT"/symbols_final_ssl.txt "$BUILD_ROOT"/ssl/libssl.a
-  # For grep's basic regular expression language the meta-characters (e.g. "?",
-  # "|", etc.) are interpreted as literal characters. To keep their
-  # meta-character semantics, they must be escaped with "\".
-  # Deciphering the pattern "^_\?\(bignum\|curve25519_x25519\)":
-  #  * "^": anchor at start of line.
-  #  * "_\?": might contain underscore.
-  #  * "\(bignum\|curve25519_x25519\)": match string of either "bignum" or "curve25519_x25519".
-  # Recall that the option "-v" reverse the pattern matching. So, we are really
-  # filtering out lines that contain either "bignum" or "curve25519_x25519".
-  cat "$BUILD_ROOT"/symbols_final_crypto.txt  "$BUILD_ROOT"/symbols_final_ssl.txt | grep -v -e '^_\?\(bignum\|curve25519_x25519\|edwards25519\)' >  "$SRC_ROOT"/symbols_final.txt
+  cat "$BUILD_ROOT"/symbols_final_crypto.txt  "$BUILD_ROOT"/symbols_final_ssl.txt >  "$SRC_ROOT"/symbols_final.txt
   # Now filter out every line that has the unique prefix $CUSTOM_PREFIX. If we
   # have any lines left, then some symbol(s) weren't prefixed, unexpectedly.
   if [ $(grep -c -v ${CUSTOM_PREFIX}  "$SRC_ROOT"/symbols_final.txt) -ne 0 ]; then

--- a/third_party/s2n-bignum/include/_internal_s2n_bignum.h
+++ b/third_party/s2n-bignum/include/_internal_s2n_bignum.h
@@ -15,3 +15,7 @@
 #else
 #   define S2N_BN_SYM_PRIVACY_DIRECTIVE(name)  /* NO-OP: S2N_BN_SYM_PRIVACY_DIRECTIVE */
 #endif
+
+#ifdef AWSLC_PRIVATE_BUILD
+    #include <openssl/boringssl_prefix_symbols.h>
+#endif

--- a/third_party/s2n-bignum/include/_internal_s2n_bignum.h
+++ b/third_party/s2n-bignum/include/_internal_s2n_bignum.h
@@ -15,7 +15,3 @@
 #else
 #   define S2N_BN_SYM_PRIVACY_DIRECTIVE(name)  /* NO-OP: S2N_BN_SYM_PRIVACY_DIRECTIVE */
 #endif
-
-#ifdef AWSLC_PRIVATE_BUILD
-    #include <openssl/boringssl_prefix_symbols.h>
-#endif


### PR DESCRIPTION
### Description of changes: 

Symbols from s2n-bignum needed special build shenanigans because they essentially are "third-party" (although still AWS owned) in the context of what code AWS-LC repository can touch. Therefore they didn't have the special "prefix" header files. This corrupts the prefix build in two ways that needed to be handled:
- references to s2n-bignum files are prefixed, but the definitions are not. Obviously, this doesn't work...
- when we test the prefix build, we must take care to not assume s2n-bignum symbols are prefixed...

Removing these two corruptions, means it's now a bit easier to import s2n-bignum code. A small step closer to maybe switching to a submodule.

Should also make the rust build easier. Hopefully...

### Call-outs:

Originally I went with a method that required s2n-bignum source code changes. Essentially, one can define a path to prefix symbols and inject into the pre-processor we run s2n-bignum files through. The benefit is that we don't have to reason about tooling. It's just simple macro gymnastics.

Andrew suggested `--include` flag as a way to not do s2n-bignum code changes. That seems a bit easier for now. We can revert to another more portable method if required. Having more AWS-LC special sauce in s2n-bignum is not the preferred for sure.

### Testing:

CI has several test suites for the prefix build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
