### PR TITLE
Update aws-lc-nginx.patch

### DIFF
--- a/tests/ci/integration/nginx_patch/aws-lc-nginx.patch
+++ b/tests/ci/integration/nginx_patch/aws-lc-nginx.patch
@@ -1,5 +1,4 @@
-diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
-index c062f91..447f003 100644
+diff --color=auto --color -uNr a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
 --- a/src/event/ngx_event_openssl.h
 +++ b/src/event/ngx_event_openssl.h
 @@ -25,7 +25,7 @@
@@ -11,11 +10,10 @@ index c062f91..447f003 100644
  #include <openssl/hkdf.h>
  #include <openssl/chacha.h>
  #else
-diff --git a/src/event/quic/ngx_event_quic.c b/src/event/quic/ngx_event_quic.c
-index b0cf056..c1ba43f 100644
+diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic.c b/src/event/quic/ngx_event_quic.c
 --- a/src/event/quic/ngx_event_quic.c
 +++ b/src/event/quic/ngx_event_quic.c
-@@ -969,7 +969,7 @@ ngx_quic_handle_payload(ngx_connection_t *c, ngx_quic_header_t *pkt)
+@@ -965,7 +965,7 @@
          return NGX_DECLINED;
      }
  
@@ -24,20 +22,19 @@ index b0cf056..c1ba43f 100644
      /* OpenSSL provides read keys for an application level before it's ready */
  
      if (pkt->level == ssl_encryption_application && !c->ssl->handshaked) {
-diff --git a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic/ngx_event_quic_protection.c
-index 88e6954..cd67eac 100644
+diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic/ngx_event_quic_protection.c
 --- a/src/event/quic/ngx_event_quic_protection.c
 +++ b/src/event/quic/ngx_event_quic_protection.c
-@@ -30,7 +30,7 @@ static uint64_t ngx_quic_parse_pn(u_char **pos, ngx_int_t len, u_char *mask,
+@@ -33,7 +33,7 @@
  
  static ngx_int_t ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out,
-     u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
+     const u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
 -#ifndef OPENSSL_IS_BORINGSSL
 +#if !defined (OPENSSL_IS_BORINGSSL) && !defined (OPENSSL_IS_AWSLC)
  static ngx_int_t ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out,
-     u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
+     const u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
  #endif
-@@ -55,7 +55,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
+@@ -58,7 +58,7 @@
      switch (id) {
  
      case TLS1_3_CK_AES_128_GCM_SHA256:
@@ -46,7 +43,7 @@ index 88e6954..cd67eac 100644
          ciphers->c = EVP_aead_aes_128_gcm();
  #else
          ciphers->c = EVP_aes_128_gcm();
-@@ -66,7 +66,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
+@@ -69,7 +69,7 @@
          break;
  
      case TLS1_3_CK_AES_256_GCM_SHA384:
@@ -55,7 +52,7 @@ index 88e6954..cd67eac 100644
          ciphers->c = EVP_aead_aes_256_gcm();
  #else
          ciphers->c = EVP_aes_256_gcm();
-@@ -77,12 +77,12 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
+@@ -80,12 +80,12 @@
          break;
  
      case TLS1_3_CK_CHACHA20_POLY1305_SHA256:
@@ -70,7 +67,7 @@ index 88e6954..cd67eac 100644
          ciphers->hp = (const EVP_CIPHER *) EVP_aead_chacha20_poly1305();
  #else
          ciphers->hp = EVP_chacha20();
-@@ -91,7 +91,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
+@@ -94,7 +94,7 @@
          len = 32;
          break;
  
@@ -79,7 +76,7 @@ index 88e6954..cd67eac 100644
      case TLS1_3_CK_AES_128_CCM_SHA256:
          ciphers->c = EVP_aes_128_ccm();
          ciphers->hp = EVP_aes_128_ctr();
-@@ -259,7 +259,7 @@ static ngx_int_t
+@@ -262,7 +262,7 @@
  ngx_hkdf_expand(u_char *out_key, size_t out_len, const EVP_MD *digest,
      const uint8_t *prk, size_t prk_len, const u_char *info, size_t info_len)
  {
@@ -88,7 +85,7 @@ index 88e6954..cd67eac 100644
  
      if (HKDF_expand(out_key, out_len, digest, prk, prk_len, info, info_len)
          == 0)
-@@ -321,7 +321,7 @@ ngx_hkdf_extract(u_char *out_key, size_t *out_len, const EVP_MD *digest,
+@@ -324,7 +324,7 @@
      const u_char *secret, size_t secret_len, const u_char *salt,
      size_t salt_len)
  {
@@ -97,7 +94,7 @@ index 88e6954..cd67eac 100644
  
      if (HKDF_extract(out_key, out_len, digest, secret, secret_len, salt,
                       salt_len)
-@@ -384,7 +384,7 @@ ngx_quic_crypto_init(const ngx_quic_cipher_t *cipher, ngx_quic_secret_t *s,
+@@ -387,7 +387,7 @@
      ngx_quic_md_t *key, ngx_int_t enc, ngx_log_t *log)
  {
  
@@ -106,8 +103,8 @@ index 88e6954..cd67eac 100644
      EVP_AEAD_CTX  *ctx;
  
      ctx = EVP_AEAD_CTX_new(cipher, key->data, key->len,
-@@ -444,7 +444,7 @@ static ngx_int_t
- ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out, u_char *nonce,
+@@ -447,7 +447,7 @@
+ ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
      ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log)
  {
 -#ifdef OPENSSL_IS_BORINGSSL
@@ -115,8 +112,8 @@ index 88e6954..cd67eac 100644
      if (EVP_AEAD_CTX_open(s->ctx, out->data, &out->len, out->len, nonce,
                            s->iv.len, in->data, in->len, ad->data, ad->len)
          != 1)
-@@ -464,7 +464,7 @@ ngx_int_t
- ngx_quic_crypto_seal(ngx_quic_secret_t *s, ngx_str_t *out, u_char *nonce,
+@@ -467,7 +467,7 @@
+ ngx_quic_crypto_seal(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
      ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log)
  {
 -#ifdef OPENSSL_IS_BORINGSSL
@@ -124,7 +121,7 @@ index 88e6954..cd67eac 100644
      if (EVP_AEAD_CTX_seal(s->ctx, out->data, &out->len, out->len, nonce,
                            s->iv.len, in->data, in->len, ad->data, ad->len)
          != 1)
-@@ -480,7 +480,7 @@ ngx_quic_crypto_seal(ngx_quic_secret_t *s, ngx_str_t *out, u_char *nonce,
+@@ -483,7 +483,7 @@
  }
  
  
@@ -132,8 +129,8 @@ index 88e6954..cd67eac 100644
 +#if !defined (OPENSSL_IS_BORINGSSL) && !defined (OPENSSL_IS_AWSLC)
  
  static ngx_int_t
- ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out, u_char *nonce,
-@@ -559,7 +559,7 @@ void
+ ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out,
+@@ -562,7 +562,7 @@
  ngx_quic_crypto_cleanup(ngx_quic_secret_t *s)
  {
      if (s->ctx) {
@@ -142,7 +139,7 @@ index 88e6954..cd67eac 100644
          EVP_AEAD_CTX_free(s->ctx);
  #else
          EVP_CIPHER_CTX_free(s->ctx);
-@@ -575,7 +575,7 @@ ngx_quic_crypto_hp_init(const EVP_CIPHER *cipher, ngx_quic_secret_t *s,
+@@ -578,7 +578,7 @@
  {
      EVP_CIPHER_CTX  *ctx;
  
@@ -151,7 +148,7 @@ index 88e6954..cd67eac 100644
      if (cipher == (EVP_CIPHER *) EVP_aead_chacha20_poly1305()) {
          /* no EVP interface */
          s->hp_ctx = NULL;
-@@ -610,7 +610,7 @@ ngx_quic_crypto_hp(ngx_quic_secret_t *s, u_char *out, u_char *in,
+@@ -614,7 +614,7 @@
  
      ctx = s->hp_ctx;
  
@@ -160,8 +157,7 @@ index 88e6954..cd67eac 100644
      uint32_t         cnt;
  
      if (ctx == NULL) {
-diff --git a/src/event/quic/ngx_event_quic_protection.h b/src/event/quic/ngx_event_quic_protection.h
-index 34cfee6..20cd910 100644
+diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_protection.h b/src/event/quic/ngx_event_quic_protection.h
 --- a/src/event/quic/ngx_event_quic_protection.h
 +++ b/src/event/quic/ngx_event_quic_protection.h
 @@ -24,7 +24,7 @@
@@ -173,8 +169,7 @@ index 34cfee6..20cd910 100644
  #define ngx_quic_cipher_t             EVP_AEAD
  #define ngx_quic_crypto_ctx_t         EVP_AEAD_CTX
  #else
-diff --git a/src/event/quic/ngx_event_quic_ssl.c b/src/event/quic/ngx_event_quic_ssl.c
-index 7872783..163e0c5 100644
+diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_ssl.c b/src/event/quic/ngx_event_quic_ssl.c
 --- a/src/event/quic/ngx_event_quic_ssl.c
 +++ b/src/event/quic/ngx_event_quic_ssl.c
 @@ -11,6 +11,7 @@
@@ -185,7 +180,7 @@ index 7872783..163e0c5 100644
      || defined LIBRESSL_VERSION_NUMBER                                        \
      || NGX_QUIC_OPENSSL_COMPAT
  #define NGX_QUIC_BORINGSSL_API   1
-@@ -578,7 +579,7 @@ ngx_quic_init_connection(ngx_connection_t *c)
+@@ -583,7 +584,7 @@
          return NGX_ERROR;
      }
  


### PR DESCRIPTION
Updated aws-lc-nginx patch for nginx v1.27.3

### Description of changes: 
Current integration patch fails to apply on the latest nginx v1.27.3. Updated patch file aligns with the latest nginx v1.27.3 code changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
