### PR TITLE
WIP: Adding the OpenSSL s_client tool

### DIFF
--- a/crypto/ocsp/ocsp_integration_test.cc
+++ b/crypto/ocsp/ocsp_integration_test.cc
@@ -204,7 +204,7 @@ TEST_P(OCSPIntegrationTest, AmazonTrustServices) {
   // certificate chain the endpoint uses.
   int sock = -1;
   ASSERT_TRUE(InitSocketLibrary());
-  ASSERT_TRUE(Connect(&sock, t.url_host));
+  ASSERT_TRUE(Connect(&sock, t.url_host, 0));
   ASSERT_TRUE(SSL_library_init());
   bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
   ASSERT_TRUE(ssl_ctx);

--- a/tool-openssl/CMakeLists.txt
+++ b/tool-openssl/CMakeLists.txt
@@ -4,12 +4,15 @@ add_executable(
     ../tool/args.cc
     ../tool/file.cc
     ../tool/fd.cc
+    ../tool/client.cc
+    ../tool/transport_common.cc
 
     dgst.cc
     rsa.cc
     tool.cc
     x509.cc
     version.cc
+    s_client.cc
 )
 
 target_include_directories(openssl PUBLIC ${PROJECT_SOURCE_DIR}/include)
@@ -52,6 +55,8 @@ if(BUILD_TESTING)
         ../tool/file.cc
         ../tool/fd.cc
         ../crypto/test/test_util.cc
+        ../tool/client.cc
+        ../tool/transport_common.cc
 
         dgst.cc
         dgst_test.cc
@@ -59,6 +64,7 @@ if(BUILD_TESTING)
         rsa_test.cc
         x509.cc
         x509_test.cc
+        s_client.cc
     )
 
     target_link_libraries(tool_openssl_test boringssl_gtest_main ssl crypto)

--- a/tool-openssl/internal.h
+++ b/tool-openssl/internal.h
@@ -33,5 +33,6 @@ bool md5Tool(const args_list_t &args);
 bool rsaTool(const args_list_t &args);
 bool X509Tool(const args_list_t &args);
 bool VersionTool(const args_list_t &args);
+bool SClientTool(const args_list_t &args);
 
 #endif //INTERNAL_H

--- a/tool-openssl/s_client.cc
+++ b/tool-openssl/s_client.cc
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <openssl/base.h>
+#include <openssl/pem.h>
+#include "internal.h"
+#include "../tool/internal.h"
+
+static const argument_t kArguments[] = {
+        { "-help", kBooleanArgument, "Display option summary" },
+        { "-connect", kRequiredArgument,
+          "The hostname and port of the server to connect to, e.g. foo.com:443" },
+        // In OpenSSL, CAFile by itself may not neccessitate verification, verify if this
+        // is the case or not (-verify option may be needed). In AWS-LC it is and verify option not supported for bssl.
+        { "-CAfile", kOptionalArgument,
+          "A filename containing one or more PEM root certificates. Implies that "
+          "verification is required." },
+        { "-showcerts", kBooleanArgument,
+          "Displays the server certificate list as sent by the server: it only "
+          "consists of certificates the server has sent (in the order the server "
+          "has sent them). It is not a verified chain. " },
+        { "-verify", kOptionalArgument,
+          "The verify depth to use. This specifies the maximum length of the server "
+          "certificate chain and turns on server certificate verification. "
+          "Currently the verify operation continues after errors so all the problems "
+          "with a certificate chain can be seen. As a side effect the connection will "
+          "never fail due to a server certificate verify failure." },
+        { "", kOptionalArgument, "" },
+};
+
+bool SClientTool(const args_list_t &args) {
+  std::map<std::string, std::string> args_map;
+
+  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+    PrintUsage(kArguments);
+    return false;
+  }
+
+  if(args_map.count("help")) {
+    fprintf(stderr, "Usage: s_client [options] [host:port]\n");
+    PrintUsage(kArguments);
+    return false;
+  }
+
+  return DoClient(args_map, 1);
+}

