### PR TITLE
Fix i2d behavior for i2d_SSL_SESSION

### DIFF
--- a/crypto/bytestring/internal.h
+++ b/crypto/bytestring/internal.h
@@ -64,7 +64,7 @@ OPENSSL_EXPORT int CBS_get_asn1_implicit_string(CBS *in, CBS *out,
 // error, it calls |CBB_cleanup| on |cbb|.
 //
 // This function may be used to help implement legacy i2d ASN.1 functions.
-int CBB_finish_i2d(CBB *cbb, uint8_t **outp);
+OPENSSL_EXPORT int CBB_finish_i2d(CBB *cbb, uint8_t **outp);
 
 
 // Unicode utilities.

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -2040,6 +2040,17 @@ TEST(SSLTest, SessionEncoding) {
         << "i2d_SSL_SESSION did not advance ptr correctly";
     EXPECT_EQ(Bytes(encoded.get(), encoded_len), Bytes(input))
         << "SSL_SESSION_to_bytes did not round-trip";
+
+    // Verify that |i2d_SSL_SESSION| works correctly when |pp| is non-NULL, but
+    // |*pp| is NULL. A newly-allocated buffer containing the result should be
+    // created. See |i2d_SAMPLE| for more details.
+    uint8_t *ptr2 = nullptr;
+    int len2 = i2d_SSL_SESSION(session.get(), &ptr2);
+    ASSERT_TRUE(ptr2);
+    ASSERT_GT(len2, 0);
+    bssl::UniquePtr<uint8_t> encoded2(ptr2);
+    EXPECT_EQ(Bytes(encoded2.get(), len2), Bytes(input))
+        << "SSL_SESSION_to_bytes did not round-trip";
   }
 
   for (const char *input_b64 : {


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2700`

### Description of changes: 
`i2d_SSL_SESSION` wasn't exactly following the correct behavior of the legacy `i2d` functions when `pp` is non-NULL, but `*pp` is NULL. This caused issues with functions expecting a newly allocated buffer when calling `i2d_SSL_SESSION` with the recommended documented behavior. See `i2d_SAMPLE` for more details.
https://github.com/aws/aws-lc/blob/48a40573eae3b09ef9b0c3d2d0180506fb214b0c/include/openssl/asn1.h#L254-L266

### Call-outs:
N/A

### Testing:
New test below usage of `i2d_SSL_SESSION` to verify the behavior.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
