### PR TITLE
Use illegal_parameter instead of decode_error for invalid key shares

### DIFF
--- a/ssl/ssl_key_share.cc
+++ b/ssl/ssl_key_share.cc
@@ -87,7 +87,7 @@ class ECKeyShare : public SSLKeyShare {
         !EC_POINT_oct2point(group_, peer_point.get(), peer_key.data(),
                             peer_key.size(), /*ctx=*/nullptr)) {
       OPENSSL_PUT_ERROR(SSL, SSL_R_BAD_ECPOINT);
-      *out_alert = SSL_AD_DECODE_ERROR;
+      *out_alert = SSL_AD_ILLEGAL_PARAMETER;
       return false;
     }
 
@@ -153,7 +153,7 @@ class X25519KeyShare : public SSLKeyShare {
 
     if (peer_key.size() != 32 ||
         !X25519(secret.data(), private_key_, peer_key.data())) {
-      *out_alert = SSL_AD_DECODE_ERROR;
+      *out_alert = SSL_AD_ILLEGAL_PARAMETER;
       OPENSSL_PUT_ERROR(SSL, SSL_R_BAD_ECPOINT);
       return false;
     }
@@ -286,7 +286,7 @@ class KEMKeyShare : public SSLKeyShare {
       EVP_PKEY_kem_new_raw_public_key(nid_, peer_key.begin(), peer_key.size()));
 
     if (!pkey) {
-      *out_alert = SSL_AD_DECODE_ERROR;
+      *out_alert = SSL_AD_ILLEGAL_PARAMETER;
       OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
       return false;
     }
@@ -387,7 +387,7 @@ class KEMKeyShare : public SSLKeyShare {
                               &secret_bytes_written, ciphertext,
                               peer_key.size()) ||
                               secret_bytes_written != secret_len) {
-      OPENSSL_PUT_ERROR(SSL, SSL_R_BAD_KEM_CIPHERTEXT);
+      OPENSSL_PUT_ERROR(SSL, SSL_AD_ILLEGAL_PARAMETER);
       return false;
     }
 
