### PR TITLE
Account for cipher auth with multiple cert slots

### DIFF
--- a/ssl/extensions.cc
+++ b/ssl/extensions.cc
@@ -4139,7 +4139,7 @@ bool tls1_choose_signature_algorithm(SSL_HANDSHAKE *hs, uint16_t *out) {
   // Before TLS 1.2, the signature algorithm isn't negotiated as part of the
   // handshake.
   if (ssl_protocol_version(ssl) < TLS1_2_VERSION) {
-    if (tls1_get_legacy_signature_algorithm(out, hs->local_pubkey.get()) ||
+    if (ssl_public_key_supports_legacy_signature_algorithm(out, hs) ||
         ssl_cert_private_keys_supports_legacy_signature_algorithm(out, hs)) {
       return true;
     }

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -1140,6 +1140,11 @@ enum ssl_private_key_result_t ssl_private_key_decrypt(SSL_HANDSHAKE *hs,
 bool ssl_public_key_supports_signature_algorithm(SSL_HANDSHAKE *hs,
                                                  uint16_t sigalg);
 
+// ssl_public_key_supports_legacy_signature_algorithm is the tls1.0/1.1
+// version of |ssl_public_key_supports_signature_algorithm|.
+bool ssl_public_key_supports_legacy_signature_algorithm(uint16_t *out,
+                                                        SSL_HANDSHAKE *hs);
+
 // ssl_cert_private_keys_supports_signature_algorithm returns whether any of
 // |hs|'s available private keys supports |sigalg|. If one does, we switch to
 // using that private key and the corresponding certificate for the rest of the

--- a/ssl/ssl_privkey.cc
+++ b/ssl/ssl_privkey.cc
@@ -388,9 +388,9 @@ static bool tls12_pkey_supports_cipher_auth(SSL_HANDSHAKE *hs,
   SSL *const ssl = hs->ssl;
   // We may have a private key that supports the signature algorithm, but we
   // need to verify that the negotiated cipher allows it. This behavior is only
-  // done prior to TLS 1.2 servers in OpenSSL since TLS 1.3 does not have
-  // cipher-based authentication configuration. Since cipher-based
-  // authentication is already built into TLS 1.3, we use the |SSL_aGENERIC|
+  // done in OpenSSL servers with TLS version 1.2 and below since TLS 1.3 does
+  // not have cipher-based authentication configuration. Since authentication is
+  // configured outside the ciphersuite in TLS 1.3, we use the |SSL_aGENERIC|
   // flag defined for all TLS 1.3 ciphers to indicate support.
   return !ssl->server || (hs->new_cipher->algorithm_auth &
                           (ssl_cipher_auth_mask_for_key(key) | SSL_aGENERIC));

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -6528,7 +6528,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(MultipleCertificateSlotTest, CertificateSlotIndex) {
   if (version < TLS1_2_VERSION && slot_index == SSL_PKEY_ED25519) {
     // ED25519 is not supported in versions prior to TLS1.2.
-    return;
+    GTEST_SKIP();
   }
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
   bssl::UniquePtr<SSL_CTX> server_ctx(CreateContextWithCertificate(
@@ -6546,7 +6546,7 @@ TEST_P(MultipleCertificateSlotTest, CertificateSlotIndex) {
 TEST_P(MultipleCertificateSlotTest, SetChainAndKeyIndex) {
   if (version < TLS1_2_VERSION && slot_index == SSL_PKEY_ED25519) {
     // ED25519 is not supported in versions prior to TLS1.2.
-    return;
+    GTEST_SKIP();
   }
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
   bssl::UniquePtr<SSL_CTX> server_ctx(SSL_CTX_new(TLS_method()));
@@ -6574,7 +6574,7 @@ TEST_P(MultipleCertificateSlotTest, SetChainAndKeyIndex) {
 TEST_P(MultipleCertificateSlotTest, AutomaticSelectionSigAlgs) {
   if (version < TLS1_2_VERSION && slot_index == SSL_PKEY_ED25519) {
     // ED25519 is not supported in versions prior to TLS1.2.
-    return;
+    GTEST_SKIP();
   }
 
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
@@ -6610,7 +6610,7 @@ TEST_P(MultipleCertificateSlotTest, AutomaticSelectionCipherAuth) {
       version >= TLS1_3_VERSION) {
     // ED25519 is not supported in versions prior to TLS1.2.
     // TLS 1.3 not have cipher-based authentication configuration.
-    return;
+    GTEST_SKIP();
   }
 
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
@@ -6652,7 +6652,7 @@ TEST_P(MultipleCertificateSlotTest, AutomaticSelectionCipherAuth) {
 TEST_P(MultipleCertificateSlotTest, MissingCertificate) {
   if (version < TLS1_2_VERSION && slot_index == SSL_PKEY_ED25519) {
     // ED25519 is not supported in versions prior to TLS1.2.
-    return;
+    GTEST_SKIP();
   }
 
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
@@ -6679,7 +6679,7 @@ TEST_P(MultipleCertificateSlotTest, MissingCertificate) {
 TEST_P(MultipleCertificateSlotTest, MissingPrivateKey) {
   if (version < TLS1_2_VERSION && slot_index == SSL_PKEY_ED25519) {
     // ED25519 is not supported in versions prior to TLS1.2.
-    return;
+    GTEST_SKIP();
   }
 
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -195,7 +195,7 @@ static UniquePtr<STACK_OF(CRYPTO_BUFFER)> new_leafless_chain(void) {
 
 // ssl_cert_set_chain sets elements 1.. of |cert->chain| to the serialised
 // forms of elements of |chain|. It returns one on success or zero on error, in
-// which case no change to |cert->chain| is made. It preverses the existing
+// which case no change to |cert->chain| is made. It preserves the existing
 // leaf from |cert->chain|, if any.
 static bool ssl_cert_set_chain(CERT *cert, STACK_OF(X509) *chain) {
   if (!ssl_cert_check_cert_private_keys_usage(cert)) {


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2699`

### Description of changes: 
Ruby has a dependency on the multiple certificate slot mechanisms that OpenSSL allows for. We've already done the work to support this, but [another Ruby 3.1 test](https://github.com/ruby/ruby/blame/ruby_3_1/test/openssl/test_ssl.rb#L137-L178) has exposed a gap in our support. We were only depending on the negotiated signature algorithms to retrieve the right certificate for the server to send back, but the cipher authentication scheme was [also checked in OpenSSL](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/ssl/t1_lib.c#L2576-L2593) as well. Ruby's tests happen to only depend on configuring the authentication scheme which brought this to light.
We happen to do only do this when checking private keys for TLS 1.0/1.1 , this also fixes it to check the cipher against the initial public key. This change also introduces all of the mentioned cipher authenticated check behavior  for TLS 1.2.

### Call-outs:
N/A

### Testing:
New unit test that allows all possible sigalgs, with the cipher authentication suite being the only restriction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
