### PR TITLE
Missing functionality + Adding Nmap to our CI

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -98,6 +98,18 @@ jobs:
       - name: Run integration build
         run: |
           ./tests/ci/integration/run_socat_integration.sh
+  nmap:
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make libcairo2.dev gobject-introspection libgirepository1.0-dev
+      - uses: actions/checkout@v3
+      - name: Run nmap build
+        run: |
+          ./tests/ci/integration/run_nmap_integration.sh
   python-main:
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install OS Dependencies
         run: |
           sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
-          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make libcairo2.dev gir1.2-gtk-3.0 python3-gi gobject-introspection libgirepository1.0-dev
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make cairo libcario2 libcairo2-dev gir1.2-gtk-3.0 python3-gi gobject-introspection libgirepository1.0-dev
       - uses: actions/checkout@v3
       - name: Run nmap build
         run: |

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install OS Dependencies
         run: |
           sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
-          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make libcairo2.dev gobject-introspection libgirepository1.0-dev
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make libcairo2.dev gir1.2-gtk-3.0 python3-gi gobject-introspection libgirepository1.0-dev
       - uses: actions/checkout@v3
       - name: Run nmap build
         run: |

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install OS Dependencies
         run: |
           sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
-          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make cairo libcario2 libcairo2-dev gir1.2-gtk-3.0 python3-gi gobject-introspection libgirepository1.0-dev
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make gobject-introspection
       - uses: actions/checkout@v3
       - name: Run nmap build
         run: |

--- a/crypto/bio/pair.c
+++ b/crypto/bio/pair.c
@@ -467,6 +467,11 @@ int BIO_new_bio_pair(BIO** bio1_p, size_t writebuf1_len,
   return 1;
 }
 
+int BIO_destroy_bio_pair(BIO *b) {
+  bio_destroy_pair(b);
+  return 1;
+}
+
 size_t BIO_ctrl_get_read_request(BIO *bio) {
   return BIO_ctrl(bio, BIO_C_GET_READ_REQUEST, 0, NULL);
 }

--- a/crypto/bio/pair.c
+++ b/crypto/bio/pair.c
@@ -468,6 +468,9 @@ int BIO_new_bio_pair(BIO** bio1_p, size_t writebuf1_len,
 }
 
 int BIO_destroy_bio_pair(BIO *b) {
+  if (b == NULL) {
+    return 0;
+  }
   bio_destroy_pair(b);
   return 1;
 }

