### PR TITLE
Modified posix builds to enable dilithium by default

### DIFF
--- a/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
+++ b/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
@@ -31,7 +31,8 @@ int crypto_sign_keypair_internal(ml_dsa_params *params,
   uint8_t tr[TRBYTES];
   const uint8_t *rho, *rhoprime, *key;
   polyvecl mat[DILITHIUM_K_MAX];
-  polyvecl s1, s1hat;
+  polyvecl s1 = {0};
+  polyvecl s1hat;
   polyveck s2, t1, t0;
 
   OPENSSL_memcpy(seedbuf, seed, SEEDBYTES);

--- a/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
+++ b/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
@@ -35,6 +35,9 @@ int crypto_sign_keypair_internal(ml_dsa_params *params,
   polyvecl s1hat;
   polyveck s2, t1, t0;
 
+  /* Some compilers require that s1 is initalised before first use */
+  OPENSSL_cleanse(&s1, sizeof(s1));
+
   OPENSSL_memcpy(seedbuf, seed, SEEDBYTES);
   seedbuf[SEEDBYTES+0] = params->k;
   seedbuf[SEEDBYTES+1] = params->l;
@@ -49,9 +52,6 @@ int crypto_sign_keypair_internal(ml_dsa_params *params,
   /* FIPS 204: line 4 Sample short vectors s1 and s2 */
   polyvecl_uniform_eta(params, &s1, rhoprime, 0);
   polyveck_uniform_eta(params, &s2, rhoprime, params->l);
-
-  /* Some compilers require that s1 is initalised before first use */
-  OPENSSL_cleanse(&s1, sizeof(s1));
 
   /* FIPS 204: line 5 Matrix-vector multiplication */
   s1hat = s1;

--- a/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
+++ b/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
@@ -31,12 +31,9 @@ int crypto_sign_keypair_internal(ml_dsa_params *params,
   uint8_t tr[TRBYTES];
   const uint8_t *rho, *rhoprime, *key;
   polyvecl mat[DILITHIUM_K_MAX];
-  polyvecl s1;
+  polyvecl s1 = {{0}};
   polyvecl s1hat;
   polyveck s2, t1, t0;
-
-  /* Some compilers require that s1 is initalised before first use */
-  OPENSSL_cleanse(&s1, sizeof(s1));
 
   OPENSSL_memcpy(seedbuf, seed, SEEDBYTES);
   seedbuf[SEEDBYTES+0] = params->k;

--- a/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
+++ b/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
@@ -31,7 +31,7 @@ int crypto_sign_keypair_internal(ml_dsa_params *params,
   uint8_t tr[TRBYTES];
   const uint8_t *rho, *rhoprime, *key;
   polyvecl mat[DILITHIUM_K_MAX];
-  polyvecl s1 = {0};
+  polyvecl s1[] = {0};
   polyvecl s1hat;
   polyveck s2, t1, t0;
 

--- a/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
+++ b/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
@@ -31,7 +31,7 @@ int crypto_sign_keypair_internal(ml_dsa_params *params,
   uint8_t tr[TRBYTES];
   const uint8_t *rho, *rhoprime, *key;
   polyvecl mat[DILITHIUM_K_MAX];
-  polyvecl s1[] = {0};
+  polyvecl s1;
   polyvecl s1hat;
   polyveck s2, t1, t0;
 
@@ -49,6 +49,9 @@ int crypto_sign_keypair_internal(ml_dsa_params *params,
   /* FIPS 204: line 4 Sample short vectors s1 and s2 */
   polyvecl_uniform_eta(params, &s1, rhoprime, 0);
   polyveck_uniform_eta(params, &s2, rhoprime, params->l);
+
+  /* Some compilers require that s1 is initalised before first use */
+  OPENSSL_cleanse(&s1, sizeof(s1));
 
   /* FIPS 204: line 5 Matrix-vector multiplication */
   s1hat = s1;

--- a/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
+++ b/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
@@ -31,7 +31,7 @@ int crypto_sign_keypair_internal(ml_dsa_params *params,
   uint8_t tr[TRBYTES];
   const uint8_t *rho, *rhoprime, *key;
   polyvecl mat[DILITHIUM_K_MAX];
-  polyvecl s1 = {{0}};
+  polyvecl s1 = {{{0}}};
   polyvecl s1hat;
   polyveck s2, t1, t0;
 

--- a/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
+++ b/crypto/dilithium/pqcrystals_dilithium_ref_common/sign.c
@@ -31,7 +31,7 @@ int crypto_sign_keypair_internal(ml_dsa_params *params,
   uint8_t tr[TRBYTES];
   const uint8_t *rho, *rhoprime, *key;
   polyvecl mat[DILITHIUM_K_MAX];
-  polyvecl s1 = {{{0}}};
+  polyvecl s1 = {{{{0}}}};
   polyvecl s1hat;
   polyveck s2, t1, t0;
 

--- a/tests/ci/run_posix_sanitizers.sh
+++ b/tests/ci/run_posix_sanitizers.sh
@@ -7,7 +7,7 @@ set -exo pipefail
 source tests/ci/common_posix_setup.sh
 
 build_type=Release
-cflags=("-DCMAKE_BUILD_TYPE=${build_type}")
+cflags=("-DCMAKE_BUILD_TYPE=${build_type}" "-DENABLE_DILITHIUM=ON")
 if [ $(uname -p) == "aarch64" ]; then
   # BoringSSL provides two sets tests: the C/C++ tests and the blackbox tests.
   # Details: https://github.com/google/boringssl/blob/master/BUILDING.md

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -7,36 +7,36 @@ set -exo pipefail
 source tests/ci/common_posix_setup.sh
 
 echo "Testing AWS-LC in debug mode."
-build_and_test
-
-echo "Testing AWS-LC in release mode."
-build_and_test -DCMAKE_BUILD_TYPE=Release
-
-echo "Testing AWS-LC with Dilithium3 enabled."
 build_and_test -DENABLE_DILITHIUM=ON
 
+echo "Testing AWS-LC in release mode."
+build_and_test -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+
+echo "Testing AWS-LC with Dilithium3 disabled."
+build_and_test -DENABLE_DILITHIUM=OFF
+
 echo "Testing AWS-LC small compilation."
-build_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
+build_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
 
 echo "Testing AWS-LC with libssl off."
-build_and_test -DBUILD_LIBSSL=OFF -DCMAKE_BUILD_TYPE=Release
+build_and_test -DBUILD_LIBSSL=OFF -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
 
 echo "Testing AWS-LC in no asm mode."
-build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
+build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
 
 echo "Testing building shared lib."
-build_and_test -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
+build_and_test -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
 
 echo "Testing with a SysGenId."
 TEST_SYSGENID_PATH=$(mktemp)
 dd if=/dev/zero of="${TEST_SYSGENID_PATH}" bs=1 count=4096
-build_and_test -DTEST_SYSGENID_PATH="${TEST_SYSGENID_PATH}"
+build_and_test -DTEST_SYSGENID_PATH="${TEST_SYSGENID_PATH}" -DENABLE_DILITHIUM=ON
 
 echo "Testing with pre-generated assembly code."
-build_and_test -DDISABLE_PERL=ON
+build_and_test -DDISABLE_PERL=ON -DENABLE_DILITHIUM=ON
 
 echo "Testing building with AArch64 Data-Independent Timing (DIT) on."
-build_and_test -DENABLE_DATA_INDEPENDENT_TIMING=ON -DCMAKE_BUILD_TYPE=Release
+build_and_test -DENABLE_DATA_INDEPENDENT_TIMING=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
 
 if [[ "${AWSLC_C99_TEST}" == "1" ]]; then
     echo "Testing the C99 compatability of AWS-LC headers."
@@ -54,10 +54,10 @@ build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "
 
 ## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
 for build_option in "${build_options_to_test[@]}"; do
-  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
+  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON -DENABLE_DILITHIUM=ON
 done
 
 ## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 for build_option in "${build_options_to_test[@]}"; do
-  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON
+  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON -DENABLE_DILITHIUM=ON
 done


### PR DESCRIPTION
### Issues:
Addresses #P175809809

### Description of changes: 
As we prepare ML-DSA and the removal of the `enable_dilithium` flag, we prepare our builds to all enable dilithium. This should also catch addition bugs in the CI.

One such bug has already been found by testing this addition, that has also been addressed in this PR:

```
In file included from /crypto/dilithium/ml_dsa.c:20:
/crypto/dilithium/./pqcrystals_dilithium_ref_common/sign.c: In function ‘crypto_sign_keypair_internal’:
/crypto/dilithium/./pqcrystals_dilithium_ref_common/sign.c:54:9: error: ‘s1’ may be used uninitialized [-Werror=maybe-uninitialized]
 54 | s1hat = s1;
 | ~~~~^~
crypto/dilithium/./pqcrystals_dilithium_ref_common/sign.c:35:12: note: ‘s1’ declared here
 35 | polyvecl s1, s1hat;
 | ^~
```

### Testing:
Found through testing for linux builds/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
