### PR TITLE
Also test w/ gcc 4.8

### DIFF
--- a/.github/docker_images/gcc-4.8/Dockerfile
+++ b/.github/docker_images/gcc-4.8/Dockerfile
@@ -14,7 +14,11 @@ RUN curl -LOk "https://github.com/Kitware/CMake/releases/download/v3.6.3/cmake-3
 RUN sha256sum cmake-3.6.3-Linux-x86_64.tar.gz | grep -q "9d915d505c07d84b610e1be6242c7cad68b4b7a4090ce85ecf9cec5effa47c43"
 RUN tar -C /usr/local -xzf cmake-3.6.3-Linux-x86_64.tar.gz
 RUN rm cmake-3.6.3-Linux-x86_64.tar.gz
+RUN curl -LOk "https://go.dev/dl/go1.18.10.linux-amd64.tar.gz"
+RUN sha256sum go1.18.10.linux-amd64.tar.gz | grep -q "5e05400e4c79ef5394424c0eff5b9141cb782da25f64f79d54c98af0a37f8d49"
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.10.linux-amd64.tar.gz
+RUN rm go1.18.10.linux-amd64.tar.gz
 
-ENV PATH="${PATH}:/usr/local/cmake-3.6.3-Linux-x86_64/bin"
+ENV PATH="${PATH}:/usr/local/cmake-3.6.3-Linux-x86_64/bin:/usr/local/go/bin"
 
 ENTRYPOINT ["/entry.sh"]

--- a/.github/docker_images/gcc-4.8/awslc_build.sh
+++ b/.github/docker_images/gcc-4.8/awslc_build.sh
@@ -12,7 +12,7 @@ SRC_DIR="${SRC_DIR:-/awslc}"
 
 pushd "${BUILD_DIR}"
 
-cmake "${SRC_DIR}" "-DDISABLE_GO=ON" "-DDISABLE_PERL=ON" "-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=1"
-make -j 4 ssl
+cmake "${SRC_DIR}" "-DDISABLE_PERL=ON" "-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=1"
+cmake --build "${BUILD_DIR}" --target run_tests
 
 popd # ${BUILD_DIR}

--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -1153,6 +1153,8 @@ static bssl::UniquePtr<EVP_PKEY> ParsePrivateKey(int type, const uint8_t *in,
   return pkey;
 }
 
+#if !defined(__GNUC__) || (__GNUC__ > 4)
+
 static std::string PrintToString(const EVP_PKEY *pkey, int indent,
                                  int (*print_func)(BIO *out,
                                                    const EVP_PKEY *pkey,
@@ -1453,6 +1455,8 @@ TEST(EVPExtraTest, Print) {
       4b:cf:72:22:c1
 )");
 }
+
+#endif
 
 // Tests loading a bad key in PKCS8 format.
 TEST(EVPExtraTest, BadECKey) {


### PR DESCRIPTION
### Context
* GCC v4.x compilers lack support for multiline C++11 raw string literals: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55971
* We have one test file that has string literals that fail to compile on GCC 4.8.  Otherwise, all of our tests compile and run successfully using GCC 4.8.

### Description of changes: 
* Preprocessor guard placed around section of test that uses multiline C++11 raw string literals so that compilation does not fail using GCC v4.x.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
