### PR TITLE
Add PKCS7_print_ctx as a no-op

### DIFF
--- a/crypto/pkcs7/pkcs7_asn1.c
+++ b/crypto/pkcs7/pkcs7_asn1.c
@@ -186,3 +186,13 @@ ASN1_SEQUENCE(PKCS7_ENVELOPE) = {
                 PKCS7_ENC_CONTENT)} ASN1_SEQUENCE_END(PKCS7_ENVELOPE)
 
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_ENVELOPE)
+
+int PKCS7_print_ctx(BIO *bio, PKCS7 *pkcs7, int indent, const ASN1_PCTX *pctx) {
+  GUARD_PTR(bio);
+  GUARD_PTR(pkcs7);
+
+  if (BIO_printf(bio, "PKCS7 printing is not supported") <= 0) {
+    return 0;
+  }
+  return 1;
+}

--- a/crypto/pkcs7/pkcs7_test.cc
+++ b/crypto/pkcs7/pkcs7_test.cc
@@ -2032,3 +2032,14 @@ TEST(PKCS7Test, TestSigned) {
   EXPECT_FALSE(PKCS7_verify(p7.get(), certs.get(), store.get(), bio_in.get(),
                             bio_out.get(), /*flags*/ 0));
 }
+
+TEST(PKCS7Test, PKCS7PrintNoop) {
+  bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
+  bssl::UniquePtr<PKCS7> p7(PKCS7_new());
+  ASSERT_TRUE(PKCS7_print_ctx(bio.get(), p7.get(), 0, nullptr));
+
+  const uint8_t *contents;
+  size_t len;
+  ASSERT_TRUE(BIO_mem_contents(bio.get(), &contents, &len));
+  EXPECT_EQ(Bytes(contents, len), Bytes("PKCS7 printing is not supported"));
+}

--- a/include/openssl/pkcs7.h
+++ b/include/openssl/pkcs7.h
@@ -523,6 +523,11 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED PKCS7 *SMIME_read_PKCS7(BIO *in, BIO **bcont);
 OPENSSL_EXPORT OPENSSL_DEPRECATED int SMIME_write_PKCS7(BIO *out, PKCS7 *p7,
                                                         BIO *data, int flags);
 
+// PKCS7_print_ctx prints "PKCS7 printing is not supported" and returns 1.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int PKCS7_print_ctx(BIO *bio, PKCS7 *pkcs7,
+                                                      int indent,
+                                                      const ASN1_PCTX *pctx);
+
 #if defined(__cplusplus)
 }  // extern C
 


### PR DESCRIPTION
### Description of changes: 
Ruby's mainline branch has added support for printing the contents for a PKCS7 structure:https://github.com/ruby/ruby/commit/841b45a4421a7f103b0312f84c14ece522833617 The hooks to print ASN1_items have been removed from AWS-LC, so this would require a lot for us to add back and support. 
This is only a print function though, I think we can no-op this for a better build and indicate we don't support printing the contents.

### Call-outs:
N/A

### Testing:
Minor test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
