### PR TITLE
Use getentropy for OpenBSD, FreeBSD, and MacOS

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -475,6 +475,7 @@ add_library(
   rand_extra/deterministic.c
   rand_extra/entropy_passive.c
   rand_extra/forkunsafe.c
+  rand_extra/getentropy.c
   rand_extra/rand_extra.c
   rand_extra/pq_custom_randombytes.c
   rand_extra/windows.c

--- a/crypto/fipsmodule/rand/getrandom_fillin.h
+++ b/crypto/fipsmodule/rand/getrandom_fillin.h
@@ -18,7 +18,7 @@
 #include <openssl/base.h>
 
 
-#if defined(OPENSSL_LINUX)
+#if defined(OPENSSL_RAND_URANDOM)
 
 #include <sys/syscall.h>
 

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -25,11 +25,12 @@
 extern "C" {
 #endif
 
-
 #if defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE)
 #define OPENSSL_RAND_DETERMINISTIC
 #elif defined(OPENSSL_WINDOWS)
 #define OPENSSL_RAND_WINDOWS
+#elif defined(OPENSSL_MACOS) || defined(OPENSSL_OPENBSD) || defined(OPENSSL_FREEBSD)
+#define OPENSSL_RAND_GETENTROPY
 #else
 #define OPENSSL_RAND_URANDOM
 #endif

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -388,7 +388,7 @@ static int fill_with_entropy(uint8_t *out, size_t len, int block, int seed) {
     return 1;
   }
 
-#if defined(OPENSSL_APPLE)
+#if defined(OPENSSL_IOS)
   // To get system randomness on MacOS and iOS we use |CCRandomGenerateBytes|
   // rather than |getentropy| and /dev/urandom.
   if (CCRandomGenerateBytes(out, len) == kCCSuccess) {
@@ -399,9 +399,22 @@ static int fill_with_entropy(uint8_t *out, size_t len, int block, int seed) {
   }
 #endif
 
+#if defined(OPENSSL_MACOS)
+  // To get system randomness on MacOS and iOS we use |CCRandomGenerateBytes|
+  // rather than |getentropy| and /dev/urandom.
+  // TODO at most can do 256 bytes
+  if (getentropy(out, len) == 0) {
+    return 1;
+  } else {
+    fprintf(stderr, "getentropy failed.\n");
+    abort();
+  }
+#endif
+
 #if defined(OPENSSL_OPENBSD)
   // Return value is void, no error to check
-  arc4random_buf(out, len);
+  // TODO at most can do 256 bytes
+  getentropy(out, len);
   return 1;
 #endif
 

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -400,6 +400,8 @@ static int fill_with_entropy(uint8_t *out, size_t len, int block, int seed) {
 #endif
 
 #if defined(OPENSSL_MACOS)
+  // POSIX 2024 says unistd, but man page for macos says the former
+  #include <sys/random.h>
   // To get system randomness on MacOS and iOS we use |CCRandomGenerateBytes|
   // rather than |getentropy| and /dev/urandom.
   // TODO at most can do 256 bytes
@@ -412,6 +414,8 @@ static int fill_with_entropy(uint8_t *out, size_t len, int block, int seed) {
 #endif
 
 #if defined(OPENSSL_OPENBSD)
+  #include <unistd.h>
+    // POSIX 2024 says the latter, but man page for macos says the former
   // Return value is void, no error to check
   // TODO at most can do 256 bytes
   getentropy(out, len);

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -22,7 +22,8 @@
 #include "internal.h"
 #include "../../ube/snapsafe_detect.h"
 
-#if defined(OPENSSL_X86_64) && !defined(BORINGSSL_SHARED_LIBRARY) && \
+#if defined(OPENSSL_RAND_URANDOM) && defined(OPENSSL_X86_64) && \
+    !defined(BORINGSSL_SHARED_LIBRARY) && \
     !defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE) && \
     defined(USE_NR_getrandom) && !defined(AWSLC_SNAPSAFE_TESTING)
 

--- a/crypto/rand_extra/getentropy.c
+++ b/crypto/rand_extra/getentropy.c
@@ -1,0 +1,48 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#if !defined(_DEFAULT_SOURCE)
+// Needed for getentropy on musl and glibc per man pages.
+#define _DEFAULT_SOURCE
+#endif
+
+#include <openssl/rand.h>
+
+#include "../fipsmodule/rand/internal.h"
+
+#if defined(OPENSSL_RAND_GETENTROPY)
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#if defined(OPENSSL_MACOS)
+// MacOS does not declare getentropy in uinstd.h like other OS's. 
+#include <sys/random.h>
+#endif
+
+#if !defined(GETENTROPY_MAX)
+// Per POSIX 2024
+// https://pubs.opengroup.org/onlinepubs/9799919799/functions/getentropy.html
+#define GETENTROPY_MAX 256
+#endif
+
+void CRYPTO_sysrand(uint8_t *out, size_t requested) {
+  // getentropy max request size is GETENTROPY_MAX.
+  while (requested > 0) {
+    size_t request_chunk = (requested > GETENTROPY_MAX) ? GETENTROPY_MAX : requested;
+    if (getentropy(out, request_chunk) != 0) {
+      fprintf(stderr, "getentropy failed.\n");
+      abort();
+    }
+    requested -= request_chunk;
+    out += request_chunk;
+  }
+}
+
+void CRYPTO_sysrand_for_seed(uint8_t *out, size_t requested) {
+  CRYPTO_sysrand(out, requested);
+}
+
+#endif

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -87,17 +87,6 @@ extern "C" {
 #define AWSLC_FIPS
 #endif
 
-#if defined(__APPLE__)
-// Note |TARGET_OS_MAC| is set for all Apple OS variants. |TARGET_OS_OSX|
-// targets macOS specifically.
-#if defined(TARGET_OS_OSX) && TARGET_OS_OSX
-#define OPENSSL_MACOS
-#endif
-#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-#define OPENSSL_IOS
-#endif
-#endif
-
 #define AWSLC_VERSION_NAME "AWS-LC"
 #define OPENSSL_IS_AWSLC
 // |OPENSSL_VERSION_NUMBER| should match the version number in opensslv.h.

--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -80,9 +80,6 @@
 
 #if defined(__APPLE__)
 #define OPENSSL_APPLE
-#endif
-
-#if defined(__APPLE__)
 // Note |TARGET_OS_MAC| is set for all Apple OS variants. |TARGET_OS_OSX|
 // targets macOS specifically.
 #if defined(TARGET_OS_OSX) && TARGET_OS_OSX

--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -82,6 +82,17 @@
 #define OPENSSL_APPLE
 #endif
 
+#if defined(__APPLE__)
+// Note |TARGET_OS_MAC| is set for all Apple OS variants. |TARGET_OS_OSX|
+// targets macOS specifically.
+#if defined(TARGET_OS_OSX) && TARGET_OS_OSX
+#define OPENSSL_MACOS
+#endif
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#define OPENSSL_IOS
+#endif
+#endif
+
 #if defined(_WIN32)
 #define OPENSSL_WINDOWS
 #endif


### PR DESCRIPTION
### Description of changes: 

Use `getentropy` for some operating systems. Namely, Apple MacOS, OpenBSD, and FreeBSD. `getentropy` is closer to the noise sources.

See also q/3t08AyoE0m4q.

### Testing:

Even though we didn't use `getentropy` prior to this PR, we had a unit test. Just re-use that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
