### PR TITLE
Init variable to avoid "may be used uninitialized" warning

### DIFF
--- a/crypto/fipsmodule/ec/ec_montgomery.c
+++ b/crypto/fipsmodule/ec/ec_montgomery.c
@@ -335,7 +335,11 @@ void ec_GFp_mont_dbl(const EC_GROUP *group, EC_JACOBIAN *r,
     // Coq transcription and correctness proof:
     // <https://github.com/mit-plv/fiat-crypto/blob/79f8b5f39ed609339f0233098dee1a3c4e6b3080/src/Curves/Weierstrass/Jacobian.v#L93>
     // <https://github.com/mit-plv/fiat-crypto/blob/79f8b5f39ed609339f0233098dee1a3c4e6b3080/src/Curves/Weierstrass/Jacobian.v#L201>
-    EC_FELEM delta, gamma, beta, ftmp, ftmp2, tmptmp, alpha, fourbeta;
+
+    // Initialize variables to avoid "may be used uninitialized" warning.
+    // https://github.com/aws/aws-lc/issues/1185
+    EC_FELEM delta = {{0}}, gamma = {{0}}, beta = {{0}}, ftmp = {{0}}, ftmp2 = {{0}}, tmptmp = {{0}}, alpha = {{0}}, fourbeta = {{0}};
+    
     // delta = z^2
     ec_GFp_mont_felem_sqr(group, &delta, &a->Z);
     // gamma = y^2

--- a/crypto/fipsmodule/ec/ec_montgomery.c
+++ b/crypto/fipsmodule/ec/ec_montgomery.c
@@ -338,7 +338,8 @@ void ec_GFp_mont_dbl(const EC_GROUP *group, EC_JACOBIAN *r,
 
     // Initialize variables to avoid "may be used uninitialized" warning.
     // https://github.com/aws/aws-lc/issues/1185
-    EC_FELEM delta = {{0}}, gamma = {{0}}, beta = {{0}}, ftmp = {{0}}, ftmp2 = {{0}}, tmptmp = {{0}}, alpha = {{0}}, fourbeta = {{0}};
+    EC_FELEM delta = {{0}}, gamma = {{0}}, beta = {{0}}, ftmp = {{0}};
+    EC_FELEM ftmp2 = {{0}}, tmptmp = {{0}}, alpha = {{0}}, fourbeta = {{0}};
     
     // delta = z^2
     ec_GFp_mont_felem_sqr(group, &delta, &a->Z);


### PR DESCRIPTION
Previous discussion here: https://github.com/aws/aws-lc/issues/1185
Similar issues here: https://github.com/aws/aws-lc/commit/305ec03e73c8c5858466ce775fbaa87ce461e805
Similar issues here: https://github.com/aws/aws-lc/commit/d0501c589165a70491f875551bc83096e3abddb9#diff-6fde57725bf74f073ccac9d404387d74a39824fbc2465a02cfe37e86e679bbe8R34

Causes CI fails

### Issues:
Resolves #P188618529

### Description of changes: 
Zero variables before use.

### Call-outs:
The fail only occurs for gcc-12 with ubuntu2204 on x86_64.
Only variables `|ftmp2|` and `|fourbeta|` are caught as maybe uninitialized `error: 'var_name' may be used uninitialized [-Werror=maybe-uninitialized]`.

### Testing:
CI tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
