### PR TITLE
Only need libunwind for testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ if(NOT DISABLE_PERL)
   find_package(Perl REQUIRED)
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" AND NOT CMAKE_CROSSCOMPILING)
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" AND BUILD_TESTING AND NOT CMAKE_CROSSCOMPILING)
   find_package(PkgConfig QUIET)
   if (PkgConfig_FOUND)
     pkg_check_modules(LIBUNWIND libunwind-generic)


### PR DESCRIPTION
### Notice
This change does not modify the FIPS module boundary. This change only avoids having CMake check for the availability of `Libunwind` when no tests are being built.

### Description of changes:
* Libunwind is only needed when building tests.
* See same change made for main: https://github.com/aws/aws-lc/pull/2093

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.