### PR TITLE
Fix no-thread test and default generation value

### DIFF
--- a/crypto/fipsmodule/rand/new_rand.c
+++ b/crypto/fipsmodule/rand/new_rand.c
@@ -331,7 +331,12 @@ static void rand_state_initialize(struct rand_thread_local_state *state) {
 
   state->reseed_calls_since_initialization = 0;
   state->generate_calls_since_seed = 0;
-  state->generation_number = 0;
+  uint64_t current_generation_number = 0;
+  if (CRYPTO_get_ube_generation_number(&current_generation_number) != 1) {
+    state->generation_number = 0;
+  } else {
+    state->generation_number = current_generation_number;
+  }
   CRYPTO_MUTEX_init(&state->state_clear_lock);
 
   OPENSSL_cleanse(seed, CTR_DRBG_ENTROPY_LEN);

--- a/crypto/fipsmodule/rand/new_rand_test.cc
+++ b/crypto/fipsmodule/rand/new_rand_test.cc
@@ -60,7 +60,9 @@ TEST(NewRand, Basic) {
     ASSERT_TRUE(myFlags[i]) << "Thread " << i << " failed.";
   }
 #else
-  randBasicTests();
+  bool myFlag = false;
+  randBasicTests(&myFlag);
+  ASSERT_TRUE(myFlag);
 #endif
 }
 

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -50,7 +50,7 @@ fi
 
 # Lightly verify that uncommon build options does not break the build. Fist
 # define a list of typical build options to verify the special build option with
-build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DDISABLE_PERL=ON -DDISABLE_GO=ON")
+build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DDISABLE_PERL=ON -DDISABLE_GO=ON" "-DOPENSSL_NO_THREADS_CORRUPT_MEMORY_AND_LEAK_SECRETS_IF_THREADED=1")
 
 ## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
 for build_option in "${build_options_to_test[@]}"; do


### PR DESCRIPTION
### Description of changes: 

Default generation number value should be the current value to avoid an immediate reseed.

The function used in the randomness generation test for no-thread was missing an argument. Not caught because no build in CI exercise that code path (apparently). Can invoke that by defining `OPENSSL_NO_THREADS_CORRUPT_MEMORY_AND_LEAK_SECRETS_IF_THREADED`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
