### PR TITLE
fix `-Wcast-function-type` build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,8 +404,10 @@ if(GCC OR CLANG)
   endif()
   set(C_CXX_FLAGS "${C_CXX_FLAGS} -Werror -Wformat=2 -Wsign-compare -Wmissing-field-initializers -Wwrite-strings")
 
-  if(GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "8")
+  if((GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "8") OR
+     (CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS "13"))
     # GCC 8.x added a warning called -Wcast-function-type to the -Wextra umbrella.
+    # Also suppress for all clang versions supporting this warning.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-cast-function-type")
   endif()
 

--- a/crypto/rand_extra/windows.c
+++ b/crypto/rand_extra/windows.c
@@ -65,7 +65,7 @@ static void init_processprng(void) {
   if (hmod == NULL) {
     abort();
   }
-  g_processprng_fn = (ProcessPrngFunction)GetProcAddress(hmod, "ProcessPrng");
+  g_processprng_fn = (ProcessPrngFunction)(void(*)(void))GetProcAddress(hmod, "ProcessPrng");
   if (g_processprng_fn == NULL) {
     abort();
   }


### PR DESCRIPTION
### Issues:
Resolves #1971

### Description of changes: 
- silence `-Werror,-Wcast-function-type-mismatch` in `crypto/rand_extra/windows.c`.
- extend `-Wno-cast-function-type` to clang versions supporting it.
  Should address https://gitlab.gnome.org/GNOME/gnome-terminal/-/issues/96 also for clang builds.
  Ref: #155

### Call-outs:

### Testing:
I build-tested both changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
