### PR TITLE
Avoid allocating EVP_PKEY on size checks

### DIFF
--- a/crypto/fipsmodule/evp/evp_ctx.c
+++ b/crypto/fipsmodule/evp/evp_ctx.c
@@ -468,7 +468,17 @@ int EVP_PKEY_keygen_deterministic(EVP_PKEY_CTX *ctx,
     goto end;
   }
 
-  if (!out_pkey) {
+  if ((out_pkey == NULL) != (seed == NULL)) {
+    OPENSSL_PUT_ERROR(EVP, EVP_R_INVALID_PARAMETERS);
+    goto end;
+  }
+
+  // Caller is performing a size check.
+  if (out_pkey == NULL && seed == NULL) {
+    if (!ctx->pmeth->keygen_deterministic(ctx, NULL, NULL, seed_len)) {
+      goto end;
+    }
+    ret = 1;
     goto end;
   }
 

--- a/include/openssl/experimental/kem_deterministic_api.h
+++ b/include/openssl/experimental/kem_deterministic_api.h
@@ -19,9 +19,9 @@ extern "C" {
 // performs deterministic keygen based on the value specified in |seed| of
 // length |seed_len| bytes.
 //
-// If |seed| is set to NULL it is assumed that the caller is doing a size check:
-// the function will write the size of the required seed in |seed_len| and return
-// successfully.
+// If |out_pkey| and |seed| are set to NULL it is assumed that the caller is
+// doing a size check and the function will write the size of the required seed
+// in |seed_len| and return successfully.
 //
 // EVP_PKEY_keygen_deterministic performs a deterministic key generation
 // operation using the values from |ctx|, and the given |seed|. If |*out_pkey|

--- a/util/fipstools/acvp/modulewrapper/modulewrapper.cc
+++ b/util/fipstools/acvp/modulewrapper/modulewrapper.cc
@@ -2918,7 +2918,7 @@ static bool ML_KEM_KEYGEN(const Span<const uint8_t> args[],
   bssl::UniquePtr<EVP_PKEY_CTX> ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_KEM, nullptr));
   if (!EVP_PKEY_CTX_kem_set_params(ctx.get(), nid) ||
       !EVP_PKEY_keygen_init(ctx.get()) ||
-      !EVP_PKEY_keygen_deterministic(ctx.get(), &raw, NULL, &seed_len) ||
+      !EVP_PKEY_keygen_deterministic(ctx.get(), NULL, NULL, &seed_len) ||
       seed_len != seed.size() ||
       !EVP_PKEY_keygen_deterministic(ctx.get(), &raw, seed.data(), &seed_len)) {
     return false;


### PR DESCRIPTION
### Issues:
PQCrypto-103 

### Description of changes: 
`EVP_PKEY_keygen_deterministic` allows callers to query the required
size for the `seed` parameter. This change avoids the unnecessary
allocation of memory for the `out_pkey` parameter to ensure that this
integer getter has no side effects.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Updated the unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
