### PR TITLE
Expose BN_set_flags as a no-op

### DIFF
--- a/crypto/fipsmodule/bn/bn.c
+++ b/crypto/fipsmodule/bn/bn.c
@@ -445,3 +445,5 @@ void bn_set_minimal_width(BIGNUM *bn) {
 int BN_get_flags(const BIGNUM *bn, int flags) {
   return bn->flags & flags;
 }
+
+void BN_set_flags(BIGNUM *b, int n) { }

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -1021,6 +1021,11 @@ OPENSSL_EXPORT int BN_mod_exp_mont_consttime_x2(BIGNUM *rr1, const BIGNUM *a1, c
                                                 const BIGNUM *m2, const BN_MONT_CTX *in_mont2,
                                                 BN_CTX *ctx);
 
+// BN_set_flags does nothing. See comments regarding |BN_FLG_CONSTTIME| being
+// intentionally omitted for more details.
+OPENSSL_DEPRECATED OPENSSL_EXPORT void BN_set_flags(BIGNUM *b, int n);
+
+
 // Private functions
 
 struct bignum_st {
@@ -1066,7 +1071,6 @@ OPENSSL_EXPORT unsigned BN_num_bits_word(BN_ULONG l);
 #define BN_FLG_STATIC_DATA 0x02
 
 #ifdef AWS_LC_INTERNAL_IGNORE_BN_SET_FLAGS
-#define BN_set_flags(x, y) /* Ignored */
 #define BN_FLG_CONSTTIME 0x04
 #endif /* AWS_LC_INTERNAL_IGNORE_BN_SET_FLAGS */
 

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -1070,10 +1070,6 @@ OPENSSL_EXPORT unsigned BN_num_bits_word(BN_ULONG l);
 #define BN_FLG_MALLOCED 0x01
 #define BN_FLG_STATIC_DATA 0x02
 
-#ifdef AWS_LC_INTERNAL_IGNORE_BN_SET_FLAGS
-#define BN_FLG_CONSTTIME 0x04
-#endif /* AWS_LC_INTERNAL_IGNORE_BN_SET_FLAGS */
-
 // |BN_FLG_CONSTTIME| has been removed and intentionally omitted so code relying
 // on it will not compile unless the flag above is set. Consumers should use the
 // higher-level cryptographic algorithms exposed by other modules. Consumers

--- a/tests/ci/integration/run_openssh_integration.sh
+++ b/tests/ci/integration/run_openssh_integration.sh
@@ -52,7 +52,7 @@ function openssh_build() {
   # The RSA_meth_XXX functions are not implemented by AWS-LC, and the implementation provided by OpenSSH also doesn't compile for us.
   # Fortunately, these functions are only needed for pkcs11 support, which is disabled for our build.
   # See: https://github.com/openssh/openssh-portable/pull/385
-  export CFLAGS="-DAWS_LC_INTERNAL_IGNORE_BN_SET_FLAGS=1 -DHAVE_RSA_METH_FREE=1 -DHAVE_RSA_METH_DUP=1 -DHAVE_RSA_METH_SET1_NAME=1 -DHAVE_RSA_METH_GET_FINISH=1 -DHAVE_RSA_METH_SET_PRIV_ENC=1 -DHAVE_RSA_METH_SET_PRIV_DEC=1 -DHAVE_RSA_METH_SET_FINISH=1 "
+  export CFLAGS="-DBN_FLG_CONSTTIME=0x04 -DHAVE_RSA_METH_FREE=1 -DHAVE_RSA_METH_DUP=1 -DHAVE_RSA_METH_SET1_NAME=1 -DHAVE_RSA_METH_GET_FINISH=1 -DHAVE_RSA_METH_SET_PRIV_ENC=1 -DHAVE_RSA_METH_SET_PRIV_DEC=1 -DHAVE_RSA_METH_SET_FINISH=1 "
   ./configure --with-ssl-dir="${AWS_LC_INSTALL_FOLDER}" --prefix="${OPENSSH_INSTALL_FOLDER}" --disable-pkcs11
   make -j "$NUM_CPU_THREADS"
   make install


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1477`

### Description of changes: 
We're currently leaning towards continuing to not support `BN_FLG_CONSTTIME`. It's a problematic flag that's poorly documented and could lead to constant time violations if we aren't careful.
We can expose `BN_set_flags` as a no-op however. Ruby has logic to get around the `BN_FLG_CONSTTIME` flag, but not around `BN_set/get_flags`. Exposing the set symbol would allow for a cleaner patch/build.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
