### PR TITLE
CI gcc-4.8 - use 4.8.5 tag

### DIFF
--- a/.github/docker_images/gcc-4.8/Dockerfile
+++ b/.github/docker_images/gcc-4.8/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
-FROM gcc:4.8
+FROM gcc:4.8.5
 
 VOLUME ["/awslc"]
 


### PR DESCRIPTION
### Problem
The CI job started [failing in the last few days](https://github.com/aws/aws-lc/actions/runs/11782211980/job/32818623601?pr=1979).
```
...
  > [ 1/12] FROM docker.io/library/gcc:4.8@sha256:43c6eaefe26ad414b2eefbee68688d1467823424cacbbd1703da4a50ce2c7654:
------
Dockerfile:4
--------------------
   2 |     # SPDX-License-Identifier: Apache-2.0 OR ISC
   3 |     
   4 | >>> FROM gcc:4.8
   5 |     
   6 |     VOLUME ["/awslc"]
--------------------
ERROR: failed to solve: no signatures
Error: Process completed with exit code 1.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
