### PR TITLE
Fix perl handling of paths w/ spaces

### DIFF
--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, windows-latest, macos-14-xlarge ]
         fips:
           - "0"
           - "1"

--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -115,5 +115,7 @@ jobs:
           options: CMAKE_BUILD_TYPE=Release FIPS=1 BUILD_SHARED_LIBS=${{ (matrix.os == 'ubuntu-latest' && '0') || '1' }}
       - name: Build Project
         run: cmake --build "path has spaces/build-fips" --target all
-      - name: Run tests
+        # TODO: Fix the FIPS ACVP tests on Windows to handle spaces in the path
+      - if: ${{ matrix.os != 'windows-latest' }}
+        name: Run tests
         run: cmake --build "path has spaces/build-fips" --target run_tests

--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -77,3 +77,37 @@ jobs:
           echo "Error: PR description does not contain the required license statement."
           exit 1
         fi
+  path-has-spaces:
+    if: github.repository_owner == 'aws'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-13, macos-14-xlarge ]
+        fips:
+          - "0"
+          - "1"
+    steps:
+      - if: ${{ matrix.os == 'windows-latest' }}
+        name: Install NASM
+        uses: ilammy/setup-nasm@v1.5.1
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: "path has spaces/aws-lc"
+      - if: ${{ matrix.os != 'windows-latest' }}
+        name: See directory
+        run: pwd
+      - name: Setup CMake
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          source-dir: 'path has spaces/aws-lc'
+          build-dir: 'path has spaces/build'
+          generator: Ninja
+      - name: Build Project
+        run: cmake --build "path has spaces/build" --target all
+      - name: Run tests
+        run: cmake --build "path has spaces/build" --target run_tests

--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -84,9 +84,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-14-xlarge ]
-        fips:
-          - "0"
-          - "1"
     steps:
       - if: ${{ matrix.os == 'windows-latest' }}
         name: Install NASM
@@ -98,15 +95,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: "path has spaces/aws-lc"
-      - if: ${{ matrix.os != 'windows-latest' }}
-        name: See directory
-        run: pwd
       - name: Setup CMake
         uses: threeal/cmake-action@v1.3.0
         with:
           source-dir: 'path has spaces/aws-lc'
           build-dir: 'path has spaces/build'
           generator: Ninja
+      - name: Build Project
+        run: cmake --build "path has spaces/build" --target all
+      - name: Run tests
+        run: cmake --build "path has spaces/build" --target run_tests
+      - name: Setup CMake FIPS
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          source-dir: 'path has spaces/aws-lc'
+          build-dir: 'path has spaces/build'
+          generator: Ninja
+          options: FIPS=1 BUILD_SHARED_LIBS=${{ (matrix.os == 'ubuntu-latest' && '0') || '1' }}
       - name: Build Project
         run: cmake --build "path has spaces/build" --target all
       - name: Run tests

--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -95,6 +95,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: "path has spaces/aws-lc"
+      - uses: ilammy/msvc-dev-cmd@v1
       - name: Setup CMake
         uses: threeal/cmake-action@v1.3.0
         with:
@@ -111,7 +112,7 @@ jobs:
           source-dir: 'path has spaces/aws-lc'
           build-dir: 'path has spaces/build-fips'
           generator: Ninja
-          options: FIPS=1 BUILD_SHARED_LIBS=${{ (matrix.os == 'ubuntu-latest' && '0') || '1' }}
+          options: CMAKE_BUILD_TYPE=Release FIPS=1 BUILD_SHARED_LIBS=${{ (matrix.os == 'ubuntu-latest' && '0') || '1' }}
       - name: Build Project
         run: cmake --build "path has spaces/build-fips" --target all
       - name: Run tests

--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -109,10 +109,10 @@ jobs:
         uses: threeal/cmake-action@v1.3.0
         with:
           source-dir: 'path has spaces/aws-lc'
-          build-dir: 'path has spaces/build'
+          build-dir: 'path has spaces/build-fips'
           generator: Ninja
           options: FIPS=1 BUILD_SHARED_LIBS=${{ (matrix.os == 'ubuntu-latest' && '0') || '1' }}
       - name: Build Project
-        run: cmake --build "path has spaces/build" --target all
+        run: cmake --build "path has spaces/build-fips" --target all
       - name: Run tests
-        run: cmake --build "path has spaces/build" --target run_tests
+        run: cmake --build "path has spaces/build-fips" --target run_tests

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -16,6 +16,8 @@ jobs:
         uses: ilammy/setup-nasm@v1.5.1
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: "path has spaces/aws-lc"
       - name: Setup MinGW
         uses: egor-tensin/setup-mingw@v2.2.0
         id: setup_mingw
@@ -25,6 +27,8 @@ jobs:
         uses: threeal/cmake-action@v1.3.0
         with:
           generator: Ninja