--- a/tool-openssl/s_client.cc
+++ b/tool-openssl/s_client.cc
@@ -9,22 +9,22 @@
 static const argument_t kArguments[] = {
         { "-help", kBooleanArgument, "Display option summary" },
         { "-connect", kRequiredArgument,
-          "The hostname and port of the server to connect to, e.g. foo.com:443" },
-        // In OpenSSL, CAFile by itself may not neccessitate verification, verify if this
-        // is the case or not (-verify option may be needed). In AWS-LC it is and verify option not supported for bssl.
+                "The hostname and port of the server to connect to, e.g. foo.com:443" },
         { "-CAfile", kOptionalArgument,
-          "A filename containing one or more PEM root certificates. Implies that "
-          "verification is required." },
+                "A file containing trusted certificates to use during server authentication "
+                "and to use when attempting to build the client certificate chain. " },
+        { "-CApath", kOptionalArgument,
+                "The directory to use for server certificate verification. " },
         { "-showcerts", kBooleanArgument,
-          "Displays the server certificate list as sent by the server: it only "
-          "consists of certificates the server has sent (in the order the server "
-          "has sent them). It is not a verified chain. " },
+                "Displays the server certificate list as sent by the server: it only "
+                "consists of certificates the server has sent (in the order the server "
+                "has sent them). It is not a verified chain. " },
         { "-verify", kOptionalArgument,
-          "The verify depth to use. This specifies the maximum length of the server "
-          "certificate chain and turns on server certificate verification. "
-          "Currently the verify operation continues after errors so all the problems "
-          "with a certificate chain can be seen. As a side effect the connection will "
-          "never fail due to a server certificate verify failure." },
+                "The verify depth to use. This specifies the maximum length of the server "
+                "certificate chain and turns on server certificate verification. "
+                "Currently the verify operation continues after errors so all the problems "
+                "with a certificate chain can be seen. As a side effect the connection will "
+                "never fail due to a server certificate verify failure." },
         { "", kOptionalArgument, "" },
 };
 

--- a/tool-openssl/tool.cc
+++ b/tool-openssl/tool.cc
@@ -15,12 +15,13 @@
 
 #include "./internal.h"
 
