### PR TITLE
aws-lc-rs scripts now use nightly

### DIFF
--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: https://proxy.golang.org,direct
   AWS_LC_SYS_CMAKE_BUILDER: 1
   RUST_NIGHTLY_TOOLCHAIN: nightly
-  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly-2024-05-22
+  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly
 jobs:
   aws-lc-rs-bindgen:
     if: github.repository_owner == 'aws'


### PR DESCRIPTION
### Description of changes: 
Recently merged change in aws-lc-rs switched the toolchain used by scripts: 
* aws/aws-lc-rs#641

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
