### PR TITLE
Support Armv8.5 RNDR as prediction resistance

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -802,6 +802,7 @@ if(BUILD_TESTING)
     fipsmodule/rand/ctrdrbg_test.cc
     fipsmodule/rand/cpu_jitter_test.cc
     fipsmodule/rand/new_rand_test.cc
+    fipsmodule/rand/entropy/entropy_source_tests.cc
     fipsmodule/service_indicator/service_indicator_test.cc
     fipsmodule/sha/sha_test.cc
     fipsmodule/sha/sha3_test.cc

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -100,6 +100,7 @@ if(ARCH STREQUAL "aarch64")
     md5-armv8.${ASM_EXT}
     p256-armv8-asm.${ASM_EXT}
     p256_beeu-armv8-asm.${ASM_EXT}
+    rndr-armv8.${ASM_EXT}
     sha1-armv8.${ASM_EXT}
     sha256-armv8.${ASM_EXT}
     sha512-armv8.${ASM_EXT}
@@ -149,6 +150,7 @@ if(PERL_EXECUTABLE)
   perlasm(p256-armv8-asm.${ASM_EXT} ec/asm/p256-armv8-asm.pl)
   perlasm(p256_beeu-armv8-asm.${ASM_EXT} ec/asm/p256_beeu-armv8-asm.pl)
   perlasm(rdrand-x86_64.${ASM_EXT} rand/asm/rdrand-x86_64.pl)
+  perlasm(rndr-armv8.${ASM_EXT} rand/asm/rndr-armv8.pl)
   perlasm(rsaz-avx2.${ASM_EXT} bn/asm/rsaz-avx2.pl)
   perlasm(rsaz-2k-avx512.${ASM_EXT} bn/asm/rsaz-2k-avx512.pl)
   perlasm(rsaz-3k-avx512.${ASM_EXT} bn/asm/rsaz-3k-avx512.pl)

