### PR TITLE
Add more debug logging to channelID test failures

### DIFF
--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -903,7 +903,7 @@ func doExchange(test *testCase, config *Config, conn net.Conn, isResume bool, tr
 			return fmt.Errorf("incorrect channel ID")
 		}
 	} else if connState.ChannelID != nil {
-		return fmt.Errorf("channel ID unexpectedly negotiated")
+		return fmt.Errorf("channel ID unexpectedly negotiated, got id: %v, full connState: %+v", connState.ChannelID, connState)
 	}
 
 	if expected := expectations.nextProto; expected != "" {


### PR DESCRIPTION
### Description of changes: 
The [GitHub Mac runners occasionally fail](https://github.com/aws/aws-lc/actions/runs/12839452846/job/35806842991?pr=2127) the Channel ID tests with an error like:
```
bad error (wanted ':CHANNEL_ID_SIGNATURE_INVALID:' / ''): local error 'channel ID unexpectedly negotiated', child error 'exit status 1', stdout:
```
This change tries to log more things to get more info to make progress debugging these failures. 

### Call-outs:
I wasn't able to test this code path locally because I can't get these failures to reproduce locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
