### PR TITLE
Ensure values are 0-initialized

### DIFF
--- a/crypto/fipsmodule/ec/ec_montgomery.c
+++ b/crypto/fipsmodule/ec/ec_montgomery.c
@@ -335,7 +335,8 @@ void ec_GFp_mont_dbl(const EC_GROUP *group, EC_JACOBIAN *r,
     // Coq transcription and correctness proof:
     // <https://github.com/mit-plv/fiat-crypto/blob/79f8b5f39ed609339f0233098dee1a3c4e6b3080/src/Curves/Weierstrass/Jacobian.v#L93>
     // <https://github.com/mit-plv/fiat-crypto/blob/79f8b5f39ed609339f0233098dee1a3c4e6b3080/src/Curves/Weierstrass/Jacobian.v#L201>
-    EC_FELEM delta, gamma, beta, ftmp, ftmp2, tmptmp, alpha, fourbeta;
+    EC_FELEM delta = {0}, gamma = {0}, beta = {0}, ftmp = {0}, ftmp2 = {0},
+             tmptmp = {0}, alpha = {0}, fourbeta = {0};
     // delta = z^2
     ec_GFp_mont_felem_sqr(group, &delta, &a->Z);
     // gamma = y^2


### PR DESCRIPTION
### Issues:
Resolves P188618529

### Description of changes: 
* gcc12 on x86_64 sporadically fails when inlining functions called from `ec_GFp_mont_dbl` due to detecting that values were not previously initialized.
```
    inlined from 'ec_GFp_mont_dbl' at /codebuild/output/src2124611008/src/github.com/aws/aws-lc/crypto/fipsmodule/ec/ec_montgomery.c:350:5:
/codebuild/output/src2124611008/src/github.com/aws/aws-lc/crypto/fipsmodule/ec/felem.c:76:3: error: 'ftmp2' may be used uninitialized [-Werror=maybe-uninitialized]
   76 |   bn_mod_add_words(out->words, a->words, b->words, group->field.N.d, tmp.words,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   77 |                    group->field.N.width);
```
* This change ensures that the values are 0-initialized prior to use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
