### PR TITLE
Add Cyrus-SASL to our CI

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -149,6 +149,19 @@ jobs:
       - name: Build AWS-LC, build openldap, run tests
         run: |
           ./tests/ci/integration/run_openldap_integration.sh master OPENLDAP_REL_ENG_2_5
+  cyrus-sasl:
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-latest
+    name: Cyrus-SASL
+    steps:
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
+      - uses: actions/checkout@v3
+      - name: Build AWS-LC, build cyrus, run tests
+        run: |
+          ./tests/ci/integration/run_cyrus_sasl_integration.sh
   bind9:
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -159,7 +159,7 @@ jobs:
           sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
           sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
       - uses: actions/checkout@v3
-      - name: Build AWS-LC, build cyrus, run tests
+      - name: Build AWS-LC, build cyrus
         run: |
           ./tests/ci/integration/run_cyrus_sasl_integration.sh
   bind9:

--- a/tests/ci/integration/run_cyrus_sasl_integration.sh
+++ b/tests/ci/integration/run_cyrus_sasl_integration.sh
@@ -20,7 +20,6 @@ SCRATCH_FOLDER="${SRC_ROOT}/CYRUS_BUILD_ROOT"
 CYRUS_SRC_FOLDER="${SCRATCH_FOLDER}/cyrus"
 CYRUS_BUILD_PREFIX="${CYRUS_SRC_FOLDER}/build/install"
 CYRUS_BUILD_EPREFIX="${CYRUS_SRC_FOLDER}/build/exec-install"
-CYRUS_PATCH_FOLDER="${SRC_ROOT}/tests/ci/integration/cyrus_patch"
 
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
@@ -29,27 +28,26 @@ mkdir -p ${SCRATCH_FOLDER}
 rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
-function cyrus_build() {
-   sh ./autogen.sh \
-   --prefix="$CYRUS_BUILD_PREFIX" \
-   --exec-prefix="$CYRUS_BUILD_EPREFIX" \
-   --with-openssl="$AWS_LC_INSTALL_FOLDER"
+export CFLAGS="-I$AWS_LC_INSTALL_FOLDER/include ${CFLAGS:=}"
+export CPPFLAGS="-I$AWS_LC_INSTALL_FOLDER/include ${CXXFLAGS:=}"
+export CXXFLAGS="-I$AWS_LC_INSTALL_FOLDER/include ${CXXFLAGS:=}"
+export LDFLAGS="-L$AWS_LC_INSTALL_FOLDER/lib ${LDFLAGS:=}"
 
+function cyrus_build() {
+  sh ./autogen.sh \
+  --prefix="$CYRUS_BUILD_PREFIX" \
+  --exec-prefix="$CYRUS_BUILD_EPREFIX" \
+  --with-openssl="$AWS_LC_INSTALL_FOLDER"
 
   make -j install
+
+  # Assert Cyrus-SASL was built with AWS-LC
+  local cyrus_executable="${CYRUS_SRC_FOLDER}/build/exec-install/lib/libsasl2.so"
+  ldd ${cyrus_executable} \
+    | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
 }
 
-## TODO: Remove this when we make an upstream contribution.
-#function nmap_patch_build() {
-#   for patchfile in $(find -L "${NMAP_PATCH_FOLDER}" -type f -name '*.patch'); do
-#     echo "Apply patch $patchfile..."
-#     patch -p1 --quiet -i "$patchfile"
-#   done
-#}
-
-function cyrus_run_tests() {
-  make check
-}
+# TO-DO: Setup Kerberos and DB, then use sample client and server programs to test GSSAPI
 
 git clone --depth 1 https://github.com/cyrusimap/cyrus-sasl.git ${CYRUS_SRC_FOLDER}
 cd ${CYRUS_SRC_FOLDER}
@@ -58,10 +56,8 @@ ls
 
 aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${AWS_LC_INSTALL_FOLDER}/lib/"
+export LD_LIBRARY_PATH="${AWS_LC_INSTALL_FOLDER}/lib/":${LD_LIBRARY_PATH:-}
 
 # Build cyrus from source.
 pushd ${CYRUS_SRC_FOLDER}
-#nmap_patch_build
 cyrus_build
-cyrus_run_tests

--- a/tests/ci/integration/run_cyrus_sasl_integration.sh
+++ b/tests/ci/integration/run_cyrus_sasl_integration.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -exu
+
+source tests/ci/common_posix_setup.sh
+
+# Set up environment.
+
+# SYS_ROOT
+#  - SRC_ROOT(aws-lc)
+#    - SCRATCH_FOLDER
+#      - CYRUS_SRC_FOLDER
+#      - AWS_LC_BUILD_FOLDER
+#      - AWS_LC_INSTALL_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER="${SRC_ROOT}/CYRUS_BUILD_ROOT"
+CYRUS_SRC_FOLDER="${SCRATCH_FOLDER}/cyrus"
+CYRUS_BUILD_PREFIX="${CYRUS_SRC_FOLDER}/build/install"
+CYRUS_BUILD_EPREFIX="${CYRUS_SRC_FOLDER}/build/exec-install"
+CYRUS_PATCH_FOLDER="${SRC_ROOT}/tests/ci/integration/cyrus_patch"
+
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf "${SCRATCH_FOLDER:?}"/*
+cd ${SCRATCH_FOLDER}
+
+function cyrus_build() {
+   sh ./autogen.sh \
+   --prefix="$CYRUS_BUILD_PREFIX" \
+   --exec-prefix="$CYRUS_BUILD_EPREFIX" \
+   --with-openssl="$AWS_LC_INSTALL_FOLDER"
+
+
+  make -j install
+}
+
+## TODO: Remove this when we make an upstream contribution.
+#function nmap_patch_build() {
+#   for patchfile in $(find -L "${NMAP_PATCH_FOLDER}" -type f -name '*.patch'); do
+#     echo "Apply patch $patchfile..."
+#     patch -p1 --quiet -i "$patchfile"
+#   done
+#}
+
+function cyrus_run_tests() {
+  make check
+}
+
+git clone --depth 1 https://github.com/cyrusimap/cyrus-sasl.git ${CYRUS_SRC_FOLDER}
+cd ${CYRUS_SRC_FOLDER}
+mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
+ls
+
+aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
+
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${AWS_LC_INSTALL_FOLDER}/lib/"
+
+# Build cyrus from source.
+pushd ${CYRUS_SRC_FOLDER}
+#nmap_patch_build
+cyrus_build
+cyrus_run_tests


### PR DESCRIPTION
### Issues:
`CryptoAlg-2554`

### Description of changes: 
Add Cyrus-SASL to our CI

### Call-outs:
There is no general testing suite for Cyrus. To test the GSSAPI with Kerberos, we can use provided sample_client and sample_server applications. However, this requires a working Kerberos setup with a KDC and another script to support communication between the sample_client and server programs. This is not being added as of now. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
