### PR TITLE
Align X509 PARTIAL_CHAIN behavior with 1.1.1 (#1917)

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -363,6 +363,20 @@ int X509_verify_cert(X509_STORE_CTX *ctx) {
         ok = 0;
         goto end;
       }
+
+      // OpenSSL 1.1.1 continuously re-checks for trust and breaks the loop
+      // as soon as trust has been established. 1.0.2 builds the chain with all
+      // possible certs first and only checks for trust if the final cert in
+      // the chain is self-signed.
+      // This caused additional unanticipated certs to be in the established
+      // certificate chain, particularly when |X509_V_FLAG_PARTIAL_CHAIN| was
+      // set. We try checking continuously for trust here for better 1.1.1
+      // compatibility.
+      trust = check_trust(ctx);
+      if (trust == X509_TRUST_TRUSTED || trust == X509_TRUST_REJECTED) {
+        break;
+      }
+
       num++;
     }
 


### PR DESCRIPTION
Some consumers noticed that a behavior difference between AWS-LC and OpenSSL when the trust store contains certificates that are issued by other certificates that are also in the trust store. A common example of this would be the trust store containing both the intermediate and the root for the cert chain (`leaf -> intermediate -> root`). The default settings of AWS-LC and OpenSSL require `root` to be self signed for the chain to be verified.

Many TLS implementations set the `X509_V_FLAG_PARTIAL_CHAIN` flag however, which allows non self signed certificates to be trusted in the trust store. When `X509_V_FLAG_PARTIAL_CHAIN` is set, OpenSSL 1.1.1 will only verify leaf and intermediate, since intermediate is a trusted certificate. However, AWS-LC will continue building a certificate chain and include root within the chain of trust. This causes a behavioral difference with `X509_STORE_CTX_get0_chain`, where AWS-LC will return all 3 certificates (`leaf -> intermediate -> root`) and OpenSSL 1.1.1 will only return the first two (`leaf -> intermediate `).

Our upstream forked a bit before OpenSSL 1.0.2, so we don't have the new behavior. This described behavioral difference was introduced in openssl/openssl@d9b8b89 (along with many others), but the commit introduces too many backwards incompatible changes for us to take as a whole.
This subtle difference was due to OpenSSL 1.1.1 continuously checking for trust while the chain's being established. The search for the next valid cert breaks early as soon as a valid chain has been built. Our current behavior builds the chain with all possible certs first and only breaks the loop if the final cert in the chain is self-signed. We can inherit this part of 1.1.1's new behavior to fix this issue.

### Call-outs:
I don't believe this really changes our X509 chain building or verification by much. We're only adding an additional check for trust while the chain is being established and the final chain still needs to go through the same building/verification process that exists in AWS-LC today.

### Testing:
Specific test for new behavior in `X509_V_FLAG_PARTIAL_CHAIN`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

(cherry picked from commit 9fbfa706c9b7fece478605f57d4706b1d72c7b8e)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
