### PR TITLE
Support encode or decode ∞ like OpenSSL

### DIFF
--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1260,7 +1260,9 @@ TEST(ECTest, BIGNUMConvert) {
   // Test specific openssl/openssl#10329 case for |BN_zero|.
   bssl::UniquePtr<BIGNUM> zero(BN_new());
   BN_zero(zero.get());
-  EXPECT_TRUE(EC_POINT_bn2point(group.get(), zero.get(), nullptr, nullptr));
+  bssl::UniquePtr<EC_POINT> infinity(
+      EC_POINT_bn2point(group.get(), zero.get(), nullptr, nullptr));
+  ASSERT_TRUE(infinity);
 }
 
 TEST(ECTest, SetKeyWithoutGroup) {


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2697`

### Description of changes: 
Ruby [has tests](https://github.com/ruby/ruby/blob/ruby_3_1/test/openssl/test_pkey_ec.rb#L373-L378) asserting that OpenSSL encodes and decodes infinity points to 0. This doesn't quite make sense, but our hand is sort of forced here. It does show that there's dependence on this subtle behavior and we might as well support it since we're trying to gain better compatibility.

```
    assert_equal false, point.infinity?
    point.set_to_infinity!
    assert_equal true, point.infinity?
    assert_equal 0.to_bn, point.to_bn
    assert_equal B(%w{ 00 }), point.to_octet_string(:uncompressed)
    assert_equal true, point.on_curve?
```

### Call-outs:
Tweak against changes from these commits;
* https://github.com/aws/aws-lc/commit/d9e27021e171d5f8c790b282315a07bde735da97
* https://github.com/aws/aws-lc/commit/a7185da20d39d91c2916529fcd7fc3a1eda222b7

### Testing:
Tweaked existing tests that checked we did not support this behavior. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
