### PR TITLE
Add more test coverage for Ruby/OpenSSL gem

### DIFF
--- a/tests/ci/integration/ruby_patch/ruby_patch_common/net-http.patch
+++ b/tests/ci/integration/ruby_patch/ruby_patch_common/net-http.patch
@@ -1,0 +1,22 @@
+diff --git a/test/net/http/test_https.rb b/test/net/http/test_https.rb
+index a24f5e0..26ab754 100644
+--- a/test/net/http/test_https.rb
++++ b/test/net/http/test_https.rb
+@@ -167,6 +167,8 @@ def test_session_reuse
+   def test_session_reuse_but_expire
+     # FIXME: The new_session_cb is known broken for clients in OpenSSL 1.1.0h.
+     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 1.1.0h')
++    # "AWS-LC does not support internal session caching on the client".
++    omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('AWS-LC')
+ 
+     http = Net::HTTP.new(HOST, config("port"))
+     http.use_ssl = true
+@@ -237,7 +239,7 @@ def test_certificate_verify_failure
+     ex = assert_raise(OpenSSL::SSL::SSLError){
+       http.request_get("/") {|res| }
+     }
+-    assert_match(/certificate verify failed/, ex.message)
++    assert_match(/certificate verify failed|CERTIFICATE_VERIFY_FAILED/, ex.message)
+     unless /mswin|mingw/ =~ RUBY_PLATFORM
+       # on Windows, Errno::ECONNRESET will be raised, and it'll be eaten by
+       # WEBrick

--- a/tests/ci/integration/ruby_patch/ruby_release_backport/Fix-wrong-certificate-version.patch
+++ b/tests/ci/integration/ruby_patch/ruby_release_backport/Fix-wrong-certificate-version.patch
@@ -1,0 +1,31 @@
+From 226ae828c5cc2c87245417e9a372b9403c91a54c Mon Sep 17 00:00:00 2001
+From: Jeremy Evans <code@jeremyevans.net>
+Date: Tue, 4 Jun 2024 16:35:06 -0700
+Subject: [PATCH] Fix wrong certificate version
+
+OpenSSL::X509::Certificate#version= calls X509_set_version, and
+that sets the version stored in the certificate.  However, the
+version stored in certificate is one less than the actual
+certificate version (https://www.openssl.org/docs/manmaster/man3/X509_set_version.html).
+There are no version 4 certificates, and when using recent LibreSSL,
+drb ssl tests all fail without this change.
+---
+ lib/drb/ssl.rb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/drb/ssl.rb b/lib/drb/ssl.rb
+index 392d656..4e4d992 100644
+--- a/lib/drb/ssl.rb
++++ b/lib/drb/ssl.rb
+@@ -185,7 +185,7 @@ module DRb
+         }
+ 
+         cert = OpenSSL::X509::Certificate.new
+-        cert.version = 3
++        cert.version = 2
+         cert.serial = 0
+         name = OpenSSL::X509::Name.new(self[:SSLCertName])
+         cert.subject = name
+-- 
+2.25.1
+


### PR DESCRIPTION
### Description of changes: 
Follow up from https://github.com/aws/aws-lc/pull/1563#discussion_r1880802258 where we add more test coverage for the Ruby/OpenSSL gem. 
* `ruby_release_backport` is for any commits that are already on the main branch and are required for some tests on older releases to pass through.
* `ruby_patch_common` is for commits that all branches should need for additional tests to pass. These are outside of the ruby/openssl gem boundary, so I chose to consolidate the logic in a separate patch. Patches in this folder would be submitted to their respective repos instead of https://github.com/ruby/openssl.

### Call-outs:
N/A

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
