### PR TITLE
Add more logging for SSL_ERROR_SYSCALL errors in bssl_shim.cc

### DIFF
--- a/ssl/test/bssl_shim.cc
+++ b/ssl/test/bssl_shim.cc
@@ -31,6 +31,7 @@ OPENSSL_MSVC_PRAGMA(warning(pop))
 #endif
 
 #include <assert.h>
+#include <errno.h>
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
@@ -986,6 +987,11 @@ static bool DoConnection(bssl::UniquePtr<SSL_SESSION> *out_session,
     int ssl_err = SSL_get_error(ssl.get(), -1);
     if (ssl_err != SSL_ERROR_NONE) {
       fprintf(stderr, "SSL error: %s\n", SSL_error_description(ssl_err));
+      if (ssl_err == SSL_ERROR_SYSCALL) {
+        int err = errno;
+        fprintf(stderr, "Error occurred: errno = %d, description = %s\n", err, std::strerror(err));
+
+      }
     }
     return false;
   }

--- a/ssl/test/bssl_shim.cc
+++ b/ssl/test/bssl_shim.cc
@@ -989,7 +989,7 @@ static bool DoConnection(bssl::UniquePtr<SSL_SESSION> *out_session,
       fprintf(stderr, "SSL error: %s\n", SSL_error_description(ssl_err));
       if (ssl_err == SSL_ERROR_SYSCALL) {
         int err = errno;
-        fprintf(stderr, "Error occurred: errno = %d, description = %s\n", err, std::strerror(err));
+        fprintf(stderr, "Error occurred: errno = %d, description = %s\n", err, strerror(err));
 
       }
     }


### PR DESCRIPTION
### Issues:
Addresses V1370176317

### Description of changes: 
Attempt to get more information about SSL test failures. In the event of [SSL_ERROR_SYSCALL](https://github.com/aws/aws-lc/blob/main/include/openssl/ssl.h#L578-L583) errno might have more information about the issue.

### Testing:
I can't reproduce the failures locally, but hopefully this prints more information that might help.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
