### PR TITLE
Use aws-lc-verification branch spefically for the 2024 release, update submodules with depth 1

### DIFF
--- a/tests/ci/run_formal_verification.sh
+++ b/tests/ci/run_formal_verification.sh
@@ -10,12 +10,10 @@ cd ../
 ROOT=$(pwd)
 
 rm -rf aws-lc-verification-build
-git clone https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
+git clone --branch fips-2024-09-27 --depth 1 https://github.com/awslabs/aws-lc-verification.git aws-lc-verification-build
 
 cd aws-lc-verification-build
-# Checkout a version of the formal verification repo that works with this version of AWS-LC
-git checkout b19e155db93518ea1bf23eb40c38ad27c8899c7a
-git submodule update --init
+git submodule update --init --depth 1
 
 # aws-lc-verification has aws-lc as one submodule under 'src' dir.
 # Below is to copy code of **target** aws-lc to 'src' dir.


### PR DESCRIPTION
### Description of changes: 
Talked with @pennyannn and they setup a specific branch in the verification repo so now that branch should always work with this 2024 FIPS branch and stay in sync with it.

### Testing:
Ran locally and verified it got the right branch and is a little faster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
