### PR TITLE
Provide FIPS_is_entropy_cpu_jitter()

### DIFF
--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -73,6 +73,14 @@ TEST(CryptoTest, Strndup) {
   EXPECT_STREQ("", str.get());
 }
 
+TEST(CryptoTest, aws_lc_assert_entropy_cpu_jitter) {
+#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
+  ASSERT_EQ(1, FIPS_is_entropy_cpu_jitter());
+#else
+  ASSERT_EQ(0, FIPS_is_entropy_cpu_jitter());
+#endif
+}
+
 TEST(CryptoTest, OPENSSL_hexstr2buf) {
   const char *test_cases[][2] = {{"a2", "\xa2"},
                                  {"a213", "\xa2\x13"},

--- a/crypto/fipsmodule/self_check/fips.c
+++ b/crypto/fipsmodule/self_check/fips.c
@@ -28,6 +28,14 @@ int FIPS_mode(void) {
 #endif
 }
 
+int FIPS_is_entropy_cpu_jitter(void) {
+#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
+  return 1;
+#else
+  return 0;
+#endif
+}
+
 int FIPS_mode_set(int on) { return on == FIPS_mode(); }
 
 #if defined(BORINGSSL_FIPS_140_3)

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -117,8 +117,8 @@ OPENSSL_EXPORT void armv8_enable_dit(void);
 // which case it returns one.
 OPENSSL_EXPORT int FIPS_mode(void);
 
-// RAND_is_entropy_cpu_jitter returns 1 if CPU jitter entropy
-// was not enabled for the build. Otherwise, returns 0;
+// FIPS_is_entropy_cpu_jitter returns 1 if CPU jitter is used as the entropy source
+// for AWS-LC. Otherwise, returns 0;
 OPENSSL_EXPORT int FIPS_is_entropy_cpu_jitter(void);
 
 // fips_counter_t denotes specific APIs/algorithms. A counter is maintained for

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -117,6 +117,10 @@ OPENSSL_EXPORT void armv8_enable_dit(void);
 // which case it returns one.
 OPENSSL_EXPORT int FIPS_mode(void);
 
+// RAND_is_entropy_cpu_jitter returns 1 if CPU jitter entropy
+// was not enabled for the build. Otherwise, returns 0;
+OPENSSL_EXPORT int FIPS_is_entropy_cpu_jitter(void);
+
 // fips_counter_t denotes specific APIs/algorithms. A counter is maintained for
 // each in FIPS mode so that tests can be written to assert that the expected,
 // FIPS functions are being called by a certain peice of code.


### PR DESCRIPTION
### Issues:
Addresses: CryptoAlg-2814

### Description of changes: 
* Provides `FIPS_is_entropy_cpu_jitter()` for consumers to confirm build is using CPU jitter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
