### PR TITLE
Cleanup test File utilities

### DIFF
--- a/crypto/test/file_util.cc
+++ b/crypto/test/file_util.cc
@@ -122,7 +122,9 @@ bool TemporaryFile::Init(bssl::Span<const uint8_t> content) {
 #else
   std::string path = temp_dir + "bssl_tmp_file.XXXXXX";
   // TODO(davidben): Use |path.data()| when we require C++17.
+  mode_t prev_umask = umask(S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
   int fd = mkstemp(&path[0]);
+  umask(prev_umask);
   if (fd < 0) {
     perror("Could not create temporary file");
     return false;

--- a/crypto/test/file_util.h
+++ b/crypto/test/file_util.h
@@ -46,11 +46,14 @@ class ScopedFD {
   explicit ScopedFD(int fd) : fd_(fd) {}
   ~ScopedFD() { reset(); }
 
-  ScopedFD(ScopedFD &&other) { *this = std::move(other); }
-  ScopedFD &operator=(ScopedFD other) {
+  ScopedFD(ScopedFD &&other) noexcept { *this = std::move(other); }
+  ScopedFD &operator=(ScopedFD&& other) {
     reset(other.release());
     return *this;
   }
+
+  ScopedFD(const ScopedFD &other) = delete;
+  ScopedFD &operator=(ScopedFD& other) = delete;
 
   bool is_valid() const { return fd_ >= 0; }
   int get() const { return fd_; }

--- a/crypto/test/file_util.h
+++ b/crypto/test/file_util.h
@@ -85,7 +85,7 @@ class TemporaryFile {
   TemporaryFile() = default;
   ~TemporaryFile();
 
-  TemporaryFile(TemporaryFile &other) { *this = std::move(other); }
+  TemporaryFile(TemporaryFile&& other) noexcept { *this = std::move(other); }
   TemporaryFile& operator=(TemporaryFile&&other) {
     // Ensure |path_| is empty so it doesn't try to delete the File.
     auto old_other_path = other.path_;
@@ -93,6 +93,9 @@ class TemporaryFile {
     path_ = old_other_path;
     return *this;
   }
+
+  TemporaryFile(const TemporaryFile&) = delete;
+  TemporaryFile& operator=(const TemporaryFile&) = delete;
 
   // Init initializes the temporary file with the specified content. It returns
   // true on success and false on error. On error, callers should call


### PR DESCRIPTION
### Issues:
Addresses: P168988559

### Description of changes: 
* Only use move semantic for `TemporaryFile` and `ScopedFD`.
* Set umask prior to creating temporary file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
