### PR TITLE
Add 2024 FIPS and fix build issues on older arm FIPS

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -114,7 +114,7 @@ extern "C" {
 // A consumer may use this symbol in the preprocessor to temporarily build
 // against multiple revisions of BoringSSL at the same time. It is not
 // recommended to do so for longer than is necessary.
-#define AWSLC_API_VERSION 30
+#define AWSLC_API_VERSION 31
 
 // This string tracks the most current production release version on Github
 // https://github.com/aws/aws-lc/releases.

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -380,6 +380,6 @@ batch:
         type: ARM_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:ubuntu-20.04_clang-7x_latest
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:ubuntu-20.04_clang-7x-bm-framework_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_benchmark_build_tests.sh"

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -373,3 +373,13 @@ batch:
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2023_gcc-11x_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_ssl_runner_valgrind_tests.sh"
+
+    - identifier: ubuntu2004_clang7x_aarch_benchmark
+      buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:ubuntu-20.04_clang-7x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/run_benchmark_build_tests.sh"

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -207,6 +207,19 @@ function build_openssl {
     rm -rf "${scratch_folder}/openssl-${branch}"
 }
 
+function build_openssl_no_debug {
+    branch=$1
+    echo "building OpenSSL ${branch}"
+    git clone --depth 1 --branch "${branch}" "${openssl_url}" "${scratch_folder}/openssl-${branch}"
+    pushd "${scratch_folder}/openssl-${branch}"
+    mkdir -p "${install_dir}/openssl-${branch}"
+    ./config --prefix="${install_dir}/openssl-${branch}" --openssldir="${install_dir}/openssl-${branch}"
+    make "-j${NUM_CPU_THREADS}" > /dev/null
+    make install_sw
+    popd
+    rm -rf "${scratch_folder}/openssl-${branch}"
+}
+
 print_executable_information "cmake" "--version" "CMake version"
 print_executable_information "cmake3" "--version" "CMake version (cmake3 executable)"
 print_executable_information "go" "version" "Go version"

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -74,6 +74,7 @@ build_aws_lc_fips
 
 build_aws_lc_branch fips-2021-10-20
 build_aws_lc_branch fips-2022-11-02
+build_aws_lc_branch fips-2024-09-27
 build_openssl $openssl_1_0_2_branch
 build_openssl $openssl_1_1_1_branch
 build_openssl $openssl_3_1_branch
@@ -84,14 +85,17 @@ build_boringssl
 run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=14 -DCMAKE_C_STANDARD=11 -DENABLE_DILITHIUM=ON -DBENCHMARK_LIBS="\
 aws-lc-fips-2021:${install_dir}/aws-lc-fips-2021-10-20;\
 aws-lc-fips-2022:${install_dir}/aws-lc-fips-2022-11-02;\
+aws-lc-fips-2024:${install_dir}/aws-lc-fips-2024-09-27;\
 open102:${install_dir}/openssl-${openssl_1_0_2_branch};\
 open111:${install_dir}/openssl-${openssl_1_1_1_branch};\
 open31:${install_dir}/openssl-${openssl_3_1_branch};\
 open32:${install_dir}/openssl-${openssl_3_2_branch};\
 openmaster:${install_dir}/openssl-${openssl_master_branch};\
 boringssl:${install_dir}/boringssl;"
+
 LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2021-10-20/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2021" -timeout_ms 10
-LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2022/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2022-11-02/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10
+LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2024-09-27/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10
 LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_1_0_2_branch}/lib" "${BUILD_ROOT}/tool/open102" -timeout_ms 10
 LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_1_1_1_branch}/lib" "${BUILD_ROOT}/tool/open111" -timeout_ms 10
 LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_3_1_branch}/lib64" "${BUILD_ROOT}/tool/open31" -timeout_ms 10

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -75,11 +75,11 @@ build_aws_lc_fips
 build_aws_lc_branch fips-2021-10-20
 build_aws_lc_branch fips-2022-11-02
 build_aws_lc_branch fips-2024-09-27
-build_openssl $openssl_1_0_2_branch
-build_openssl $openssl_1_1_1_branch
-build_openssl $openssl_3_1_branch
-build_openssl $openssl_3_2_branch
-build_openssl $openssl_master_branch
+build_openssl_no_debug $openssl_1_0_2_branch
+build_openssl_no_debug $openssl_1_1_1_branch
+build_openssl_no_debug $openssl_3_1_branch
+build_openssl_no_debug $openssl_3_2_branch
+build_openssl_no_debug $openssl_master_branch
 build_boringssl
 
 run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=14 -DCMAKE_C_STANDARD=11 -DENABLE_DILITHIUM=ON -DBENCHMARK_LIBS="\

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -37,7 +37,6 @@
 #if defined(OPENSSL_IS_AWSLC)
 #include "bssl_bm.h"
 #include "../crypto/internal.h"
