### PR TITLE
800-131Ar1: length of the key-derivation key shall be at least 112 bits.

### DIFF
--- a/crypto/fipsmodule/kdf/kbkdf.c
+++ b/crypto/fipsmodule/kdf/kbkdf.c
@@ -104,7 +104,7 @@ err:
   HMAC_CTX_free(hmac_ctx);
   FIPS_service_indicator_unlock_state();
   if (ret) {
-    KBKDF_ctr_hmac_verify_service_indicator(digest);
+    KBKDF_ctr_hmac_verify_service_indicator(digest, secret_len);
   }
   return ret;
 }

--- a/crypto/fipsmodule/service_indicator/internal.h
+++ b/crypto/fipsmodule/service_indicator/internal.h
@@ -55,7 +55,7 @@ void TLSKDF_verify_service_indicator(const EVP_MD *dgst, const char *label,
                                      size_t label_len);
 void SSKDF_digest_verify_service_indicator(const EVP_MD *dgst);
 void SSKDF_hmac_verify_service_indicator(const EVP_MD *dgst);
-void KBKDF_ctr_hmac_verify_service_indicator(const EVP_MD *dgst);
+void KBKDF_ctr_hmac_verify_service_indicator(const EVP_MD *dgst, size_t secret_len);
 void EVP_PKEY_encapsulate_verify_service_indicator(const EVP_PKEY_CTX* ctx);
 void EVP_PKEY_decapsulate_verify_service_indicator(const EVP_PKEY_CTX* ctx);
 
@@ -127,7 +127,7 @@ OPENSSL_INLINE void SSKDF_digest_verify_service_indicator(
 OPENSSL_INLINE void SSKDF_hmac_verify_service_indicator(
     OPENSSL_UNUSED const EVP_MD *dgst) {}
 
-OPENSSL_INLINE void KBKDF_ctr_hmac_verify_service_indicator(OPENSSL_UNUSED const EVP_MD *dgst) {}
+OPENSSL_INLINE void KBKDF_ctr_hmac_verify_service_indicator(OPENSSL_UNUSED const EVP_MD *dgst, size_t secret_len) {}
 
 OPENSSL_INLINE void EVP_PKEY_encapsulate_verify_service_indicator(OPENSSL_UNUSED const EVP_PKEY_CTX* ctx) {}
 

--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -609,7 +609,7 @@ void SSKDF_hmac_verify_service_indicator(const EVP_MD *dgst) {
 //
 // Sourced from NIST SP 800-108r1-upd1 Section 3:  Pseudorandom Function (PRF)
 // https://doi.org/10.6028/NIST.SP.800-108r1-upd1
-void KBKDF_ctr_hmac_verify_service_indicator(const EVP_MD *dgst) {
+void KBKDF_ctr_hmac_verify_service_indicator(const EVP_MD *dgst, size_t secret_len) {
   switch (dgst->type) {
     case NID_sha1:
     case NID_sha224:
@@ -618,7 +618,10 @@ void KBKDF_ctr_hmac_verify_service_indicator(const EVP_MD *dgst) {
     case NID_sha512:
     case NID_sha512_224:
     case NID_sha512_256:
-      FIPS_service_indicator_update_state();
+      // SP 800-131Ar1, Section 8: "The length of the key-derivation key shall be at least 112 bits.” 
+      if (secret_len >= 14) {
+        FIPS_service_indicator_update_state();
+      }
       break;
     default:
       break;


### PR DESCRIPTION
### Description of changes: 
* KBKDF: Per SP 800-131Ar1, Section 8: "The length of the key-derivation key shall be at least 112 bits.” There must be a non-approved service indicator for KBKDF with KDK < 112 bits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
