### PR TITLE
Prepare v1.38.0 release

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5245,7 +5245,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.37.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.38.0");
 }
 
 #else
@@ -5288,6 +5288,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.37.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.38.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.37.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.38.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* 800-131Ar1: length of the key-derivation key shall be at least 112 bits. by @skmcgrail in https://github.com/aws/aws-lc/pull/1924
* Marshalling/Unmarshalling DH public keys by @justsmth in https://github.com/aws/aws-lc/pull/1916
* Also prune SSM documents from ec2-test-framework by @samuel40791765 in https://github.com/aws/aws-lc/pull/1925
* Use illegal_parameter instead of decode_error for invalid key shares by @justsmth in https://github.com/aws/aws-lc/pull/1923
* Add null check in dh testing by @torben-hansen in https://github.com/aws/aws-lc/pull/1937
* DH paramgen callback by @justsmth in https://github.com/aws/aws-lc/pull/1928
* Upstream merge 2024 10 17 by @torben-hansen in https://github.com/aws/aws-lc/pull/1934
* Remove old Intel CPU types by @justsmth in https://github.com/aws/aws-lc/pull/1942
* Remove retries on PCT failure in EC and RSA key generation. by @nebeid in https://github.com/aws/aws-lc/pull/1938
* Add p4p, bump up time by @justsmth in https://github.com/aws/aws-lc/pull/1943
* PQ README by @jakemas in https://github.com/aws/aws-lc/pull/1932
* bump mysql CI to 9.1.0 by @justsmth in https://github.com/aws/aws-lc/pull/1939
* HKDF, HKDF_expand, and PBKDF Truncated SHA2-512 by @skmcgrail in https://github.com/aws/aws-lc/pull/1946
* Missing functionality + Adding Nmap to our CI by @smittals2 in https://github.com/aws/aws-lc/pull/1915
* Fix FIPS.md typo by @justsmth in https://github.com/aws/aws-lc/pull/1950
* Support encode or decode ∞ like OpenSSL by @samuel40791765 in https://github.com/aws/aws-lc/pull/1930
* Expand support for EVP_PKEY_HMAC by @justsmth in https://github.com/aws/aws-lc/pull/1933
* Add PKCS7-internal BIO_f_cipher by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1836
* Add PKCS7-internal BIO_f_md by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/1886
* Ruby Support - DSA custom md by @justsmth in https://github.com/aws/aws-lc/pull/1953
* Add support for POINT_CONVERSION_HYBRID by @samuel40791765 in https://github.com/aws/aws-lc/pull/1936
* Fixes for Coverity Alerts by @smittals2 in https://github.com/aws/aws-lc/pull/1960
* Also test w/ gcc 4.8 by @justsmth in https://github.com/aws/aws-lc/pull/1962
* Actually add support for SSL_get_server/peer_tmp_key by @samuel40791765 in https://github.com/aws/aws-lc/pull/1945
* Coverity Fix Null Check by @smittals2 in https://github.com/aws/aws-lc/pull/1965
* ML-KEM keygen Pairwise Consistency Test by @dkostic in https://github.com/aws/aws-lc/pull/1964
* EDDSA PCT by @torben-hansen in https://github.com/aws/aws-lc/pull/1968
* Expose AES_cfb1_encrypt and AES_cfb8_encrypt by @skmcgrail in https://github.com/aws/aws-lc/pull/1967

**Full Changelog**: https://github.com/aws/aws-lc/compare/v1.37.0...v1.38.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
