### PR TITLE
Let ECDSA_verify return -1 for ASN1 parsing fail

### DIFF
--- a/crypto/fipsmodule/ecdsa/ecdsa.c
+++ b/crypto/fipsmodule/ecdsa/ecdsa.c
@@ -412,7 +412,7 @@ err:
 int ECDSA_verify(int type, const uint8_t *digest, size_t digest_len,
                  const uint8_t *sig, size_t sig_len, const EC_KEY *eckey) {
   ECDSA_SIG *s;
-  int ret = 0;
+  int ret = -1;
   uint8_t *der = NULL;
 
   // Decode the ECDSA signature.

--- a/include/openssl/ecdsa.h
+++ b/include/openssl/ecdsa.h
@@ -82,8 +82,8 @@ OPENSSL_EXPORT int ECDSA_sign(int type, const uint8_t *digest,
 
 // ECDSA_verify verifies that |sig_len| bytes from |sig| constitute a valid
 // signature by |key| of |digest|. (The |type| argument should be zero.) It
-// returns one on success or zero if the signature is invalid or an error
-// occurred.
+// returns one on success or zero if the signature is invalid. It returns -1
+// if any other error has occurred such as invalid ASN1 input.
 //
 // WARNING: |digest| must be the output of some hash function on the data to be
 // verified. Passing unhashed inputs will not result in a secure signature


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2697`

### Description of changes: 
Ruby 3.1 [has a test which expects a fatal failure](https://github.com/ruby/ruby/blob/master/test/openssl/test_pkey_ec.rb#L143-L146) when parsing arbitrary ASN1 data during signature verification. I pinned this down to [Ruby's call](https://github.com/ruby/ruby/blob/7be9a333cabd97a17a2926b15f756f2ef9e57243/ext/openssl/ossl_pkey.c#L1394-L1408) to `EVP_PKEY_verify` which calls `ECDSA_verify` for EC operations. It turns out [OpenSSL](https://github.com/openssl/openssl/blob/master/crypto/ec/ecdsa_ossl.c#L419-L442) returns a -1 on any ASN1 parsing errors and only returns 0/1 to indicate signature verification failure/success. Ruby was dependent on the fatal error to determine whether to indicate an actual signature verification failure/success.
Tweaking the return code in `ECDSA_verify` in our code allows this test to pass.

### Call-outs:
Also tweaked the function documentation, this aligns with OpenSSL's documented behavior: https://github.com/openssl/openssl/blob/f4c467452694e1211395d17c2c027d99c35ee1e1/include/openssl/ec.h#L1455-L1467

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
