### PR TITLE
Expose AES_cfb1_encrypt and AES_cfb8_encrypt

### DIFF
--- a/crypto/fipsmodule/cipher/internal.h
+++ b/crypto/fipsmodule/cipher/internal.h
@@ -201,15 +201,6 @@ ctr128_f aes_ctr_set_key(AES_KEY *aes_key, GCM128_KEY *gcm_key,
                          block128_f *out_block, const uint8_t *key,
                          size_t key_bytes);
 
-// AES_cfb1_encrypt calls |CRYPTO_cfb128_1_encrypt| using the block
-// |AES_encrypt|.
-void AES_cfb1_encrypt(const uint8_t *in, uint8_t *out, size_t bits,
-                      const AES_KEY *key, uint8_t *ivec, int *num, int enc);
-
-// AES_cfb8_encrypt calls |CRYPTO_cfb128_8_encrypt| using the block
-// |AES_encrypt|.
-void AES_cfb8_encrypt(const uint8_t *in, uint8_t *out, size_t len,
-                      const AES_KEY *key, uint8_t *ivec, int *num, int enc);
 
 // EXPERIMENTAL functions for use in the TLS Transfer function. See
 // |SSL_to_bytes| for more details.

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -141,6 +141,24 @@ OPENSSL_EXPORT void AES_ofb128_encrypt(const uint8_t *in, uint8_t *out,
                                        size_t len, const AES_KEY *key,
                                        uint8_t *ivec, int *num);
 
+// AES_cfb1_encrypt encrypts (or decrypts, if |enc| == |AES_DECRYPT|) |len|
+// bytes from |in| to |out|. The |num| parameter must be set to zero on the
+// first call. This function may be called in-place with |in| equal to |out|,
+// but otherwise the buffers may not partially overlap. A partial overlap may
+// overwrite input data before it is read.
+OPENSSL_EXPORT void AES_cfb1_encrypt(const uint8_t *in, uint8_t *out,
+                                     size_t bits, const AES_KEY *key,
+                                     uint8_t *ivec, int *num, int enc);
+
+// AES_cfb8_encrypt encrypts (or decrypts, if |enc| == |AES_DECRYPT|) |len|
+// bytes from |in| to |out|. The |num| parameter must be set to zero on the
+// first call. This function may be called in-place with |in| equal to |out|,
+// but otherwise the buffers may not partially overlap. A partial overlap may
+// overwrite input data before it is read.
+OPENSSL_EXPORT void AES_cfb8_encrypt(const uint8_t *in, uint8_t *out,
+                                     size_t len, const AES_KEY *key,
+                                     uint8_t *ivec, int *num, int enc);
+
 // AES_cfb128_encrypt encrypts (or decrypts, if |enc| == |AES_DECRYPT|) |len|
 // bytes from |in| to |out|. The |num| parameter must be set to zero on the
 // first call. This function may be called in-place with |in| equal to |out|,


### PR DESCRIPTION
Moved the `AES_cfb1_encrypt` and `AES_cfb8_encrypt` to the `openssl/aes.h` header to be exposed similarly too `AES_cfb128_encrypt`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