--- a/crypto/cipher_extra/cipher_extra.c
+++ b/crypto/cipher_extra/cipher_extra.c
@@ -106,6 +106,7 @@ static const struct {
   const char* name;
 } kCipherAliases[] = {
     {"3des", "des-ede3-cbc"},
+    {"DES", "des-cbc"},
     {"aes256", "aes-256-cbc"},
     {"aes128", "aes-128-cbc"},
     {"id-aes128-gcm", "aes-128-gcm"},

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -705,6 +705,11 @@ OPENSSL_EXPORT int BIO_do_connect(BIO *bio);
 OPENSSL_EXPORT int BIO_new_bio_pair(BIO **out1, size_t writebuf1, BIO **out2,
                                     size_t writebuf2);
 
+// BIO_destroy_bio_pair destroys the connection between |b| and |b->ptr->peer|.
+// It disconnects both BIOs, resets their state, but does not free their memory.
+// It always returns one to indicate success.
+OPENSSL_EXPORT int BIO_destroy_bio_pair(BIO *b);
+
 // BIO_ctrl_get_read_request returns the number of bytes that the other side of
 // |bio| tried (unsuccessfully) to read.
 OPENSSL_EXPORT size_t BIO_ctrl_get_read_request(BIO *bio);

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -113,6 +113,7 @@
 
 #include <openssl/base.h>
 #include <openssl/crypto.h>
+#include <errno.h>
 
 #if defined(__cplusplus)
 extern "C" {

--- a/tests/ci/integration/nmap_patch/aws-lc-nmap.patch
+++ b/tests/ci/integration/nmap_patch/aws-lc-nmap.patch
@@ -1,0 +1,13 @@
+diff --git a/nsock/src/nsock_ssl.c b/nsock/src/nsock_ssl.c
+index 29d7fe8..20c0e6e 100644
+--- a/nsock/src/nsock_ssl.c
++++ b/nsock/src/nsock_ssl.c
+@@ -112,7 +112,7 @@ static SSL_CTX *ssl_init_helper(const SSL_METHOD *method) {
+   if (nsock_ssl_state == NSOCK_SSL_STATE_UNINITIALIZED)
+   {
+     nsock_ssl_state = NSOCK_SSL_STATE_INITIALIZED;
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER || defined OPENSSL_IS_AWSLC
+     SSL_load_error_strings();
+     SSL_library_init();
+ #else

--- a/tests/ci/integration/run_nmap_integration.sh
+++ b/tests/ci/integration/run_nmap_integration.sh
@@ -30,58 +30,37 @@ rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 function nmap_build() {
-
-  OPENSSL_CFLAGS="-I/${AWS_LC_INSTALL_FOLDER}/include" \
-  OPENSSL_LIBS="-L/${AWS_LC_INSTALL_FOLDER}/lib -lssl -lcrypto" \
+  #export CFLAGS="$CFLAGS -I/${AWS_LC_INSTALL_FOLDER}/include"
+  #export LDFLAGS="$LDFLAGS -L/${AWS_LC_INSTALL_FOLDER}/lib -lssl -lcrypto"
+  
   ./configure \
-    --prefix="$OPENVPN_BUILD_PREFIX" \
-    --exec-prefix="$OPENVPN_BUILD_EPREFIX" \
-    --with-crypto-library=openssl \
-    --with-openssl-engine=no
+    --prefix="$NMAP_BUILD_PREFIX" \
+    --exec-prefix="$NMAP_BUILD_EPREFIX" \
+    --with-openssl="$AWS_LC_INSTALL_FOLDER"
 
   make -j install
-
-  export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib"
-
-#  local openvpn_executable="${OPENVPN_SRC_FOLDER}/build/exec-install/sbin/openvpn"
-#  ldd ${openvpn_executable} \
-#    | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
 }
 
 # TODO: Remove this when we make an upstream contribution.
-function openvpn_patch_build() {
-  case "$BRANCH_NAME" in
-    "release/2.6")
-      patchfile="${OPENVPN_PATCH_BUILD_FOLDER}/aws-lc-openvpn2-6-x.patch"
-      ;;
-    "master")
-      patchfile="${OPENVPN_PATCH_BUILD_FOLDER}/aws-lc-openvpn-master.patch"
-      ;;
-    *)
-      echo "No specific patch file for branch: $BRANCH_NAME"
-      exit 1
-      ;;
-  esac
+# function nmap_patch_build() {
+ 
+# }
 
-  echo "Apply patch $patchfile..."
-  patch -p1 --quiet -i "$patchfile"
+function nmap_run_tests() {
+  make check
 }
 
-function openvpn_run_tests() {
-  # Explicitly running as sudo and passing in LD_LIBRARY_PATH as some OpenVPN
-  # tests run as sudo and LD_LIBRARY_PATH doesn't get inherited.
-  sudo LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib" make check
-}
-
-git clone https://github.com/OpenVPN/openvpn.git ${OPENVPN_SRC_FOLDER}
-cd ${OPENVPN_SRC_FOLDER} && git checkout $BRANCH_NAME
+git clone --depth 1 https://github.com/nmap/nmap.git ${NMAP_SRC_FOLDER} 
+cd ${NMAP_SRC_FOLDER}
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 ls
 
-aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=1
+aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 
-# Build openvpn from source.
-pushd ${OPENVPN_SRC_FOLDER}
-openvpn_patch_build
-openvpn_build
-openvpn_run_tests
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${AWS_LC_INSTALL_FOLDER}/lib/"
+
+# Build nmap from source.
+pushd ${NMAP_SRC_FOLDER}
+# nmap_patch_build
+nmap_build
+nmap_run_tests

--- a/tests/ci/integration/run_nmap_integration.sh
+++ b/tests/ci/integration/run_nmap_integration.sh
@@ -20,7 +20,7 @@ SCRATCH_FOLDER="${SRC_ROOT}/NMAP_BUILD_ROOT"
 NMAP_SRC_FOLDER="${SCRATCH_FOLDER}/nmap"
 NMAP_BUILD_PREFIX="${NMAP_SRC_FOLDER}/build/install"
 NMAP_BUILD_EPREFIX="${NMAP_SRC_FOLDER}/build/exec-install"
-NMAP_PATCH_BUILD_FOLDER="${SRC_ROOT}/tests/ci/integration/nmap_patch"
+NMAP_PATCH_FOLDER="${SRC_ROOT}/tests/ci/integration/nmap_patch"
 
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
@@ -30,9 +30,6 @@ rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 function nmap_build() {
-  #export CFLAGS="$CFLAGS -I/${AWS_LC_INSTALL_FOLDER}/include"
-  #export LDFLAGS="$LDFLAGS -L/${AWS_LC_INSTALL_FOLDER}/lib -lssl -lcrypto"
-  
   ./configure \
     --prefix="$NMAP_BUILD_PREFIX" \
     --exec-prefix="$NMAP_BUILD_EPREFIX" \
@@ -42,9 +39,12 @@ function nmap_build() {
 }
 
 # TODO: Remove this when we make an upstream contribution.
-# function nmap_patch_build() {
- 
-# }
+function nmap_patch_build() {
+   for patchfile in $(find -L "${NMAP_PATCH_FOLDER}" -type f -name '*.patch'); do
+     echo "Apply patch $patchfile..."
+     patch -p1 --quiet -i "$patchfile"
+   done
+}
 
 function nmap_run_tests() {
   make check
@@ -61,6 +61,6 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${AWS_LC_INSTALL_FOLDER}/lib/"
 
 # Build nmap from source.
 pushd ${NMAP_SRC_FOLDER}
-# nmap_patch_build
+nmap_patch_build
 nmap_build
 nmap_run_tests

--- a/tests/ci/integration/run_nmap_integration.sh
+++ b/tests/ci/integration/run_nmap_integration.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -exu
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# SYS_ROOT
+#  - SRC_ROOT(aws-lc)
+#    - SCRATCH_FOLDER
+#      - OPENVPN_SRC_FOLDER
+#      - AWS_LC_BUILD_FOLDER
+#      - AWS_LC_INSTALL_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER="${SRC_ROOT}/NMAP_BUILD_ROOT"
+NMAP_SRC_FOLDER="${SCRATCH_FOLDER}/nmap"
+NMAP_BUILD_PREFIX="${NMAP_SRC_FOLDER}/build/install"
+NMAP_BUILD_EPREFIX="${NMAP_SRC_FOLDER}/build/exec-install"
+NMAP_PATCH_BUILD_FOLDER="${SRC_ROOT}/tests/ci/integration/nmap_patch"
+
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf "${SCRATCH_FOLDER:?}"/*
+cd ${SCRATCH_FOLDER}
+
+function nmap_build() {
+
+  OPENSSL_CFLAGS="-I/${AWS_LC_INSTALL_FOLDER}/include" \
+  OPENSSL_LIBS="-L/${AWS_LC_INSTALL_FOLDER}/lib -lssl -lcrypto" \
+  ./configure \
+    --prefix="$OPENVPN_BUILD_PREFIX" \
+    --exec-prefix="$OPENVPN_BUILD_EPREFIX" \
+    --with-crypto-library=openssl \
+    --with-openssl-engine=no
+
+  make -j install
+
+  export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib"
+
+#  local openvpn_executable="${OPENVPN_SRC_FOLDER}/build/exec-install/sbin/openvpn"
+#  ldd ${openvpn_executable} \
+#    | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
+}
+
+# TODO: Remove this when we make an upstream contribution.
+function openvpn_patch_build() {
+  case "$BRANCH_NAME" in
+    "release/2.6")
+      patchfile="${OPENVPN_PATCH_BUILD_FOLDER}/aws-lc-openvpn2-6-x.patch"
+      ;;
+    "master")
+      patchfile="${OPENVPN_PATCH_BUILD_FOLDER}/aws-lc-openvpn-master.patch"
+      ;;
+    *)
+      echo "No specific patch file for branch: $BRANCH_NAME"
+      exit 1
+      ;;
+  esac
+
+  echo "Apply patch $patchfile..."
+  patch -p1 --quiet -i "$patchfile"
+}
+
+function openvpn_run_tests() {
+  # Explicitly running as sudo and passing in LD_LIBRARY_PATH as some OpenVPN
+  # tests run as sudo and LD_LIBRARY_PATH doesn't get inherited.
+  sudo LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib" make check
+}
+
+git clone https://github.com/OpenVPN/openvpn.git ${OPENVPN_SRC_FOLDER}
+cd ${OPENVPN_SRC_FOLDER} && git checkout $BRANCH_NAME
+mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
+ls
+
+aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=1
+
+# Build openvpn from source.
+pushd ${OPENVPN_SRC_FOLDER}
+openvpn_patch_build
+openvpn_build
+openvpn_run_tests

--- a/tests/ci/integration/run_nmap_integration.sh
+++ b/tests/ci/integration/run_nmap_integration.sh
@@ -33,9 +33,14 @@ function nmap_build() {
   ./configure \
     --prefix="$NMAP_BUILD_PREFIX" \
     --exec-prefix="$NMAP_BUILD_EPREFIX" \
-    --with-openssl="$AWS_LC_INSTALL_FOLDER"
+    --with-openssl="$AWS_LC_INSTALL_FOLDER" \
+    --without-zenmap
 
   make -j install
+
+  local nmap_executable="${NMAP_BUILD_EPREFIX}/bin/nmap"
+    ldd ${nmap_executable} \
+      | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
 }
 
 # TODO: Remove this when we make an upstream contribution.

--- a/tests/ci/integration/run_nmap_integration.sh
+++ b/tests/ci/integration/run_nmap_integration.sh
@@ -47,6 +47,8 @@ function nmap_patch_build() {
 }
 
 function nmap_run_tests() {
+  # Add nmap executable to path, needed for zenmap tests
+  export PATH="${NMAP_BUILD_EPREFIX}/bin/:$PATH"
   make check
 }
 


### PR DESCRIPTION
### Issues:
CryptoAlg-2552

### Description of changes: 
This PR adds Nmap tip of main to our CI. It includes: 
1. A patch to Nmap
2. Adding an include for <errno.h> to <err.h>, OpenSSL does this but we previously did not
3. Adding BIO_destroy_bio_pair (the functionality was already implemented, we are simply exposing that through a new func)
4. Creating a new alias for "DES" in the EVP_CIPHER API. The "default" mode used in OpenSSL 1.1.1 and 3.1 with DES is CBC [(link)](https://docs.openssl.org/1.1.1/man1/enc/#supported-ciphers:~:text=des%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Alias%20for%20des%2Dcbc).

### Testing:
Locally built and ran nmap tests with AWS-LC and verified they pass. Conducted a dry run with the extra included file to ensure it doesn't break any consumers in live (refer to CryptoAlg-2552 for the dryrun link).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
