### PR TITLE
Update speed.cc to use the same jitter function as rand.c

### DIFF
--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -26,7 +26,8 @@ function build_aws_lc_fips {
       -DENABLE_DILITHIUM=ON \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DBUILD_SHARED_LIBS=1 \
-      -DBUILD_TESTING=OFF
+      -DBUILD_TESTING=OFF \
+      -DENABLE_FIPS_ENTROPY_CPU_JITTER=1
   pushd "$BUILD_ROOT"
   ninja install
   popd

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2369,7 +2369,7 @@ static bool SpeedJitter(size_t chunk_size) {
 
   if (!TimeFunction(&results, [&jitter_ec, &input, chunk_size]() -> bool {
         size_t bytes =
-            jent_read_entropy_safe(&jitter_ec, input.get(), chunk_size);
+            jent_read_entropy(jitter_ec, input.get(), chunk_size);
         if (bytes != chunk_size) {
           return false;
         }


### PR DESCRIPTION
### Description of changes: 
AWS-LC uses `jent_read_entropy` which should be reflected in the benchmark. Also turn on Jitter as the entropy source so the CI actually builds/runs this code path and ensures it continues to work. 

### Call-outs:
This doesn't affect the performance results, before:
```
./tool/bssl speed -filter Jitter
Did 253 Jitter (16 bytes) operations in 1081577us (233.9 ops/sec): 0.0 MB/s
Did 30 Jitter (256 bytes) operations in 1021729us (29.4 ops/sec): 0.0 MB/s
Did 6 Jitter (1350 bytes) operations in 1097450us (5.5 ops/sec): 0.0 MB/s
Did 1 Jitter (8192 bytes) operations in 1087014us (0.9 ops/sec): 0.0 MB/s
Did 1 Jitter (16384 bytes) operations in 2187891us (0.5 ops/sec): 0.0 MB/s
```
After:
```
./tool/bssl speed -filter Jitter
Did 230 Jitter (16 bytes) operations in 1013691us (226.9 ops/sec): 0.0 MB/s
Did 30 Jitter (256 bytes) operations in 1034730us (29.0 ops/sec): 0.0 MB/s
Did 6 Jitter (1350 bytes) operations in 1114960us (5.4 ops/sec): 0.0 MB/s
Did 1 Jitter (8192 bytes) operations in 1095828us (0.9 ops/sec): 0.0 MB/s
Did 1 Jitter (16384 bytes) operations in 2198877us (0.5 ops/sec): 0.0 MB/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
