### PR TITLE
Prune hanging instances longer than 2 hours

### DIFF
--- a/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
+++ b/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
@@ -10,9 +10,6 @@ mainSteps:
     inputs:
       timeoutSeconds: '7200'
       runCommand:
-        # TODO (P131897680): Parallelize the FIPS and sanitizer tests. The instance timeout can be lowered
-        #       once we do so.
-        #
         # Fallback plan to shut down the ec2 instance in 90 minutes in case it's not terminated.
         # Codebuild just "stops" the instance calling the script, so "trap cleanup" is not executed.
         - shutdown -P +90
@@ -28,6 +25,7 @@ mainSteps:
         # install aws-cli
         - killall apt apt-get
         - apt-get update
+        - apt-get -y remove needrestart
         - apt-get -y install unzip
         - curl "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_CLI_PREFIX}64.zip" -o "awscliv2.zip"
         - unzip awscliv2.zip


### PR DESCRIPTION
### Issues:
Resolves `P178122942`

### Description of changes: 
Some ec2 instances aren't successfully terminated along with the pruned commits/jobs and we don't have any additional retry logic to handle that. This adds logic to the job pruner to terminate any ec2-test-framework instances hanging longer than a couple hours. There were also some inconsistent failures with the instance wanting to be restarted, removing `needrestart` from the instance should solve that.

### Call-outs:
N/A

### Testing:
Tested in local fork: https://github.com/samuel40791765/aws-lc/pull/36

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
