### PR TITLE
CMake, use 'NOT WIN32' instead of 'UNIX'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
   set(GCC 1)
 endif()
 
-if (UNIX AND NOT APPLE)
+if (NOT WIN32 AND NOT APPLE)
   include(GNUInstallDirs)
 elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
   set(CMAKE_INSTALL_LIBDIR "lib")
@@ -737,7 +737,7 @@ if(FIPS)
     message(FATAL_ERROR "Building AWS-LC for FIPS requires Go and Perl")
   endif()
 
-  if(NOT BUILD_SHARED_LIBS AND NOT (UNIX AND NOT APPLE))
+  if(NOT BUILD_SHARED_LIBS AND NOT (NOT WIN32 AND NOT APPLE))
     message(FATAL_ERROR "Static FIPS build of AWS-LC is suported only on Linux")
   endif()
 

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -44,7 +44,7 @@ function(msbuild_aarch64_asm)
 endfunction()
 
 if(NOT OPENSSL_NO_ASM)
-  if(UNIX)
+  if(NOT WIN32)
     if(ARCH STREQUAL "aarch64")
       # The "armx" Perl scripts look for "64" in the style argument
       # in order to decide whether to generate 32- or 64-bit asm.
@@ -186,7 +186,7 @@ else()
     set(ASSEMBLY_SOURCE ${GENERATE_CODE_ROOT}/ios-arm/crypto/)
   elseif(APPLE)
     set(ASSEMBLY_SOURCE ${GENERATE_CODE_ROOT}/mac-${ARCH}/crypto/)
-  elseif(UNIX)
+  elseif(NOT WIN32)
     if(${ARCH} STREQUAL "generic")
       message(STATUS "Detected generic linux platform. No assembly files will be included.")
     else()


### PR DESCRIPTION
### Description of changes: 
CMake condition on `UNIX` should instead be `NOT WIN32` b/c some unix-like operating systems do not identify with "UNIX". 

### Callout
The "UNIX" variable appears to not be set on illumos, which leads to build failures like this: https://github.com/rust-lang/rustup/actions/runs/12384929706/job/34570334451#step:17:584

### Testing
I verified locally that with this change the build of `aws-lc-sys` for `x86_64-unknown-illumos` succeeds.
<details>

```
❯ cargo clean && cross build --target x86_64-unknown-illumos
     Removed 215 files, 74.6MiB total
[+] Building 7.1s (8/8) FINISHED                                                                                                                                                                                                                                 docker-container:container
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 843B                                                                                                                                                                                                                                                   0.0s
 => [internal] load metadata for ghcr.io/cross-rs/x86_64-unknown-illumos:main                                                                                                                                                                                                          0.3s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                        0.0s
 => [1/3] FROM ghcr.io/cross-rs/x86_64-unknown-illumos:main@sha256:ff410dca255986b9bb06f74c466f5d032502951d49c4436b401c3d7acd17a0d3                                                                                                                                                    0.0s
 => => resolve ghcr.io/cross-rs/x86_64-unknown-illumos:main@sha256:ff410dca255986b9bb06f74c466f5d032502951d49c4436b401c3d7acd17a0d3                                                                                                                                                    0.0s
 => CACHED [2/3] RUN apt-get update &&     apt-get install --assume-yes --no-install-recommends gpg-agent software-properties-common &&     add-apt-repository --yes ppa:longsleep/golang-backports &&     apt-get update &&     apt-get install --assume-yes --no-install-recommends  0.0s
 => CACHED [3/3] RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable &&     . $HOME/.cargo/env &&     cargo install --force --locked bindgen-cli && mv $HOME/.cargo/bin/bindgen /usr/bin &&     rm -rf $HOME/.ca  0.0s
 => exporting to docker image format                                                                                                                                                                                                                                                   6.7s
 => => exporting layers                                                                                                                                                                                                                                                                0.0s
 => => exporting manifest sha256:e61a79c40bbd531f030688b9306e726757fb3b45ac9a62a81fced103d4c12344                                                                                                                                                                                      0.0s
 => => exporting config sha256:6cc549d380a42123a4f54e820fd0d1b09817b446fc521540a6ad799c3bdb6c72                                                                                                                                                                                        0.0s
 => => sending tarball                                                                                                                                                                                                                                                                 6.7s
 => importing to docker                                                                                                                                                                                                                                                                0.0s
   Compiling libc v0.2.168
   Compiling shlex v1.3.0
   Compiling fs_extra v1.3.0
   Compiling paste v1.0.15
   Compiling dunce v1.0.5
   Compiling jobserver v0.1.32
   Compiling cc v1.2.3
   Compiling cmake v0.1.52
   Compiling aws-lc-sys v0.24.0 (/Users/justsmth/repos/aws-lc-rs/aws-lc-sys)
warning: aws-lc-sys@0.24.0: Building with: CMake
warning: aws-lc-sys@0.24.0: Symbol Prefix: Some("aws_lc_0_24_0")
warning: aws-lc-sys@0.24.0: CMAKE environment variable set: cmake
warning: aws-lc-sys@0.24.0: Generating bindings - external bindgen. Platform: x86_64-unknown-illumos
warning: aws-lc-sys@0.24.0: Compilation of 'c11.c' succeeded - Ok(["/target/x86_64-unknown-illumos/debug/build/aws-lc-sys-00266876999d9957/out/out-c11/7dfda64fdf5a526c-c11.o"]).
warning: aws-lc-sys@0.24.0: CC environment variable set: clang
warning: aws-lc-sys@0.24.0: CXX environment variable set: clang++
warning: aws-lc-sys@0.24.0: Setting CFLAGS: "-O0 -ffunction-sections -fdata-sections -fPIC -g -fno-omit-frame-pointer -m64 -std=c11 -I /Users/justsmth/repos/aws-lc-rs/aws-lc-sys/generated-include -I /Users/justsmth/repos/aws-lc-rs/aws-lc-sys/include -I /Users/justsmth/repos/aws-lc-rs/aws-lc-sys/aws-lc/include -I /Users/justsmth/repos/aws-lc-rs/aws-lc-sys/aws-lc/third_party/s2n-bignum/include -Wall -Wextra -Wno-unused-parameter -DBORINGSSL_IMPLEMENTATION=1 -DBORINGSSL_PREFIX=aws_lc_0_24_0"
warning: aws-lc-sys@0.24.0: CMAKE_TOOLCHAIN_FILE environment variable set: /opt/toolchain.cmake
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 36.72s
```

</details>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