-#include "../crypto/fipsmodule/cpucap/internal.h"
 #include <thread>
 #include <sstream>
 #elif defined(OPENSSL_IS_BORINGSSL)
@@ -86,7 +85,10 @@ static inline void *align_pointer(void *ptr, size_t alignment) {
 }
 #endif
 
-#if defined(OPENSSL_IS_AWSLC) && defined(AARCH64_DIT_SUPPORTED)
+
+
+#if defined(OPENSSL_IS_AWSLC) && defined(AARCH64_DIT_SUPPORTED) && (AWSLC_API_VERSION > 30)
+#include "../crypto/fipsmodule/cpucap/internal.h"
 #define DIT_OPTION
 #endif
 


### PR DESCRIPTION
### Issues:

P162016551

### Description of changes: 

Firstly, when building multiple versions of `bssl` using the `main` branch as the base, builds on Arm will fail when using older versions of AWS-LC e.g. FIPS 2021 from the 2021 FIPS branch. The reason is that an internal header file `[...]/cpucap/nternal.h` is included into the compilation unit by `#include "..."`. The gcc search path will then, irrespective of any user-specified search paths via `-I`, pick up the `main` branch header files. This include identifiers such as `ARMV8_NEOVERSE_V2`. But the definition of this identifier is in `arm_arch.h`, which is transitively included into the compilation unit via `#include <..>` directives. The search path for these DO follow the user-specified search path from `-I` (at least on GCC) and use e.g. the FIPS 2021 include file version of `arm_arch.h` that does not have the identifier defined. The result of this are build errors. For example, from one of the performance canary hosts:
```
/home/ec2-user/canary/src-AWS-LC/tool/../crypto/fipsmodule/cpucap/internal.h:245:32: error: use of undeclared identifier 'ARMV8_NEOVERSE_V2'
           (OPENSSL_armcap_P & ARMV8_NEOVERSE_V2) != 0 ||
                               ^

[...]

/home/ec2-user/canary/src-AWS-LC/tool/../crypto/fipsmodule/cpucap/internal.h:257:18: error: use of undeclared identifier 'ARMV8_DIT_ALLOWED'
    (ARMV8_DIT | ARMV8_DIT_ALLOWED);
                 ^
8 errors generated.
```

The pattern of adding internal header files to a consuming application that is going to be build with multiple old version of the library is not ideal, because one can hit these hidden incompatibilities that. But now it's a bit rusted-in and it's not apparent to me if there is a much easier way to organise it currently. Leaving that as an open question and simply fix by guarding the inclusion for now.

Secondly, the reason this even escaped as a bug, is that the CI doesn't test the special multiple-build of `bssl` with other library sources on Arm. We only test on x86_64. The above is purely an Arm-specific bug because for som reason there is a special Arm header file(?). I added an Arm stanza to the Arm omnibus config file that will execute the relevant test script. ~~However, this needs to be deployed before taking effect.~~ (EDIT: no, actually not...)

Thirdly, the `LD_LIBRARY_PATH` option was incorrect for  `aws-lc-fips-2022`, when testing the executable. But, in fact, this doesn't actually matter for `bssl`, because `DT_RPATH` is set in the resulting executables, e.g.:
```
$ readelf -d aws-lc-fips-2022 | grep RPATH                       
 0x000000000000000f (RPATH)              Library rpath: [/home/benchmark-scratch/libcrypto_install_dir/aws-lc-fips-2022-11-02/lib64]
```
When resolving the dynamic dependency at load-time, `DT_RPATH` takes precedence over `LD_LIBRARY_PATH`. As an example, trying to resolve to another library version still resolve to `DT_RPATH` from the executable:
```
$ LD_LIBRARY_PATH=/home/benchmark-scratch/libcrypto_install_dir/aws-lc-fips-2024-09-27/lib64 ldd aws-lc-fips-2022 
        libcrypto.so => /home/benchmark-scratch/libcrypto_install_dir/aws-lc-fips-2022-11-02/lib64/libcrypto.so (0x0000ffffb050d000)
[...]
```

Finally, added the new FIPS 2024 prospective branch to the test cases.

### Testing:

I tested the changes to the speed tool locally to ensure that build errors are resolved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
