### PR TITLE
build: fix pkgconfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1258,6 +1258,11 @@ set(VERSION 1.1.1)
 # the downstream integration may build with the system's OpenSSL version instead.
 # Consider adjusting the PKG_CONFIG_PATH environment to get around this.
 file(GLOB OPENSSL_PKGCONFIGS "pkgconfig/*.pc.in")
+
+include(cmake/JoinPaths.cmake)
+join_paths(libdir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+join_paths(includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+
 foreach(in_file ${OPENSSL_PKGCONFIGS})
   file(RELATIVE_PATH in_file ${PROJECT_SOURCE_DIR} ${in_file})
   string(REPLACE ".in" "" pc_file ${in_file})

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+function(join_paths joined_path first_path_segment)
+  set(temp_path "${first_path_segment}")
+  foreach(current_segment IN LISTS ARGN)
+    if(NOT ("${current_segment}" STREQUAL ""))
+      if(IS_ABSOLUTE "${current_segment}")
+        set(temp_path "${current_segment}")
+      else()
+        set(temp_path "${temp_path}/${current_segment}")
+      endif()
+    endif()
+  endforeach()
+  file(TO_NATIVE_PATH "${temp_path}" temp_path)
+  set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/pkgconfig/libcrypto.pc.in
+++ b/pkgconfig/libcrypto.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
 
 Name: AWS-LC-libcrypto
 Description: AWS-LC cryptography library

--- a/pkgconfig/libssl.pc.in
+++ b/pkgconfig/libssl.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
 
 Name: AWS-LC-libssl
 Description: AWS-LC (OpenSSL SHIM)

--- a/pkgconfig/openssl.pc.in
+++ b/pkgconfig/openssl.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
 
 Name: AWS-LC
 Description: AWS-LC (OpenSSL SHIM)


### PR DESCRIPTION
### Description of changes: 

Currently the pkgconfig files are broken when aws-lc is built with Nix. 

See https://github.com/jtojnar/cmake-snips?tab=readme-ov-file#concatenating-paths-when-building-pkg-config-files, and the PR made to libfmt https://github.com/fmtlib/fmt/pull/1657

### Call-outs:

I'm not sure if bumping the minimum required CMake version is preferred. The alternative would be to add https://github.com/jtojnar/cmake-snips/blob/master/CMakeScripts/JoinPaths.cmake to the `cmake/` directory in the repository. However, most linux distributions have at least CMake 3.20, if not 3.25 so I don't see why this would be a problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
