### PR TITLE
Fixes for Coverity Alerts

### DIFF
--- a/crypto/pkcs7/bio/bio_md_test.cc
+++ b/crypto/pkcs7/bio/bio_md_test.cc
@@ -198,9 +198,9 @@ TEST_P(BIOMessageDigestTest, Randomized) {
       message.insert(message.end(), &message_buf[0], &message_buf[io_size]);
     }
     EVP_DigestUpdate(ctx.get(), message.data(), message.size());
-    unsigned digest_size;
-    EVP_DigestFinal_ex(ctx.get(), digest_buf, &digest_size);
-    ASSERT_EQ(EVP_MD_CTX_size(ctx.get()), digest_size);
+    int digest_size;
+    EVP_DigestFinal_ex(ctx.get(), digest_buf, reinterpret_cast<unsigned int*>(&digest_size));
+    ASSERT_EQ(EVP_MD_CTX_size(ctx.get()), (unsigned int)digest_size);
     expected_digest.insert(expected_digest.begin(), &digest_buf[0],
                            &digest_buf[digest_size]);
     OPENSSL_cleanse(digest_buf, sizeof(digest_buf));
@@ -221,7 +221,8 @@ TEST_P(BIOMessageDigestTest, Randomized) {
     }
     digest_size =
         BIO_gets(bio_md.get(), (char *)digest_buf, sizeof(digest_buf));
-    ASSERT_EQ(EVP_MD_CTX_size(ctx.get()), digest_size);
+    ASSERT_GE(digest_size, 0);
+    ASSERT_EQ(EVP_MD_CTX_size(ctx.get()), (unsigned int)digest_size);
     EXPECT_EQ(Bytes(expected_digest.data(), expected_digest.size()),
               Bytes(digest_buf, digest_size));
     OPENSSL_cleanse(digest_buf, sizeof(digest_buf));
@@ -243,7 +244,8 @@ TEST_P(BIOMessageDigestTest, Randomized) {
     EXPECT_TRUE(BIO_eof(bio.get()));
     digest_size =
         BIO_gets(bio_md.get(), (char *)digest_buf, sizeof(digest_buf));
-    ASSERT_EQ(EVP_MD_CTX_size(ctx.get()), digest_size);
+    ASSERT_GE(digest_size, 0);
+    ASSERT_EQ(EVP_MD_CTX_size(ctx.get()), (unsigned int)digest_size);
     EXPECT_EQ(Bytes(expected_digest.data(), expected_digest.size()),
               Bytes(digest_buf, digest_size));
     OPENSSL_cleanse(digest_buf, sizeof(digest_buf));

--- a/crypto/x509/v3_lib.c
+++ b/crypto/x509/v3_lib.c
@@ -150,7 +150,7 @@ const X509V3_EXT_METHOD *X509V3_EXT_get_nid(int nid) {
 
 const X509V3_EXT_METHOD *X509V3_EXT_get(const X509_EXTENSION *ext) {
   int nid;
-  if ((nid = OBJ_obj2nid(ext->object)) == NID_undef) {
+  if (ext == NULL || (nid = OBJ_obj2nid(ext->object)) == NID_undef) {
     return NULL;
   }
   return X509V3_EXT_get_nid(nid);


### PR DESCRIPTION
### Description of changes: 
Added null check to mitigate alert by coverity. Changed two tests to account for negative return value. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
