### PR TITLE
Prepare release 1.41.1

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5246,7 +5246,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.40.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.41.1");
 }
 
 #else
@@ -5289,6 +5289,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.40.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.41.1");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.40.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.41.1"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Prepare release v1.41.1

### Call-outs:
* Forgot version bump for [v1.41.0](https://github.com/aws/aws-lc/releases/tag/v1.41.0). 😬

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
