### PR TITLE
Fix python tests for upstream PR 128036

### DIFF
--- a/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
@@ -1,16 +1,3 @@
-diff --git a/Lib/test/test_httplib.py b/Lib/test/test_httplib.py
-index 6e63a88..7dc83d7 100644
---- a/Lib/test/test_httplib.py
-+++ b/Lib/test/test_httplib.py
-@@ -2066,7 +2066,7 @@ def test_host_port(self):
- 
-     def test_tls13_pha(self):
-         import ssl
--        if not ssl.HAS_TLSv1_3:
-+        if not ssl.HAS_TLSv1_3 or "AWS-LC" in ssl.OPENSSL_VERSION:
-             self.skipTest('TLS 1.3 support required')
-         # just check status of PHA flag
-         h = client.HTTPSConnection('localhost', 443)
 diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
 index 0e50d09..f4b7b3c 100644
 --- a/Lib/test/test_ssl.py
@@ -74,50 +61,6 @@ index 0e50d09..f4b7b3c 100644
          server_context.minimum_version = ssl.TLSVersion.TLSv1_3
          server_context.set_ciphers('PSK')
          server_context.set_psk_server_callback(server_callback, identity_hint)
-@@ -4461,7 +4463,10 @@ def server_callback(identity):
-                 s.connect((HOST, server.port))
- 
- 
--@unittest.skipUnless(has_tls_version('TLSv1_3'), "Test needs TLS 1.3")
-+@unittest.skipUnless(
-+    has_tls_version('TLSv1_3') and not Py_OPENSSL_IS_AWSLC,
-+    "Test needs TLS 1.3; AWS-LC doesn't support PHA"
-+)
- class TestPostHandshakeAuth(unittest.TestCase):
-     def test_pha_setter(self):
-         protocols = [
-@@ -4737,6 +4742,31 @@ def test_internal_chain_server(self):
-                 self.assertEqual(res, b'\x02\n')
- 
- 
-+@unittest.skipUnless(Py_OPENSSL_IS_AWSLC, "Only test this against AWS-LC")
-+class TestPostHandshakeAuthAwsLc(unittest.TestCase):
-+    def test_pha(self):
-+        protocols = [
-+            ssl.PROTOCOL_TLS_SERVER, ssl.PROTOCOL_TLS_CLIENT
-+        ]
-+        for protocol in protocols:
-+            client_ctx, server_ctx, hostname = testing_context()
-+            client_ctx.load_cert_chain(SIGNED_CERTFILE)
-+            self.assertEqual(client_ctx.post_handshake_auth, None)
-+            with self.assertRaises(AttributeError):
-+                client_ctx.post_handshake_auth = True
-+            with self.assertRaises(AttributeError):
-+                server_ctx.post_handshake_auth = True
-+
-+            with ThreadedEchoServer(context=server_ctx) as server:
-+                with client_ctx.wrap_socket(
-+                    socket.socket(),
-+                    server_hostname=hostname
-+                ) as ssock:
-+                    ssock.connect((HOST, server.port))
-+                    with self.assertRaises(NotImplementedError):
-+                        ssock.verify_client_post_handshake()
-+
-+
- HAS_KEYLOG = hasattr(ssl.SSLContext, 'keylog_filename')
- requires_keylog = unittest.skipUnless(
-     HAS_KEYLOG, 'test requires OpenSSL 1.1.1 with keylog callback')
 diff --git a/Modules/Setup b/Modules/Setup
 index cd1cf24..53bcc4c 100644
 --- a/Modules/Setup


### PR DESCRIPTION
### Issues:
n/a

### Description of changes: 

Upstream PR 128036 added a new `ssl.HAS_PHA` boolean property and allows CPython's tests to account for lack of post-handshake authentication support. This allows us to delete relevant patch sets.

### Call-outs:

n/a

### Testing:

- CI


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
