### PR TITLE
ML-KEM FIPS 203 destruction of intermediate values

### DIFF
--- a/crypto/fipsmodule/ml_kem/ml_kem_ref/indcpa.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem_ref/indcpa.c
@@ -190,6 +190,9 @@ void gen_matrix(ml_kem_params *params, polyvec *a, const uint8_t seed[KYBER_SYMB
       }
     }
   }
+  
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
+  OPENSSL_cleanse(buf, sizeof(buf));
 }
 
 /*************************************************
@@ -244,6 +247,14 @@ void indcpa_keypair_derand(ml_kem_params *params,
 
   pack_sk(params, sk, &skpv);
   pack_pk(params, pk, &pkpv, publicseed);
+
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
+  OPENSSL_cleanse(buf, sizeof(buf));
+  OPENSSL_cleanse(coins_with_domain_separator, sizeof(coins_with_domain_separator));
+  OPENSSL_cleanse(a, sizeof(a));
+  OPENSSL_cleanse(&e, sizeof(e));
+  OPENSSL_cleanse(&pkpv, sizeof(pkpv));
+  OPENSSL_cleanse(&skpv, sizeof(skpv));
 }
 
 
@@ -303,6 +314,17 @@ void indcpa_enc(ml_kem_params *params,
   poly_reduce(&v);
 
   pack_ciphertext(params, c, &b, &v);
+
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
+  OPENSSL_cleanse(seed, sizeof(seed));
+  OPENSSL_cleanse(&sp, sizeof(sp));
+  OPENSSL_cleanse(&pkpv, sizeof(pkpv));
+  OPENSSL_cleanse(&ep, sizeof(ep));
+  OPENSSL_cleanse(at, sizeof(at));
+  OPENSSL_cleanse(&b, sizeof(b));
+  OPENSSL_cleanse(&v, sizeof(v));
+  OPENSSL_cleanse(&k, sizeof(k));
+  OPENSSL_cleanse(&epp, sizeof(epp));
 }
 
 /*************************************************
@@ -340,4 +362,11 @@ void indcpa_dec(ml_kem_params *params,
   poly_reduce(&mp);
 
   poly_tomsg(m, &mp);
+
+
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
+  OPENSSL_cleanse(&b, sizeof(b));
+  OPENSSL_cleanse(&skpv, sizeof(skpv));
+  OPENSSL_cleanse(&v, sizeof(v));
+  OPENSSL_cleanse(&mp, sizeof(mp));
 }

--- a/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
@@ -57,6 +57,9 @@ int crypto_kem_keypair(ml_kem_params *params,
   uint8_t coins[2*KYBER_SYMBYTES];
   RAND_bytes(coins, 2*KYBER_SYMBYTES);
   crypto_kem_keypair_derand(params, pk, sk, coins);
+
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
+  OPENSSL_cleanse(coins, sizeof(coins));
   return 0;
 }
 
@@ -218,6 +221,10 @@ int crypto_kem_enc_derand(ml_kem_params *params,
   indcpa_enc(params, ct, buf, pk, kr+KYBER_SYMBYTES);
 
   memcpy(ss,kr,KYBER_SYMBYTES);
+
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
+  OPENSSL_cleanse(buf, sizeof(buf));
+  OPENSSL_cleanse(kr, sizeof(kr));
   return 0;
 }
 
@@ -248,6 +255,9 @@ int crypto_kem_enc(ml_kem_params *params,
   uint8_t coins[KYBER_SYMBYTES];
   RAND_bytes(coins, KYBER_SYMBYTES);
   crypto_kem_enc_derand(params, ct, ss, pk, coins);
+
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
+  OPENSSL_cleanse(coins, sizeof(coins));
   return 0;
 }
 
@@ -301,5 +311,9 @@ int crypto_kem_dec(ml_kem_params *params,
   /* Copy true key to return buffer if fail is false */
   cmov(ss,kr,KYBER_SYMBYTES,!fail);
 
+  // FIPS 203. Section 3.3 Destruction of intermediate values.
+  OPENSSL_cleanse(buf, sizeof(buf));
+  OPENSSL_cleanse(kr, sizeof(kr));
+  OPENSSL_cleanse(cmp, sizeof(cmp));
   return 0;
 }


### PR DESCRIPTION
### Issues:
CryptoAlg-2616

### Description of changes: 
FIPS 203 Section 3.3 requires destruction of intermediate values.
AWS-LC ML-KEM implementation allocates intermediate values
only on stack, so this destruction seems a bit silly, but we do it
anyway for compliance.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
