### PR TITLE
Update BoringSSL benchmark to use C++17

### DIFF
--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -82,7 +82,7 @@ build_openssl_no_debug $openssl_3_2_branch
 build_openssl_no_debug $openssl_master_branch
 build_boringssl
 
-run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=14 -DCMAKE_C_STANDARD=11 -DENABLE_DILITHIUM=ON -DBENCHMARK_LIBS="\
+run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DCMAKE_C_STANDARD=11 -DENABLE_DILITHIUM=ON -DBENCHMARK_LIBS="\
 aws-lc-fips-2021:${install_dir}/aws-lc-fips-2021-10-20;\
 aws-lc-fips-2022:${install_dir}/aws-lc-fips-2022-11-02;\
 aws-lc-fips-2024:${install_dir}/aws-lc-fips-2024-09-27;\


### PR DESCRIPTION
### Description of changes: 
BoringSSL now requires C++17 after https://github.com/google/boringssl/commit/9ff849165a4b6c33efc2e1b10b71400ce2257fed. When we build speed.cc with BoringSSL's headers we need to specify our our build to use C++17. This is blocking all of our CI with failures like [this](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiWk5IUWJGRGxBcTJ2Mkp4WGF3dnBwYjc5V0ZZYSt5SVVGbkwvODkydTNTaVQ2V2FMN3hwa0tjSWNFemw2QWtCWW5welFWV3lpRFpKVitwejgvelhpRWh3NDNqcWhKalpPYW9hL2tLMDlJSDFPT1NkNyIsIml2UGFyYW1ldGVyU3BlYyI6Ilp4VXRNQXFGM1BZYVlaRkIiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D/build/73b9a032-23e0-493c-b4f2-08fce7df7798). 

### Call-outs:
This does not change AWS-LC's normal C++11 requirement.

### Testing:
The CI will build this. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
