### PR TITLE
Just use releasecheck with tcpdump ci

### DIFF
--- a/tests/ci/integration/run_tcpdump_integration.sh
+++ b/tests/ci/integration/run_tcpdump_integration.sh
@@ -42,7 +42,6 @@ function tcpdump_build() {
 }
 
 function tcpdump_run_tests() {
-  make -j "$NUM_CPU_THREADS" check
   make -j "$NUM_CPU_THREADS" releasecheck
 }
 


### PR DESCRIPTION
Resolves `V1564319359`

### Description of changes: 
The CI issues we've been having stems from some new tests tcpdump has for the upcoming 2038 problem. However, these tests will fail with outdated versions of libpcap that don't support the preprocessor macro `_TIME_BITS` (Documented in https://github.com/the-tcpdump-group/tcpdump/pull/1147)

Tcpdump's fixed the issue when running release-check: https://github.com/the-tcpdump-group/tcpdump/commit/0546e6a33ae2f70bb480556a2317780aa22e83bf. Release-check also runs with check, but with a more defined process. 
Since upstream's just running release-check to encapsulate everything, I think we can just run release-check here to get rid of CI issues.

### Call-outs:
N/A

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
