### PR TITLE
New Year New Broken Mirrors

### DIFF
--- a/tests/ci/docker_images/linux-aarch/ubuntu-22.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-aarch/ubuntu-22.04_base/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ENV BOOST_PACKAGE_NAME=boost_1_77_0
 ENV BOOST_TARBALL="${BOOST_PACKAGE_NAME}.tar.bz2"
-ENV BOOST_SRC_URL="https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/${BOOST_TARBALL}"
+ENV BOOST_SRC_URL="https://d2yr98kym3baw0.cloudfront.net/${BOOST_TARBALL}"
 ENV DEPENDENCIES_DIR=/home/dependencies
 ENV LLVM_PROJECT_HOME=${DEPENDENCIES_DIR}/llvm-project
 ENV ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_base/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ENV BOOST_PACKAGE_NAME=boost_1_77_0
 ENV BOOST_TARBALL="${BOOST_PACKAGE_NAME}.tar.bz2"
-ENV BOOST_SRC_URL="https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/${BOOST_TARBALL}"
+ENV BOOST_SRC_URL="https://d2yr98kym3baw0.cloudfront.net/${BOOST_TARBALL}"
 ENV DEPENDENCIES_DIR=/home/dependencies
 ENV LLVM_PROJECT_HOME=${DEPENDENCIES_DIR}/llvm-project
 ENV ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer


### PR DESCRIPTION
### Description of changes: 
* Seems this mirror for boost artifacts no-longer works in 2025, but did in December 2024. Just stuck a copy in our CloudFront distribution to avoid this all together going forward.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
