### PR TITLE
Align guard macros for OPENSSL_cpuid_setup

### DIFF
--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -258,7 +258,7 @@ static void BORINGSSL_bcm_power_on_self_test(void) {
 // TODO: remove !defined(OPENSSL_PPC64BE) from the check below when starting to support
 // PPC64BE that has VCRYPTO capability. In that case, add `|| defined(OPENSSL_PPC64BE)`
 // to `#if defined(OPENSSL_PPC64LE)` wherever it occurs.
-#if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_PPC32BE) && !defined(OPENSSL_PPC64BE)
+#if defined(HAS_OPENSSL_CPUID_SETUP) && !defined(OPENSSL_NO_ASM)
   OPENSSL_cpuid_setup();
 #endif
 

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -9,6 +9,7 @@ extern "C" {
 
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || defined(OPENSSL_ARM) || \
     defined(OPENSSL_AARCH64) || defined(OPENSSL_PPC64LE)
+#define HAS_OPENSSL_CPUID_SETUP
 // OPENSSL_cpuid_setup initializes the platform-specific feature cache.
 void OPENSSL_cpuid_setup(void);
 #endif


### PR DESCRIPTION
### Issues:
Addresses aws/aws-lc-rs#655

### Description of changes: 
* The criteria for invoking `OPENSSL_cpuid_setup` should align with the criteria for defining `OPENSSL_cpuid_setup`.

### Call-outs:
Consumers building `aws-lc-fips-sys` for `s390x` were seeing the following failure:
```
.../boringssl_prefix_symbols.h:20:26: error: implicit declaration of function 'aws_lc_fips_0_13_1_OPENSSL_cpuid_setup'; did you mean 'aws_lc_fips_0_13_1_OPENSSL_sk_set'? [-Werror=implicit-function-declaration]
```

### Testing:
I verified this fix works for the `aws-lc-fips-sys` build for `s390x-unknown-linux-gnu`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