@@ -504,7 +504,7 @@ class HybridKeyShare : public SSLKeyShare {
         // Verify that |peer_key| contains enough data
         if (peer_key_read_index + component_key_size > peer_key.size()) {
           CBB_cleanup(&hybrid_shared_secret);
-          *out_alert = SSL_AD_DECODE_ERROR;
+          *out_alert = SSL_AD_ILLEGAL_PARAMETER;
           OPENSSL_PUT_ERROR(SSL, SSL_R_BAD_HYBRID_KEYSHARE);
           return false;
         }
@@ -612,7 +612,7 @@ class HybridKeyShare : public SSLKeyShare {
       // Final validation that |peer_key| was the correct size
       if (peer_key_index != peer_key.size()) {
         CBB_cleanup(&hybrid_shared_secret);
-        *out_alert = SSL_AD_DECODE_ERROR;
+        *out_alert = SSL_AD_ILLEGAL_PARAMETER;
         OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
         return false;
       }

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -11905,7 +11905,7 @@ TEST_P(BadKemKeyShareAcceptTest, BadKemKeyShareAccept) {
     EXPECT_FALSE(server_key_share->Accept(&server_out_public_key,
                                           &server_secret, &server_alert,
                                           client_public_key));
-    EXPECT_EQ(server_alert, SSL_AD_DECODE_ERROR);
+    EXPECT_EQ(server_alert, SSL_AD_ILLEGAL_PARAMETER);
     CBB_cleanup(&server_out_public_key);
     CBB_cleanup(&client_out_public_key);
   }
@@ -11935,7 +11935,7 @@ TEST_P(BadKemKeyShareAcceptTest, BadKemKeyShareAccept) {
     EXPECT_FALSE(server_key_share->Accept(&server_out_public_key,
                                           &server_secret, &server_alert,
                                           client_public_key));
-    EXPECT_EQ(server_alert, SSL_AD_DECODE_ERROR);
+    EXPECT_EQ(server_alert, SSL_AD_ILLEGAL_PARAMETER);
     CBB_cleanup(&server_out_public_key);
     CBB_cleanup(&client_out_public_key);
   }
@@ -12394,7 +12394,7 @@ TEST_P(BadHybridKeyShareAcceptTest, BadHybridKeyShareAccept) {
     EXPECT_FALSE(server_key_share->Accept(&server_out_public_key,
                                           &server_secret, &server_alert,
                                           client_public_key));
-    EXPECT_EQ(server_alert, SSL_AD_DECODE_ERROR);
+    EXPECT_EQ(server_alert, SSL_AD_ILLEGAL_PARAMETER);
     CBB_cleanup(&server_out_public_key);
   }
 
@@ -12422,7 +12422,7 @@ TEST_P(BadHybridKeyShareAcceptTest, BadHybridKeyShareAccept) {
     EXPECT_FALSE(server_key_share->Accept(&server_out_public_key,
                                           &server_secret, &server_alert,
                                           client_public_key));
-    EXPECT_EQ(server_alert, SSL_AD_DECODE_ERROR);
+    EXPECT_EQ(server_alert, SSL_AD_ILLEGAL_PARAMETER);
     CBB_cleanup(&server_out_public_key);
     CBB_cleanup(&client_out_public_key);
   }
@@ -12547,7 +12547,7 @@ TEST_P(BadHybridKeyShareAcceptTest, BadHybridKeyShareAccept) {
         // The Accept() functionality for the NIST curves (e.g. P256) is
         // written so that it will return failure if the key share is invalid.
         EXPECT_EQ(hybrid_group->component_group_ids[i], SSL_GROUP_SECP256R1);
-        EXPECT_EQ(server_alert, SSL_AD_DECODE_ERROR);
+        EXPECT_EQ(server_alert, SSL_AD_ILLEGAL_PARAMETER);
       }
 
       client_public_key_index += t.offer_share_sizes[i];
@@ -12713,7 +12713,7 @@ TEST_P(BadHybridKeyShareFinishTest, BadHybridKeyShareFinish) {
                                       CBB_len(&server_out_public_key));
 
     EXPECT_FALSE(client_key_share->Finish(&client_secret, &client_alert, server_public_key));
-    EXPECT_EQ(client_alert, SSL_AD_DECODE_ERROR);
+    EXPECT_EQ(client_alert, SSL_AD_ILLEGAL_PARAMETER);
 
     CBB_cleanup(&server_out_public_key);
     CBB_cleanup(&client_out_public_key);
@@ -12809,7 +12809,7 @@ TEST_P(BadHybridKeyShareFinishTest, BadHybridKeyShareFinish) {
         // The Finish() functionality for the NIST curves (e.g. P256) is
         // written so that it will return failure if the key share is invalid.
         EXPECT_EQ(hybrid_group->component_group_ids[i], SSL_GROUP_SECP256R1);
-        EXPECT_EQ(client_alert, SSL_AD_DECODE_ERROR);
+        EXPECT_EQ(client_alert, SSL_AD_ILLEGAL_PARAMETER);
       }
 
       server_public_key_index += t.accept_share_sizes[i];


### PR DESCRIPTION
### Cherry-picked commit
* https://github.com/google/boringssl/commit/72a60506ded3407454d6ddc1d848c266020c0c82

### Original commit message
This is extremely silly and a huge waste of everyone's time (I deeply regret disambiguating illegal_parameter and decode_error for RFC 8446), but so it goes. Technically these errors pass the TLS syntax and are an invalid value, so they should be illegal_parameter.

   Note: TLS defines two generic alerts (see Section 6) to use upon
   failure to parse a message.  Peers which receive a message which
   cannot be parsed according to the syntax (e.g., have a length
   extending beyond the message boundary or contain an out-of-range
   length) MUST terminate the connection with a "decode_error" alert.
   Peers which receive a message which is syntactically correct but
   semantically invalid (e.g., a DHE share of p - 1, or an invalid enum)
   MUST terminate the connection with an "illegal_parameter" alert.

Update-Note: The error sent on invalid key share is now more correct. This does not change which connections do or do not fail, only which of two practically identical alert codes is sent to the other side.

Change-Id: If0ddf511d6cf23383c6134ad30e3ae080c4f2769
Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/71627
Auto-Submit: David Benjamin <davidben@google.com>
Reviewed-by: Bob Beck <bbe@google.com>
Commit-Queue: Bob Beck <bbe@google.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
