### PR TITLE
Expose a bit of lhash/conf for Ruby

### DIFF
--- a/crypto/conf/internal.h
+++ b/crypto/conf/internal.h
@@ -26,10 +26,6 @@ extern "C" {
 
 DEFINE_LHASH_OF(CONF_VALUE)
 
-struct conf_st {
-  LHASH_OF(CONF_VALUE) *data;
-};
-
 // CONF_VALUE_new returns a freshly allocated and zeroed |CONF_VALUE|.
 CONF_VALUE *CONF_VALUE_new(void);
 

--- a/crypto/lhash/internal.h
+++ b/crypto/lhash/internal.h
@@ -105,7 +105,6 @@ typedef int (*lhash_cmp_func_helper)(lhash_cmp_func func, const void *a,
 typedef uint32_t (*lhash_hash_func)(const void *a);
 typedef uint32_t (*lhash_hash_func_helper)(lhash_hash_func func, const void *a);
 
-typedef struct lhash_st _LHASH;
 
 // OPENSSL_lh_new returns a new, empty hash table or NULL on error.
 OPENSSL_EXPORT _LHASH *OPENSSL_lh_new(lhash_hash_func hash,

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -347,3 +347,7 @@ void OPENSSL_lh_doall_arg(_LHASH *lh, void (*func)(void *, void *), void *arg) {
   // resizing is done here.
   lh_maybe_resize(lh);
 }
+
+void lh_doall_arg(_LHASH *lh, void (*func)(void *, void *), void *arg) {
+  OPENSSL_lh_doall_arg(lh, func, arg);
+}

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -94,6 +94,9 @@ struct conf_value_st {
 DEFINE_STACK_OF(CONF_VALUE)
 DECLARE_LHASH_OF(CONF_VALUE)
 
+struct conf_st {
+  LHASH_OF(CONF_VALUE) *data;
+};
 
 // NCONF_new returns a fresh, empty |CONF|, or NULL on error. The |method|
 // argument must be NULL.

--- a/include/openssl/lhash.h
+++ b/include/openssl/lhash.h
@@ -63,6 +63,7 @@
 extern "C" {
 #endif
 
+typedef struct lhash_st _LHASH;
 
 // lhash is an internal library and not exported for use outside BoringSSL. This
 // header is provided for compatibility with code that expects OpenSSL.
@@ -72,6 +73,18 @@ extern "C" {
 // |X509V3_EXT_conf_nid|. Do not use these symbols outside BoringSSL.
 #define LHASH_OF(type) struct lhash_st_##type
 #define DECLARE_LHASH_OF(type) LHASH_OF(type);
+
+OPENSSL_EXPORT void lh_doall_arg(_LHASH *lh, void (*func)(void *, void *),
+                                 void *arg);
+
+// These two macros are the bare minimum of |LHASH| macros downstream consumers
+// use.
+#define IMPLEMENT_LHASH_DOALL_ARG_FN(name, o_type, a_type) \
+	void name##_LHASH_DOALL_ARG(void *arg1, void *arg2) { \
+		o_type *a = arg1; \
+		a_type *b = arg2; \
+		name##_doall_arg(a, b); }
+#define LHASH_DOALL_ARG_FN(name) name##_LHASH_DOALL_ARG
 
 
 #if defined(__cplusplus)


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2449`

### Description of changes: 
This extends upon https://github.com/aws/aws-lc/pull/1986.

We do have all the necessary support for "LHASH", it's just been renamed and made internal by upstream: https://github.com/aws/aws-lc/commit/b8441aced4090488a31375af81c4f7e5014fe791. Ruby's CONF module happens to have a [dependency](https://github.com/ruby/ruby/blob/ee1cd1656fc667840282a4e9c3f2cc5e3154e50e/ext/openssl/ossl_config.c#L255) on a couple of LHASH macros OpenSSL created and the non-opaqueness of `CONF`.
Although we aren't likely to be supporting CONF files for the time being, this change seems to reasonable for enough us to maintain so we can get a better build/patch for Ruby. We still fail most CONF related tests in Ruby, so we'll have to work around those. But this commit lets us gracefully build with the underlying C code for Ruby CONF without any AWS-LC specific logic. 


### Call-outs:
N/A

### Testing:
Verified that this passes the build for Ruby

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
