### PR TITLE
strdup is not C99

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -106,6 +106,16 @@
  * (eay@cryptsoft.com).  This product includes software written by Tim
  * Hudson (tjh@cryptsoft.com). */
 
+// `strdup` was only officially added in C23:
+// * https://en.cppreference.com/w/c/string/byte/strdup
+// The following macros are needed to ensure its definition
+// is provided by the headers.
+#ifdef __STDC_ALLOC_LIB__
+#define __STDC_WANT_LIB_EXT2__ 1
+#else
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 // Ensure we can't call OPENSSL_malloc circularly.
 #define _BORINGSSL_PROHIBIT_OPENSSL_MALLOC
 #include <openssl/err.h>


### PR DESCRIPTION
### Issues:
Addresses:
* aws/aws-lc-rs#610

### Description of changes: 
`strdup` was only officially [added to libc in C23](https://en.cppreference.com/w/c/string/byte/strdup). Platforms we support may require the `__STDC_WANT_LIB_EXT2__` or `_POSIX_C_SOURCE` macros to be defined prior to the inclusion of the "string.h" header.

### Call-outs:
* Reference: https://en.cppreference.com/w/c/experimental/dynamic/strdup


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
