### PR TITLE
Allow ASN1_get_object to parse indefinite and universal

### DIFF
--- a/crypto/asn1/asn1_test.cc
+++ b/crypto/asn1/asn1_test.cc
@@ -2303,7 +2303,8 @@ TEST(ASN1Test, GetObject) {
 
   static const uint8_t kIndefinite[] = {0x30, 0x80, 0x00, 0x00};
   ptr = kIndefinite;
-  EXPECT_EQ(0x80, ASN1_get_object(&ptr, &length, &tag, &tag_class,
+  // 0x21 indicates the indefinite form
+  EXPECT_EQ(0x21, ASN1_get_object(&ptr, &length, &tag, &tag_class,
                                   sizeof(kIndefinite)));
 }
 

--- a/crypto/asn1/asn1_test.cc
+++ b/crypto/asn1/asn1_test.cc
@@ -2291,21 +2291,69 @@ TEST(ASN1Test, PrintASN1Object) {
             std::string(reinterpret_cast<const char *>(bio_data), bio_len));
 }
 
-TEST(ASN1Test, GetObject) {
-  // The header is valid, but there are not enough bytes for the length.
-  static const uint8_t kTruncated[] = {0x30, 0x01};
-  const uint8_t *ptr = kTruncated;
+const struct GetObjectTestData {
+  std::vector<uint8_t> in;
+  const int expected_return;
+  const int expected_tag;
+  const int expected_class;
+  const int expected_length;
+} kGetObjectTests[] = {
+    // OpenSSL succeeds for all test cases below.
+    // The header is valid, but there are not enough bytes for the length.
+    {{0x30, 0x01}, 0x80, 0, 0, 0},
+    {{0x30, 0x80, 0x00, 0x00}, 0x21, 0x10, 0, 0},
+    {{0x00, 0x00}, 0x00, 0x00, 0x00, 0},
+    {{0x01, 0x00}, 0x00, 0x01, 0x00, 0},
+    {{0x41, 0x00}, 0x00, 0x01, 0x40, 0},
+    {{0x81, 0x00}, 0x00, 0x01, 0x80, 0},
+    {{0xC1, 0x00}, 0x00, 0x01, 0xC0, 0},
+    {{0x1F, 0x20, 0x00}, 0x00, 0x20, 0x00, 0},
+      // Rejected to avoid ambiguity with V_ASN1_NEG. Ruby has a test case expecting this to succeed.
+    {{0x1F, 0xC0, 0x20, 0x00}, 0x80, 0x00, 0x00, 0},
+    {{0x41, 0x02, 0xAB, 0xCD}, 0x00, 0x01, 0x40, 2},
+    {{0x61, 0x00}, 0x20, 0x01, 0x40, 0},
+    {{0x61, 0x80, 0xC2, 0x02, 0xAB, 0xCD, 0x00, 0x00}, 0x21, 0x01, 0x40, 0},
+};
+
+static void verifyGetObject(GetObjectTestData t) {
   long length;
   int tag;
   int tag_class;
-  EXPECT_EQ(0x80, ASN1_get_object(&ptr, &length, &tag, &tag_class,
-                                  sizeof(kTruncated)));
 
-  static const uint8_t kIndefinite[] = {0x30, 0x80, 0x00, 0x00};
-  ptr = kIndefinite;
-  // 0x21 indicates the indefinite form
-  EXPECT_EQ(0x21, ASN1_get_object(&ptr, &length, &tag, &tag_class,
-                                  sizeof(kIndefinite)));
+  SCOPED_TRACE(Bytes(t.in));
+  const uint8_t *ptr = t.in.data();
+  EXPECT_EQ(t.expected_return,
+            ASN1_get_object(&ptr, &length, &tag, &tag_class, t.in.size()));
+  if (!(t.expected_return & 0x80)) {
+    EXPECT_EQ(t.expected_length, length);
+    EXPECT_EQ(t.expected_tag, tag);
+    EXPECT_EQ(t.expected_class, tag_class);
+  }
+}
+
+TEST(ASN1Test, GetObject) {
+  for (const auto &t : kGetObjectTests) {
+    verifyGetObject(t);
+  }
+
+  {
+    GetObjectTestData test_case{ {0x41, 0x81, 0x80}, 0x00, 0x01, 0x40, 128 };
+    for(int i = 0; i < 64; i++) {
+      test_case.in.push_back(0xAB);
+      test_case.in.push_back(0xCD);
+    }
+    verifyGetObject(test_case);
+  }
+
+  {
+    GetObjectTestData test_case{ {0x41, 0x82, 0x01, 0x00}, 0x00, 0x01, 0x40, 256 };
+    for(int i = 0; i < 128; i++) {
+      test_case.in.push_back(0xAB);
+      test_case.in.push_back(0xCD);
+    }
+    verifyGetObject(test_case);
+  }
+
 }
 
 template <typename T>

--- a/crypto/asn1/internal.h
+++ b/crypto/asn1/internal.h
@@ -217,6 +217,21 @@ void asn1_type_cleanup(ASN1_TYPE *a);
 // ASN.1 PrintableString, and zero otherwise.
 int asn1_is_printable(uint32_t value);
 
+// asn1_get_object_maybe_indefinite parses an ASN.1 header, including tag, class,
+// and length information. The tag number is written to |*out_tag|. The class is
+// written to |*out_class|. If the tag is not indefinite, the content length is
+// written to |*out_len|. |inp| is advanced past the header in the input buffer.
+//
+// If |indefinite_ok| is non-zero, indefinite-length encoding and universal tags
+// are allowed, otherwise these will produce errors.
+//
+// The return value may have the following bits set:
+//   * 0x80: error occurred while parsing.
+//   * 0x20: the encoding is constructed, not primitive.
+//   * 0x01: indefinite-length constructed encoding.
+int asn1_get_object_maybe_indefinite(const unsigned char **inp, long *out_len, int *out_tag,
+                        int *out_class, long in_len, int indefinite_ok);
+
 // asn1_bit_string_length returns the number of bytes in |str| and sets
 // |*out_padding_bits| to the number of padding bits.
 //

--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -867,7 +867,7 @@ static int asn1_check_tlen(long *olen, int *otag, unsigned char *oclass,
   const unsigned char *p;
   p = *in;
 
-  i = ASN1_get_object(&p, &plen, &ptag, &pclass, len);
+  i = asn1_get_object_maybe_indefinite(&p, &plen, &ptag, &pclass, len, /*indefinite_ok=*/0);
   if (i & 0x80) {
     OPENSSL_PUT_ERROR(ASN1, ASN1_R_BAD_OBJECT_HEADER);
     return 0;

--- a/crypto/bytestring/internal.h
+++ b/crypto/bytestring/internal.h
@@ -88,6 +88,26 @@ OPENSSL_EXPORT int cbb_add_latin1(CBB *cbb, uint32_t u);
 OPENSSL_EXPORT int cbb_add_ucs2_be(CBB *cbb, uint32_t u);
 OPENSSL_EXPORT int cbb_add_utf32_be(CBB *cbb, uint32_t u);
 
+// cbs_get_any_asn1_element parses an ASN.1 element from |cbs|. |*out_indefinite|
+// is set to one if the length was indefinite and zero otherwise. On success,
+// if the length is indefinite |out| will only contain the ASN.1 header,
+// otherwise is will contain both the header and the content. If |out_tag| is
+// not NULL, |*out_tag| is set to the element's tag number. If |out_header_len|
+// is not NULL, |*out_header_len| is set to the length of the header.
+//
+// If |ber_ok| is one, BER encoding is permitted. In this case, if
+// |out_ber_found| is not NULL and BER-specific encoding was found,
+// |*out_ber_found| is set to one. If |out_indefinite| is not NULL and the
+// element has indefinite-length, |*out_indefinite| is set to one.
+// If |ber_ok| is zero, both |out_ber_found| and |out_indefinite| must be NULL.
+//
+// If |universal_tag_ok| is 1, universal tags are permitted. Otherwise, only
+// context-specific tags are accepted.
+//
+// It returns one on success and zero on failure.
+int cbs_get_any_asn1_element(CBS *cbs, CBS *out, CBS_ASN1_TAG *out_tag,
+                                      size_t *out_header_len, int *out_ber_found,
+                                      int *out_indefinite, int ber_ok, int universal_tag_ok);
 
 #if defined(__cplusplus)
 }  // extern C


### PR DESCRIPTION
### Issues:
Addresses: CryptoAlg-2693

### Description of changes: 
* Loosen the restrictions on ASN1 parsing on calls made to `ASN1_get_object`. Other places that parse ASN1 should be unaffected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
