### PR TITLE
Finalize asn.1 module

### DIFF
--- a/crypto/evp_extra/p_pqdsa_asn1.c
+++ b/crypto/evp_extra/p_pqdsa_asn1.c
@@ -112,7 +112,6 @@ static int pqdsa_pub_encode(CBB *out, const EVP_PKEY *pkey) {
   }
 
   // See https://datatracker.ietf.org/doc/draft-ietf-lamps-dilithium-certificates/ section 4.
-  // TODO: finalize this definition - OCTETSTRING to BITSTRING conversion.
   CBB spki, algorithm, oid, key_bitstring;
   if (!CBB_add_asn1(out, &spki, CBS_ASN1_SEQUENCE) ||
       !CBB_add_asn1(&spki, &algorithm, CBS_ASN1_SEQUENCE) ||


### PR DESCRIPTION
### Issues:
Aligned with https://datatracker.ietf.org/doc/draft-ietf-lamps-dilithium-certificates/06/ on ML-DSA ASN.1 encoding and decoding.

### Description of changes: 
Will and I checked through the ASN.1 encoding and decoding functions to check compatibility with the draft RFC. We have confirmed that we are in alignment with the standard, so can remove this TODO.

### Call-outs:
For reference, the padding bit `0` used in `!CBB_add_u8(&key_bitstring, 0 /* padding */) ||` is present because DER-encoded bit strings use the first "value" byte to give the number of (least significant) 0-padding bits at the end of byte sequence. As the padding is 0 for ML-DSA keys, we encode this value at the start of the bitstring.

For private keys, OCTET STRING encoding is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
