### PR TITLE
Also prune SSM documents from ec2-test-framework

### DIFF
--- a/tests/ci/cdk/cdk/components.py
+++ b/tests/ci/cdk/cdk/components.py
@@ -63,6 +63,7 @@ class PruneStaleGitHubBuilds(Construct):
                 iam.PolicyStatement(effect=iam.Effect.ALLOW,
                                     actions=[
                                         "ssm:ListDocuments",
+                                        # "ssm:DeleteDocument",
                                     ],
                                     resources=["arn:aws:ssm:{}:{}:*".format(AWS_REGION, AWS_ACCOUNT)]))
 

--- a/tests/ci/cdk/cdk/components.py
+++ b/tests/ci/cdk/cdk/components.py
@@ -63,7 +63,7 @@ class PruneStaleGitHubBuilds(Construct):
                 iam.PolicyStatement(effect=iam.Effect.ALLOW,
                                     actions=[
                                         "ssm:ListDocuments",
-                                        # "ssm:DeleteDocument",
+                                        "ssm:DeleteDocument",
                                     ],
                                     resources=["arn:aws:ssm:{}:{}:*".format(AWS_REGION, AWS_ACCOUNT)]))
 

--- a/tests/ci/cdk/cdk/components.py
+++ b/tests/ci/cdk/cdk/components.py
@@ -59,6 +59,12 @@ class PruneStaleGitHubBuilds(Construct):
                                         "ec2:DescribeInstances",
                                     ],
                                     resources=["*"]))
+            lambda_function.add_to_role_policy(
+                iam.PolicyStatement(effect=iam.Effect.ALLOW,
+                                    actions=[
+                                        "ssm:ListDocuments",
+                                    ],
+                                    resources=["arn:aws:ssm:{}:{}:*".format(AWS_REGION, AWS_ACCOUNT)]))
 
 
         events.Rule(scope=self, id="PurgeEventRule",

--- a/tests/ci/common_ssm_setup.sh
+++ b/tests/ci/common_ssm_setup.sh
@@ -4,7 +4,7 @@
 #$1 is the prefix for the ssm document, echos the doc name so we can capture the output
 create_ssm_document() {
   local doc_name
-  doc_name="$1"_ssm_document_"${CODEBUILD_SOURCE_VERSION}"
+  doc_name=""${CODEBUILD_SOURCE_VERSION}"_""$1"_ssm_document
   aws ssm create-document --content file://tests/ci/cdk/cdk/ssm/"$1"_ssm_document.yaml \
     --name "${doc_name}" \
     --document-type Command \

--- a/tests/ci/common_ssm_setup.sh
+++ b/tests/ci/common_ssm_setup.sh
@@ -4,7 +4,7 @@
 #$1 is the prefix for the ssm document, echos the doc name so we can capture the output
 create_ssm_document() {
   local doc_name
-  doc_name=""${CODEBUILD_SOURCE_VERSION}"_""$1"_ssm_document
+  doc_name="$1"_ssm_document_"${CODEBUILD_SOURCE_VERSION}"
   aws ssm create-document --content file://tests/ci/cdk/cdk/ssm/"$1"_ssm_document.yaml \
     --name "${doc_name}" \
     --document-type Command \

--- a/tests/ci/lambda/Cargo.lock
+++ b/tests/ci/lambda/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -136,6 +136,7 @@ dependencies = [
  "aws-sdk-codebuild",
  "aws-sdk-ec2",
  "aws-sdk-secretsmanager",
+ "aws-sdk-ssm",
  "env_logger",
  "lambda_runtime",
  "log",
@@ -147,14 +148,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42c2d4218de4dcd890a109461e2f799a1a2ba3bcd2cde9af88360f5df9266c6"
+checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
@@ -220,6 +222,29 @@ name = "aws-sdk-secretsmanager"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f468d566c05086b1b6a08e9de12dca141071a717580dc075f180d0fe11b6190f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssm"
+version = "1.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27d420415f7f7ab7eef079a108b01fa7b1fdf2a27b2e1631e3c6bbb408d649e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -307,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
+checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -341,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.9"
+version = "0.60.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9cd0ae3d97daa0a2bf377a4d8e8e1362cae590c4a1aad0d40058ebca18eb91e"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -380,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.3"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abbf454960d0db2ad12684a1640120e7557294b0ff8e2f11236290a1b293225"
+checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -424,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.2"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cee7cadb433c781d3299b916fbf620fea813bf38f49db282fb6858141a05cc8"
+checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
 dependencies = [
  "base64-simd",
  "bytes",

--- a/tests/ci/lambda/Cargo.toml
+++ b/tests/ci/lambda/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 aws-config = "1.1.7"
 aws-sdk-codebuild = "1.44.0"
 aws-sdk-ec2 = "1.59.0"
+aws-sdk-ssm = "1.51.0"
 aws-sdk-secretsmanager = "1.39.0"
 lambda_runtime = "0.8.0"
 log = "0.4.17"


### PR DESCRIPTION
### Issues:
Resolves `P149524833`

### Description of changes: 
There were some leaking SSM documents that weren't being pruned with the ec2 instances used. This adds the corresponding logic to remove them.

### Call-outs:
N/A

### Testing:
Tested on personal fork: https://github.com/samuel40791765/aws-lc/pull/35

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
