### PR TITLE
Avoid compiler warning

### DIFF
--- a/crypto/fipsmodule/modes/gcm.c
+++ b/crypto/fipsmodule/modes/gcm.c
@@ -421,18 +421,17 @@ int CRYPTO_gcm128_aad(GCM128_CONTEXT *ctx, const uint8_t *aad, size_t len) {
     len -= len_blocks;
   }
 
-  // This is needed to avoid a compiler warning on powerpc64le using GCC 12.2:
-  // .../aws-lc/crypto/fipsmodule/modes/gcm.c:428:18: error: writing 1 byte into
-  // a region of size 0 [-Werror=stringop-overflow=]
-  // 428 | ctx->Xi[i] ^= aad[i];
-  //     | ~~~~~~~~~~~^~~~~~~~~
-  if (len > 16) {
-    abort();
-    return 0;
-  }
-
   // Process the remainder.
   if (len != 0) {
+    // This is needed to avoid a compiler warning on powerpc64le using GCC 12.2:
+    // .../aws-lc/crypto/fipsmodule/modes/gcm.c:428:18: error: writing 1 byte into
+    // a region of size 0 [-Werror=stringop-overflow=]
+    // 428 | ctx->Xi[i] ^= aad[i];
+    //     | ~~~~~~~~~~~^~~~~~~~~
+    if (len > 16) {
+      abort();
+      return 0;
+    }
     n = (unsigned int)len;
     for (size_t i = 0; i < len; ++i) {
       ctx->Xi[i] ^= aad[i];
@@ -690,20 +689,18 @@ int CRYPTO_gcm128_encrypt_ctr32(GCM128_CONTEXT *ctx, const AES_KEY *key,
     GHASH(ctx, out, len_blocks);
     out += len_blocks;
   }
-
-  // This is needed to avoid a compiler warning on powerpc64le using GCC 12.2:
-  // .../aws-lc/crypto/fipsmodule/modes/gcm.c:688:18: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
-  // 688 |       ctx->Xi[n] ^= out[n] = in[n] ^ ctx->EKi[n];
-  //     |                  ^~
-  if ((n + len) > 16) {
-    abort();
-    return 0;
-  }
-
   if (len) {
     (*ctx->gcm_key.block)(ctx->Yi, ctx->EKi, key);
     ++ctr;
     CRYPTO_store_u32_be(ctx->Yi + 12, ctr);
+    // This is needed to avoid a compiler warning on powerpc64le using GCC 12.2:
+    // .../aws-lc/crypto/fipsmodule/modes/gcm.c:688:18: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
+    // 688 |       ctx->Xi[n] ^= out[n] = in[n] ^ ctx->EKi[n];
+    //     |                  ^~
+    if ((n + len) > 16) {
+      abort();
+      return 0;
+    }
     while (len--) {
       ctx->Xi[n] ^= out[n] = in[n] ^ ctx->EKi[n];
       ++n;
@@ -796,21 +793,19 @@ int CRYPTO_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx, const AES_KEY *key,
     in += len_blocks;
     len -= len_blocks;
   }
-
-  // This is needed to avoid a compiler warning on powerpc64le using GCC 12.2:
-  // aws-lc/crypto/fipsmodule/modes/gcm.c:785:18: error: writing 1 byte into a
-  // region of size 0 [-Werror=stringop-overflow=]
-  // 785 | ctx->Xi[n] ^= c;
-  //     | ~~~~~~~~~~~^~~~
-  if ((n + len) > 16) {
-    abort();
-    return 0;
-  }
-
   if (len) {
     (*ctx->gcm_key.block)(ctx->Yi, ctx->EKi, key);
     ++ctr;
     CRYPTO_store_u32_be(ctx->Yi + 12, ctr);
+    // This is needed to avoid a compiler warning on powerpc64le using GCC 12.2:
+    // aws-lc/crypto/fipsmodule/modes/gcm.c:785:18: error: writing 1 byte into a
+    // region of size 0 [-Werror=stringop-overflow=]
+    // 785 | ctx->Xi[n] ^= c;
+    //     | ~~~~~~~~~~~^~~~
+    if ((n + len) > 16) {
+      abort();
+      return 0;
+    }
     while (len--) {
       uint8_t c = in[n];
       ctx->Xi[n] ^= c;


### PR DESCRIPTION
### Issues:
Addresses aws/aws-lc-rs#574

### Context
The compiler cannot always confirm that the array indices used are within the required bounds.  On certain platform, specifically powerpc64le in this case, the compiler may generate a warning about it.  For our build, warnings are treated as errors thus causing compilation to fail.

### Description of changes: 
Adds sanity checks to several locations in `gcm.c` that abort if the logic would reference an out-of-bounds index of an array.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
