### PR TITLE
EDDSA PCT

### DIFF
--- a/crypto/fipsmodule/curve25519/curve25519.c
+++ b/crypto/fipsmodule/curve25519/curve25519.c
@@ -103,6 +103,18 @@ void ED25519_keypair_from_seed(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
     ED25519_PUBLIC_KEY_LEN);
 }
 
+static void ed25519_keypair_pct(uint8_t public_key[ED25519_PUBLIC_KEY_LEN],
+  uint8_t private_key[ED25519_PRIVATE_KEY_LEN]) {
+#if defined(AWSLC_FIPS)
+  uint8_t msg[16] = {16};
+  uint8_t out_sig[ED25519_SIGNATURE_LEN];
+  if (ED25519_sign_no_self_test(out_sig, msg, 16, private_key) != 1 ||
+      ED25519_verify_no_self_test(msg, 16, out_sig, public_key) != 1) {
+    abort();
+  }
+#endif
+}
+
 void ED25519_keypair(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
   uint8_t out_private_key[ED25519_PRIVATE_KEY_LEN]) {
   boringssl_ensure_eddsa_self_test();
@@ -117,6 +129,8 @@ void ED25519_keypair(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
   // description why this is useful.
   ED25519_keypair_from_seed(out_public_key, out_private_key, seed);
   OPENSSL_cleanse(seed, ED25519_SEED_LEN);
+
+  ed25519_keypair_pct(out_public_key, out_private_key);
 
   FIPS_service_indicator_update_state();
 }

--- a/crypto/fipsmodule/curve25519/curve25519.c
+++ b/crypto/fipsmodule/curve25519/curve25519.c
@@ -110,7 +110,7 @@ static void ed25519_keypair_pct(uint8_t public_key[ED25519_PUBLIC_KEY_LEN],
   uint8_t out_sig[ED25519_SIGNATURE_LEN];
   if (ED25519_sign_no_self_test(out_sig, msg, 16, private_key) != 1 ||
       ED25519_verify_no_self_test(msg, 16, out_sig, public_key) != 1) {
-    abort();
+    BORINGSSL_FIPS_abort();
   }
 #endif
 }


### PR DESCRIPTION
### Description of changes: 

Per 10.3.A, Ed25519 needs a PCT. Only implement for FIPS build type and make it a simple sign-verify cycle. Abort on failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
