### PR TITLE
Add CRYPTO_sysrand benchmarks to speed.cc

### DIFF
--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -45,12 +45,12 @@ void RAND_bytes_with_additional_data(uint8_t *out, size_t out_len,
 
 // CRYPTO_sysrand fills |len| bytes at |buf| with entropy from the operating
 // system.
-void CRYPTO_sysrand(uint8_t *buf, size_t len);
+OPENSSL_EXPORT void CRYPTO_sysrand(uint8_t *buf, size_t len);
 
 // CRYPTO_sysrand_for_seed fills |len| bytes at |buf| with entropy from the
 // operating system. It may draw from the |GRND_RANDOM| pool on Android,
 // depending on the vendor's configuration.
-void CRYPTO_sysrand_for_seed(uint8_t *buf, size_t len);
+OPENSSL_EXPORT void CRYPTO_sysrand_for_seed(uint8_t *buf, size_t len);
 
 #if defined(OPENSSL_RAND_URANDOM) || defined(OPENSSL_RAND_WINDOWS)
 // CRYPTO_init_sysrand initializes long-lived resources needed to draw entropy


### PR DESCRIPTION
### Description of changes: 
Add two new benchmarks by refactoring the existing RNG benchmark to support multiple functions. 

### Call-outs:
Looking at the tree DRBG PR got me interested in the performance impact of calling CRYPTO_sysrand. These benchmarks will be very OS dependent. 

### Testing:
On an M1 mac:
```
./tool/bssl speed -filter RNG
Did 2572000 RNG (16 bytes) operations in 1000160us (2571588.5 ops/sec): 41.1 MB/s
Did 2323000 RNG (256 bytes) operations in 1000233us (2322458.9 ops/sec): 594.5 MB/s
Did 1714000 RNG (1350 bytes) operations in 1000052us (1713910.9 ops/sec): 2313.8 MB/s
Did 631000 RNG (8192 bytes) operations in 1000242us (630847.3 ops/sec): 5167.9 MB/s
Did 360000 RNG (16384 bytes) operations in 1001003us (359639.3 ops/sec): 5892.3 MB/s

./tool/bssl speed -filter CRYPTO_sys
Did 4014000 CRYPTO_sysrand (16 bytes) operations in 1000088us (4013646.8 ops/sec): 64.2 MB/s
Did 3459000 CRYPTO_sysrand (256 bytes) operations in 1000071us (3458754.4 ops/sec): 885.4 MB/s
Did 1703000 CRYPTO_sysrand (1350 bytes) operations in 1000478us (1702186.4 ops/sec): 2298.0 MB/s
Did 397000 CRYPTO_sysrand (8192 bytes) operations in 1000532us (396788.9 ops/sec): 3250.5 MB/s
Did 200000 CRYPTO_sysrand (16384 bytes) operations in 1000393us (199921.4 ops/sec): 3275.5 MB/s
Did 4041000 CRYPTO_sysrand_for_seed (16 bytes) operations in 1000045us (4040818.2 ops/sec): 64.7 MB/s
Did 3404500 CRYPTO_sysrand_for_seed (256 bytes) operations in 1000055us (3404312.8 ops/sec): 871.5 MB/s
Did 1663250 CRYPTO_sysrand_for_seed (1350 bytes) operations in 1000120us (1663050.4 ops/sec): 2245.1 MB/s
Did 387000 CRYPTO_sysrand_for_seed (8192 bytes) operations in 1002271us (386123.1 ops/sec): 3163.1 MB/s
Did 198000 CRYPTO_sysrand_for_seed (16384 bytes) operations in 1000206us (197959.2 ops/sec): 3243.4 MB/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
