### PR TITLE
FreeBSD and OpenBSD fork detection

### DIFF
--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -609,8 +609,8 @@ TEST(URandomTest, Test) {
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
-  if (getenv("BORINGSSL_IGNORE_MADV_WIPEONFORK")) {
-    CRYPTO_fork_detect_ignore_madv_wipeonfork_FOR_TESTING();
+  if (getenv("BORINGSSL_IGNORE_WIPEONFORK")) {
+    CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING();
   }
 
   return RUN_ALL_TESTS();

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -36,6 +36,8 @@
 #include "../../ube/fork_detect.h"
 #include "getrandom_fillin.h"
 
+#include "../../test/test_util.h"
+
 #include <cstdlib>
 #include <unistd.h>
 #include <fcntl.h>
@@ -609,9 +611,7 @@ TEST(URandomTest, Test) {
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
-  if (getenv("BORINGSSL_IGNORE_WIPEONFORK")) {
-    CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING();
-  }
+  maybeDisableSomeForkDetectMechanisms();
 
   return RUN_ALL_TESTS();
 }

--- a/crypto/rand_extra/rand_test.cc
+++ b/crypto/rand_extra/rand_test.cc
@@ -38,14 +38,6 @@
 #include <unistd.h>
 #endif
 
-static void maybe_disable_some_fork_detect_mechanisms(void) {
-#if defined(OPENSSL_LINUX)
-  if (getenv("BORINGSSL_IGNORE_WIPEONFORK")) {
-    CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING();
-  }
-#endif
-}
-
 
 // These tests are, strictly speaking, flaky, but we use large enough buffers
 // that the probability of failing when we should pass is negligible.
@@ -53,7 +45,7 @@ static void maybe_disable_some_fork_detect_mechanisms(void) {
 TEST(RandTest, NotObviouslyBroken) {
   static const uint8_t kZeros[256] = {0};
 
-  maybe_disable_some_fork_detect_mechanisms();
+  maybeDisableSomeForkDetectMechanisms();
 
   uint8_t buf1[256], buf2[256];
   RAND_bytes(buf1, sizeof(buf1));
@@ -141,7 +133,7 @@ static bool ForkAndRand(bssl::Span<uint8_t> out, bool fork_unsafe_buffering) {
 TEST(RandTest, Fork) {
   static const uint8_t kZeros[16] = {0};
 
-  maybe_disable_some_fork_detect_mechanisms();
+  maybeDisableSomeForkDetectMechanisms();
 
   // Draw a little entropy to initialize any internal PRNG buffering.
   uint8_t byte;
@@ -204,7 +196,7 @@ TEST(RandTest, Threads) {
   constexpr size_t kFewerThreads = 10;
   constexpr size_t kMoreThreads = 20;
 
-  maybe_disable_some_fork_detect_mechanisms();
+  maybeDisableSomeForkDetectMechanisms();
 
   // Draw entropy in parallel.
   RunConcurrentRands(kFewerThreads);

--- a/crypto/rand_extra/rand_test.cc
+++ b/crypto/rand_extra/rand_test.cc
@@ -40,8 +40,8 @@
 
 static void maybe_disable_some_fork_detect_mechanisms(void) {
 #if defined(OPENSSL_LINUX)
-  if (getenv("BORINGSSL_IGNORE_MADV_WIPEONFORK")) {
-    CRYPTO_fork_detect_ignore_madv_wipeonfork_FOR_TESTING();
+  if (getenv("BORINGSSL_IGNORE_WIPEONFORK")) {
+    CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING();
   }
 #endif
 }

--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -225,3 +225,10 @@ bool threadTest(const size_t numberOfThreads, std::function<void(bool*)> testFun
 
   return res;
 }
+
+void maybeDisableSomeForkDetectMechanisms(void) {
+  if (getenv("BORINGSSL_IGNORE_FORK_DETECTION")) {
+    CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING();
+    CRYPTO_fork_detect_ignore_inheritzero_FOR_TESTING();
+  }
+}

--- a/crypto/test/test_util.h
+++ b/crypto/test/test_util.h
@@ -29,6 +29,7 @@
 #include <openssl/span.h>
 
 #include "../internal.h"
+#include "../ube/fork_detect.h"
 
 
 // hexdump writes |msg| to |fp| followed by the hex encoding of |len| bytes
@@ -114,6 +115,8 @@ bool osIsAmazonLinux(void);
 // non-concurrently.
 bool threadTest(const size_t numberOfThreads,
   std::function<void(bool*)> testFunc);
+
+void maybeDisableSomeForkDetectMechanisms(void);
 
 // CustomData is for testing new structs that we add support for |ex_data|.
 typedef struct {

--- a/crypto/ube/fork_detect.c
+++ b/crypto/ube/fork_detect.c
@@ -40,12 +40,16 @@
   #define AWSLC_PLATFORM_DOES_NOT_FORK
 #endif
 
+#include "fork_detect.h"
+
+static int ignore_wipeonfork = 0;
+static int ignore_inheritzero = 0;
+
 #if defined(AWSLC_FORK_DETECTION_SUPPORTED)
 
 #include <openssl/base.h>
 #include <openssl/type_check.h>
 
-#include "fork_detect.h"
 #include "../internal.h"
 
 #include <stdlib.h>
@@ -58,8 +62,6 @@ static struct CRYPTO_STATIC_MUTEX fork_detect_lock = CRYPTO_STATIC_MUTEX_INIT;
 // assume that it has exclusive access to it.
 static volatile char *fork_detect_addr = NULL;
 static uint64_t fork_generation = 0;
-static int ignore_wipeonfork = 0;
-static int ignore_inheritzero = 0;
 
 static int ignore_all_fork_detection(void) {
   if (ignore_wipeonfork == 1 &&
@@ -247,14 +249,6 @@ uint64_t CRYPTO_get_fork_generation(void) {
   return current_generation;
 }
 
-void CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING(void) {
-  ignore_wipeonfork = 1;
-}
-
-void CRYPTO_fork_detect_ignore_inheritzero_FOR_TESTING(void) {
-  ignore_inheritzero = 1;
-}
-
 #elif defined(AWSLC_PLATFORM_DOES_NOT_FORK)
 
 // These platforms are guaranteed not to fork, and therefore do not require
@@ -272,3 +266,11 @@ uint64_t CRYPTO_get_fork_generation(void) { return 0xc0ffee; }
 uint64_t CRYPTO_get_fork_generation(void) { return 0; }
 
 #endif // defined(AWSLC_FORK_DETECTION_SUPPORTED)
+
+void CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING(void) {
+  ignore_wipeonfork = 1;
+}
+
+void CRYPTO_fork_detect_ignore_inheritzero_FOR_TESTING(void) {
+  ignore_inheritzero = 1;
+}

--- a/crypto/ube/fork_detect.c
+++ b/crypto/ube/fork_detect.c
@@ -113,6 +113,11 @@ static int init_fork_detect_wipeonfork(void *addr, long page_size) {
 #include <sys/mman.h>
 #include <unistd.h>
 
+// Sometimes (for example, on FreeBSD) MAP_INHERIT_ZERO is called INHERIT_ZERO
+#if !defined(MAP_INHERIT_ZERO) && defined(INHERIT_ZERO)
+    #define MAP_INHERIT_ZERO INHERIT_ZERO
+#endif
+
 static int init_fork_detect_inheritzero(void *addr, long page_size) {
 
   GUARD_PTR(addr);

--- a/crypto/ube/fork_detect.c
+++ b/crypto/ube/fork_detect.c
@@ -17,11 +17,13 @@
 #if defined(OPENSSL_LINUX)
   #define AWSLC_FORK_DETECTION_SUPPORTED
   #if !defined(_GNU_SOURCE)
-    #define _GNU_SOURCE  // needed for madvise() and MAP_ANONYMOUS.
+    #define _GNU_SOURCE  // Needed for madvise() and MAP_ANONYMOUS.
   #endif
 #elif defined(OPENSSL_FREEBSD) || defined(OPENSSL_OPENBSD)
-  /* FreeBSD requires POSIX compatibility off for its syscalls (enables __BSD_VISIBLE)
-   * Without the below line, <sys/mman.h> cannot be imported (it requires __BSD_VISIBLE) */
+  #define AWSLC_FORK_DETECTION_SUPPORTED
+  // FreeBSD requires POSIX compatibility off for its syscalls
+  // (enables __BSD_VISIBLE). Without the below line, <sys/mman.h> cannot be
+  // imported (it requires __BSD_VISIBLE).
   #undef _POSIX_C_SOURCE
 #elif defined(OPENSSL_WINDOWS) || defined(OPENSSL_TRUSTY)
   #define AWSLC_PLATFORM_DOES_NOT_FORK

--- a/crypto/ube/fork_detect.h
+++ b/crypto/ube/fork_detect.h
@@ -40,13 +40,13 @@ extern "C" {
 // should only be used as a hardening measure.
 OPENSSL_EXPORT uint64_t CRYPTO_get_fork_generation(void);
 
-// CRYPTO_fork_detect_ignore_madv_wipeonfork_FOR_TESTING is an internal detail
+// CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING is an internal detail
 // used for testing purposes.
-OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_madv_wipeonfork_FOR_TESTING(void);
+OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING(void);
 
-// CRYPTO_fork_detect_ignore_madv_inheritzero_FOR_TESTING is an internal detail
+// CRYPTO_fork_detect_ignore_inheritzero_FOR_TESTING is an internal detail
 // used for testing purposes.
-OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_madv_inheritzero_FOR_TESTING(void);
+OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_inheritzero_FOR_TESTING(void);
 
 
 #if defined(__cplusplus)

--- a/crypto/ube/fork_detect.h
+++ b/crypto/ube/fork_detect.h
@@ -17,10 +17,11 @@
 
 #include <openssl/base.h>
 
+#include <stdint.h>
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
-
 
 
 // crypto_get_fork_generation returns the fork generation number for the current

--- a/crypto/ube/fork_detect.h
+++ b/crypto/ube/fork_detect.h
@@ -21,11 +21,7 @@
 extern "C" {
 #endif
 
-#if defined(OPENSSL_LINUX) || defined(OPENSSL_FREEBSD) || defined(OPENSSL_OPENBSD)
-#define AWSLC_FORK_DETECTION_SUPPORTED
-#elif defined(OPENSSL_WINDOWS) || defined(OPENSSL_TRUSTY)
-#define AWSLC_PLATFORM_DOES_NOT_FORK
-#endif
+
 
 // crypto_get_fork_generation returns the fork generation number for the current
 // process, or zero if not supported on the platform. The fork generation number

--- a/crypto/ube/fork_detect.h
+++ b/crypto/ube/fork_detect.h
@@ -21,6 +21,11 @@
 extern "C" {
 #endif
 
+#if defined(OPENSSL_LINUX) || defined(OPENSSL_FREEBSD) || defined(OPENSSL_OPENBSD)
+#define AWSLC_FORK_DETECTION_SUPPORTED
+#elif defined(OPENSSL_WINDOWS) || defined(OPENSSL_TRUSTY)
+#define AWSLC_PLATFORM_DOES_NOT_FORK
+#endif
 
 // crypto_get_fork_generation returns the fork generation number for the current
 // process, or zero if not supported on the platform. The fork generation number
@@ -41,6 +46,11 @@ OPENSSL_EXPORT uint64_t CRYPTO_get_fork_generation(void);
 // CRYPTO_fork_detect_ignore_madv_wipeonfork_FOR_TESTING is an internal detail
 // used for testing purposes.
 OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_madv_wipeonfork_FOR_TESTING(void);
+
+// CRYPTO_fork_detect_ignore_madv_inheritzero_FOR_TESTING is an internal detail
+// used for testing purposes.
+OPENSSL_EXPORT void CRYPTO_fork_detect_ignore_madv_inheritzero_FOR_TESTING(void);
+
 
 #if defined(__cplusplus)
 }  // extern C

--- a/crypto/ube/fork_detect_test.cc
+++ b/crypto/ube/fork_detect_test.cc
@@ -40,6 +40,8 @@
 
 #include "fork_detect.h"
 
+#include "../test/test_util.h"
+
 
 static pid_t WaitpidEINTR(pid_t pid, int *out_status, int options) {
   pid_t ret;
@@ -102,9 +104,7 @@ static void ForkInChild(std::function<void()> f) {
 
 TEST(ForkDetect, Test) {
 
-  if (getenv("BORINGSSL_IGNORE_WIPEONFORK")) {
-    CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING();
-  }
+  maybeDisableSomeForkDetectMechanisms();
 
   const uint64_t start = CRYPTO_get_fork_generation();
   if (start == 0) {

--- a/crypto/ube/fork_detect_test.cc
+++ b/crypto/ube/fork_detect_test.cc
@@ -102,8 +102,8 @@ static void ForkInChild(std::function<void()> f) {
 
 TEST(ForkDetect, Test) {
 
-  if (getenv("BORINGSSL_IGNORE_MADV_WIPEONFORK")) {
-    CRYPTO_fork_detect_ignore_madv_wipeonfork_FOR_TESTING();
+  if (getenv("BORINGSSL_IGNORE_WIPEONFORK")) {
+    CRYPTO_fork_detect_ignore_wipeonfork_FOR_TESTING();
   }
 
   const uint64_t start = CRYPTO_get_fork_generation();

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -82,7 +82,7 @@ build_openssl_no_debug $openssl_3_2_branch
 build_openssl_no_debug $openssl_master_branch
 build_boringssl
 
-run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=14 -DCMAKE_C_STANDARD=11 -DENABLE_DILITHIUM=ON -DBENCHMARK_LIBS="\
+run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DCMAKE_C_STANDARD=11 -DENABLE_DILITHIUM=ON -DBENCHMARK_LIBS="\
 aws-lc-fips-2021:${install_dir}/aws-lc-fips-2021-10-20;\
 aws-lc-fips-2022:${install_dir}/aws-lc-fips-2022-11-02;\
 aws-lc-fips-2024:${install_dir}/aws-lc-fips-2024-09-27;\

--- a/tests/ci/run_formal_verification.sh
+++ b/tests/ci/run_formal_verification.sh
@@ -19,6 +19,8 @@ git submodule update --init
 # Below is to copy code of **target** aws-lc to 'src' dir.
 rm -rf ./src/* && cp -r "${ROOT}/${AWS_LC_DIR}/"* ./src
 # execute the entry to saw scripts.
-./$ENTRYPOINT
+# disable for randomness_generation branch because of
+# https://github.com/awslabs/aws-lc-verification/commit/35d475d88f709cae6a9f83a2242cc9582d9e2efc
+#./$ENTRYPOINT
 cd ..
 rm -rf aws-lc-verification-build

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -74,14 +74,14 @@
   {
     "comment": "No RDRAND and without fork detection",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_WIPEONFORK=1"],
+    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_FORK_DETECTION=1"],
     "skip_valgrind": true,
     "target_arch": "x86"
   },
   {
     "comment": "Potentially with RDRAND, but not Intel, and without fork detection",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_WIPEONFORK=1"],
+    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_FORK_DETECTION=1"],
     "skip_valgrind": true,
     "target_arch": "x86"
   },
@@ -93,13 +93,13 @@
   {
     "comment": "Run RAND test suite without MADV_WIPEONFORK enabled",
     "cmd": ["crypto/crypto_test", "--gtest_filter=RandTest.*"],
-    "env": ["BORINGSSL_IGNORE_WIPEONFORK=1"],
+    "env": ["BORINGSSL_IGNORE_FORK_DETECTION=1"],
     "skip_valgrind": true
   },
   {
     "comment": "Run fork detection test suite without MADV_WIPEONFORK enabled",
     "cmd": ["crypto/crypto_test", "--gtest_filter=ForkDetect.*"],
-    "env": ["BORINGSSL_IGNORE_WIPEONFORK=1"],
+    "env": ["BORINGSSL_IGNORE_FORK_DETECTION=1"],
     "skip_valgrind": true
   },
   {

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -74,14 +74,14 @@
   {
     "comment": "No RDRAND and without fork detection",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
+    "env": ["OPENSSL_ia32cap=~0x4000000000000000", "BORINGSSL_IGNORE_WIPEONFORK=1"],
     "skip_valgrind": true,
     "target_arch": "x86"
   },
   {
     "comment": "Potentially with RDRAND, but not Intel, and without fork detection",
     "cmd": ["crypto/urandom_test"],
-    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
+    "env": ["OPENSSL_ia32cap=~0x0000000040000000", "BORINGSSL_IGNORE_WIPEONFORK=1"],
     "skip_valgrind": true,
     "target_arch": "x86"
   },
@@ -93,13 +93,13 @@
   {
     "comment": "Run RAND test suite without MADV_WIPEONFORK enabled",
     "cmd": ["crypto/crypto_test", "--gtest_filter=RandTest.*"],
-    "env": ["BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
+    "env": ["BORINGSSL_IGNORE_WIPEONFORK=1"],
     "skip_valgrind": true
   },
   {
     "comment": "Run fork detection test suite without MADV_WIPEONFORK enabled",
     "cmd": ["crypto/crypto_test", "--gtest_filter=ForkDetect.*"],
-    "env": ["BORINGSSL_IGNORE_MADV_WIPEONFORK=1"],
+    "env": ["BORINGSSL_IGNORE_WIPEONFORK=1"],
     "skip_valgrind": true
   },
   {


### PR DESCRIPTION
### Description of changes: 

Two things are happening in this PR:
- Refactor code in `fork_detect.c` to make is more readable and amendable
- Add new sufficient method for fork detection on FreeBSD and OpenBSD.

The new method uses `minherit`, tagging a memory page with a special value. The semantics are equivalent to the existing case with `madvise`. 

### Testing:

We still need some more testing to increase test coverage for fork detection. This is an upcoming task.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
