### PR TITLE
Fail FIPS rsa_keygen_pubexp on change

### DIFF
--- a/crypto/fipsmodule/evp/evp_ctx_test.cc
+++ b/crypto/fipsmodule/evp/evp_ctx_test.cc
@@ -130,11 +130,13 @@ TEST_F(EvpPkeyCtxCtrlStrTest, RsaKeygenPubexp) {
   ASSERT_TRUE(ctx);
   ASSERT_TRUE(EVP_PKEY_keygen_init(ctx.get()));
 #if defined(BORINGSSL_FIPS)
+  ASSERT_EQ(EVP_PKEY_CTX_ctrl_str(ctx.get(), "rsa_keygen_pubexp", "65537"), 1);
   ASSERT_EQ(EVP_PKEY_CTX_ctrl_str(ctx.get(), "rsa_keygen_pubexp", "729"), 0);
 #else
-  EVP_PKEY *raw = nullptr;
   ASSERT_EQ(EVP_PKEY_CTX_ctrl_str(ctx.get(), "rsa_keygen_pubexp", "729"), 1);
+#endif
   ASSERT_EQ(EVP_PKEY_CTX_ctrl_str(ctx.get(), "rsa_keygen_pubexp", "gg"), -2);
+  EVP_PKEY *raw = nullptr;
   ASSERT_TRUE(EVP_PKEY_keygen(ctx.get(), &raw));
   bssl::UniquePtr<EVP_PKEY> pkey(raw);
   ASSERT_TRUE(pkey);
@@ -143,12 +145,15 @@ TEST_F(EvpPkeyCtxCtrlStrTest, RsaKeygenPubexp) {
   ASSERT_TRUE(rsa_key);
   const BIGNUM *const_pe_bn = RSA_get0_e(rsa_key.get());
   ASSERT_TRUE(const_pe_bn != nullptr);
-
+#if defined(BORINGSSL_FIPS)
+  const uint64_t expected_pe = 65537;
+#else
   const uint64_t expected_pe = 729;
+#endif
   uint64_t pe_u64;
   ASSERT_TRUE(BN_get_u64(const_pe_bn, &pe_u64));
   EXPECT_EQ(pe_u64, expected_pe);
-#endif
+
 }
 
 TEST_F(EvpPkeyCtxCtrlStrTest, RsaMgf1Md) {

--- a/crypto/fipsmodule/evp/p_rsa.c
+++ b/crypto/fipsmodule/evp/p_rsa.c
@@ -558,18 +558,18 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2) {
       return 1;
 
     case EVP_PKEY_CTRL_RSA_KEYGEN_PUBEXP:
-#if defined(AWSLC_FIPS)
-      OPENSSL_PUT_ERROR(EVP, EVP_R_INVALID_OPERATION);
-      return 0;
-#else
       if (!p2) {
         return 0;
       }
+#if defined(AWSLC_FIPS)
+      if (BN_get_word(p2) != RSA_F4) {
+        OPENSSL_PUT_ERROR(EVP, EVP_R_INVALID_OPERATION);
+        return 0;
+      }
+#endif
       BN_free(rctx->pub_exp);
       rctx->pub_exp = p2;
       return 1;
-#endif
-
     case EVP_PKEY_CTRL_RSA_OAEP_MD:
     case EVP_PKEY_CTRL_GET_RSA_OAEP_MD:
       if (rctx->pad_mode != RSA_PKCS1_OAEP_PADDING) {


### PR DESCRIPTION
### Description of changes: 
* FIPS only allows 0x10001 for public exponent.  We will fail any attempt to change that when in FIPS mode.

### Testing:
Updated tests to provide better coverage for FIPS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
