### PR TITLE
Minor symbols to work with Ruby's mainline

### DIFF
--- a/crypto/fipsmodule/evp/digestsign.c
+++ b/crypto/fipsmodule/evp/digestsign.c
@@ -363,3 +363,15 @@ void EVP_MD_CTX_set_pkey_ctx(EVP_MD_CTX *ctx, EVP_PKEY_CTX *pctx) {
     ctx->flags &= ~EVP_MD_CTX_FLAG_KEEP_PKEY_CTX;
   }
 }
+
+EVP_PKEY_CTX *EVP_MD_CTX_get_pkey_ctx(const EVP_MD_CTX *ctx) {
+  SET_DIT_AUTO_RESET;
+  if(ctx == NULL) {
+    return NULL;
+  }
+  return ctx->pctx;
+}
+
+EVP_PKEY_CTX *EVP_MD_CTX_pkey_ctx(const EVP_MD_CTX *ctx) {
+  return EVP_MD_CTX_get_pkey_ctx(ctx);
+}

--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -318,6 +318,12 @@ OPENSSL_EXPORT int EVP_MD_nid(const EVP_MD *md);
 OPENSSL_EXPORT void EVP_MD_CTX_set_pkey_ctx(EVP_MD_CTX *ctx,
                                             EVP_PKEY_CTX *pctx);
 
+// EVP_MD_CTX_get_pkey_ctx returns the pointer of |ctx|'s |EVP_PKEY_CTX|.
+OPENSSL_EXPORT EVP_PKEY_CTX *EVP_MD_CTX_get_pkey_ctx(const EVP_MD_CTX *ctx);
+
+// EVP_MD_CTX_pkey_ctx is a legacy alias of |EVP_MD_CTX_get_pkey_ctx|.
+OPENSSL_EXPORT EVP_PKEY_CTX *EVP_MD_CTX_pkey_ctx(const EVP_MD_CTX *ctx);
+
 struct evp_md_pctx_ops;
 
 struct env_md_ctx_st {

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2731,6 +2731,11 @@ OPENSSL_EXPORT void X509_STORE_CTX_set_cert(X509_STORE_CTX *c, X509 *x);
 #define X509_V_ERR_INVALID_CALL 65
 #define X509_V_ERR_STORE_LOOKUP 66
 #define X509_V_ERR_NAME_CONSTRAINTS_WITHOUT_SANS 67
+// The following error codes are related to security levels in OpenSSL and are
+// unused in AWS-LC. See |SSL_CTX_set_security_level|.
+#define X509_V_ERR_EE_KEY_TOO_SMALL 68
+#define X509_V_ERR_CA_KEY_TOO_SMALL 69
+#define X509_V_ERR_CA_MD_TOO_WEAK 70
 
 // X509_STORE_CTX_get_error, after |X509_verify_cert| returns, returns
 // |X509_V_OK| if verification succeeded or an |X509_V_ERR_*| describing why


### PR DESCRIPTION
### Description of changes: 
Ruby's made a couple larger refactors to require versions later than OpenSSL 1.1.1.
* https://github.com/ruby/ruby/commit/441862dc9f11d83e9e35c3b965fe84e42e178a35
* https://github.com/ruby/ruby/commit/43c48e3030c513c17bfcf4c37bbe533097fa1a22

These changes require us to make a few tweaks to the patch in https://github.com/aws/aws-lc/pull/2071 and have exposed a couple minor symbols that we don't support. Adding support for the ones that aren't complicated in this PR. 

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
