### PR TITLE
Enable RDRAND for all x86_64 except known prohibitively slow CPU models

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_intel.c
+++ b/crypto/fipsmodule/cpucap/cpu_intel.c
@@ -179,6 +179,31 @@ static void handle_cpu_env(uint32_t *out, const char *in) {
 
 extern uint8_t OPENSSL_cpucap_initialized;
 
+static int amd_rdrand_maybe_apply_restrictions(const uint32_t family,
+                                               const uint32_t model) {
+
+  // Disable RDRAND on AMD families before 0x17 (Zen) due to reported failures
+  // after suspend. https://bugzilla.redhat.com/show_bug.cgi?id=1150286
+  // Also disable for family 0x17, models 0x70–0x7f, due to possible RDRAND
+  // failures there too.
+  if (family < 0x17 || (family == 0x17 && 0x70 <= model && model <= 0x7f)) {
+    return 1;
+  }
+
+  // Zen2 EPYC have prohibitively slow RDRAND implementations. Specifically,
+  // measured on the model EPYC 7R32. Please see q/VxC3AiwXpAjJ.
+  // We assume that slow implementations is universal to all AMD models based
+  // on the Zen2 uarch. Additionally, extend this assumptions to Zen1 based
+  // AMD models as well because Zen1 and Zen2 shares family number.
+  if (family == 0x17) {
+    return 1;
+  }
+
+  // No restrictions.
+  return 0;
+}
+
+
 void OPENSSL_cpuid_setup(void) {
   // Determine the vendor and maximum input value.
   uint32_t eax, ebx, ecx, edx;
@@ -216,12 +241,7 @@ void OPENSSL_cpuid_setup(void) {
       model |= ext_model << 4;
     }
 
-    if (family < 0x17 || (family == 0x17 && 0x70 <= model && model <= 0x7f)) {
-      // Disable RDRAND on AMD families before 0x17 (Zen) due to reported
-      // failures after suspend.
-      // https://bugzilla.redhat.com/show_bug.cgi?id=1150286
-      // Also disable for family 0x17, models 0x70–0x7f, due to possible RDRAND
-      // failures there too.
+    if (amd_rdrand_maybe_apply_restrictions(family, model) != 0) {
       ecx &= ~(1u << 30);
     }
   }

--- a/crypto/fipsmodule/rand/entropy/entropy_sources.c
+++ b/crypto/fipsmodule/rand/entropy/entropy_sources.c
@@ -42,7 +42,7 @@ DEFINE_LOCAL_DATA(struct entropy_source_methods, tree_jitter_entropy_source_meth
   out->free_thread = tree_jitter_free_thread_drbg;
   out->get_seed = tree_jitter_get_seed;
   out->get_extra_entropy = entropy_get_extra_entropy;
-  if (have_hw_rng_x86_64_fast() == 1 ||
+  if (have_hw_rng_x86_64() == 1 ||
       have_hw_rng_aarch64() == 1) {
     out->get_prediction_resistance = entropy_get_prediction_resistance;
   } else {

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -101,15 +101,13 @@ int rdrand(uint8_t *buf, const size_t len);
 
 #if defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM)
 
+// Certain operating environments will disable RDRAND for both security and
+// performance reasons. See initialization of CPU capability vector for details.
+// At the moment, we must implement this logic there because the CPU capability
+// vector does not carry CPU family/model information which is required to
+// determine restrictions.
 OPENSSL_INLINE int have_hw_rng_x86_64(void) {
   return CRYPTO_is_RDRAND_capable();
-}
-
-// have_fast_rdrand returns true if RDRAND is supported and it's reasonably
-// fast. Concretely the latter is defined by whether the chip is Intel (fast) or
-// not (assumed slow).
-OPENSSL_INLINE int have_hw_rng_x86_64_fast(void) {
-  return CRYPTO_is_RDRAND_capable() && CRYPTO_is_intel_cpu();
 }
 
 // TODO only allow multiples of 8 from rdrand
@@ -126,10 +124,6 @@ int CRYPTO_rdrand_multiple8_buf(uint8_t *buf, size_t len);
 #else  // defined(OPENSSL_X86_64) && !defined(OPENSSL_NO_ASM)
 
 OPENSSL_INLINE int have_hw_rng_x86_64(void) {
-  return 0;
-}
-
-OPENSSL_INLINE int have_hw_rng_x86_64_fast(void) {
   return 0;
 }
 

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -400,7 +400,7 @@ void RAND_bytes_with_additional_data(uint8_t *out, size_t out_len,
   uint8_t additional_data[32];
   // Intel chips have fast RDRAND instructions while, in other cases, RDRAND can
   // be _slower_ than a system call.
-  if (!have_hw_rng_x86_64_fast() ||
+  if (!have_hw_rng_x86_64() ||
       !rdrand(additional_data, sizeof(additional_data))) {
     // Without a hardware RNG to save us from address-space duplication, the OS
     // entropy is used. This can be expensive (one read per |RAND_bytes| call)

--- a/crypto/fipsmodule/rand/urandom_test.cc
+++ b/crypto/fipsmodule/rand/urandom_test.cc
@@ -498,7 +498,7 @@ static std::vector<Event> TestFunctionPRNGModel(unsigned flags) {
   const size_t kPersonalizationStringLength = CTR_DRBG_ENTROPY_LEN;
   const size_t kPassiveEntropyWithWhitenFactor = PASSIVE_ENTROPY_LOAD_LENGTH;
   const bool kHaveRdrand = have_hw_rng_x86_64();
-  const bool kHaveFastRdrand = have_hw_rng_x86_64_fast();
+  const bool kHaveFastRdrand = have_hw_rng_x86_64();
   const bool kHaveForkDetection = have_fork_detection();
 
   // Additional data might be drawn on each invocation of RAND_bytes(). In case


### PR DESCRIPTION
### Description of changes: 

Remove the need to have a "fast" rdrand. Instead flip the model to exclude known prohibitively slow rdrand implementations. In particular, this includes the AMD Zen1 and Zen2 generation microarchitectures. See q/VxC3AiwXpAjJ for some data on that.

This change is made to increase the usage of prediction resistance.

### Testing:

To test the new family detection, I patched like this:
```
$ git diff
diff --git a/crypto/fipsmodule/cpucap/cpu_intel.c b/crypto/fipsmodule/cpucap/cpu_intel.c
index 8504ec3c4..96bdb6199 100644
--- a/crypto/fipsmodule/cpucap/cpu_intel.c
+++ b/crypto/fipsmodule/cpucap/cpu_intel.c
@@ -242,7 +242,10 @@ void OPENSSL_cpuid_setup(void) {
     }
 
     if (amd_rdrand_maybe_apply_restrictions(family, model) != 0) {
+      printf("amd_rdrand_maybe_apply_restrictions() returned 1\n");
       ecx &= ~(1u << 30);
+    } else {
+      printf("amd_rdrand_maybe_apply_restrictions() returned 0\n");
     }
   }
```

and ran the code on both a c5a and c6a instance. The former is Zen2 based, the latter is Zen3 based.

c5a:
```
$ ./tool/bssl version
amd_rdrand_maybe_apply_restrictions() returned 1
```

c6a:
```
$ ./tool/bssl version
amd_rdrand_maybe_apply_restrictions() returned 0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
