### PR TITLE
Alias OpenSSL SECLEVEL directives to ALL

### DIFF
--- a/ssl/ssl_cipher.cc
+++ b/ssl/ssl_cipher.cc
@@ -1187,11 +1187,14 @@ static bool ssl_cipher_process_rulestr(const char *rule_str,
 
     // Ok, we have the rule, now apply it.
     if (rule == CIPHER_SPECIAL) {
-      if (buf_len != 8 || strncmp(buf, "STRENGTH", 8) != 0) {
+      if (buf_len == 8 && strncmp(buf, "STRENGTH", 8) == 0) {
+        if (!ssl_cipher_strength_sort(head_p, tail_p)) {
+          return false;
+        }
+      } else if (buf_len >= 8 && strncmp(buf, "SECLEVEL", 8) == 0) {
+        // do nothing, process the rest of the rule
+      } else {
         OPENSSL_PUT_ERROR(SSL, SSL_R_INVALID_COMMAND);
-        return false;
-      }
-      if (!ssl_cipher_strength_sort(head_p, tail_p)) {
         return false;
       }
 
@@ -1219,6 +1222,9 @@ static const char *kKnownKeywordFilterRulesMappingToDefault[] = {
   "DEFAULT",
   "FIPS",
   "HIGH",
+  "SECLEVEL=0",
+  "SECLEVEL=1",
+  "SECLEVEL=2",
 };
 
 static bool is_known_default_alias_keyword_filter_rule(const char *rule,

--- a/ssl/ssl_cipher.cc
+++ b/ssl/ssl_cipher.cc
@@ -1191,7 +1191,7 @@ static bool ssl_cipher_process_rulestr(const char *rule_str,
         if (!ssl_cipher_strength_sort(head_p, tail_p)) {
           return false;
         }
-      } else if (buf_len >= 8 && strncmp(buf, "SECLEVEL", 8) == 0) {
+      } else if (buf_len >= 10 && strncmp(buf, "SECLEVEL=0", 10) == 0) {
         // do nothing, process the rest of the rule
       } else {
         OPENSSL_PUT_ERROR(SSL, SSL_R_INVALID_COMMAND);
@@ -1223,8 +1223,6 @@ static const char *kKnownKeywordFilterRulesMappingToDefault[] = {
   "FIPS",
   "HIGH",
   "SECLEVEL=0",
-  "SECLEVEL=1",
-  "SECLEVEL=2",
 };
 
 static bool is_known_default_alias_keyword_filter_rule(const char *rule,

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -566,7 +566,7 @@ static const char *kBadRules[] = {
 };
 
 static const char *kMustNotIncludeNull[] = {
-    "ALL",  "DEFAULT", "HIGH",  "FIPS",  "SHA",
+    "ALL",  "DEFAULT", "HIGH",  "FIPS",  "SHA", "SECLEVEL=0",
     "SHA1", "RSA",     "SSLv3", "TLSv1", "TLSv1.2",
 };
 
@@ -575,10 +575,11 @@ static const char *kTLSv13MustNotIncludeNull[] = {
     "DEFAULT",
     "HIGH",
     "FIPS",
+    "SECLEVEL=0",
 };
 
 static const char *kMustNotInclude3DES[] = {
-    "ALL", "DEFAULT", "HIGH", "FIPS", "SSLv3", "TLSv1", "TLSv1.2",
+    "ALL", "DEFAULT", "HIGH", "FIPS", "SSLv3", "TLSv1", "TLSv1.2", "SECLEVEL=0",
 };
 
 static const CurveTest kCurveTests[] = {
@@ -1761,6 +1762,7 @@ TEST(SSLTest, TLSv13CipherRules) {
     ASSERT_TRUE(ssl);
 
     EXPECT_FALSE(SSL_CTX_set_ciphersuites(ctx.get(), t.rule));
+    // TODO [childw]
     EXPECT_FALSE(SSL_set_ciphersuites(ssl.get(), t.rule));
     ASSERT_EQ(ERR_GET_REASON(ERR_get_error()), SSL_R_NO_CIPHER_MATCH);
     ERR_clear_error();

--- a/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
@@ -2,28 +2,11 @@ diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
 index 0e50d09..f4b7b3c 100644
 --- a/Lib/test/test_ssl.py
 +++ b/Lib/test/test_ssl.py
-@@ -41,6 +41,7 @@
- from ssl import Purpose, TLSVersion, _TLSContentType, _TLSMessageType, _TLSAlertType
- 
- Py_DEBUG_WIN32 = support.Py_DEBUG and sys.platform == 'win32'
-+Py_OPENSSL_IS_AWSLC = "AWS-LC" in ssl.OPENSSL_VERSION
- 
- PROTOCOLS = sorted(ssl._PROTOCOL_NAMES)
- HOST = socket_helper.HOST
-@@ -174,7 +175,7 @@ def is_ubuntu():
-     except FileNotFoundError:
-         return False
- 
--if is_ubuntu():
-+if is_ubuntu() and not Py_OPENSSL_IS_AWSLC:
-     def seclevel_workaround(*ctxs):
-         """"Lower security level to '1' and allow all ciphers for TLS 1.0/1"""
-         for ctx in ctxs:
-@@ -4001,6 +4002,7 @@ def test_no_legacy_server_connect(self):
+@@ -4034,6 +4034,7 @@ def test_no_legacy_server_connect(self):
                                     sni_name=hostname)
- 
+
      @unittest.skipIf(Py_DEBUG_WIN32, "Avoid mixing debug/release CRT on Windows")
-+    @unittest.skipIf(Py_OPENSSL_IS_AWSLC, "AWS-LC doesn't support (FF)DHE")
++    @unittest.skipIf("AWS-LC" in ssl.OPENSSL_VERSION, "AWS-LC doesn't support")
      def test_dh_params(self):
          # Check we can get a connection with ephemeral Diffie-Hellman
          client_context, server_context, hostname = testing_context()


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-2792

### Description of changes: 

To increase compatibility with OpenSSL's notion of "security levels", this commit aliases all security levels ≤ 2 to AWS-LC's `ALL` alias. Described [here](https://docs.openssl.org/master/man3/SSL_CTX_set_security_level/#default-callback-behaviour), OpenSSL's security level 0 provides no minimum.

### Testing:

- CI with reduced CPython patch set

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
