### PR TITLE
Use older image with gcc-13 for alpine linux ci

### DIFF
--- a/.github/docker_images/alpine-linux/Dockerfile
+++ b/.github/docker_images/alpine-linux/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
-FROM alpine:latest
+# TODO(CryptoAlg-2491 & Issue#2010): latest pins to gcc-14, but it's broken with FIPS.
+FROM alpine:3.20
 
 ARG CC=gcc
 ARG CXX=g++


### PR DESCRIPTION
### Description of changes: 
Alpine Linux has started using gcc-14 as the default compiler. This is broken with our FIPS build which has started causing CI failures. See https://github.com/aws/aws-lc/issues/2010

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