-static const std::array<Tool, 5> kTools = {{
+static const std::array<Tool, 6> kTools = {{
     {"dgst", dgstTool},
     {"md5", md5Tool},
     {"rsa", rsaTool},
     {"x509", X509Tool},
-    {"version", VersionTool}
+    {"version", VersionTool},
+    {"s_client", SClientTool},
 }};
 
 static void usage(const std::string &name) {

--- a/tool/client.cc
+++ b/tool/client.cc
@@ -245,17 +245,90 @@ static bool WaitForSession(SSL *ssl, int sock) {
   return true;
 }
 
+static void PrintOpenSSLConnectionInfo(SSL *ssl, int show_certs) {
+  STACK_OF(X509) *sk;
+  X509 *peer;
+  int i;
+//  EVP_PKEY *public_key;
+//
+  sk = SSL_get_peer_cert_chain(ssl);
+  if (sk != NULL) {
+    fprintf(stdout, "---\nCertificate chain\n");
+    for (i = 0; i < (int) sk_X509_num(sk); i++) {
+      fprintf(stdout, "%2d s:", i);
+      X509_NAME_print_ex_fp(stdout, X509_get_subject_name(sk_X509_value(sk, i)),
+                            0, XN_FLAG_ONELINE);
+      fprintf(stdout, "\n   i:");
+      X509_NAME_print_ex_fp(stdout, X509_get_issuer_name(sk_X509_value(sk, i)),
+                            0, XN_FLAG_ONELINE);
+      fprintf(stdout, "\n");
+//      public_key = X509_get_pubkey(sk_X509_value(sk, i));
+//      if (public_key != NULL) {
+//        fprintf(stdout, "   a:PKEY: %s, %d (bit); sigalg: %s\n",
+//                   OBJ_nid2sn(EVP_PKEY_get_base_id(public_key)),
+//                   EVP_PKEY_get_bits(public_key),
+//                   OBJ_nid2sn(X509_get_signature_nid(sk_X509_value(sk, i))));
+//        EVP_PKEY_free(public_key);
+//      }
+//      fprintf(stdout, "   v:NotBefore: ");
+      BIO *out = BIO_new_fp(stdout, BIO_CLOSE);
+//      ASN1_TIME_print(out, X509_get0_notBefore(sk_X509_value(sk, i)));
+//      BIO_printf(out, "; NotAfter: ");
+//      ASN1_TIME_print(out, X509_get0_notAfter(sk_X509_value(sk, i)));
+//      BIO_puts(out, "\n");
+      if (show_certs) {
+        PEM_write_bio_X509(out, sk_X509_value(sk, i));
+      }
+    }
+  }
+
+  fprintf(stdout, "---\n");
+  peer = SSL_get_peer_certificate(ssl);
+  if (peer != NULL) {
+    fprintf(stdout, "Server certificate\n");
+    PEM_write_X509(stdout, peer);
+    fprintf(stdout, "subject=");
+    X509_NAME_print_ex_fp(stdout,
+                       X509_get_subject_name(peer),
+                       0, XN_FLAG_ONELINE);
+    fprintf(stdout, "\n\nissuer=");
+    X509_NAME_print_ex_fp(stdout,
+                          X509_get_issuer_name(peer),
+                          0, XN_FLAG_ONELINE);
+    fprintf(stdout, "\n\n---\n");
+  } else {
+    fprintf(stdout, "no peer certificate available\n");
+  }
+//  print_ca_names(bio, s);
+//
+//  ssl_print_sigalgs(bio, s);
+//  ssl_print_tmp_key(bio, s);
+
+  fprintf(stdout,
+             "---\nSSL handshake has read %d bytes "
+             "and written %d bytes\n",
+        (int)BIO_number_read(SSL_get_rbio(ssl)),
+        (int)BIO_number_written(SSL_get_wbio(ssl)));
+
+  X509_free(peer);
+}
+
 static bool DoConnection(SSL_CTX *ctx,
                          std::map<std::string, std::string> args_map,
-                         bool (*cb)(SSL *ssl, int sock)) {
+                         bool (*cb)(SSL *ssl, int sock), int tool) {
   int sock = -1;
   if (args_map.count("-http-tunnel") != 0) {
-    if (!Connect(&sock, args_map["-http-tunnel"]) ||
+    if (!Connect(&sock, args_map["-http-tunnel"], tool) ||
         !DoHTTPTunnel(sock, args_map["-connect"])) {
       return false;
     }
-  } else if (!Connect(&sock, args_map["-connect"])) {
+  } else if (!Connect(&sock, args_map["-connect"], tool)) {
     return false;
+  }
+
+  // print for openssl tool
+  if (tool) {
+    fprintf(stdout, "CONNECTED(%08X)\n", sock);
   }
 
   if (args_map.count("-starttls") != 0) {
@@ -357,9 +430,14 @@ static bool DoConnection(SSL_CTX *ctx,
     }
   }
 
-  fprintf(stderr, "Connected.\n");
-  bssl::UniquePtr<BIO> bio_stderr(BIO_new_fp(stderr, BIO_NOCLOSE));
-  PrintConnectionInfo(bio_stderr.get(), ssl.get());
+  // print for bssl
+  if (!tool) {
+    fprintf(stderr, "Connected.\n");
+    bssl::UniquePtr<BIO> bio_stderr(BIO_new_fp(stderr, BIO_NOCLOSE));
+    PrintConnectionInfo(bio_stderr.get(), ssl.get());
+  } else { // print for openssl
+    PrintOpenSSLConnectionInfo(ssl.get(), args_map.count("-showcerts"));
+  }
 
   return cb(ssl.get(), sock);
 }
@@ -378,15 +456,88 @@ static void InfoCallback(const SSL *ssl, int type, int value) {
   }
 }
 
-bool Client(const std::vector<std::string> &args) {
-  if (!InitSocketLibrary()) {
-    return false;
+static int verify_cb(int ok, X509_STORE_CTX *ctx)
+{
+  X509 *err_cert;
+  int err, depth;
+  BIO* bio_err = BIO_new_fp(stdout, BIO_CLOSE);
+
+  err_cert = X509_STORE_CTX_get_current_cert(ctx);
+  err = X509_STORE_CTX_get_error(ctx);
+  depth = X509_STORE_CTX_get_error_depth(ctx);
+
+  BIO_printf(bio_err, "depth=%d ", depth);
+  if (err_cert != NULL) {
+    X509_NAME_print_ex(bio_err,
+                       X509_get_subject_name(err_cert),
+                       0, XN_FLAG_ONELINE);
+    BIO_puts(bio_err, "\n");
+  } else {
+    BIO_puts(bio_err, "<no cert>\n");
   }
 
+  if (!ok) {
+    BIO_printf(bio_err, "verify error:num=%d:%s\n", err,
+               X509_verify_cert_error_string(err));
+    ok = 1;
+  }
+
+  switch (err) {
+    case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
+      if (err_cert != NULL) {
+        BIO_puts(bio_err, "issuer= ");
+        X509_NAME_print_ex(bio_err, X509_get_issuer_name(err_cert),
+                           0, XN_FLAG_ONELINE);
+        BIO_puts(bio_err, "\n");
+      }
+      ok = 1;
+      break;
+    case X509_V_ERR_CERT_NOT_YET_VALID:
+    case X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD:
+      if (err_cert != NULL) {
+        BIO_printf(bio_err, "notBefore=");
+        ASN1_TIME_print(bio_err, X509_get0_notBefore(err_cert));
+        BIO_printf(bio_err, "\n");
+      }
+      ok = 1;
+      break;
+    case X509_V_ERR_CERT_HAS_EXPIRED:
+    case X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD:
+      if (err_cert != NULL) {
+        BIO_printf(bio_err, "notAfter=");
+        ASN1_TIME_print(bio_err, X509_get0_notAfter(err_cert));
+        BIO_printf(bio_err, "\n");
+      }
+      ok = 1;
+      break;
+    case X509_V_ERR_NO_EXPLICIT_POLICY:
+      //policies_print(ctx);
+      ok = 1;
+      break;
+  }
+//  if (err == X509_V_OK && ok == 2) {
+//    policies_print(ctx);
+//  }
+
+  BIO_printf(bio_err, "verify return:%d\n", ok);
+
+  return ok;
+}
+
+
+bool Client(const std::vector<std::string> &args) {
   std::map<std::string, std::string> args_map;
 
   if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
     PrintUsage(kArguments);
+    return false;
+  }
+
+  return DoClient(args_map, 0);
+}
+
+bool DoClient(std::map<std::string, std::string> args_map, int tool) {
+  if (!InitSocketLibrary()) {
     return false;
   }
 
@@ -540,14 +691,33 @@ bool Client(const std::vector<std::string> &args) {
     SSL_CTX_set_permute_extensions(ctx.get(), 1);
   }
 
+  std::string certPathFlag;
+  int verify = SSL_VERIFY_NONE;
   if (args_map.count("-root-certs") != 0) {
+    certPathFlag = "-root-certs";
+    verify = SSL_VERIFY_PEER;
+  }
+  // For the OpenSSL tool, simply specifying -CAfile does not imply verification
+  if (args_map.count("-CAfile") != 0) {
+    certPathFlag = "-CAfile";
+  }
+  if (!certPathFlag.empty()) {
     if (!SSL_CTX_load_verify_locations(
-            ctx.get(), args_map["-root-certs"].c_str(), nullptr)) {
+            ctx.get(), args_map[certPathFlag].c_str(), nullptr)) {
       fprintf(stderr, "Failed to load root certificates.\n");
       ERR_print_errors_fp(stderr);
       return false;
     }
-    SSL_CTX_set_verify(ctx.get(), SSL_VERIFY_PEER, nullptr);
+  }
+
+  if (args_map.count("-verify") != 0) {
+    unsigned int depth;
+    if (!GetUnsigned(&depth, "-verify", 0, args_map)) {
+      fprintf(stderr, "s_client: Can't parse \"%s\" as a number\n", args_map.find("-verify")->second.c_str());
+      return false;
+    }
+    fprintf(stdout, "verify depth is %d\n", depth);
+    verify = SSL_VERIFY_PEER;
   }
 
   if (args_map.count("-root-cert-dir") != 0) {
@@ -557,7 +727,13 @@ bool Client(const std::vector<std::string> &args) {
       ERR_print_errors_fp(stderr);
       return false;
     }
-    SSL_CTX_set_verify(ctx.get(), SSL_VERIFY_PEER, nullptr);
+    verify = SSL_VERIFY_PEER;
+  }
+
+  if (tool) { // openssl tool
+    SSL_CTX_set_verify(ctx.get(), verify, verify_cb);
+  } else {
+    SSL_CTX_set_verify(ctx.get(), verify, nullptr);
   }
 
   if (args_map.count("-early-data") != 0) {
@@ -575,10 +751,10 @@ bool Client(const std::vector<std::string> &args) {
       return false;
     }
 
-    if (!DoConnection(ctx.get(), args_map, &WaitForSession)) {
+    if (!DoConnection(ctx.get(), args_map, &WaitForSession, tool)) {
       return false;
     }
   }
 
-  return DoConnection(ctx.get(), args_map, &TransferData);
+  return DoConnection(ctx.get(), args_map, &TransferData, tool);
 }

--- a/tool/internal.h
+++ b/tool/internal.h
@@ -137,6 +137,11 @@ bool WriteToFile(const std::string &path, const uint8_t *in, size_t in_len);
 
 bool Ciphers(const std::vector<std::string> &args);
 bool Client(const std::vector<std::string> &args);
+// DoClient is a common function used to support the s_client option in both
+// bssl and openssl tools. It takes an additional parameter |tool| to indicate
+// which tool's s_client is being invoked. 1 indicates openssl and 0 indicates
+// bssl.
+bool DoClient(std::map<std::string, std::string> args_map, int tool);
 bool DoPKCS12(const std::vector<std::string> &args);
 bool GenerateECH(const std::vector<std::string> &args);
 bool GenerateEd25519Key(const std::vector<std::string> &args);

--- a/tool/transport_common.cc
+++ b/tool/transport_common.cc
@@ -137,7 +137,7 @@ static void PrintSocketError(const char *function) {
 // Connect sets |*out_sock| to be a socket connected to the destination given
 // in |hostname_and_port|, which should be of the form "www.example.com:123".
 // It returns true on success and false otherwise.
-bool Connect(int *out_sock, const std::string &hostname_and_port) {
+bool Connect(int *out_sock, const std::string &hostname_and_port, int quiet) {
   std::string hostname, port;
   SplitHostPort(&hostname, &port, hostname_and_port);
 
@@ -153,7 +153,7 @@ bool Connect(int *out_sock, const std::string &hostname_and_port) {
   hint.ai_socktype = SOCK_STREAM;
 
   int ret = getaddrinfo(hostname.c_str(), port.c_str(), &hint, &result);
-  if (ret != 0) {
+  if (ret != 0 && !quiet) {
 #if defined(OPENSSL_WINDOWS)
     const char *error = gai_strerrorA(ret);
 #else
@@ -173,22 +173,24 @@ bool Connect(int *out_sock, const std::string &hostname_and_port) {
     goto out;
   }
 
-  switch (result->ai_family) {
-    case AF_INET: {
-      struct sockaddr_in *sin =
-          reinterpret_cast<struct sockaddr_in *>(result->ai_addr);
-      fprintf(stderr, "Connecting to %s:%d\n",
-              inet_ntop(result->ai_family, &sin->sin_addr, buf, sizeof(buf)),
-              ntohs(sin->sin_port));
-      break;
-    }
-    case AF_INET6: {
-      struct sockaddr_in6 *sin6 =
-          reinterpret_cast<struct sockaddr_in6 *>(result->ai_addr);
-      fprintf(stderr, "Connecting to [%s]:%d\n",
-              inet_ntop(result->ai_family, &sin6->sin6_addr, buf, sizeof(buf)),
-              ntohs(sin6->sin6_port));
-      break;
+  if(!quiet) {
+    switch (result->ai_family) {
+      case AF_INET: {
+        struct sockaddr_in *sin =
+                reinterpret_cast<struct sockaddr_in *>(result->ai_addr);
+        fprintf(stderr, "Connecting to %s:%d\n",
+                inet_ntop(result->ai_family, &sin->sin_addr, buf, sizeof(buf)),
+                ntohs(sin->sin_port));
+        break;
+      }
+      case AF_INET6: {
+        struct sockaddr_in6 *sin6 =
+                reinterpret_cast<struct sockaddr_in6 *>(result->ai_addr);
+        fprintf(stderr, "Connecting to [%s]:%d\n",
+                inet_ntop(result->ai_family, &sin6->sin6_addr, buf, sizeof(buf)),
+                ntohs(sin6->sin6_port));
+        break;
+      }
     }
   }
 

--- a/tool/transport_common.h
+++ b/tool/transport_common.h
@@ -25,8 +25,10 @@ bool InitSocketLibrary();
 
 // Connect sets |*out_sock| to be a socket connected to the destination given
 // in |hostname_and_port|, which should be of the form "www.example.com:123".
+// |quiet| when set to 1 suppresses any output to stdout or stderr from this
+// function.
 // It returns true on success and false otherwise.
-bool Connect(int *out_sock, const std::string &hostname_and_port);
+bool Connect(int *out_sock, const std::string &hostname_and_port, int quiet);
 
 class Listener {
  public:


### PR DESCRIPTION
### Issues:
`CryptoAlg-2679`

### Description of changes: 
Adding the s_client tool to our openssl CLI executable. It mostly uses the same code from our existing bssl CLI s_client tool. There are various changes to functions to help distinguish which CLI variant is being called. The output of bssl's CLI for s_client is also very different from OpenSSL 1.1.1. There are a lot of utility printing functions added and changes in logic to suppress output when using the openssl CLI. 

### Call-outs:
The verification output still doesn't match OpenSSL 1.1.1 fully. There is also some missing data like peer CAs, peer tmp key, public key bits, and sig_algs. 

### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