--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -35,6 +35,7 @@ static uint64_t armv8_cpuid_probe(void) {
 
 void OPENSSL_cpuid_setup(void) {
   unsigned long hwcap = getauxval(AT_HWCAP);
+  unsigned long hwcap2 = getauxval(AT_HWCAP2);
 
   // See /usr/include/asm/hwcap.h on an aarch64 installation for the source of
   // these values.
@@ -46,6 +47,8 @@ void OPENSSL_cpuid_setup(void) {
   static const unsigned long kSHA512 = 1 << 21;
   static const unsigned long kSHA3 = 1 << 17;
   static const unsigned long kCPUID = 1 << 11;
+
+  static const unsigned long kRNGhwcap2 = 1 << 16;;
 
   uint64_t OPENSSL_arm_midr = 0;
 
@@ -95,6 +98,10 @@ void OPENSSL_cpuid_setup(void) {
   // Before setting/resetting the DIT flag, check it's available in HWCAP
   if (hwcap & kDIT) {
     OPENSSL_armcap_P |= (ARMV8_DIT | ARMV8_DIT_ALLOWED);
+  }
+
+  if (hwcap2 & kRNGhwcap2) {
+    OPENSSL_armcap_P |= ARMV8_RNG;
   }
 
   // OPENSSL_armcap is a 32-bit, unsigned value which may start with "0x" to

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -260,6 +260,10 @@ OPENSSL_INLINE int CRYPTO_is_ARMv8_DIT_capable(void) {
 // This function is used only for testing; hence, not inlined
 OPENSSL_EXPORT int CRYPTO_is_ARMv8_DIT_capable_for_testing(void);
 
+OPENSSL_INLINE int CRYPTO_is_RNDR_capable(void) {
+  return (OPENSSL_armcap_P & ARMV8_RNG) != 0;
+}
+
 #endif  // OPENSSL_ARM || OPENSSL_AARCH64
 
 #if defined(AARCH64_DIT_SUPPORTED)

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -260,7 +260,7 @@ OPENSSL_INLINE int CRYPTO_is_ARMv8_DIT_capable(void) {
 // This function is used only for testing; hence, not inlined
 OPENSSL_EXPORT int CRYPTO_is_ARMv8_DIT_capable_for_testing(void);
 
-OPENSSL_INLINE int CRYPTO_is_RNDR_capable(void) {
+OPENSSL_INLINE int CRYPTO_is_ARMv8_RNDR_capable(void) {
   return (OPENSSL_armcap_P & ARMV8_RNG) != 0;
 }
 

--- a/crypto/fipsmodule/rand/asm/rndr-armv8.pl
+++ b/crypto/fipsmodule/rand/asm/rndr-armv8.pl
@@ -22,8 +22,6 @@ die "can't locate arm-xlate.pl";
 open OUT,"| \"$^X\" $xlate $flavour $output";
 *STDOUT=*OUT;
 
-my $rndr_reg = "s3_3_c2_c4_0";
-
 $code.=<<___;
 #include <openssl/arm_arch.h>
 
@@ -35,23 +33,25 @@ $code.=<<___;
 .type CRYPTO_rndr,%function
 .align 4
 CRYPTO_rndr:
-  mov x2, #0
+  cbz x1, .Lrndr_error        // out_len = 0 is not supported
+  mov x4, x1                  // out_len: requested number of bytes
+  mov x2, #0                  // Counts number of bytes generated
 
 .Lrndr_loop:
-  cbz x1, .Lrndr_done // out_len == 0?
+  mrs x3, s3_3_c2_c4_0        // rndr instruction
+  cbz x3, .Lrndr_error        // Check if RNDR failed
 
-  mrs x3, $rndr_reg
-  cbz x3, .Lrndr_done // Check of RNDR failed
-
-  cmp x1, #8 // Sets N if strictly less than 8 bytes left
+  cmp x1, #8                  // Sets N if strictly less than 8 bytes left
   blt .Lrndr_less_than_8_bytes
 
-  str x3, [x0], #8 // Copy 8 bytes to *out and increment pointer by 8
-  add x2, x2, #8 // Adds 8 to return value
+  str x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
+  add x2, x2, #8              // Adds 8 to counter
   sub x1, x1, #8
+  cbz x1, .Lrndr_done         // If multiple of 8 this will be 0 eventually
   b .Lrndr_loop
 
 .Lrndr_less_than_8_bytes:
+  // Copy remaining bytes one by one
   strb  w3, [x0]
   lsr x3, x3, #8
   add x2, x2, #1
@@ -60,7 +60,13 @@ CRYPTO_rndr:
   cbnz x1, .Lrndr_less_than_8_bytes
 
 .Lrndr_done:
-  mov x0, x2 // Return value
+  cmp x2, x4                  // Ensure correct number of bytes were generated
+  bne .Lrndr_error
+  mov x0, #1                 // Return value success
+  ret
+
+.Lrndr_error:
+  mov x0, #0                  // Return value error
   ret
 .size CRYPTO_rndr,.-CRYPTO_rndr
 ___

--- a/crypto/fipsmodule/rand/asm/rndr-armv8.pl
+++ b/crypto/fipsmodule/rand/asm/rndr-armv8.pl
@@ -26,7 +26,6 @@ my $rndr_reg = "s3_3_c2_c4_0";
 
 $code.=<<___;
 #include <openssl/arm_arch.h>
-#if __ARM_MAX_ARCH__ >= 8
 
 .arch armv8-a
 .text
@@ -64,7 +63,6 @@ CRYPTO_rndr:
   mov x0, x2 // Return value
   ret
 .size CRYPTO_rndr,.-CRYPTO_rndr
-#endif
 ___
 
 print $code;

--- a/crypto/fipsmodule/rand/asm/rndr-armv8.pl
+++ b/crypto/fipsmodule/rand/asm/rndr-armv8.pl
@@ -62,7 +62,7 @@ CRYPTO_rndr:
 .Lrndr_done:
   cmp x2, x4                  // Ensure correct number of bytes were generated
   bne .Lrndr_error
-  mov x0, #1                 // Return value success
+  mov x0, #1                  // Return value success
   ret
 
 .Lrndr_error:

--- a/crypto/fipsmodule/rand/asm/rndr-armv8.pl
+++ b/crypto/fipsmodule/rand/asm/rndr-armv8.pl
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
 # RNDR from ARMv8.5-A.
-# System register encoding: s3_3_c2_c4_0
+# System register encoding: s3_3_c2_c4_0.
 # see https://developer.arm.com/documentation/ddi0601/2024-09/AArch64-Registers/RNDR--Random-Number
 
 # The first two arguments should always be the flavour and output file path.
@@ -38,11 +38,11 @@ CRYPTO_rndr:
   mov x2, #0                  // Counts number of bytes generated
 
 .Lrndr_loop:
-  mrs x3, s3_3_c2_c4_0        // rndr instruction
-  cbz x3, .Lrndr_error        // Check if RNDR failed
+  mrs x3, s3_3_c2_c4_0        // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
+  cbz x3, .Lrndr_error        // Check if rndr failed
 
-  cmp x1, #8                  // Sets N if strictly less than 8 bytes left
-  blt .Lrndr_less_than_8_bytes
+  cmp x1, #8                  // If strictly less than 8, does not set condition flag C
+  blo .Lrndr_less_than_8_bytes
 
   str x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
   add x2, x2, #8              // Adds 8 to counter

--- a/crypto/fipsmodule/rand/asm/rndr-armv8.pl
+++ b/crypto/fipsmodule/rand/asm/rndr-armv8.pl
@@ -28,13 +28,13 @@ $code.=<<___;
 .arch armv8-a
 .text
 
-# size_t CRYPTO_rndr(uint8_t *out, size_t out_len)
+# int CRYPTO_rndr(uint8_t *out, const size_t len)
 .globl CRYPTO_rndr
 .type CRYPTO_rndr,%function
 .align 4
 CRYPTO_rndr:
-  cbz x1, .Lrndr_error        // out_len = 0 is not supported
-  mov x4, x1                  // out_len: requested number of bytes
+  cbz x1, .Lrndr_error        // len = 0 is not supported
+  mov x4, x1                  // len: requested number of bytes
   mov x2, #0                  // Counts number of bytes generated
 
 .Lrndr_loop:

--- a/crypto/fipsmodule/rand/asm/rndr-armv8.pl
+++ b/crypto/fipsmodule/rand/asm/rndr-armv8.pl
@@ -1,0 +1,71 @@
+#! /usr/bin/env perl
+
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+# RNDR from ARMv8.5-A.
+# System register encoding: s3_3_c2_c4_0
+# see https://developer.arm.com/documentation/ddi0601/2024-09/AArch64-Registers/RNDR--Random-Number
+
+# The first two arguments should always be the flavour and output file path.
+if ($#ARGV < 1) { die "Not enough arguments provided.
+  Two arguments are necessary: the flavour and the output file path."; }
+
+my $flavour = shift;
+my $output  = shift;
+
+$0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
+( $xlate="${dir}arm-xlate.pl" and -f $xlate ) or
+( $xlate="${dir}../../../perlasm/arm-xlate.pl" and -f $xlate) or
+die "can't locate arm-xlate.pl";
+
+open OUT,"| \"$^X\" $xlate $flavour $output";
+*STDOUT=*OUT;
+
+my $rndr_reg = "s3_3_c2_c4_0";
+
+$code.=<<___;
+#include <openssl/arm_arch.h>
+#if __ARM_MAX_ARCH__ >= 8
+
+.arch armv8-a
+.text
+
+# size_t CRYPTO_rndr(uint8_t *out, size_t out_len)
+.globl CRYPTO_rndr
+.type CRYPTO_rndr,%function
+.align 4
+CRYPTO_rndr:
+  mov x2, #0
+
+.Lrndr_loop:
+  cbz x1, .Lrndr_done // out_len == 0?
+
+  mrs x3, $rndr_reg
+  cbz x3, .Lrndr_done // Check of RNDR failed
+
+  cmp x1, #8 // Sets N if strictly less than 8 bytes left
+  blt .Lrndr_less_than_8_bytes
+
+  str x3, [x0], #8 // Copy 8 bytes to *out and increment pointer by 8
+  add x2, x2, #8 // Adds 8 to return value
+  sub x1, x1, #8
+  b .Lrndr_loop
+
+.Lrndr_less_than_8_bytes:
+  strb  w3, [x0]
+  lsr x3, x3, #8
+  add x2, x2, #1
+  add x0, x0, #1
+  sub  x1, x1, #1
+  cbnz x1, .Lrndr_less_than_8_bytes
+
+.Lrndr_done:
+  mov x0, x2 // Return value
+  ret
+.size CRYPTO_rndr,.-CRYPTO_rndr
+#endif
+___
+
+print $code;
+close STDOUT or die "error closing STDOUT: $!"; # enforce flush

--- a/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
+++ b/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
@@ -1,0 +1,27 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <gtest/gtest.h>
+
+#include "internal.h"
+#include "../internal.h"
+
+#define MAX_EXTRACT_FROM_RNG (8*16)
+
+// In the future this test can be improved by being able to predict whether the
+// test is running on hardware that we expect to support RNDR. This will require
+// amending the CI with such information.
+// For now, simply ensure we exercise all code-paths in the CRYPTO_rndr
+// implementation.
+TEST(EntropySupport, Aarch64) {
+#if !defined(OPENSSL_AARCH64)
+  ASSERT_FALSE(have_hw_rng_aarch64());
+#else
+  uint8_t buf[MAX_EXTRACT_FROM_RNG] = { 0 } ;
+  if (have_hw_rng_aarch64() == 1) {
+    for (size_t i = 0; i < MAX_EXTRACT_FROM_RNG; i++) {
+      ASSERT_TRUE(CRYPTO_rndr(buf, i));
+    }
+  }
+#endif
+}

--- a/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
+++ b/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
@@ -4,8 +4,6 @@
 #include <gtest/gtest.h>
 
 #include "internal.h"
-#include "../internal.h"
-#include "../../cpucap/internal.h"
 
 #define MAX_EXTRACT_FROM_RNG (8*16)
 
@@ -16,15 +14,15 @@
 // implementation.
 TEST(EntropySupport, Aarch64) {
 #if !defined(OPENSSL_AARCH64)
-  ASSERT_FALSE(have_hw_rng_aarch64());
+  ASSERT_FALSE(have_hw_rng_aarch64_for_testing());
 #else
   uint8_t buf[MAX_EXTRACT_FROM_RNG] = { 0 } ;
-  if (have_hw_rng_aarch64() == 1) {
+  if (have_hw_rng_aarch64_for_testing() == 1) {
     // Extracting 0 bytes is not supported.
-    ASSERT_FALSE(CRYPTO_rndr(buf, 0));
+    ASSERT_FALSE(rndr(buf, 0));
 
     for (size_t i = 1; i < MAX_EXTRACT_FROM_RNG; i++) {
-      ASSERT_TRUE(CRYPTO_rndr(buf, i));
+      ASSERT_TRUE(rndr(buf, i));
     }
   }
 #endif

--- a/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
+++ b/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
@@ -19,7 +19,10 @@ TEST(EntropySupport, Aarch64) {
 #else
   uint8_t buf[MAX_EXTRACT_FROM_RNG] = { 0 } ;
   if (have_hw_rng_aarch64() == 1) {
-    for (size_t i = 0; i < MAX_EXTRACT_FROM_RNG; i++) {
+    // Extracting 0 bytes is not supported.
+    ASSERT_FALSE(CRYPTO_rndr(buf, 0));
+
+    for (size_t i = 1; i < MAX_EXTRACT_FROM_RNG; i++) {
       ASSERT_TRUE(CRYPTO_rndr(buf, i));
     }
   }

--- a/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
+++ b/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
@@ -5,6 +5,7 @@
 
 #include "internal.h"
 #include "../internal.h"
+#include "../cpucap/internal.h"
 
 #define MAX_EXTRACT_FROM_RNG (8*16)
 

--- a/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
+++ b/crypto/fipsmodule/rand/entropy/entropy_source_tests.cc
@@ -5,7 +5,7 @@
 
 #include "internal.h"
 #include "../internal.h"
-#include "../cpucap/internal.h"
+#include "../../cpucap/internal.h"
 
 #define MAX_EXTRACT_FROM_RNG (8*16)
 

--- a/crypto/fipsmodule/rand/entropy/entropy_sources.c
+++ b/crypto/fipsmodule/rand/entropy/entropy_sources.c
@@ -13,11 +13,16 @@
 static int entropy_get_prediction_resistance(
   const struct entropy_source_t *entropy_source,
   uint8_t pred_resistance[RAND_PRED_RESISTANCE_LEN]) {
-  if (have_fast_rdrand() == 1 &&
-      rdrand(pred_resistance, RAND_PRED_RESISTANCE_LEN) != 1) {
-    return 0;
+#if defined(OPENSSL_X86_64)
+  if (rdrand(pred_resistance, RAND_PRED_RESISTANCE_LEN) == 1) {
+    return 1;
   }
-  return 1;
+#elif defined(OPENSSL_AARCH64)
+  if (CRYPTO_rndr(pred_resistance, RAND_PRED_RESISTANCE_LEN) == 1) {
+    return 1;
+  }
+#endif
+  return 0;
 }
 
 static int entropy_get_extra_entropy(
@@ -37,7 +42,8 @@ DEFINE_LOCAL_DATA(struct entropy_source_methods, tree_jitter_entropy_source_meth
   out->free_thread = tree_jitter_free_thread_drbg;
   out->get_seed = tree_jitter_get_seed;
   out->get_extra_entropy = entropy_get_extra_entropy;
-  if (have_fast_rdrand() == 1) {
+  if (have_hw_rng_x86_64_fast() == 1 ||
+      have_hw_rng_aarch64() == 1) {
     out->get_prediction_resistance = entropy_get_prediction_resistance;
   } else {
     out->get_prediction_resistance = NULL;

--- a/crypto/fipsmodule/rand/entropy/entropy_sources.c
+++ b/crypto/fipsmodule/rand/entropy/entropy_sources.c
@@ -18,7 +18,7 @@ static int entropy_get_prediction_resistance(
     return 1;
   }
 #elif defined(OPENSSL_AARCH64)
-  if (CRYPTO_rndr(pred_resistance, RAND_PRED_RESISTANCE_LEN) == 1) {
+  if (rndr(pred_resistance, RAND_PRED_RESISTANCE_LEN) == 1) {
     return 1;
   }
 #endif
@@ -73,4 +73,12 @@ struct entropy_source_t * get_entropy_source(void) {
   }
 
   return entropy_source;
+}
+
+int rndr(uint8_t *buf, const size_t len) {
+  return CRYPTO_rndr(buf, len);
+}
+
+int have_hw_rng_aarch64_for_testing(void) {
+  return have_hw_rng_aarch64();
 }

--- a/crypto/fipsmodule/rand/entropy/entropy_sources.c
+++ b/crypto/fipsmodule/rand/entropy/entropy_sources.c
@@ -18,7 +18,7 @@ static int entropy_get_prediction_resistance(
     return 1;
   }
 #elif defined(OPENSSL_AARCH64)
-  if (rndr(pred_resistance, RAND_PRED_RESISTANCE_LEN) == 1) {
+  if (rndr_multiple8(pred_resistance, RAND_PRED_RESISTANCE_LEN) == 1) {
     return 1;
   }
 #endif
@@ -75,8 +75,11 @@ struct entropy_source_t * get_entropy_source(void) {
   return entropy_source;
 }
 
-int rndr(uint8_t *buf, const size_t len) {
-  return CRYPTO_rndr(buf, len);
+int rndr_multiple8(uint8_t *buf, const size_t len) {
+  if (len == 0 || ((len & 0x7) != 0)) {
+    return 0;
+  }
+  return CRYPTO_rndr_multiple8(buf, len);
 }
 
 int have_hw_rng_aarch64_for_testing(void) {

--- a/crypto/fipsmodule/rand/entropy/internal.h
+++ b/crypto/fipsmodule/rand/entropy/internal.h
@@ -50,7 +50,7 @@ OPENSSL_EXPORT int have_hw_rng_aarch64_for_testing(void);
 int CRYPTO_rndr(uint8_t *out, size_t out_len);
 
 OPENSSL_INLINE int have_hw_rng_aarch64(void) {
-  return CRYPTO_is_RNDR_capable();
+  return CRYPTO_is_ARMv8_RNDR_capable();
 }
 
 #else  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)

--- a/crypto/fipsmodule/rand/entropy/internal.h
+++ b/crypto/fipsmodule/rand/entropy/internal.h
@@ -41,21 +41,30 @@ OPENSSL_EXPORT void tree_jitter_free_thread_drbg(struct entropy_source_t *entrop
 OPENSSL_EXPORT int tree_jitter_get_seed(
   const struct entropy_source_t *entropy_source, uint8_t seed[CTR_DRBG_ENTROPY_LEN]);
 
+// rndr_multiple8 writes |len| number of bytes to |buf| generated using the
+// rndr instruction. |len| must be a multiple of 8.
+// Outputs 1 on success, 0 otherwise.
+OPENSSL_EXPORT int rndr_multiple8(uint8_t *buf, const size_t len);
 
-OPENSSL_EXPORT int rndr(uint8_t *buf, const size_t len);
+// have_hw_rng_aarch64_for_testing wraps |have_hw_rng_aarch64| to allow usage
+// in testing.
 OPENSSL_EXPORT int have_hw_rng_aarch64_for_testing(void);
 
 #if defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
 
-int CRYPTO_rndr(uint8_t *out, size_t out_len);
+// rndr_multiple8 writes |len| number of bytes to |buf| generated using the
+// rndr instruction. |len| must be a multiple of 8 and positive.
+// Outputs 1 on success, 0 otherwise.
+int CRYPTO_rndr_multiple8(uint8_t *out, size_t out_len);
 
+// Returns 1 if Armv8-A instruction rndr is available, 0 otherwise.
 OPENSSL_INLINE int have_hw_rng_aarch64(void) {
   return CRYPTO_is_ARMv8_RNDR_capable();
 }
 
 #else  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
 
-OPENSSL_INLINE int CRYPTO_rndr(uint8_t *out, size_t out_len) {
+OPENSSL_INLINE int CRYPTO_rndr_multiple8(uint8_t *out, size_t out_len) {
   return 0;
 }
 

--- a/crypto/fipsmodule/rand/entropy/internal.h
+++ b/crypto/fipsmodule/rand/entropy/internal.h
@@ -52,8 +52,8 @@ OPENSSL_EXPORT int have_hw_rng_aarch64_for_testing(void);
 
 #if defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
 
-// rndr_multiple8 writes |len| number of bytes to |buf| generated using the
-// rndr instruction. |len| must be a multiple of 8 and positive.
+// CRYPTO_rndr_multiple8 writes |len| number of bytes to |buf| generated using
+// the rndr instruction. |len| must be a multiple of 8 and positive.
 // Outputs 1 on success, 0 otherwise.
 int CRYPTO_rndr_multiple8(uint8_t *out, size_t out_len);
 

--- a/crypto/fipsmodule/rand/entropy/internal.h
+++ b/crypto/fipsmodule/rand/entropy/internal.h
@@ -7,6 +7,7 @@
 #include <openssl/ctrdrbg.h>
 
 #include "../new_rand_internal.h"
+#include "../../cpucap/internal.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -39,6 +40,30 @@ OPENSSL_EXPORT void tree_jitter_zeroize_thread_drbg(struct entropy_source_t *ent
 OPENSSL_EXPORT void tree_jitter_free_thread_drbg(struct entropy_source_t *entropy_source);
 OPENSSL_EXPORT int tree_jitter_get_seed(
   const struct entropy_source_t *entropy_source, uint8_t seed[CTR_DRBG_ENTROPY_LEN]);
+
+
+OPENSSL_EXPORT int rndr(uint8_t *buf, const size_t len);
+OPENSSL_EXPORT int have_hw_rng_aarch64_for_testing(void);
+
+#if defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
+
+int CRYPTO_rndr(uint8_t *out, size_t out_len);
+
+OPENSSL_INLINE int have_hw_rng_aarch64(void) {
+  return CRYPTO_is_RNDR_capable();
+}
+
+#else  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
+
+OPENSSL_INLINE int CRYPTO_rndr(uint8_t *out, size_t out_len) {
+  return 0;
+}
+
+OPENSSL_INLINE int have_hw_rng_aarch64(void) {
+  return 0;
+}
+
+#endif  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
 
 #if defined(__cplusplus)
 }  // extern C

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -133,28 +133,6 @@ OPENSSL_INLINE int have_hw_rng_x86_64_fast(void) {
 
 #endif  // defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM)
 
-#if defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
-
-size_t CRYPTO_rndr(uint8_t *out, size_t out_len);
-
-OPENSSL_INLINE int have_hw_rng_aarch64(void) {
-  return CRYPTO_is_RNDR_capable();
-}
-
-#else  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
-
-OPENSSL_INLINE size_t CRYPTO_rndr(uint8_t *out, size_t out_len) {
-  return 0;
-}
-
-OPENSSL_INLINE int have_hw_rng_aarch64(void) {
-  return 0;
-}
-
-#endif  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
-
-
-
 // Don't retry forever. There is no science in picking this number and can be
 // adjusted in the future if need be. We do not backoff forever, because we
 // believe that it is easier to detect failing calls than detecting infinite

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -112,6 +112,8 @@ OPENSSL_INLINE int have_hw_rng_x86_64_fast(void) {
   return CRYPTO_is_RDRAND_capable() && CRYPTO_is_intel_cpu();
 }
 
+// TODO only allow multiples of 8 from rdrand
+
 // CRYPTO_rdrand writes eight bytes of random data from the hardware RNG to
 // |out|. It returns one on success or zero on hardware failure.
 int CRYPTO_rdrand(uint8_t out[8]);

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -101,14 +101,14 @@ int rdrand(uint8_t *buf, const size_t len);
 
 #if defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM)
 
-OPENSSL_INLINE int have_rdrand(void) {
+OPENSSL_INLINE int have_hw_rng_x86_64(void) {
   return CRYPTO_is_RDRAND_capable();
 }
 
 // have_fast_rdrand returns true if RDRAND is supported and it's reasonably
 // fast. Concretely the latter is defined by whether the chip is Intel (fast) or
 // not (assumed slow).
-OPENSSL_INLINE int have_fast_rdrand(void) {
+OPENSSL_INLINE int have_hw_rng_x86_64_fast(void) {
   return CRYPTO_is_RDRAND_capable() && CRYPTO_is_intel_cpu();
 }
 
@@ -121,17 +121,40 @@ int CRYPTO_rdrand(uint8_t out[8]);
 // one on success and zero on hardware failure.
 int CRYPTO_rdrand_multiple8_buf(uint8_t *buf, size_t len);
 
-#else  // OPENSSL_X86_64 && !OPENSSL_NO_ASM
+#else  // defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM)
 
-OPENSSL_INLINE int have_rdrand(void) {
+OPENSSL_INLINE int have_hw_rng_x86_64(void) {
   return 0;
 }
 
-OPENSSL_INLINE int have_fast_rdrand(void) {
+OPENSSL_INLINE int have_hw_rng_x86_64_fast(void) {
   return 0;
 }
 
-#endif  // OPENSSL_X86_64 && !OPENSSL_NO_ASM
+#endif  // defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM)
+
+#if defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
+
+size_t CRYPTO_rndr(uint8_t *out, size_t out_len);
+
+OPENSSL_INLINE int have_hw_rng_aarch64(void) {
+  return CRYPTO_is_RNDR_capable();
+}
+
+
+#else  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
+
+size_t CRYPTO_rndr(uint8_t *out, size_t out_len) {
+  return 0;
+}
+
+OPENSSL_INLINE int have_hw_rng_aarch64(void) {
+  return 0;
+}
+
+#endif  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
+
+
 
 // Don't retry forever. There is no science in picking this number and can be
 // adjusted in the future if need be. We do not backoff forever, because we

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -133,9 +133,9 @@ OPENSSL_INLINE int have_hw_rng_x86_64_fast(void) {
 
 #endif  // defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM)
 
-size_t CRYPTO_rndr(uint8_t *out, size_t out_len);
-
 #if defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
+
+size_t CRYPTO_rndr(uint8_t *out, size_t out_len);
 
 OPENSSL_INLINE int have_hw_rng_aarch64(void) {
   return CRYPTO_is_RNDR_capable();

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -133,18 +133,17 @@ OPENSSL_INLINE int have_hw_rng_x86_64_fast(void) {
 
 #endif  // defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM)
 
-#if defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
-
 size_t CRYPTO_rndr(uint8_t *out, size_t out_len);
+
+#if defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
 
 OPENSSL_INLINE int have_hw_rng_aarch64(void) {
   return CRYPTO_is_RNDR_capable();
 }
 
-
 #else  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
 
-size_t CRYPTO_rndr(uint8_t *out, size_t out_len) {
+OPENSSL_INLINE size_t CRYPTO_rndr(uint8_t *out, size_t out_len) {
   return 0;
 }
 

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -343,7 +343,7 @@ void CRYPTO_get_seed_entropy(uint8_t entropy[PASSIVE_ENTROPY_LOAD_LENGTH],
                              int *out_want_additional_input) {
   *out_want_additional_input = 0;
 
-  if (have_rdrand() == 1) {
+  if (have_hw_rng_x86_64() == 1) {
     if (rdrand(entropy, PASSIVE_ENTROPY_LOAD_LENGTH) != 1) {
       abort();
     }
@@ -400,7 +400,7 @@ void RAND_bytes_with_additional_data(uint8_t *out, size_t out_len,
   uint8_t additional_data[32];
   // Intel chips have fast RDRAND instructions while, in other cases, RDRAND can
   // be _slower_ than a system call.
-  if (!have_fast_rdrand() ||
+  if (!have_hw_rng_x86_64_fast() ||
       !rdrand(additional_data, sizeof(additional_data))) {
     // Without a hardware RNG to save us from address-space duplication, the OS
     // entropy is used. This can be expensive (one read per |RAND_bytes| call)
@@ -411,7 +411,7 @@ void RAND_bytes_with_additional_data(uint8_t *out, size_t out_len,
     if ((snapsafe_status != 0 && fork_generation != 0) ||
         fork_unsafe_buffering) {
       OPENSSL_memset(additional_data, 0, sizeof(additional_data));
-    } else if (!have_rdrand()) {
+    } else if (!have_hw_rng_x86_64()) {
       // No alternative so block for OS entropy.
       CRYPTO_sysrand(additional_data, sizeof(additional_data));
     } else if (!CRYPTO_sysrand_if_available(additional_data,

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -495,8 +495,8 @@ static std::vector<Event> TestFunctionPRNGModel(unsigned flags) {
   const size_t kAdditionalDataLength = 32;
   const size_t kPersonalizationStringLength = CTR_DRBG_ENTROPY_LEN;
   const size_t kPassiveEntropyWithWhitenFactor = PASSIVE_ENTROPY_LOAD_LENGTH;
-  const bool kHaveRdrand = have_rdrand();
-  const bool kHaveFastRdrand = have_fast_rdrand();
+  const bool kHaveRdrand = have_hw_rng_x86_64();
+  const bool kHaveFastRdrand = have_hw_rng_x86_64_fast();
   const bool kHaveForkDetection = have_fork_detection();
 
   // Additional data might be drawn on each invocation of RAND_bytes(). In case

--- a/crypto/rand_extra/rand_test.cc
+++ b/crypto/rand_extra/rand_test.cc
@@ -217,7 +217,7 @@ TEST(RandTest, Threads) {
 
 #if defined(OPENSSL_X86_64) && defined(SUPPORTS_ABI_TEST)
 TEST(RandTest, RdrandABI) {
-  if (!have_rdrand()) {
+  if (!have_hw_rng_x86_64()) {
     fprintf(stderr, "rdrand not supported. Skipping.\n");
     return;
   }
@@ -275,7 +275,7 @@ TEST(RandTest, PassiveEntropyDepletedObviouslyNotBroken) {
 // we can only validate the correct value is set on the static build type.
 #if !defined(BORINGSSL_SHARED_LIBRARY)
   int want_additional_input_expect = 0;
-  if (have_rdrand()) {
+  if (have_hw_rng_x86_64()) {
     want_additional_input_expect = 1;
   }
   EXPECT_EQ(out_want_additional_input_false_default, want_additional_input_expect);

--- a/generated-src/ios-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -1,0 +1,54 @@
+// This file is generated from a similarly-named Perl script in the BoringSSL
+// source tree. Do not edit by hand.
+
+#include <openssl/asm_base.h>
+
+#if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_AARCH64) && defined(__APPLE__)
+#include <openssl/arm_arch.h>
+
+
+.text
+
+# size_t CRYPTO_rndr(uint8_t *out, size_t out_len)
+.globl	_CRYPTO_rndr
+.private_extern	_CRYPTO_rndr
+
+.align	4
+_CRYPTO_rndr:
+	cbz	x1, Lrndr_error        // out_len = 0 is not supported
+	mov	x4, x1                  // out_len: requested number of bytes
+	mov	x2, #0                  // Counts number of bytes generated
+
+Lrndr_loop:
+	mrs	x3, s3_3_c2_c4_0        // rndr instruction
+	cbz	x3, Lrndr_error        // Check if RNDR failed
+
+	cmp	x1, #8                  // Sets N if strictly less than 8 bytes left
+	blt	Lrndr_less_than_8_bytes
+
+	str	x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
+	add	x2, x2, #8              // Adds 8 to counter
+	sub	x1, x1, #8
+	cbz	x1, Lrndr_done         // If multiple of 8 this will be 0 eventually
+	b	Lrndr_loop
+
+Lrndr_less_than_8_bytes:
+  // Copy remaining bytes one by one
+	strb	w3, [x0]
+	lsr	x3, x3, #8
+	add	x2, x2, #1
+	add	x0, x0, #1
+	sub	x1, x1, #1
+	cbnz	x1, Lrndr_less_than_8_bytes
+
+Lrndr_done:
+	cmp	x2, x4                  // Ensure correct number of bytes were generated
+	bne	Lrndr_error
+	mov	x0, #1                 // Return value success
+	ret
+
+Lrndr_error:
+	mov	x0, #0                  // Return value error
+	ret
+
+#endif  // !OPENSSL_NO_ASM && defined(OPENSSL_AARCH64) && defined(__APPLE__)

--- a/generated-src/ios-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -9,22 +9,22 @@
 
 .text
 
-# size_t CRYPTO_rndr(uint8_t *out, size_t out_len)
+# int CRYPTO_rndr(uint8_t *out, const size_t len)
 .globl	_CRYPTO_rndr
 .private_extern	_CRYPTO_rndr
 
 .align	4
 _CRYPTO_rndr:
-	cbz	x1, Lrndr_error        // out_len = 0 is not supported
-	mov	x4, x1                  // out_len: requested number of bytes
+	cbz	x1, Lrndr_error        // len = 0 is not supported
+	mov	x4, x1                  // len: requested number of bytes
 	mov	x2, #0                  // Counts number of bytes generated
 
 Lrndr_loop:
-	mrs	x3, s3_3_c2_c4_0        // rndr instruction
-	cbz	x3, Lrndr_error        // Check if RNDR failed
+	mrs	x3, s3_3_c2_c4_0        // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
+	cbz	x3, Lrndr_error        // Check if rndr failed
 
-	cmp	x1, #8                  // Sets N if strictly less than 8 bytes left
-	blt	Lrndr_less_than_8_bytes
+	cmp	x1, #8                  // If strictly less than 8, does not set condition flag C
+	blo	Lrndr_less_than_8_bytes
 
 	str	x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
 	add	x2, x2, #8              // Adds 8 to counter
@@ -44,7 +44,7 @@ Lrndr_less_than_8_bytes:
 Lrndr_done:
 	cmp	x2, x4                  // Ensure correct number of bytes were generated
 	bne	Lrndr_error
-	mov	x0, #1                 // Return value success
+	mov	x0, #1                  // Return value success
 	ret
 
 Lrndr_error:

--- a/generated-src/ios-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -9,46 +9,29 @@
 
 .text
 
-# int CRYPTO_rndr(uint8_t *out, const size_t len)
-.globl	_CRYPTO_rndr
-.private_extern	_CRYPTO_rndr
+# int CRYPTO_rndr_multiple8(uint8_t *out, const size_t len)
+.globl	_CRYPTO_rndr_multiple8
+.private_extern	_CRYPTO_rndr_multiple8
 
 .align	4
-_CRYPTO_rndr:
-	cbz	x1, Lrndr_error        // len = 0 is not supported
-	mov	x4, x1                  // len: requested number of bytes
-	mov	x2, #0                  // Counts number of bytes generated
+_CRYPTO_rndr_multiple8:
+	cbz	x1, Lrndr_multiple8_error  // len = 0 is not supported
 
-Lrndr_loop:
-	mrs	x3, s3_3_c2_c4_0        // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
-	cbz	x3, Lrndr_error        // Check if rndr failed
+Lrndr_multiple8_loop:
+	mrs	x2, s3_3_c2_c4_0             // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
+	cbz	x2, Lrndr_multiple8_error   // Check if rndr failed
 
-	cmp	x1, #8                  // If strictly less than 8, does not set condition flag C
-	blo	Lrndr_less_than_8_bytes
-
-	str	x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
-	add	x2, x2, #8              // Adds 8 to counter
+	str	x2, [x0], #8               // Copy 8 bytes to *out and increment pointer by 8
 	sub	x1, x1, #8
-	cbz	x1, Lrndr_done         // If multiple of 8 this will be 0 eventually
-	b	Lrndr_loop
+	cbz	x1, Lrndr_multiple8_done       // If multiple of 8 this will be 0 eventually
+	b	Lrndr_multiple8_loop
 
-Lrndr_less_than_8_bytes:
-  // Copy remaining bytes one by one
-	strb	w3, [x0]
-	lsr	x3, x3, #8
-	add	x2, x2, #1
-	add	x0, x0, #1
-	sub	x1, x1, #1
-	cbnz	x1, Lrndr_less_than_8_bytes
-
-Lrndr_done:
-	cmp	x2, x4                  // Ensure correct number of bytes were generated
-	bne	Lrndr_error
-	mov	x0, #1                  // Return value success
+Lrndr_multiple8_done:
+	mov	x0, #1                            // Return value success
 	ret
 
-Lrndr_error:
-	mov	x0, #0                  // Return value error
+Lrndr_multiple8_error:
+	mov	x0, #0                            // Return value error
 	ret
 
 #endif  // !OPENSSL_NO_ASM && defined(OPENSSL_AARCH64) && defined(__APPLE__)

--- a/generated-src/linux-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -1,0 +1,54 @@
+// This file is generated from a similarly-named Perl script in the BoringSSL
+// source tree. Do not edit by hand.
+
+#include <openssl/asm_base.h>
+
+#if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_AARCH64) && defined(__ELF__)
+#include <openssl/arm_arch.h>
+
+.arch	armv8-a
+.text
+
+# size_t CRYPTO_rndr(uint8_t *out, size_t out_len)
+.globl	CRYPTO_rndr
+.hidden	CRYPTO_rndr
+.type	CRYPTO_rndr,%function
+.align	4
+CRYPTO_rndr:
+	cbz	x1, .Lrndr_error        // out_len = 0 is not supported
+	mov	x4, x1                  // out_len: requested number of bytes
+	mov	x2, #0                  // Counts number of bytes generated
+
+.Lrndr_loop:
+	mrs	x3, s3_3_c2_c4_0        // rndr instruction
+	cbz	x3, .Lrndr_error        // Check if RNDR failed
+
+	cmp	x1, #8                  // Sets N if strictly less than 8 bytes left
+	blt	.Lrndr_less_than_8_bytes
+
+	str	x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
+	add	x2, x2, #8              // Adds 8 to counter
+	sub	x1, x1, #8
+	cbz	x1, .Lrndr_done         // If multiple of 8 this will be 0 eventually
+	b	.Lrndr_loop
+
+.Lrndr_less_than_8_bytes:
+  // Copy remaining bytes one by one
+	strb	w3, [x0]
+	lsr	x3, x3, #8
+	add	x2, x2, #1
+	add	x0, x0, #1
+	sub	x1, x1, #1
+	cbnz	x1, .Lrndr_less_than_8_bytes
+
+.Lrndr_done:
+	cmp	x2, x4                  // Ensure correct number of bytes were generated
+	bne	.Lrndr_error
+	mov	x0, #1                 // Return value success
+	ret
+
+.Lrndr_error:
+	mov	x0, #0                  // Return value error
+	ret
+.size	CRYPTO_rndr,.-CRYPTO_rndr
+#endif  // !OPENSSL_NO_ASM && defined(OPENSSL_AARCH64) && defined(__ELF__)

--- a/generated-src/linux-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -9,22 +9,22 @@
 .arch	armv8-a
 .text
 
-# size_t CRYPTO_rndr(uint8_t *out, size_t out_len)
+# int CRYPTO_rndr(uint8_t *out, const size_t len)
 .globl	CRYPTO_rndr
 .hidden	CRYPTO_rndr
 .type	CRYPTO_rndr,%function
 .align	4
 CRYPTO_rndr:
-	cbz	x1, .Lrndr_error        // out_len = 0 is not supported
-	mov	x4, x1                  // out_len: requested number of bytes
+	cbz	x1, .Lrndr_error        // len = 0 is not supported
+	mov	x4, x1                  // len: requested number of bytes
 	mov	x2, #0                  // Counts number of bytes generated
 
 .Lrndr_loop:
-	mrs	x3, s3_3_c2_c4_0        // rndr instruction
-	cbz	x3, .Lrndr_error        // Check if RNDR failed
+	mrs	x3, s3_3_c2_c4_0        // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
+	cbz	x3, .Lrndr_error        // Check if rndr failed
 
-	cmp	x1, #8                  // Sets N if strictly less than 8 bytes left
-	blt	.Lrndr_less_than_8_bytes
+	cmp	x1, #8                  // If strictly less than 8, does not set condition flag C
+	blo	.Lrndr_less_than_8_bytes
 
 	str	x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
 	add	x2, x2, #8              // Adds 8 to counter
@@ -44,7 +44,7 @@ CRYPTO_rndr:
 .Lrndr_done:
 	cmp	x2, x4                  // Ensure correct number of bytes were generated
 	bne	.Lrndr_error
-	mov	x0, #1                 // Return value success
+	mov	x0, #1                  // Return value success
 	ret
 
 .Lrndr_error:

--- a/generated-src/linux-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -9,46 +9,29 @@
 .arch	armv8-a
 .text
 
-# int CRYPTO_rndr(uint8_t *out, const size_t len)
-.globl	CRYPTO_rndr
-.hidden	CRYPTO_rndr
-.type	CRYPTO_rndr,%function
+# int CRYPTO_rndr_multiple8(uint8_t *out, const size_t len)
+.globl	CRYPTO_rndr_multiple8
+.hidden	CRYPTO_rndr_multiple8
+.type	CRYPTO_rndr_multiple8,%function
 .align	4
-CRYPTO_rndr:
-	cbz	x1, .Lrndr_error        // len = 0 is not supported
-	mov	x4, x1                  // len: requested number of bytes
-	mov	x2, #0                  // Counts number of bytes generated
+CRYPTO_rndr_multiple8:
+	cbz	x1, .Lrndr_multiple8_error  // len = 0 is not supported
 
-.Lrndr_loop:
-	mrs	x3, s3_3_c2_c4_0        // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
-	cbz	x3, .Lrndr_error        // Check if rndr failed
+.Lrndr_multiple8_loop:
+	mrs	x2, s3_3_c2_c4_0             // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
+	cbz	x2, .Lrndr_multiple8_error   // Check if rndr failed
 
-	cmp	x1, #8                  // If strictly less than 8, does not set condition flag C
-	blo	.Lrndr_less_than_8_bytes
-
-	str	x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
-	add	x2, x2, #8              // Adds 8 to counter
+	str	x2, [x0], #8               // Copy 8 bytes to *out and increment pointer by 8
 	sub	x1, x1, #8
-	cbz	x1, .Lrndr_done         // If multiple of 8 this will be 0 eventually
-	b	.Lrndr_loop
+	cbz	x1, .Lrndr_multiple8_done       // If multiple of 8 this will be 0 eventually
+	b	.Lrndr_multiple8_loop
 
-.Lrndr_less_than_8_bytes:
-  // Copy remaining bytes one by one
-	strb	w3, [x0]
-	lsr	x3, x3, #8
-	add	x2, x2, #1
-	add	x0, x0, #1
-	sub	x1, x1, #1
-	cbnz	x1, .Lrndr_less_than_8_bytes
-
-.Lrndr_done:
-	cmp	x2, x4                  // Ensure correct number of bytes were generated
-	bne	.Lrndr_error
-	mov	x0, #1                  // Return value success
+.Lrndr_multiple8_done:
+	mov	x0, #1                            // Return value success
 	ret
 
-.Lrndr_error:
-	mov	x0, #0                  // Return value error
+.Lrndr_multiple8_error:
+	mov	x0, #0                            // Return value error
 	ret
-.size	CRYPTO_rndr,.-CRYPTO_rndr
+.size	CRYPTO_rndr_multiple8,.-CRYPTO_rndr_multiple8
 #endif  // !OPENSSL_NO_ASM && defined(OPENSSL_AARCH64) && defined(__ELF__)

--- a/generated-src/win-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -9,7 +9,7 @@
 .arch	armv8-a
 .text
 
-# size_t CRYPTO_rndr(uint8_t *out, size_t out_len)
+# int CRYPTO_rndr(uint8_t *out, const size_t len)
 .globl	CRYPTO_rndr
 
 .def CRYPTO_rndr
@@ -17,16 +17,16 @@
 .endef
 .align	4
 CRYPTO_rndr:
-	cbz	x1, Lrndr_error        // out_len = 0 is not supported
-	mov	x4, x1                  // out_len: requested number of bytes
+	cbz	x1, Lrndr_error        // len = 0 is not supported
+	mov	x4, x1                  // len: requested number of bytes
 	mov	x2, #0                  // Counts number of bytes generated
 
 Lrndr_loop:
-	mrs	x3, s3_3_c2_c4_0        // rndr instruction
-	cbz	x3, Lrndr_error        // Check if RNDR failed
+	mrs	x3, s3_3_c2_c4_0        // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
+	cbz	x3, Lrndr_error        // Check if rndr failed
 
-	cmp	x1, #8                  // Sets N if strictly less than 8 bytes left
-	blt	Lrndr_less_than_8_bytes
+	cmp	x1, #8                  // If strictly less than 8, does not set condition flag C
+	blo	Lrndr_less_than_8_bytes
 
 	str	x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
 	add	x2, x2, #8              // Adds 8 to counter
@@ -46,7 +46,7 @@ Lrndr_less_than_8_bytes:
 Lrndr_done:
 	cmp	x2, x4                  // Ensure correct number of bytes were generated
 	bne	Lrndr_error
-	mov	x0, #1                 // Return value success
+	mov	x0, #1                  // Return value success
 	ret
 
 Lrndr_error:

--- a/generated-src/win-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -1,0 +1,56 @@
+// This file is generated from a similarly-named Perl script in the BoringSSL
+// source tree. Do not edit by hand.
+
+#include <openssl/asm_base.h>
+
+#if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_AARCH64) && defined(_WIN32)
+#include <openssl/arm_arch.h>
+
+.arch	armv8-a
+.text
+
+# size_t CRYPTO_rndr(uint8_t *out, size_t out_len)
+.globl	CRYPTO_rndr
+
+.def CRYPTO_rndr
+   .type 32
+.endef
+.align	4
+CRYPTO_rndr:
+	cbz	x1, Lrndr_error        // out_len = 0 is not supported
+	mov	x4, x1                  // out_len: requested number of bytes
+	mov	x2, #0                  // Counts number of bytes generated
+
+Lrndr_loop:
+	mrs	x3, s3_3_c2_c4_0        // rndr instruction
+	cbz	x3, Lrndr_error        // Check if RNDR failed
+
+	cmp	x1, #8                  // Sets N if strictly less than 8 bytes left
+	blt	Lrndr_less_than_8_bytes
+
+	str	x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
+	add	x2, x2, #8              // Adds 8 to counter
+	sub	x1, x1, #8
+	cbz	x1, Lrndr_done         // If multiple of 8 this will be 0 eventually
+	b	Lrndr_loop
+
+Lrndr_less_than_8_bytes:
+  // Copy remaining bytes one by one
+	strb	w3, [x0]
+	lsr	x3, x3, #8
+	add	x2, x2, #1
+	add	x0, x0, #1
+	sub	x1, x1, #1
+	cbnz	x1, Lrndr_less_than_8_bytes
+
+Lrndr_done:
+	cmp	x2, x4                  // Ensure correct number of bytes were generated
+	bne	Lrndr_error
+	mov	x0, #1                 // Return value success
+	ret
+
+Lrndr_error:
+	mov	x0, #0                  // Return value error
+	ret
+
+#endif  // !OPENSSL_NO_ASM && defined(OPENSSL_AARCH64) && defined(_WIN32)

--- a/generated-src/win-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -9,48 +9,31 @@
 .arch	armv8-a
 .text
 
-# int CRYPTO_rndr(uint8_t *out, const size_t len)
-.globl	CRYPTO_rndr
+# int CRYPTO_rndr_multiple8(uint8_t *out, const size_t len)
+.globl	CRYPTO_rndr_multiple8
 
-.def CRYPTO_rndr
+.def CRYPTO_rndr_multiple8
    .type 32
 .endef
 .align	4
-CRYPTO_rndr:
-	cbz	x1, Lrndr_error        // len = 0 is not supported
-	mov	x4, x1                  // len: requested number of bytes
-	mov	x2, #0                  // Counts number of bytes generated
+CRYPTO_rndr_multiple8:
+	cbz	x1, Lrndr_multiple8_error  // len = 0 is not supported
 
-Lrndr_loop:
-	mrs	x3, s3_3_c2_c4_0        // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
-	cbz	x3, Lrndr_error        // Check if rndr failed
+Lrndr_multiple8_loop:
+	mrs	x2, s3_3_c2_c4_0             // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
+	cbz	x2, Lrndr_multiple8_error   // Check if rndr failed
 
-	cmp	x1, #8                  // If strictly less than 8, does not set condition flag C
-	blo	Lrndr_less_than_8_bytes
-
-	str	x3, [x0], #8            // Copy 8 bytes to *out and increment pointer by 8
-	add	x2, x2, #8              // Adds 8 to counter
+	str	x2, [x0], #8               // Copy 8 bytes to *out and increment pointer by 8
 	sub	x1, x1, #8
-	cbz	x1, Lrndr_done         // If multiple of 8 this will be 0 eventually
-	b	Lrndr_loop
+	cbz	x1, Lrndr_multiple8_done       // If multiple of 8 this will be 0 eventually
+	b	Lrndr_multiple8_loop
 
-Lrndr_less_than_8_bytes:
-  // Copy remaining bytes one by one
-	strb	w3, [x0]
-	lsr	x3, x3, #8
-	add	x2, x2, #1
-	add	x0, x0, #1
-	sub	x1, x1, #1
-	cbnz	x1, Lrndr_less_than_8_bytes
-
-Lrndr_done:
-	cmp	x2, x4                  // Ensure correct number of bytes were generated
-	bne	Lrndr_error
-	mov	x0, #1                  // Return value success
+Lrndr_multiple8_done:
+	mov	x0, #1                            // Return value success
 	ret
 
-Lrndr_error:
-	mov	x0, #0                  // Return value error
+Lrndr_multiple8_error:
+	mov	x0, #0                            // Return value error
 	ret
 
 #endif  // !OPENSSL_NO_ASM && defined(OPENSSL_AARCH64) && defined(_WIN32)

--- a/include/openssl/arm_arch.h
+++ b/include/openssl/arm_arch.h
@@ -98,6 +98,9 @@
 // |armv8_disable_dit| and |armv8_enable_dit|, respectively.
 #define ARMV8_DIT_ALLOWED (1 << 16)
 
+// ARMV8_RNG indicates supports for hardware RNG instruction RNDR.
+#define ARMV8_RNG (1 << 17)
+
 
 //
 // MIDR_EL1 system register

--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -2418,7 +2418,8 @@ func localEntryName(name string) string {
 func isSynthesized(symbol string, processor processorType) bool {
 	SymbolisSynthesized := strings.HasSuffix(symbol, "_bss_get") ||
 		symbol == "OPENSSL_ia32cap_get" ||
-		symbol == "BORINGSSL_bcm_text_hash"
+		symbol == "BORINGSSL_bcm_text_hash" ||
+		symbol == "s3_3_c2_c4_0"
 
 	// While BORINGSSL_bcm_text_[start,end] are known symbols, on aarch64 we go
 	// through the GOT because adr doesn't have adequate reach.


### PR DESCRIPTION
### Description of changes: 

Adds Arm as a hardware source for prediction resistance, if supported. This covers Linux+Armv8.5-A that impements `rndr`. For exmaple, this should be enabled on Graviton3/Graviton4+Amazon Linux.

Note, only multiples of 8 are supported. That's what we need now and I don't see that need changing.

### Call-outs:

Wrap the libcrypto inlined functions to workaround the Arm capability vector having internal linkage.

Apple doesn't implement `FEAT_RNG` on any of their M's. Might be able to implement for Windows. But I don't see a way to probe for the instruction here https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent.

Added `s3_3_c2_c4_0` as a known symbol to the delocator to avoid it from interpreting the string as an external symbol that needs a trampoline... It's not really a symbol... And this was the quickest way to move forward.

### Testing:

Tested that the function is executed successfully on a Graviton3 instance. This might also be executed through codebuild depending on which instances are spawned.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
