### PR TITLE
Add support for POINT_CONVERSION_HYBRID

### DIFF
--- a/crypto/fipsmodule/ec/ec.c
+++ b/crypto/fipsmodule/ec/ec.c
@@ -1152,12 +1152,6 @@ int EC_METHOD_get_field_type(const EC_METHOD *meth) {
 
 void EC_GROUP_set_point_conversion_form(EC_GROUP *group,
                                         point_conversion_form_t form) {
-  /* NO-OP. However, abort if consumer attempts to set a representation that is
-   * not supported. */
-  if (form != POINT_CONVERSION_UNCOMPRESSED &&
-      form != POINT_CONVERSION_COMPRESSED) {
-    abort();
-  }
   // |conv_form| can only be set with OpenSSL compatible dynamically allocated
   // groups.
   if (group->mutable_ec_group) {

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -211,6 +211,19 @@ static const uint8_t kP224PublicKey_compressed_0x02[] = {
   0xc5, 0x82, 0x78, 0x85
 };
 
+static const uint8_t kP224PublicKey_hybrid_0x02[] = {
+  /* uncompressed */
+  0x06,
+  /* x-coordinate */
+  0xd6, 0xf5, 0xf0, 0x6e, 0xf4, 0xc5, 0x56, 0x0a, 0xff, 0x8f, 0x49, 0x90,
+  0xef, 0xdb, 0xa5, 0x9a, 0xf8, 0xa8, 0xd3, 0x77, 0x0d, 0x80, 0x14, 0x6a,
+  0xc5, 0x82, 0x78, 0x85,
+  /* y-coordinate */
+  0xe0, 0x43, 0xae, 0x7b, 0xae, 0xa3, 0x77, 0x28, 0x60, 0x39, 0xc0, 0x7c,
+  0x04, 0x1b, 0x7a, 0x3b, 0x5d, 0x76, 0x96, 0xda, 0xdd, 0xa7, 0x05, 0x1a,
+  0xd6, 0x45, 0xa3, 0xea
+};
+
 static const uint8_t kP224PublicKey_uncompressed_0x03[] = {
   /* uncompressed */
   0x04,
@@ -230,6 +243,19 @@ static const uint8_t kP224PublicKey_compressed_0x03[] = {
   0xd6, 0xf5, 0xf0, 0x6e, 0xf4, 0xc5, 0x56, 0x0a, 0xff, 0x8f, 0x49, 0x90,
   0xef, 0xdb, 0xa5, 0x9a, 0xf8, 0xa8, 0xd3, 0x77, 0x0d, 0x80, 0x14, 0x6a,
   0xc5, 0x82, 0x78, 0x85
+};
+
+static const uint8_t kP224PublicKey_hybrid_0x03[] = {
+  /* uncompressed */
+  0x07,
+  /* x-coordinate */
+  0xd6, 0xf5, 0xf0, 0x6e, 0xf4, 0xc5, 0x56, 0x0a, 0xff, 0x8f, 0x49, 0x90,
+  0xef, 0xdb, 0xa5, 0x9a, 0xf8, 0xa8, 0xd3, 0x77, 0x0d, 0x80, 0x14, 0x6a,
+  0xc5, 0x82, 0x78, 0x85,
+  /* y-coordinate */
+  0x1f, 0xbc, 0x51, 0x84, 0x51, 0x5c, 0x88, 0xd7, 0x9f, 0xc6, 0x3f, 0x83,
+  0xfb, 0xe4, 0x85, 0xc3, 0xa2, 0x89, 0x69, 0x25, 0x22, 0x58, 0xfa, 0xe5,
+  0x29, 0xba, 0x5c, 0x17
 };
 
 static const uint8_t kP256PublicKey_uncompressed_0x02[] = {
@@ -253,6 +279,19 @@ static const uint8_t kP256PublicKey_compressed_0x02[] = {
   0x3f, 0x92, 0x72, 0x9b, 0x31, 0xc5, 0x5f, 0x7b
 };
 
+static const uint8_t kP256PublicKey_hybrid_0x02[] = {
+  /* uncompressed */
+  0x06,
+  /* x-coordinate */
+  0xe1, 0x5a, 0x44, 0x72, 0x91, 0xf0, 0x84, 0xfe, 0x88, 0x7a, 0x6c, 0x2c,
+  0x03, 0x22, 0x9a, 0xf3, 0x04, 0x8a, 0x5d, 0xfe, 0x84, 0x73, 0x70, 0xc9,
+  0x3f, 0x92, 0x72, 0x9b, 0x31, 0xc5, 0x5f, 0x7b,
+  /* y-coordinate */
+  0xc9, 0x53, 0x67, 0xc0, 0xd2, 0x90, 0x46, 0x86, 0x61, 0x8b, 0xf6, 0xf2,
+  0xd9, 0x0b, 0x7c, 0xcb, 0x31, 0xb0, 0xb4, 0x8c, 0x60, 0xc0, 0x28, 0x55,
+  0x6d, 0x1d, 0x3a, 0xbf, 0xdc, 0xd3, 0x1e, 0x42
+};
+
 static const uint8_t kP256PublicKey_uncompressed_0x03[] = {
   /* uncompressed */
   0x04,
@@ -272,6 +311,19 @@ static const uint8_t kP256PublicKey_compressed_0x03[] = {
   0xe1, 0x5a, 0x44, 0x72, 0x91, 0xf0, 0x84, 0xfe, 0x88, 0x7a, 0x6c, 0x2c,
   0x03, 0x22, 0x9a, 0xf3, 0x04, 0x8a, 0x5d, 0xfe, 0x84, 0x73, 0x70, 0xc9,
   0x3f, 0x92, 0x72, 0x9b, 0x31, 0xc5, 0x5f, 0x7b
+};
+
+static const uint8_t kP256PublicKey_hybrid_0x03[] = {
+  /* uncompressed */
+  0x07,
+  /* x-coordinate */
+  0xe1, 0x5a, 0x44, 0x72, 0x91, 0xf0, 0x84, 0xfe, 0x88, 0x7a, 0x6c, 0x2c,
+  0x03, 0x22, 0x9a, 0xf3, 0x04, 0x8a, 0x5d, 0xfe, 0x84, 0x73, 0x70, 0xc9,
+  0x3f, 0x92, 0x72, 0x9b, 0x31, 0xc5, 0x5f, 0x7b,
+  /* y-coordinate */
+  0x36, 0xac, 0x98, 0x3e, 0x2d, 0x6f, 0xb9, 0x7a, 0x9e, 0x74, 0x09, 0x0d,
+  0x26, 0xf4, 0x83, 0x34, 0xce, 0x4f, 0x4b, 0x74, 0x9f, 0x3f, 0xd7, 0xaa,
+  0x92, 0xe2, 0xc5, 0x40, 0x23, 0x2c, 0xe1, 0xbd
 };
 
 static const uint8_t kP384PublicKey_uncompressed_0x02[] = {
@@ -298,6 +350,21 @@ static const uint8_t kP384PublicKey_compressed_0x02[] = {
   0x62, 0xb3, 0x91, 0x85, 0xf8, 0xf3, 0x95, 0xf6, 0x65, 0x73, 0x6d, 0x1d
 };
 
+static const uint8_t kP384PublicKey_hybrid_0x02[] = {
+  /* uncompressed */
+  0x06,
+  /* x-coordinate */
+  0xe4, 0xe7, 0x0e, 0x43, 0xc6, 0xd0, 0x43, 0x46, 0xdd, 0xd7, 0x62, 0xa6,
+  0x14, 0x17, 0x6d, 0x22, 0x78, 0xb0, 0x47, 0xc5, 0xec, 0x28, 0x64, 0x84,
+  0x65, 0xf2, 0xa3, 0x90, 0xf6, 0xdd, 0x6b, 0xba, 0x54, 0xb9, 0x0b, 0x1e,
+  0x62, 0xb3, 0x91, 0x85, 0xf8, 0xf3, 0x95, 0xf6, 0x65, 0x73, 0x6d, 0x1d,
+  /* y-coordinate */
+  0x06, 0x9d, 0x5d, 0x8c, 0x95, 0x31, 0xad, 0xa9, 0xe7, 0xea, 0x2a, 0x66,
+  0xac, 0x5f, 0xe6, 0xe4, 0xe0, 0x4e, 0x0d, 0x77, 0x5b, 0xa0, 0x71, 0xd7,
+  0xc2, 0xbf, 0x5a, 0x00, 0xf1, 0x7c, 0xc0, 0x0b, 0xf4, 0x29, 0xfa, 0x4d,
+  0xf3, 0x07, 0x3d, 0x93, 0xa8, 0xb2, 0xb3, 0xd1, 0xf2, 0x32, 0x31, 0xde
+};
+
 static const uint8_t kP384PublicKey_uncompressed_0x03[] = {
   /* uncompressed */
   0x04,
@@ -320,6 +387,21 @@ static const uint8_t kP384PublicKey_compressed_0x03[] = {
   0x14, 0x17, 0x6d, 0x22, 0x78, 0xb0, 0x47, 0xc5, 0xec, 0x28, 0x64, 0x84,
   0x65, 0xf2, 0xa3, 0x90, 0xf6, 0xdd, 0x6b, 0xba, 0x54, 0xb9, 0x0b, 0x1e,
   0x62, 0xb3, 0x91, 0x85, 0xf8, 0xf3, 0x95, 0xf6, 0x65, 0x73, 0x6d, 0x1d
+};
+
+static const uint8_t kP384PublicKey_hybrid_0x03[] = {
+  /* uncompressed */
+  0x07,
+  /* x-coordinate */
+  0xe4, 0xe7, 0x0e, 0x43, 0xc6, 0xd0, 0x43, 0x46, 0xdd, 0xd7, 0x62, 0xa6,
+  0x14, 0x17, 0x6d, 0x22, 0x78, 0xb0, 0x47, 0xc5, 0xec, 0x28, 0x64, 0x84,
+  0x65, 0xf2, 0xa3, 0x90, 0xf6, 0xdd, 0x6b, 0xba, 0x54, 0xb9, 0x0b, 0x1e,
+  0x62, 0xb3, 0x91, 0x85, 0xf8, 0xf3, 0x95, 0xf6, 0x65, 0x73, 0x6d, 0x1d,
+  /* y-coordinate */
+  0xf9, 0x62, 0xa2, 0x73, 0x6a, 0xce, 0x52, 0x56, 0x18, 0x15, 0xd5, 0x99,
+  0x53, 0xa0, 0x19, 0x1b, 0x1f, 0xb1, 0xf2, 0x88, 0xa4, 0x5f, 0x8e, 0x28,
+  0x3d, 0x40, 0xa5, 0xff, 0x0e, 0x83, 0x3f, 0xf3, 0x0b, 0xd6, 0x05, 0xb1,
+  0x0c, 0xf8, 0xc2, 0x6c, 0x57, 0x4d, 0x4c, 0x2f, 0x0d, 0xcd, 0xce, 0x21
 };
 
 static const uint8_t kP521PublicKey_uncompressed_0x02[] = {
@@ -352,6 +434,25 @@ static const uint8_t kP521PublicKey_compressed_0x02[] = {
   0x9f, 0x5f, 0xb4, 0xf8, 0xe7, 0x7b
 };
 
+static const uint8_t kP521PublicKey_hybrid_0x02[] = {
+  /* uncompressed */
+  0x06,
+  /* x-coordinate */
+  0x01, 0x03, 0x7e, 0x95, 0xff, 0x8e, 0x40, 0x31, 0xe0, 0xb0, 0x36, 0x1c,
+  0x58, 0xc0, 0x62, 0x61, 0x39, 0x56, 0xaa, 0x30, 0x77, 0x0c, 0xed, 0x17,
+  0x15, 0xed, 0x1b, 0x4d, 0x34, 0x29, 0x33, 0x0f, 0xac, 0x2f, 0xc5, 0xc9,
+  0x3a, 0x69, 0xf7, 0x98, 0x63, 0x3a, 0x15, 0x75, 0x5e, 0x2d, 0xb8, 0x65,
+  0x09, 0x87, 0xf5, 0x75, 0x85, 0xcd, 0xe3, 0x51, 0x6b, 0x6d, 0xd0, 0xfc,
+  0x9f, 0x5f, 0xb4, 0xf8, 0xe7, 0x7b,
+  /* y-coordinate */
+  0x00, 0xe4, 0x45, 0x33, 0xe8, 0x7f, 0xa9, 0x74, 0x64, 0xcd, 0x2b, 0x7d,
+  0xc0, 0xcd, 0x65, 0xb9, 0x27, 0xc6, 0xc6, 0x2e, 0xe7, 0x33, 0x68, 0x86,
+  0x72, 0xa2, 0x05, 0xf7, 0x4b, 0xd8, 0x2c, 0x51, 0x1b, 0x89, 0xb0, 0xb9,
+  0xb8, 0x06, 0x0d, 0xb1, 0x30, 0xf0, 0x11, 0x92, 0x9e, 0x63, 0x86, 0x8c,
+  0x57, 0xaa, 0xb5, 0x2a, 0xae, 0xec, 0xf2, 0xe1, 0xc0, 0x93, 0x62, 0xd1,
+  0x1c, 0x5d, 0x57, 0x90, 0x0a, 0x3c
+};
+
 static const uint8_t kP521PublicKey_uncompressed_0x03[] = {
   /* uncompressed */
   0x04,
@@ -380,6 +481,25 @@ static const uint8_t kP521PublicKey_compressed_0x03[] = {
   0x3a, 0x69, 0xf7, 0x98, 0x63, 0x3a, 0x15, 0x75, 0x5e, 0x2d, 0xb8, 0x65,
   0x09, 0x87, 0xf5, 0x75, 0x85, 0xcd, 0xe3, 0x51, 0x6b, 0x6d, 0xd0, 0xfc,
   0x9f, 0x5f, 0xb4, 0xf8, 0xe7, 0x7b
+};
+
+static const uint8_t kP521PublicKey_hybrid_0x03[] = {
+  /* uncompressed */
+  0x07,
+  /* x-coordinate */
+  0x01, 0x03, 0x7e, 0x95, 0xff, 0x8e, 0x40, 0x31, 0xe0, 0xb0, 0x36, 0x1c,
+  0x58, 0xc0, 0x62, 0x61, 0x39, 0x56, 0xaa, 0x30, 0x77, 0x0c, 0xed, 0x17,
+  0x15, 0xed, 0x1b, 0x4d, 0x34, 0x29, 0x33, 0x0f, 0xac, 0x2f, 0xc5, 0xc9,
+  0x3a, 0x69, 0xf7, 0x98, 0x63, 0x3a, 0x15, 0x75, 0x5e, 0x2d, 0xb8, 0x65,
+  0x09, 0x87, 0xf5, 0x75, 0x85, 0xcd, 0xe3, 0x51, 0x6b, 0x6d, 0xd0, 0xfc,
+  0x9f, 0x5f, 0xb4, 0xf8, 0xe7, 0x7b,
+  /* y-coordinate */
+  0x01, 0x1b, 0xba, 0xcc, 0x17, 0x80, 0x56, 0x8b, 0x9b, 0x32, 0xd4, 0x82,
+  0x3f, 0x32, 0x9a, 0x46, 0xd8, 0x39, 0x39, 0xd1, 0x18, 0xcc, 0x97, 0x79,
+  0x8d, 0x5d, 0xfa, 0x08, 0xb4, 0x27, 0xd3, 0xae, 0xe4, 0x76, 0x4f, 0x46,
+  0x47, 0xf9, 0xf2, 0x4e, 0xcf, 0x0f, 0xee, 0x6d, 0x61, 0x9c, 0x79, 0x73,
+  0xa8, 0x55, 0x4a, 0xd5, 0x51, 0x13, 0x0d, 0x1e, 0x3f, 0x6c, 0x9d, 0x2e,
+  0xe3, 0xa2, 0xa8, 0x6f, 0xf5, 0xc3
 };
 
 static const uint8_t ksecp256k1PublicKey_uncompressed_0x02[] = {
@@ -432,250 +552,194 @@ struct ECPublicKeyTestInput {
   size_t expected_output_key_len;
   int nid;
 } kDecodeAndEncodeInputs[] = {
-  /* Test 1: decode uncompressed |EC_KEY|, and then encode with the same |conv_form|. */
-  {
-    kP224PublicKey_uncompressed_0x02, sizeof(kP224PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP224PublicKey_uncompressed_0x02, sizeof(kP224PublicKey_uncompressed_0x02),
-    NID_secp224r1
-  },
-  {
-    kP256PublicKey_uncompressed_0x02, sizeof(kP256PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP256PublicKey_uncompressed_0x02, sizeof(kP256PublicKey_uncompressed_0x02),
-    NID_X9_62_prime256v1
-  },
-  {
-    kP384PublicKey_uncompressed_0x02, sizeof(kP384PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP384PublicKey_uncompressed_0x02, sizeof(kP384PublicKey_uncompressed_0x02),
-    NID_secp384r1
-  },
-  {
-    kP521PublicKey_uncompressed_0x02, sizeof(kP521PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP521PublicKey_uncompressed_0x02, sizeof(kP521PublicKey_uncompressed_0x02),
-    NID_secp521r1
-  },
-  {
-    ksecp256k1PublicKey_uncompressed_0x02, sizeof(ksecp256k1PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    ksecp256k1PublicKey_uncompressed_0x02, sizeof(ksecp256k1PublicKey_uncompressed_0x02),
-    NID_secp256k1
-  },
-  {
-    kP224PublicKey_uncompressed_0x03, sizeof(kP224PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP224PublicKey_uncompressed_0x03, sizeof(kP224PublicKey_uncompressed_0x03),
-    NID_secp224r1
-  },
-  {
-    kP256PublicKey_uncompressed_0x03, sizeof(kP256PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP256PublicKey_uncompressed_0x03, sizeof(kP256PublicKey_uncompressed_0x03),
-    NID_X9_62_prime256v1
-  },
-  {
-    kP384PublicKey_uncompressed_0x03, sizeof(kP384PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP384PublicKey_uncompressed_0x03, sizeof(kP384PublicKey_uncompressed_0x03),
-    NID_secp384r1
-  },
-  {
-    kP521PublicKey_uncompressed_0x03, sizeof(kP521PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP521PublicKey_uncompressed_0x03, sizeof(kP521PublicKey_uncompressed_0x03),
-    NID_secp521r1
-  },
-  {
-    ksecp256k1PublicKey_uncompressed_0x03, sizeof(ksecp256k1PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    ksecp256k1PublicKey_uncompressed_0x03, sizeof(ksecp256k1PublicKey_uncompressed_0x03),
-    NID_secp256k1
-  },
-  /* Test 2: decode compressed |EC_KEY|, and then encode with the same |conv_form|. */
-  {
-    kP224PublicKey_compressed_0x02, sizeof(kP224PublicKey_compressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    kP224PublicKey_compressed_0x02, sizeof(kP224PublicKey_compressed_0x02),
-    NID_secp224r1
-  },
-  {
-    kP256PublicKey_compressed_0x02, sizeof(kP256PublicKey_compressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    kP256PublicKey_compressed_0x02, sizeof(kP256PublicKey_compressed_0x02),
-    NID_X9_62_prime256v1
-  },
-  {
-    kP384PublicKey_compressed_0x02, sizeof(kP384PublicKey_compressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    kP384PublicKey_compressed_0x02, sizeof(kP384PublicKey_compressed_0x02),
-    NID_secp384r1
-  },
-  {
-    kP521PublicKey_compressed_0x02, sizeof(kP521PublicKey_compressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    kP521PublicKey_compressed_0x02, sizeof(kP521PublicKey_compressed_0x02),
-    NID_secp521r1
-  },
-  {
-    ksecp256k1PublicKey_compressed_0x02, sizeof(ksecp256k1PublicKey_compressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    ksecp256k1PublicKey_compressed_0x02, sizeof(ksecp256k1PublicKey_compressed_0x02),
-    NID_secp256k1
-  },
-  {
-    kP224PublicKey_compressed_0x03, sizeof(kP224PublicKey_compressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    kP224PublicKey_compressed_0x03, sizeof(kP224PublicKey_compressed_0x03),
-    NID_secp224r1
-  },
-  {
-    kP256PublicKey_compressed_0x03, sizeof(kP256PublicKey_compressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    kP256PublicKey_compressed_0x03, sizeof(kP256PublicKey_compressed_0x03),
-    NID_X9_62_prime256v1
-  },
-  {
-    kP384PublicKey_compressed_0x03, sizeof(kP384PublicKey_compressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    kP384PublicKey_compressed_0x03, sizeof(kP384PublicKey_compressed_0x03),
-    NID_secp384r1
-  },
-  {
-    kP521PublicKey_compressed_0x03, sizeof(kP521PublicKey_compressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    kP521PublicKey_compressed_0x03, sizeof(kP521PublicKey_compressed_0x03),
-    NID_secp521r1
-  },
-  {
-    ksecp256k1PublicKey_compressed_0x03, sizeof(ksecp256k1PublicKey_compressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    ksecp256k1PublicKey_compressed_0x03, sizeof(ksecp256k1PublicKey_compressed_0x03),
-    NID_secp256k1
-  },
-  /* Test 3: decode compressed |EC_KEY|, and then encode with uncompressed |conv_form|. */
-  {
-    kP224PublicKey_compressed_0x02, sizeof(kP224PublicKey_compressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP224PublicKey_uncompressed_0x02, sizeof(kP224PublicKey_uncompressed_0x02),
-    NID_secp224r1
-  },
-  {
-    kP256PublicKey_compressed_0x02, sizeof(kP256PublicKey_compressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP256PublicKey_uncompressed_0x02, sizeof(kP256PublicKey_uncompressed_0x02),
-    NID_X9_62_prime256v1
-  },
-  {
-    kP384PublicKey_compressed_0x02, sizeof(kP384PublicKey_compressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP384PublicKey_uncompressed_0x02, sizeof(kP384PublicKey_uncompressed_0x02),
-    NID_secp384r1
-  },
-  {
-    kP521PublicKey_compressed_0x02, sizeof(kP521PublicKey_compressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP521PublicKey_uncompressed_0x02, sizeof(kP521PublicKey_uncompressed_0x02),
-    NID_secp521r1
-  },
-  {
-    ksecp256k1PublicKey_compressed_0x02, sizeof(ksecp256k1PublicKey_compressed_0x02),
-    POINT_CONVERSION_UNCOMPRESSED,
-    ksecp256k1PublicKey_uncompressed_0x02, sizeof(ksecp256k1PublicKey_uncompressed_0x02),
-    NID_secp256k1
-  },
-  {
-    kP224PublicKey_compressed_0x03, sizeof(kP224PublicKey_compressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP224PublicKey_uncompressed_0x03, sizeof(kP224PublicKey_uncompressed_0x03),
-    NID_secp224r1
-  },
-  {
-    kP256PublicKey_compressed_0x03, sizeof(kP256PublicKey_compressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP256PublicKey_uncompressed_0x03, sizeof(kP256PublicKey_uncompressed_0x03),
-    NID_X9_62_prime256v1
-  },
-  {
-    kP384PublicKey_compressed_0x03, sizeof(kP384PublicKey_compressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP384PublicKey_uncompressed_0x03, sizeof(kP384PublicKey_uncompressed_0x03),
-    NID_secp384r1
-  },
-  {
-    kP521PublicKey_compressed_0x03, sizeof(kP521PublicKey_compressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    kP521PublicKey_uncompressed_0x03, sizeof(kP521PublicKey_uncompressed_0x03),
-    NID_secp521r1
-  },
-  {
-    ksecp256k1PublicKey_compressed_0x03, sizeof(ksecp256k1PublicKey_compressed_0x03),
-    POINT_CONVERSION_UNCOMPRESSED,
-    ksecp256k1PublicKey_uncompressed_0x03, sizeof(ksecp256k1PublicKey_uncompressed_0x03),
-    NID_secp256k1
-  },
-  /* Test 4: decode uncompressed |EC_KEY|, and then encode with compressed |conv_form|. */
-  {
-    kP224PublicKey_uncompressed_0x02, sizeof(kP224PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    kP224PublicKey_compressed_0x02, sizeof(kP224PublicKey_compressed_0x02),
-    NID_secp224r1
-  },
-  {
-    kP256PublicKey_uncompressed_0x02, sizeof(kP256PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    kP256PublicKey_compressed_0x02, sizeof(kP256PublicKey_compressed_0x02),
-    NID_X9_62_prime256v1
-  },
-  {
-    kP384PublicKey_uncompressed_0x02, sizeof(kP384PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    kP384PublicKey_compressed_0x02, sizeof(kP384PublicKey_compressed_0x02),
-    NID_secp384r1
-  },
-  {
-    kP521PublicKey_uncompressed_0x02, sizeof(kP521PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    kP521PublicKey_compressed_0x02, sizeof(kP521PublicKey_compressed_0x02),
-    NID_secp521r1
-  },
-  {
-    ksecp256k1PublicKey_uncompressed_0x02, sizeof(ksecp256k1PublicKey_uncompressed_0x02),
-    POINT_CONVERSION_COMPRESSED,
-    ksecp256k1PublicKey_compressed_0x02, sizeof(ksecp256k1PublicKey_compressed_0x02),
-    NID_secp256k1
-  },
-  {
-    kP224PublicKey_uncompressed_0x03, sizeof(kP224PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    kP224PublicKey_compressed_0x03, sizeof(kP224PublicKey_compressed_0x03),
-    NID_secp224r1
-  },
-  {
-    kP256PublicKey_uncompressed_0x03, sizeof(kP256PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    kP256PublicKey_compressed_0x03, sizeof(kP256PublicKey_compressed_0x03),
-    NID_X9_62_prime256v1
-  },
-  {
-    kP384PublicKey_uncompressed_0x03, sizeof(kP384PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    kP384PublicKey_compressed_0x03, sizeof(kP384PublicKey_compressed_0x03),
-    NID_secp384r1
-  },
-  {
-    kP521PublicKey_uncompressed_0x03, sizeof(kP521PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    kP521PublicKey_compressed_0x03, sizeof(kP521PublicKey_compressed_0x03),
-    NID_secp521r1
-  },
-  {
-    ksecp256k1PublicKey_uncompressed_0x03, sizeof(ksecp256k1PublicKey_uncompressed_0x03),
-    POINT_CONVERSION_COMPRESSED,
-    ksecp256k1PublicKey_compressed_0x03, sizeof(ksecp256k1PublicKey_compressed_0x03),
-    NID_secp256k1
-  }
+    // Test 1: decode uncompressed |EC_KEY|, and then encode with the same
+    // |conv_form|.
+    {kP224PublicKey_uncompressed_0x02, sizeof(kP224PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP224PublicKey_uncompressed_0x02,
+     sizeof(kP224PublicKey_uncompressed_0x02), NID_secp224r1},
+    {kP256PublicKey_uncompressed_0x02, sizeof(kP256PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP256PublicKey_uncompressed_0x02,
+     sizeof(kP256PublicKey_uncompressed_0x02), NID_X9_62_prime256v1},
+    {kP384PublicKey_uncompressed_0x02, sizeof(kP384PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP384PublicKey_uncompressed_0x02,
+     sizeof(kP384PublicKey_uncompressed_0x02), NID_secp384r1},
+    {kP521PublicKey_uncompressed_0x02, sizeof(kP521PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP521PublicKey_uncompressed_0x02,
+     sizeof(kP521PublicKey_uncompressed_0x02), NID_secp521r1},
+    {ksecp256k1PublicKey_uncompressed_0x02,
+     sizeof(ksecp256k1PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, ksecp256k1PublicKey_uncompressed_0x02,
+     sizeof(ksecp256k1PublicKey_uncompressed_0x02), NID_secp256k1},
+    {kP224PublicKey_uncompressed_0x03, sizeof(kP224PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP224PublicKey_uncompressed_0x03,
+     sizeof(kP224PublicKey_uncompressed_0x03), NID_secp224r1},
+    {kP256PublicKey_uncompressed_0x03, sizeof(kP256PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP256PublicKey_uncompressed_0x03,
+     sizeof(kP256PublicKey_uncompressed_0x03), NID_X9_62_prime256v1},
+    {kP384PublicKey_uncompressed_0x03, sizeof(kP384PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP384PublicKey_uncompressed_0x03,
+     sizeof(kP384PublicKey_uncompressed_0x03), NID_secp384r1},
+    {kP521PublicKey_uncompressed_0x03, sizeof(kP521PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP521PublicKey_uncompressed_0x03,
+     sizeof(kP521PublicKey_uncompressed_0x03), NID_secp521r1},
+    {ksecp256k1PublicKey_uncompressed_0x03,
+     sizeof(ksecp256k1PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, ksecp256k1PublicKey_uncompressed_0x03,
+     sizeof(ksecp256k1PublicKey_uncompressed_0x03), NID_secp256k1},
+    // Test 2: decode compressed |EC_KEY|, and then encode with the same
+    // |conv_form|.
+    {kP224PublicKey_compressed_0x02, sizeof(kP224PublicKey_compressed_0x02),
+     POINT_CONVERSION_COMPRESSED, kP224PublicKey_compressed_0x02,
+     sizeof(kP224PublicKey_compressed_0x02), NID_secp224r1},
+    {kP256PublicKey_compressed_0x02, sizeof(kP256PublicKey_compressed_0x02),
+     POINT_CONVERSION_COMPRESSED, kP256PublicKey_compressed_0x02,
+     sizeof(kP256PublicKey_compressed_0x02), NID_X9_62_prime256v1},
+    {kP384PublicKey_compressed_0x02, sizeof(kP384PublicKey_compressed_0x02),
+     POINT_CONVERSION_COMPRESSED, kP384PublicKey_compressed_0x02,
+     sizeof(kP384PublicKey_compressed_0x02), NID_secp384r1},
+    {kP521PublicKey_compressed_0x02, sizeof(kP521PublicKey_compressed_0x02),
+     POINT_CONVERSION_COMPRESSED, kP521PublicKey_compressed_0x02,
+     sizeof(kP521PublicKey_compressed_0x02), NID_secp521r1},
+    {ksecp256k1PublicKey_compressed_0x02,
+     sizeof(ksecp256k1PublicKey_compressed_0x02), POINT_CONVERSION_COMPRESSED,
+     ksecp256k1PublicKey_compressed_0x02,
+     sizeof(ksecp256k1PublicKey_compressed_0x02), NID_secp256k1},
+    {kP224PublicKey_compressed_0x03, sizeof(kP224PublicKey_compressed_0x03),
+     POINT_CONVERSION_COMPRESSED, kP224PublicKey_compressed_0x03,
+     sizeof(kP224PublicKey_compressed_0x03), NID_secp224r1},
+    {kP256PublicKey_compressed_0x03, sizeof(kP256PublicKey_compressed_0x03),
+     POINT_CONVERSION_COMPRESSED, kP256PublicKey_compressed_0x03,
+     sizeof(kP256PublicKey_compressed_0x03), NID_X9_62_prime256v1},
+    {kP384PublicKey_compressed_0x03, sizeof(kP384PublicKey_compressed_0x03),
+     POINT_CONVERSION_COMPRESSED, kP384PublicKey_compressed_0x03,
+     sizeof(kP384PublicKey_compressed_0x03), NID_secp384r1},
+    {kP521PublicKey_compressed_0x03, sizeof(kP521PublicKey_compressed_0x03),
+     POINT_CONVERSION_COMPRESSED, kP521PublicKey_compressed_0x03,
+     sizeof(kP521PublicKey_compressed_0x03), NID_secp521r1},
+    {ksecp256k1PublicKey_compressed_0x03,
+     sizeof(ksecp256k1PublicKey_compressed_0x03), POINT_CONVERSION_COMPRESSED,
+     ksecp256k1PublicKey_compressed_0x03,
+     sizeof(ksecp256k1PublicKey_compressed_0x03), NID_secp256k1},
+    // Test 3: decode compressed |EC_KEY|, and then encode with uncompressed
+    // |conv_form|.
+    {kP224PublicKey_compressed_0x02, sizeof(kP224PublicKey_compressed_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP224PublicKey_uncompressed_0x02,
+     sizeof(kP224PublicKey_uncompressed_0x02), NID_secp224r1},
+    {kP256PublicKey_compressed_0x02, sizeof(kP256PublicKey_compressed_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP256PublicKey_uncompressed_0x02,
+     sizeof(kP256PublicKey_uncompressed_0x02), NID_X9_62_prime256v1},
+    {kP384PublicKey_compressed_0x02, sizeof(kP384PublicKey_compressed_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP384PublicKey_uncompressed_0x02,
+     sizeof(kP384PublicKey_uncompressed_0x02), NID_secp384r1},
+    {kP521PublicKey_compressed_0x02, sizeof(kP521PublicKey_compressed_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP521PublicKey_uncompressed_0x02,
+     sizeof(kP521PublicKey_uncompressed_0x02), NID_secp521r1},
+    {ksecp256k1PublicKey_compressed_0x02,
+     sizeof(ksecp256k1PublicKey_compressed_0x02), POINT_CONVERSION_UNCOMPRESSED,
+     ksecp256k1PublicKey_uncompressed_0x02,
+     sizeof(ksecp256k1PublicKey_uncompressed_0x02), NID_secp256k1},
+    {kP224PublicKey_compressed_0x03, sizeof(kP224PublicKey_compressed_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP224PublicKey_uncompressed_0x03,
+     sizeof(kP224PublicKey_uncompressed_0x03), NID_secp224r1},
+    {kP256PublicKey_compressed_0x03, sizeof(kP256PublicKey_compressed_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP256PublicKey_uncompressed_0x03,
+     sizeof(kP256PublicKey_uncompressed_0x03), NID_X9_62_prime256v1},
+    {kP384PublicKey_compressed_0x03, sizeof(kP384PublicKey_compressed_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP384PublicKey_uncompressed_0x03,
+     sizeof(kP384PublicKey_uncompressed_0x03), NID_secp384r1},
+    {kP521PublicKey_compressed_0x03, sizeof(kP521PublicKey_compressed_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP521PublicKey_uncompressed_0x03,
+     sizeof(kP521PublicKey_uncompressed_0x03), NID_secp521r1},
+    {ksecp256k1PublicKey_compressed_0x03,
+     sizeof(ksecp256k1PublicKey_compressed_0x03), POINT_CONVERSION_UNCOMPRESSED,
+     ksecp256k1PublicKey_uncompressed_0x03,
+     sizeof(ksecp256k1PublicKey_uncompressed_0x03), NID_secp256k1},
+    // Test 4: decode uncompressed |EC_KEY|, and then encode with compressed
+    // |conv_form|.
+    {kP224PublicKey_uncompressed_0x02, sizeof(kP224PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_COMPRESSED, kP224PublicKey_compressed_0x02,
+     sizeof(kP224PublicKey_compressed_0x02), NID_secp224r1},
+    {kP256PublicKey_uncompressed_0x02, sizeof(kP256PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_COMPRESSED, kP256PublicKey_compressed_0x02,
+     sizeof(kP256PublicKey_compressed_0x02), NID_X9_62_prime256v1},
+    {kP384PublicKey_uncompressed_0x02, sizeof(kP384PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_COMPRESSED, kP384PublicKey_compressed_0x02,
+     sizeof(kP384PublicKey_compressed_0x02), NID_secp384r1},
+    {kP521PublicKey_uncompressed_0x02, sizeof(kP521PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_COMPRESSED, kP521PublicKey_compressed_0x02,
+     sizeof(kP521PublicKey_compressed_0x02), NID_secp521r1},
+    {ksecp256k1PublicKey_uncompressed_0x02,
+     sizeof(ksecp256k1PublicKey_uncompressed_0x02), POINT_CONVERSION_COMPRESSED,
+     ksecp256k1PublicKey_compressed_0x02,
+     sizeof(ksecp256k1PublicKey_compressed_0x02), NID_secp256k1},
+    {kP224PublicKey_uncompressed_0x03, sizeof(kP224PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_COMPRESSED, kP224PublicKey_compressed_0x03,
+     sizeof(kP224PublicKey_compressed_0x03), NID_secp224r1},
+    {kP256PublicKey_uncompressed_0x03, sizeof(kP256PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_COMPRESSED, kP256PublicKey_compressed_0x03,
+     sizeof(kP256PublicKey_compressed_0x03), NID_X9_62_prime256v1},
+    {kP384PublicKey_uncompressed_0x03, sizeof(kP384PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_COMPRESSED, kP384PublicKey_compressed_0x03,
+     sizeof(kP384PublicKey_compressed_0x03), NID_secp384r1},
+    {kP521PublicKey_uncompressed_0x03, sizeof(kP521PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_COMPRESSED, kP521PublicKey_compressed_0x03,
+     sizeof(kP521PublicKey_compressed_0x03), NID_secp521r1},
+    {ksecp256k1PublicKey_uncompressed_0x03,
+     sizeof(ksecp256k1PublicKey_uncompressed_0x03), POINT_CONVERSION_COMPRESSED,
+     ksecp256k1PublicKey_compressed_0x03,
+     sizeof(ksecp256k1PublicKey_compressed_0x03), NID_secp256k1},
+    // Test 5: decode uncompressed |EC_KEY|, and then encode with
+    // |POINT_CONVERSION_HYBRID|.
+    {kP224PublicKey_uncompressed_0x02, sizeof(kP224PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_HYBRID, kP224PublicKey_hybrid_0x02,
+     sizeof(kP224PublicKey_hybrid_0x02), NID_secp224r1},
+    {kP224PublicKey_uncompressed_0x03, sizeof(kP224PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_HYBRID, kP224PublicKey_hybrid_0x03,
+     sizeof(kP224PublicKey_hybrid_0x03), NID_secp224r1},
+    {kP256PublicKey_uncompressed_0x02, sizeof(kP256PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_HYBRID, kP256PublicKey_hybrid_0x02,
+     sizeof(kP256PublicKey_hybrid_0x02), NID_X9_62_prime256v1},
+    {kP256PublicKey_uncompressed_0x03, sizeof(kP256PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_HYBRID, kP256PublicKey_hybrid_0x03,
+     sizeof(kP256PublicKey_hybrid_0x03), NID_X9_62_prime256v1},
+    {kP384PublicKey_uncompressed_0x02, sizeof(kP384PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_HYBRID, kP384PublicKey_hybrid_0x02,
+     sizeof(kP384PublicKey_hybrid_0x02), NID_secp384r1},
+    {kP384PublicKey_uncompressed_0x03, sizeof(kP384PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_HYBRID, kP384PublicKey_hybrid_0x03,
+     sizeof(kP384PublicKey_hybrid_0x03), NID_secp384r1},
+    {kP521PublicKey_uncompressed_0x02, sizeof(kP521PublicKey_uncompressed_0x02),
+     POINT_CONVERSION_HYBRID, kP521PublicKey_hybrid_0x02,
+     sizeof(kP521PublicKey_hybrid_0x02), NID_secp521r1},
+    {kP521PublicKey_uncompressed_0x03, sizeof(kP521PublicKey_uncompressed_0x03),
+     POINT_CONVERSION_HYBRID, kP521PublicKey_hybrid_0x03,
+     sizeof(kP521PublicKey_hybrid_0x03), NID_secp521r1},
+    // Test 5: decode hybrid |EC_KEY|, and then encode with
+    // |POINT_CONVERSION_UNCOMPRESSED|.
+    {kP224PublicKey_hybrid_0x02, sizeof(kP224PublicKey_hybrid_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP224PublicKey_uncompressed_0x02,
+     sizeof(kP224PublicKey_uncompressed_0x02), NID_secp224r1},
+    {kP224PublicKey_hybrid_0x03, sizeof(kP224PublicKey_hybrid_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP224PublicKey_uncompressed_0x03,
+     sizeof(kP224PublicKey_uncompressed_0x03), NID_secp224r1},
+    {kP256PublicKey_hybrid_0x02, sizeof(kP256PublicKey_hybrid_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP256PublicKey_uncompressed_0x02,
+     sizeof(kP256PublicKey_uncompressed_0x02), NID_X9_62_prime256v1},
+    {kP256PublicKey_hybrid_0x03, sizeof(kP256PublicKey_hybrid_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP256PublicKey_uncompressed_0x03,
+     sizeof(kP256PublicKey_uncompressed_0x03), NID_X9_62_prime256v1},
+    {kP384PublicKey_hybrid_0x02, sizeof(kP384PublicKey_hybrid_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP384PublicKey_uncompressed_0x02,
+     sizeof(kP384PublicKey_uncompressed_0x02), NID_secp384r1},
+    {kP384PublicKey_hybrid_0x03, sizeof(kP384PublicKey_hybrid_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP384PublicKey_uncompressed_0x03,
+     sizeof(kP384PublicKey_uncompressed_0x03), NID_secp384r1},
+    {kP521PublicKey_hybrid_0x02, sizeof(kP521PublicKey_hybrid_0x02),
+     POINT_CONVERSION_UNCOMPRESSED, kP521PublicKey_uncompressed_0x02,
+     sizeof(kP521PublicKey_uncompressed_0x02), NID_secp521r1},
+    {kP521PublicKey_hybrid_0x03, sizeof(kP521PublicKey_hybrid_0x03),
+     POINT_CONVERSION_UNCOMPRESSED, kP521PublicKey_uncompressed_0x03,
+     sizeof(kP521PublicKey_uncompressed_0x03), NID_secp521r1},
 };
 
 class ECPublicKeyTest : public testing::TestWithParam<ECPublicKeyTestInput> {};

--- a/crypto/fipsmodule/ec/oct.c
+++ b/crypto/fipsmodule/ec/oct.c
@@ -75,15 +75,17 @@
 
 size_t ec_point_byte_len(const EC_GROUP *group, point_conversion_form_t form) {
   if (form != POINT_CONVERSION_COMPRESSED &&
-      form != POINT_CONVERSION_UNCOMPRESSED) {
+      form != POINT_CONVERSION_UNCOMPRESSED &&
+      form != POINT_CONVERSION_HYBRID) {
     OPENSSL_PUT_ERROR(EC, EC_R_INVALID_FORM);
     return 0;
   }
 
   const size_t field_len = BN_num_bytes(&group->field.N);
   size_t output_len = 1 /* type byte */ + field_len;
-  if (form == POINT_CONVERSION_UNCOMPRESSED) {
-    // Uncompressed points have a second coordinate.
+  if (form == POINT_CONVERSION_UNCOMPRESSED ||
+      form == POINT_CONVERSION_HYBRID) {
+    // Uncompressed and Hybrid points have a second coordinate.
     output_len += field_len;
   }
   return output_len;
@@ -110,6 +112,11 @@ size_t ec_point_to_bytes(const EC_GROUP *group, const EC_AFFINE *point,
     uint8_t y_buf[EC_MAX_BYTES];
     ec_felem_to_bytes(group, y_buf, &field_len, &point->Y);
     buf[0] = form + (y_buf[field_len - 1] & 1);
+    if (form == POINT_CONVERSION_HYBRID) {
+      // |POINT_CONVERSION_HYBRID| specifies y's solution of the quadratic
+      // equation, but also encodes the actual point along with it.
+      OPENSSL_memcpy(buf + 1 + field_len, y_buf, field_len);
+    }
   }
 
   return output_len;
@@ -118,7 +125,10 @@ size_t ec_point_to_bytes(const EC_GROUP *group, const EC_AFFINE *point,
 int ec_point_from_uncompressed(const EC_GROUP *group, EC_AFFINE *out,
                                const uint8_t *in, size_t len) {
   const size_t field_len = BN_num_bytes(&group->field.N);
-  if (len != 1 + 2 * field_len || in[0] != POINT_CONVERSION_UNCOMPRESSED) {
+  // |POINT_CONVERSION_HYBRID| has the solution of y encoded in the first byte
+  // as well.
+  if (len != 1 + 2 * field_len || (in[0] != POINT_CONVERSION_UNCOMPRESSED &&
+                                   (in[0] & ~1u) != POINT_CONVERSION_HYBRID)) {
     OPENSSL_PUT_ERROR(EC, EC_R_INVALID_ENCODING);
     return 0;
   }
@@ -153,7 +163,10 @@ static int ec_GFp_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
     return 1;
   }
 
-  if (form == POINT_CONVERSION_UNCOMPRESSED) {
+  const int y_bit = form & 1;
+  form = form & ~1u;
+  if (form == POINT_CONVERSION_UNCOMPRESSED ||
+      form == POINT_CONVERSION_HYBRID) {
     EC_AFFINE affine;
     if (!ec_point_from_uncompressed(group, &affine, buf, len)) {
       // In the event of an error, defend against the caller not checking the
@@ -165,9 +178,7 @@ static int ec_GFp_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
     return 1;
   }
 
-  const int y_bit = form & 1;
   const size_t field_len = BN_num_bytes(&group->field.N);
-  form = form & ~1u;
   if (form != POINT_CONVERSION_COMPRESSED ||
       len != 1 /* type byte */ + field_len) {
     OPENSSL_PUT_ERROR(EC, EC_R_INVALID_ENCODING);

--- a/crypto/fipsmodule/ec/oct.c
+++ b/crypto/fipsmodule/ec/oct.c
@@ -114,7 +114,7 @@ size_t ec_point_to_bytes(const EC_GROUP *group, const EC_AFFINE *point,
     buf[0] = form + (y_buf[field_len - 1] & 1);
     if (form == POINT_CONVERSION_HYBRID) {
       // |POINT_CONVERSION_HYBRID| specifies y's solution of the quadratic
-      // equation, but also encodes the actual point along with it.
+      // equation, but also encodes the y coordinate along with it.
       OPENSSL_memcpy(buf + 1 + field_len, y_buf, field_len);
     }
   }

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -91,10 +91,7 @@ typedef enum {
   POINT_CONVERSION_UNCOMPRESSED = 4,
 
   // POINT_CONVERSION_HYBRID indicates that the point is encoded as z||x||y,
-  // where z specifies which solution of the quadratic equation y is. This is
-  // not supported by the code and has never been observed in use.
-  //
-  // TODO(agl): remove once node.js no longer references this.
+  // where z specifies which solution of the quadratic equation y is.
   POINT_CONVERSION_HYBRID = 6,
 } point_conversion_form_t;
 


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2697`

### Description of changes: 
This is the first time it has come up, but Ruby depends on the `POINT_CONVERSION_HYBRID` format in its tests and expects the underlying libcrypto to support it. 
* https://github.com/ruby/ruby/blob/ruby_3_1/test/openssl/test_pkey_ec.rb#L358-L366

There's not too much a difference between `POINT_CONVERSION_HYBRID` and `POINT_CONVERSION_UNCOMPRESSED` except that the first bit contains information about the quadratic equation y is at. We have the building blocks to support and can get this working with some tweaking around.

### Call-outs:
`POINT_CONVERSION_HYBRID` works very similar to `POINT_CONVERSION_UNCOMPRESSED` so we're reusing a lot of code. Most of this change is working with the first byte `POINT_CONVERSION_HYBRID` does differently and point the encoding to the right places for parsing.

### Testing:
* Testing parsing from and back with `POINT_CONVERSION_HYBRID`. What we're parsing to and from hybrid doesn't really matter here, they're already covered by other code paths. 

* Test vectors were generated from our test cases and ran against OpenSSL with this brief test program:

```
int main() {
  // Generate |ec_key|.
  EC_KEY *ec_key = EC_KEY_new();
  EC_GROUP *group = EC_GROUP_new_by_curve_name(NID_secp521r1);
  EC_KEY_set_group(ec_key, group);

  const uint8_t *inp = kECPublicKey_uncompressed;
  // Decoding an EC point.
  o2i_ECPublicKey(&ec_key, &inp, sizeof(kECPublicKey_uncompressed));
  // On successful exit of |o2i_ECPublicKey|, |*inp| is advanced by |len| bytes.
  if(kECPublicKey_uncompressed + sizeof(kECPublicKey_uncompressed) != inp) {
    return -1;
  }
  // Set |conv_form| of |ec_key|.
  EC_KEY_set_conv_form(ec_key, POINT_CONVERSION_HYBRID);
  uint8_t *p = nullptr;
  size_t len2 = i2o_ECPublicKey(ec_key, &p);
   for(uint32_t i=0; i < len2; i++) {
      if(i%12 == 0 && i != 0){
        printf("\n");
      }
      printf("0x%02x, ", p[i]);
    }
       printf("\n");
  return 0;
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
