### PR TITLE
Coverity Fix Null Check

### DIFF
--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -159,6 +159,9 @@ int X509_REQ_print_ex(BIO *bio, X509_REQ *x, unsigned long nmflags,
           goto err;
         }
 
+        if (a == NULL) {
+          goto err;
+        }
         const int num_attrs = X509_ATTRIBUTE_count(a);
         const int obj_str_len = i2a_ASN1_OBJECT(bio, aobj);
         if (obj_str_len <= 0) {

--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -159,9 +159,6 @@ int X509_REQ_print_ex(BIO *bio, X509_REQ *x, unsigned long nmflags,
           goto err;
         }
 
-        if (a == NULL) {
-          goto err;
-        }
         const int num_attrs = X509_ATTRIBUTE_count(a);
         const int obj_str_len = i2a_ASN1_OBJECT(bio, aobj);
         if (obj_str_len <= 0) {

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -192,6 +192,9 @@ err:
 }
 
 int X509_ATTRIBUTE_count(const X509_ATTRIBUTE *attr) {
+  if (attr == NULL) {
+    return 0;
+  }
   return (int)sk_ASN1_TYPE_num(attr->set);
 }
 

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2272,7 +2272,8 @@ OPENSSL_EXPORT int X509_ATTRIBUTE_set1_data(X509_ATTRIBUTE *attr, int attrtype,
 OPENSSL_EXPORT void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *attr, int idx,
                                               int attrtype, void *unused);
 
-// X509_ATTRIBUTE_count returns the number of values in |attr|.
+// X509_ATTRIBUTE_count returns the number of values in |attr| or 0 if |attr|
+// is NULL.
 OPENSSL_EXPORT int X509_ATTRIBUTE_count(const X509_ATTRIBUTE *attr);
 
 // X509_ATTRIBUTE_get0_object returns the type of |attr|.


### PR DESCRIPTION
`X509_ATTRIBUTE_count` dereferences `a` without a NULL check, added it in. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