+          source-dir: 'path has spaces/aws-lc'
+          build-dir: 'path has spaces/build'
           c-compiler: ${{ steps.setup_mingw.outputs.gcc }}
           cxx-compiler: ${{ steps.setup_mingw.outputs.gxx }}
           options: |
@@ -37,9 +41,9 @@ jobs:
             CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
             CMAKE_BUILD_TYPE=Release \
       - name: Build Project
-        run: cmake --build ./build --target all
+        run: cmake --build "path has spaces/build" --target all
       - name: Run tests
-        run: cmake --build ./build --target run_tests
+        run: cmake --build "path has spaces/build" --target run_tests
   clang:
     if: github.repository_owner == 'aws'
     runs-on: windows-latest

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -140,10 +140,16 @@ if(PERL_EXECUTABLE)
       set(PERLASM_FLAGS "${PERLASM_FLAGS} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX")
     endif()
 
+    set(PERL_COMMAND "${PERL_EXECUTABLE}")
+    list(APPEND PERL_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/${src}")
+    list(APPEND PERL_COMMAND "${PERLASM_STYLE}")
+    list(APPEND PERL_COMMAND "${dest}")
+    list(APPEND PERL_COMMAND ${PERLASM_FLAGS})
+
     add_custom_command(
       OUTPUT ${dest}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
-      COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${src} ${PERLASM_STYLE} ${dest} ${PERLASM_FLAGS}
+      COMMAND ${PERL_COMMAND}
       DEPENDS
       ${src}
       ${PROJECT_SOURCE_DIR}/crypto/perlasm/arm-xlate.pl

--- a/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
+++ b/crypto/cipher_extra/asm/chacha20_poly1305_armv8.pl
@@ -32,7 +32,7 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../perlasm/arm-xlate.pl" and -f $xlate) or
 die "can't locate arm-xlate.pl";
 
-open OUT,"| \"$^X\" $xlate $flavour $output";
+open OUT, qq{| "$^X" "$xlate" $flavour "$output"};
 *STDOUT=*OUT;
 
 my ($oup,$inp,$inl,$adp,$adl,$keyp,$itr1,$itr2) = ("x0","x1","x2","x3","x4","x5","x6","x7");

--- a/crypto/fipsmodule/ec/asm/p256-armv8-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256-armv8-asm.pl
@@ -43,7 +43,7 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../../perlasm/arm-xlate.pl" and -f $xlate) or
 die "can't locate arm-xlate.pl";
 
-open OUT,"| \"$^X\" $xlate $flavour $output";
+open OUT, qq{| "$^X" "$xlate" $flavour "$output"};
 *STDOUT=*OUT;
 
 {

--- a/crypto/fipsmodule/ec/asm/p256_beeu-armv8-asm.pl
+++ b/crypto/fipsmodule/ec/asm/p256_beeu-armv8-asm.pl
@@ -15,7 +15,7 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../../perlasm/arm-xlate.pl" and -f $xlate) or
 die "can't locate arm-xlate.pl";
 
-open OUT,"| \"$^X\" $xlate $flavour $output";
+open OUT, qq{| "$^X" "$xlate" $flavour "$output"};
 *STDOUT=*OUT;
 #############################################################################
 # extern int beeu_mod_inverse_vartime(BN_ULONG out[P256_LIMBS],

--- a/crypto/fipsmodule/md5/asm/md5-armv8.pl
+++ b/crypto/fipsmodule/md5/asm/md5-armv8.pl
@@ -24,7 +24,7 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; my $dir=$1; my $xlate;
 ( $xlate="${dir}../../../perlasm/arm-xlate.pl" and -f $xlate) or
 die "can't locate arm-xlate.pl";
 
-open OUT,"| \"$^X\" $xlate $flavour \"$output\""
+open OUT, qq{| "$^X" "$xlate" $flavour "$output"}
     or die "can't call $xlate: $1";
 *STDOUT=*OUT;
 

--- a/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
+++ b/crypto/fipsmodule/modes/asm/aesv8-gcm-armv8.pl
@@ -191,7 +191,7 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../../perlasm/arm-xlate.pl" and -f $xlate) or
 die "can't locate arm-xlate.pl";
 
-open OUT,"| \"$^X\" $xlate $flavour $output";
+open OUT, qq{| "$^X" "$xlate" $flavour "$output"};
 *STDOUT=*OUT;
 
 $code=<<___;


### PR DESCRIPTION
### Description of changes: 
Build was failing when the source path contained spaces. This is due to there not being quotes around the `$xlate` and `$output` at the start of the script.

### Call-outs:
* Although this change alters a few Perl scripts, no changes are made to the assembly files they produce.

### Testing:
Added a test that sets up the paths for both the source and build directories to contain spaces.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
