### PR TITLE
Optimize x86/aarch64 MD5 implementation

### DIFF
--- a/crypto/fipsmodule/md5/asm/md5-armv8.pl
+++ b/crypto/fipsmodule/md5/asm/md5-armv8.pl
@@ -216,165 +216,165 @@ md5_blocks_loop:
         add w9, w9, w13               // Add constant 0x49b40821
         add w9, w9, w6                // Add aux function result
         ror w9, w9, #10               // Rotate left s=22 bits
-        bic x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x8, x17               // Aux function round 2 (~z & y)
         add w9, w8, w9                // Add X parameter round 1 B=FF(B, C, D, A, 0x49b40821, s=22, M[15])
-        and x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0x2562             // Load lower half of constant 0xf61e2562
         movk x13, #0xf61e, lsl #16    // Load upper half of constant 0xf61e2562
         add w4, w4, w20               // Add dest value
         add w4, w4, w13               // Add constant 0xf61e2562
-        add w4, w4, w6                // Add aux function result
+        and x13, x9, x17              // Aux function round 2 (x & z)
+        add w4, w4, w6                // Add (~z & y)
+        add w4, w4, w13               // Add (x & z)
         ror w4, w4, #27               // Rotate left s=5 bits
-        bic x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x9, x8                // Aux function round 2 (~z & y)
         add w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xf61e2562, s=5, M[1])
-        and x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0xb340             // Load lower half of constant 0xc040b340
         movk x13, #0xc040, lsl #16    // Load upper half of constant 0xc040b340
         add w17, w17, w7              // Add dest value
         add w17, w17, w13             // Add constant 0xc040b340
-        add w17, w17, w6              // Add aux function result
+        and x13, x4, x8               // Aux function round 2 (x & z)
+        add w17, w17, w6              // Add (~z & y)
+        add w17, w17, w13             // Add (x & z)
         ror w17, w17, #23             // Rotate left s=9 bits
-        bic x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x4, x9                // Aux function round 2 (~z & y)
         add w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xc040b340, s=9, M[6])
-        and x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0x5a51             // Load lower half of constant 0x265e5a51
         movk x13, #0x265e, lsl #16    // Load upper half of constant 0x265e5a51
         add w8, w8, w25               // Add dest value
         add w8, w8, w13               // Add constant 0x265e5a51
-        add w8, w8, w6                // Add aux function result
+        and x13, x17, x9              // Aux function round 2 (x & z)
+        add w8, w8, w6                // Add (~z & y)
+        add w8, w8, w13               // Add (x & z)
         ror w8, w8, #18               // Rotate left s=14 bits
-        bic x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x17, x4               // Aux function round 2 (~z & y)
         add w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0x265e5a51, s=14, M[11])
-        and x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0xc7aa             // Load lower half of constant 0xe9b6c7aa
         movk x13, #0xe9b6, lsl #16    // Load upper half of constant 0xe9b6c7aa
         add w9, w9, w15               // Add dest value
         add w9, w9, w13               // Add constant 0xe9b6c7aa
-        add w9, w9, w6                // Add aux function result
+        and x13, x8, x4               // Aux function round 2 (x & z)
+        add w9, w9, w6                // Add (~z & y)
+        add w9, w9, w13               // Add (x & z)
         ror w9, w9, #12               // Rotate left s=20 bits
-        bic x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x8, x17               // Aux function round 2 (~z & y)
         add w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0xe9b6c7aa, s=20, M[0])
-        and x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0x105d             // Load lower half of constant 0xd62f105d
         movk x13, #0xd62f, lsl #16    // Load upper half of constant 0xd62f105d
         add w4, w4, w22               // Add dest value
         add w4, w4, w13               // Add constant 0xd62f105d
-        add w4, w4, w6                // Add aux function result
+        and x13, x9, x17              // Aux function round 2 (x & z)
+        add w4, w4, w6                // Add (~z & y)
+        add w4, w4, w13               // Add (x & z)
         ror w4, w4, #27               // Rotate left s=5 bits
-        bic x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x9, x8                // Aux function round 2 (~z & y)
         add w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xd62f105d, s=5, M[5])
-        and x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0x1453             // Load lower half of constant 0x2441453
         movk x13, #0x244, lsl #16     // Load upper half of constant 0x2441453
         add w17, w17, w16             // Add dest value
         add w17, w17, w13             // Add constant 0x2441453
-        add w17, w17, w6              // Add aux function result
+        and x13, x4, x8               // Aux function round 2 (x & z)
+        add w17, w17, w6              // Add (~z & y)
+        add w17, w17, w13             // Add (x & z)
         ror w17, w17, #23             // Rotate left s=9 bits
-        bic x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x4, x9                // Aux function round 2 (~z & y)
         add w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0x2441453, s=9, M[10])
-        and x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0xe681             // Load lower half of constant 0xd8a1e681
         movk x13, #0xd8a1, lsl #16    // Load upper half of constant 0xd8a1e681
         add w8, w8, w27               // Add dest value
         add w8, w8, w13               // Add constant 0xd8a1e681
-        add w8, w8, w6                // Add aux function result
+        and x13, x17, x9              // Aux function round 2 (x & z)
+        add w8, w8, w6                // Add (~z & y)
+        add w8, w8, w13               // Add (x & z)
         ror w8, w8, #18               // Rotate left s=14 bits
-        bic x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x17, x4               // Aux function round 2 (~z & y)
         add w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0xd8a1e681, s=14, M[15])
-        and x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0xfbc8             // Load lower half of constant 0xe7d3fbc8
         movk x13, #0xe7d3, lsl #16    // Load upper half of constant 0xe7d3fbc8
         add w9, w9, w14               // Add dest value
         add w9, w9, w13               // Add constant 0xe7d3fbc8
-        add w9, w9, w6                // Add aux function result
+        and x13, x8, x4               // Aux function round 2 (x & z)
+        add w9, w9, w6                // Add (~z & y)
+        add w9, w9, w13               // Add (x & z)
         ror w9, w9, #12               // Rotate left s=20 bits
-        bic x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x8, x17               // Aux function round 2 (~z & y)
         add w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0xe7d3fbc8, s=20, M[4])
-        and x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0xcde6             // Load lower half of constant 0x21e1cde6
         movk x13, #0x21e1, lsl #16    // Load upper half of constant 0x21e1cde6
         add w4, w4, w24               // Add dest value
         add w4, w4, w13               // Add constant 0x21e1cde6
-        add w4, w4, w6                // Add aux function result
+        and x13, x9, x17              // Aux function round 2 (x & z)
+        add w4, w4, w6                // Add (~z & y)
+        add w4, w4, w13               // Add (x & z)
         ror w4, w4, #27               // Rotate left s=5 bits
-        bic x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x9, x8                // Aux function round 2 (~z & y)
         add w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0x21e1cde6, s=5, M[9])
-        and x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0x7d6              // Load lower half of constant 0xc33707d6
         movk x13, #0xc337, lsl #16    // Load upper half of constant 0xc33707d6
         add w17, w17, w12             // Add dest value
         add w17, w17, w13             // Add constant 0xc33707d6
-        add w17, w17, w6              // Add aux function result
+        and x13, x4, x8               // Aux function round 2 (x & z)
+        add w17, w17, w6              // Add (~z & y)
+        add w17, w17, w13             // Add (x & z)
         ror w17, w17, #23             // Rotate left s=9 bits
-        bic x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x4, x9                // Aux function round 2 (~z & y)
         add w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xc33707d6, s=9, M[14])
-        and x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0xd87              // Load lower half of constant 0xf4d50d87
         movk x13, #0xf4d5, lsl #16    // Load upper half of constant 0xf4d50d87
         add w8, w8, w21               // Add dest value
         add w8, w8, w13               // Add constant 0xf4d50d87
-        add w8, w8, w6                // Add aux function result
+        and x13, x17, x9              // Aux function round 2 (x & z)
+        add w8, w8, w6                // Add (~z & y)
+        add w8, w8, w13               // Add (x & z)
         ror w8, w8, #18               // Rotate left s=14 bits
-        bic x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x17, x4               // Aux function round 2 (~z & y)
         add w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0xf4d50d87, s=14, M[3])
-        and x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0x14ed             // Load lower half of constant 0x455a14ed
         movk x13, #0x455a, lsl #16    // Load upper half of constant 0x455a14ed
         add w9, w9, w5                // Add dest value
         add w9, w9, w13               // Add constant 0x455a14ed
-        add w9, w9, w6                // Add aux function result
+        and x13, x8, x4               // Aux function round 2 (x & z)
+        add w9, w9, w6                // Add (~z & y)
+        add w9, w9, w13               // Add (x & z)
         ror w9, w9, #12               // Rotate left s=20 bits
-        bic x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x8, x17               // Aux function round 2 (~z & y)
         add w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0x455a14ed, s=20, M[8])
-        and x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0xe905             // Load lower half of constant 0xa9e3e905
         movk x13, #0xa9e3, lsl #16    // Load upper half of constant 0xa9e3e905
         add w4, w4, w26               // Add dest value
         add w4, w4, w13               // Add constant 0xa9e3e905
-        add w4, w4, w6                // Add aux function result
+        and x13, x9, x17              // Aux function round 2 (x & z)
+        add w4, w4, w6                // Add (~z & y)
+        add w4, w4, w13               // Add (x & z)
         ror w4, w4, #27               // Rotate left s=5 bits
-        bic x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x9, x8                // Aux function round 2 (~z & y)
         add w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xa9e3e905, s=5, M[13])
-        and x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0xa3f8             // Load lower half of constant 0xfcefa3f8
         movk x13, #0xfcef, lsl #16    // Load upper half of constant 0xfcefa3f8
         add w17, w17, w3              // Add dest value
         add w17, w17, w13             // Add constant 0xfcefa3f8
-        add w17, w17, w6              // Add aux function result
+        and x13, x4, x8               // Aux function round 2 (x & z)
+        add w17, w17, w6              // Add (~z & y)
+        add w17, w17, w13             // Add (x & z)
         ror w17, w17, #23             // Rotate left s=9 bits
-        bic x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x4, x9                // Aux function round 2 (~z & y)
         add w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xfcefa3f8, s=9, M[2])
-        and x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0x2d9              // Load lower half of constant 0x676f02d9
         movk x13, #0x676f, lsl #16    // Load upper half of constant 0x676f02d9
         add w8, w8, w23               // Add dest value
         add w8, w8, w13               // Add constant 0x676f02d9
-        add w8, w8, w6                // Add aux function result
+        and x13, x17, x9              // Aux function round 2 (x & z)
+        add w8, w8, w6                // Add (~z & y)
+        add w8, w8, w13               // Add (x & z)
         ror w8, w8, #18               // Rotate left s=14 bits
-        bic x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+        bic x6, x17, x4               // Aux function round 2 (~z & y)
         add w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0x676f02d9, s=14, M[7])
-        and x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-        orr x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
         movz x13, #0x4c8a             // Load lower half of constant 0x8d2a4c8a
         movk x13, #0x8d2a, lsl #16    // Load upper half of constant 0x8d2a4c8a
         add w9, w9, w11               // Add dest value
         add w9, w9, w13               // Add constant 0x8d2a4c8a
-        add w9, w9, w6                // Add aux function result
+        and x13, x8, x4               // Aux function round 2 (x & z)
+        add w9, w9, w6                // Add (~z & y)
+        add w9, w9, w13               // Add (x & z)
         eor x6, x8, x17               // Begin aux function round 3 H(x,y,z)=(x^y^z)
         ror w9, w9, #12               // Rotate left s=20 bits
         movz x10, #0x3942             // Load lower half of constant 0xfffa3942

--- a/crypto/fipsmodule/md5/asm/md5-x86_64.pl
+++ b/crypto/fipsmodule/md5/asm/md5-x86_64.pl
@@ -51,9 +51,9 @@ sub round2_step
 	and	$x,		%r12d		/* x & z */
 	and	$y,		%r11d		/* y & (not z) */
 	mov	$k_next*4(%rsi),%r10d		/* (NEXT STEP) X[$k_next] */
-	add %r11d,	$dst		/* dst += (y & (not z)) */
+	add	%r11d,		$dst		/* dst += (y & (not z)) */
 	mov	$y,		%r11d		/* (NEXT STEP) z' = $y */
-	add %r12d,	$dst		/* dst += (x & z) */
+	add	%r12d,		$dst		/* dst += (x & z) */
 	mov	$y,		%r12d		/* (NEXT STEP) z' = $y */
 	rol	\$$s,		$dst		/* dst <<< s */
 	add	$x,		$dst		/* dst += x */

--- a/crypto/fipsmodule/md5/asm/md5-x86_64.pl
+++ b/crypto/fipsmodule/md5/asm/md5-x86_64.pl
@@ -51,9 +51,9 @@ sub round2_step
 	and	$x,		%r12d		/* x & z */
 	and	$y,		%r11d		/* y & (not z) */
 	mov	$k_next*4(%rsi),%r10d		/* (NEXT STEP) X[$k_next] */
-    add %r11d,      $dst        /* dst += (y & (not z)) */
+	add %r11d,	$dst		/* dst += (y & (not z)) */
 	mov	$y,		%r11d		/* (NEXT STEP) z' = $y */
-    add %r12d,      $dst        /* dst += (x & z) */
+	add %r12d,	$dst		/* dst += (x & z) */
 	mov	$y,		%r12d		/* (NEXT STEP) z' = $y */
 	rol	\$$s,		$dst		/* dst <<< s */
 	add	$x,		$dst		/* dst += x */

--- a/crypto/fipsmodule/md5/asm/md5-x86_64.pl
+++ b/crypto/fipsmodule/md5/asm/md5-x86_64.pl
@@ -39,7 +39,6 @@ EOF
 #   %r10d = X[k_next]
 #   %r11d = z' (copy of z for the next step)
 #   %r12d = z' (copy of z for the next step)
-# Each round2_step() takes about 5.4 clocks (11 instructions, 2.0 IPC)
 sub round2_step
 {
     my ($pos, $dst, $x, $y, $z, $k_next, $T_i, $s) = @_;
@@ -52,9 +51,9 @@ sub round2_step
 	and	$x,		%r12d		/* x & z */
 	and	$y,		%r11d		/* y & (not z) */
 	mov	$k_next*4(%rsi),%r10d		/* (NEXT STEP) X[$k_next] */
-	or	%r11d,		%r12d		/* (y & (not z)) | (x & z) */
+    add %r11d,      $dst        /* dst += (y & (not z)) */
 	mov	$y,		%r11d		/* (NEXT STEP) z' = $y */
-	add	%r12d,		$dst		/* dst += ... */
+    add %r12d,      $dst        /* dst += (x & z) */
 	mov	$y,		%r12d		/* (NEXT STEP) z' = $y */
 	rol	\$$s,		$dst		/* dst <<< s */
 	add	$x,		$dst		/* dst += x */

--- a/generated-src/ios-aarch64/crypto/fipsmodule/md5-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/md5-armv8.S
@@ -192,165 +192,165 @@ md5_blocks_loop:
 	add	w9, w9, w13               // Add constant 0x49b40821
 	add	w9, w9, w6                // Add aux function result
 	ror	w9, w9, #10               // Rotate left s=22 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 1 B=FF(B, C, D, A, 0x49b40821, s=22, M[15])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x2562             // Load lower half of constant 0xf61e2562
 	movk	x13, #0xf61e, lsl #16    // Load upper half of constant 0xf61e2562
 	add	w4, w4, w20               // Add dest value
 	add	w4, w4, w13               // Add constant 0xf61e2562
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xf61e2562, s=5, M[1])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xb340             // Load lower half of constant 0xc040b340
 	movk	x13, #0xc040, lsl #16    // Load upper half of constant 0xc040b340
 	add	w17, w17, w7              // Add dest value
 	add	w17, w17, w13             // Add constant 0xc040b340
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xc040b340, s=9, M[6])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x5a51             // Load lower half of constant 0x265e5a51
 	movk	x13, #0x265e, lsl #16    // Load upper half of constant 0x265e5a51
 	add	w8, w8, w25               // Add dest value
 	add	w8, w8, w13               // Add constant 0x265e5a51
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0x265e5a51, s=14, M[11])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xc7aa             // Load lower half of constant 0xe9b6c7aa
 	movk	x13, #0xe9b6, lsl #16    // Load upper half of constant 0xe9b6c7aa
 	add	w9, w9, w15               // Add dest value
 	add	w9, w9, w13               // Add constant 0xe9b6c7aa
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0xe9b6c7aa, s=20, M[0])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x105d             // Load lower half of constant 0xd62f105d
 	movk	x13, #0xd62f, lsl #16    // Load upper half of constant 0xd62f105d
 	add	w4, w4, w22               // Add dest value
 	add	w4, w4, w13               // Add constant 0xd62f105d
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xd62f105d, s=5, M[5])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x1453             // Load lower half of constant 0x2441453
 	movk	x13, #0x244, lsl #16     // Load upper half of constant 0x2441453
 	add	w17, w17, w16             // Add dest value
 	add	w17, w17, w13             // Add constant 0x2441453
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0x2441453, s=9, M[10])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xe681             // Load lower half of constant 0xd8a1e681
 	movk	x13, #0xd8a1, lsl #16    // Load upper half of constant 0xd8a1e681
 	add	w8, w8, w27               // Add dest value
 	add	w8, w8, w13               // Add constant 0xd8a1e681
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0xd8a1e681, s=14, M[15])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xfbc8             // Load lower half of constant 0xe7d3fbc8
 	movk	x13, #0xe7d3, lsl #16    // Load upper half of constant 0xe7d3fbc8
 	add	w9, w9, w14               // Add dest value
 	add	w9, w9, w13               // Add constant 0xe7d3fbc8
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0xe7d3fbc8, s=20, M[4])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xcde6             // Load lower half of constant 0x21e1cde6
 	movk	x13, #0x21e1, lsl #16    // Load upper half of constant 0x21e1cde6
 	add	w4, w4, w24               // Add dest value
 	add	w4, w4, w13               // Add constant 0x21e1cde6
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0x21e1cde6, s=5, M[9])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x7d6              // Load lower half of constant 0xc33707d6
 	movk	x13, #0xc337, lsl #16    // Load upper half of constant 0xc33707d6
 	add	w17, w17, w12             // Add dest value
 	add	w17, w17, w13             // Add constant 0xc33707d6
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xc33707d6, s=9, M[14])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xd87              // Load lower half of constant 0xf4d50d87
 	movk	x13, #0xf4d5, lsl #16    // Load upper half of constant 0xf4d50d87
 	add	w8, w8, w21               // Add dest value
 	add	w8, w8, w13               // Add constant 0xf4d50d87
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0xf4d50d87, s=14, M[3])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x14ed             // Load lower half of constant 0x455a14ed
 	movk	x13, #0x455a, lsl #16    // Load upper half of constant 0x455a14ed
 	add	w9, w9, w5                // Add dest value
 	add	w9, w9, w13               // Add constant 0x455a14ed
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0x455a14ed, s=20, M[8])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xe905             // Load lower half of constant 0xa9e3e905
 	movk	x13, #0xa9e3, lsl #16    // Load upper half of constant 0xa9e3e905
 	add	w4, w4, w26               // Add dest value
 	add	w4, w4, w13               // Add constant 0xa9e3e905
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xa9e3e905, s=5, M[13])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xa3f8             // Load lower half of constant 0xfcefa3f8
 	movk	x13, #0xfcef, lsl #16    // Load upper half of constant 0xfcefa3f8
 	add	w17, w17, w3              // Add dest value
 	add	w17, w17, w13             // Add constant 0xfcefa3f8
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xfcefa3f8, s=9, M[2])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x2d9              // Load lower half of constant 0x676f02d9
 	movk	x13, #0x676f, lsl #16    // Load upper half of constant 0x676f02d9
 	add	w8, w8, w23               // Add dest value
 	add	w8, w8, w13               // Add constant 0x676f02d9
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0x676f02d9, s=14, M[7])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x4c8a             // Load lower half of constant 0x8d2a4c8a
 	movk	x13, #0x8d2a, lsl #16    // Load upper half of constant 0x8d2a4c8a
 	add	w9, w9, w11               // Add dest value
 	add	w9, w9, w13               // Add constant 0x8d2a4c8a
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	eor	x6, x8, x17               // Begin aux function round 3 H(x,y,z)=(x^y^z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
 	movz	x10, #0x3942             // Load lower half of constant 0xfffa3942

--- a/generated-src/linux-aarch64/crypto/fipsmodule/md5-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/md5-armv8.S
@@ -192,165 +192,165 @@ md5_blocks_loop:
 	add	w9, w9, w13               // Add constant 0x49b40821
 	add	w9, w9, w6                // Add aux function result
 	ror	w9, w9, #10               // Rotate left s=22 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 1 B=FF(B, C, D, A, 0x49b40821, s=22, M[15])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x2562             // .Load lower half of constant 0xf61e2562
 	movk	x13, #0xf61e, lsl #16    // .Load upper half of constant 0xf61e2562
 	add	w4, w4, w20               // Add dest value
 	add	w4, w4, w13               // Add constant 0xf61e2562
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xf61e2562, s=5, M[1])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xb340             // .Load lower half of constant 0xc040b340
 	movk	x13, #0xc040, lsl #16    // .Load upper half of constant 0xc040b340
 	add	w17, w17, w7              // Add dest value
 	add	w17, w17, w13             // Add constant 0xc040b340
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xc040b340, s=9, M[6])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x5a51             // .Load lower half of constant 0x265e5a51
 	movk	x13, #0x265e, lsl #16    // .Load upper half of constant 0x265e5a51
 	add	w8, w8, w25               // Add dest value
 	add	w8, w8, w13               // Add constant 0x265e5a51
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0x265e5a51, s=14, M[11])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xc7aa             // .Load lower half of constant 0xe9b6c7aa
 	movk	x13, #0xe9b6, lsl #16    // .Load upper half of constant 0xe9b6c7aa
 	add	w9, w9, w15               // Add dest value
 	add	w9, w9, w13               // Add constant 0xe9b6c7aa
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0xe9b6c7aa, s=20, M[0])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x105d             // .Load lower half of constant 0xd62f105d
 	movk	x13, #0xd62f, lsl #16    // .Load upper half of constant 0xd62f105d
 	add	w4, w4, w22               // Add dest value
 	add	w4, w4, w13               // Add constant 0xd62f105d
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xd62f105d, s=5, M[5])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x1453             // .Load lower half of constant 0x2441453
 	movk	x13, #0x244, lsl #16     // .Load upper half of constant 0x2441453
 	add	w17, w17, w16             // Add dest value
 	add	w17, w17, w13             // Add constant 0x2441453
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0x2441453, s=9, M[10])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xe681             // .Load lower half of constant 0xd8a1e681
 	movk	x13, #0xd8a1, lsl #16    // .Load upper half of constant 0xd8a1e681
 	add	w8, w8, w27               // Add dest value
 	add	w8, w8, w13               // Add constant 0xd8a1e681
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0xd8a1e681, s=14, M[15])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xfbc8             // .Load lower half of constant 0xe7d3fbc8
 	movk	x13, #0xe7d3, lsl #16    // .Load upper half of constant 0xe7d3fbc8
 	add	w9, w9, w14               // Add dest value
 	add	w9, w9, w13               // Add constant 0xe7d3fbc8
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0xe7d3fbc8, s=20, M[4])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xcde6             // .Load lower half of constant 0x21e1cde6
 	movk	x13, #0x21e1, lsl #16    // .Load upper half of constant 0x21e1cde6
 	add	w4, w4, w24               // Add dest value
 	add	w4, w4, w13               // Add constant 0x21e1cde6
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0x21e1cde6, s=5, M[9])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x7d6              // .Load lower half of constant 0xc33707d6
 	movk	x13, #0xc337, lsl #16    // .Load upper half of constant 0xc33707d6
 	add	w17, w17, w12             // Add dest value
 	add	w17, w17, w13             // Add constant 0xc33707d6
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xc33707d6, s=9, M[14])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xd87              // .Load lower half of constant 0xf4d50d87
 	movk	x13, #0xf4d5, lsl #16    // .Load upper half of constant 0xf4d50d87
 	add	w8, w8, w21               // Add dest value
 	add	w8, w8, w13               // Add constant 0xf4d50d87
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0xf4d50d87, s=14, M[3])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x14ed             // .Load lower half of constant 0x455a14ed
 	movk	x13, #0x455a, lsl #16    // .Load upper half of constant 0x455a14ed
 	add	w9, w9, w5                // Add dest value
 	add	w9, w9, w13               // Add constant 0x455a14ed
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0x455a14ed, s=20, M[8])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xe905             // .Load lower half of constant 0xa9e3e905
 	movk	x13, #0xa9e3, lsl #16    // .Load upper half of constant 0xa9e3e905
 	add	w4, w4, w26               // Add dest value
 	add	w4, w4, w13               // Add constant 0xa9e3e905
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xa9e3e905, s=5, M[13])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xa3f8             // .Load lower half of constant 0xfcefa3f8
 	movk	x13, #0xfcef, lsl #16    // .Load upper half of constant 0xfcefa3f8
 	add	w17, w17, w3              // Add dest value
 	add	w17, w17, w13             // Add constant 0xfcefa3f8
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xfcefa3f8, s=9, M[2])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x2d9              // .Load lower half of constant 0x676f02d9
 	movk	x13, #0x676f, lsl #16    // .Load upper half of constant 0x676f02d9
 	add	w8, w8, w23               // Add dest value
 	add	w8, w8, w13               // Add constant 0x676f02d9
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0x676f02d9, s=14, M[7])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x4c8a             // .Load lower half of constant 0x8d2a4c8a
 	movk	x13, #0x8d2a, lsl #16    // .Load upper half of constant 0x8d2a4c8a
 	add	w9, w9, w11               // Add dest value
 	add	w9, w9, w13               // Add constant 0x8d2a4c8a
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	eor	x6, x8, x17               // Begin aux function round 3 H(x,y,z)=(x^y^z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
 	movz	x10, #0x3942             // .Load lower half of constant 0xfffa3942

--- a/generated-src/linux-x86_64/crypto/fipsmodule/md5-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/md5-x86_64.S
@@ -210,7 +210,7 @@ _CET_ENDBR
 	andl	%ebx,%r12d
 	andl	%ecx,%r11d
 	movl	24(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%eax
 	movl	%ecx,%r11d
 	addl	%r12d,%eax
 	movl	%ecx,%r12d
@@ -221,7 +221,7 @@ _CET_ENDBR
 	andl	%eax,%r12d
 	andl	%ebx,%r11d
 	movl	44(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%edx
 	movl	%ebx,%r11d
 	addl	%r12d,%edx
 	movl	%ebx,%r12d
@@ -232,7 +232,7 @@ _CET_ENDBR
 	andl	%edx,%r12d
 	andl	%eax,%r11d
 	movl	0(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ecx
 	movl	%eax,%r11d
 	addl	%r12d,%ecx
 	movl	%eax,%r12d
@@ -243,7 +243,7 @@ _CET_ENDBR
 	andl	%ecx,%r12d
 	andl	%edx,%r11d
 	movl	20(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ebx
 	movl	%edx,%r11d
 	addl	%r12d,%ebx
 	movl	%edx,%r12d
@@ -254,7 +254,7 @@ _CET_ENDBR
 	andl	%ebx,%r12d
 	andl	%ecx,%r11d
 	movl	40(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%eax
 	movl	%ecx,%r11d
 	addl	%r12d,%eax
 	movl	%ecx,%r12d
@@ -265,7 +265,7 @@ _CET_ENDBR
 	andl	%eax,%r12d
 	andl	%ebx,%r11d
 	movl	60(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%edx
 	movl	%ebx,%r11d
 	addl	%r12d,%edx
 	movl	%ebx,%r12d
@@ -276,7 +276,7 @@ _CET_ENDBR
 	andl	%edx,%r12d
 	andl	%eax,%r11d
 	movl	16(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ecx
 	movl	%eax,%r11d
 	addl	%r12d,%ecx
 	movl	%eax,%r12d
@@ -287,7 +287,7 @@ _CET_ENDBR
 	andl	%ecx,%r12d
 	andl	%edx,%r11d
 	movl	36(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ebx
 	movl	%edx,%r11d
 	addl	%r12d,%ebx
 	movl	%edx,%r12d
@@ -298,7 +298,7 @@ _CET_ENDBR
 	andl	%ebx,%r12d
 	andl	%ecx,%r11d
 	movl	56(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%eax
 	movl	%ecx,%r11d
 	addl	%r12d,%eax
 	movl	%ecx,%r12d
@@ -309,7 +309,7 @@ _CET_ENDBR
 	andl	%eax,%r12d
 	andl	%ebx,%r11d
 	movl	12(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%edx
 	movl	%ebx,%r11d
 	addl	%r12d,%edx
 	movl	%ebx,%r12d
@@ -320,7 +320,7 @@ _CET_ENDBR
 	andl	%edx,%r12d
 	andl	%eax,%r11d
 	movl	32(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ecx
 	movl	%eax,%r11d
 	addl	%r12d,%ecx
 	movl	%eax,%r12d
@@ -331,7 +331,7 @@ _CET_ENDBR
 	andl	%ecx,%r12d
 	andl	%edx,%r11d
 	movl	52(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ebx
 	movl	%edx,%r11d
 	addl	%r12d,%ebx
 	movl	%edx,%r12d
@@ -342,7 +342,7 @@ _CET_ENDBR
 	andl	%ebx,%r12d
 	andl	%ecx,%r11d
 	movl	8(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%eax
 	movl	%ecx,%r11d
 	addl	%r12d,%eax
 	movl	%ecx,%r12d
@@ -353,7 +353,7 @@ _CET_ENDBR
 	andl	%eax,%r12d
 	andl	%ebx,%r11d
 	movl	28(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%edx
 	movl	%ebx,%r11d
 	addl	%r12d,%edx
 	movl	%ebx,%r12d
@@ -364,7 +364,7 @@ _CET_ENDBR
 	andl	%edx,%r12d
 	andl	%eax,%r11d
 	movl	48(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ecx
 	movl	%eax,%r11d
 	addl	%r12d,%ecx
 	movl	%eax,%r12d
@@ -375,7 +375,7 @@ _CET_ENDBR
 	andl	%ecx,%r12d
 	andl	%edx,%r11d
 	movl	0(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ebx
 	movl	%edx,%r11d
 	addl	%r12d,%ebx
 	movl	%edx,%r12d

--- a/generated-src/mac-x86_64/crypto/fipsmodule/md5-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/md5-x86_64.S
@@ -205,7 +205,7 @@ L$loop:
 	andl	%ebx,%r12d
 	andl	%ecx,%r11d
 	movl	24(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%eax
 	movl	%ecx,%r11d
 	addl	%r12d,%eax
 	movl	%ecx,%r12d
@@ -216,7 +216,7 @@ L$loop:
 	andl	%eax,%r12d
 	andl	%ebx,%r11d
 	movl	44(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%edx
 	movl	%ebx,%r11d
 	addl	%r12d,%edx
 	movl	%ebx,%r12d
@@ -227,7 +227,7 @@ L$loop:
 	andl	%edx,%r12d
 	andl	%eax,%r11d
 	movl	0(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ecx
 	movl	%eax,%r11d
 	addl	%r12d,%ecx
 	movl	%eax,%r12d
@@ -238,7 +238,7 @@ L$loop:
 	andl	%ecx,%r12d
 	andl	%edx,%r11d
 	movl	20(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ebx
 	movl	%edx,%r11d
 	addl	%r12d,%ebx
 	movl	%edx,%r12d
@@ -249,7 +249,7 @@ L$loop:
 	andl	%ebx,%r12d
 	andl	%ecx,%r11d
 	movl	40(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%eax
 	movl	%ecx,%r11d
 	addl	%r12d,%eax
 	movl	%ecx,%r12d
@@ -260,7 +260,7 @@ L$loop:
 	andl	%eax,%r12d
 	andl	%ebx,%r11d
 	movl	60(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%edx
 	movl	%ebx,%r11d
 	addl	%r12d,%edx
 	movl	%ebx,%r12d
@@ -271,7 +271,7 @@ L$loop:
 	andl	%edx,%r12d
 	andl	%eax,%r11d
 	movl	16(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ecx
 	movl	%eax,%r11d
 	addl	%r12d,%ecx
 	movl	%eax,%r12d
@@ -282,7 +282,7 @@ L$loop:
 	andl	%ecx,%r12d
 	andl	%edx,%r11d
 	movl	36(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ebx
 	movl	%edx,%r11d
 	addl	%r12d,%ebx
 	movl	%edx,%r12d
@@ -293,7 +293,7 @@ L$loop:
 	andl	%ebx,%r12d
 	andl	%ecx,%r11d
 	movl	56(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%eax
 	movl	%ecx,%r11d
 	addl	%r12d,%eax
 	movl	%ecx,%r12d
@@ -304,7 +304,7 @@ L$loop:
 	andl	%eax,%r12d
 	andl	%ebx,%r11d
 	movl	12(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%edx
 	movl	%ebx,%r11d
 	addl	%r12d,%edx
 	movl	%ebx,%r12d
@@ -315,7 +315,7 @@ L$loop:
 	andl	%edx,%r12d
 	andl	%eax,%r11d
 	movl	32(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ecx
 	movl	%eax,%r11d
 	addl	%r12d,%ecx
 	movl	%eax,%r12d
@@ -326,7 +326,7 @@ L$loop:
 	andl	%ecx,%r12d
 	andl	%edx,%r11d
 	movl	52(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ebx
 	movl	%edx,%r11d
 	addl	%r12d,%ebx
 	movl	%edx,%r12d
@@ -337,7 +337,7 @@ L$loop:
 	andl	%ebx,%r12d
 	andl	%ecx,%r11d
 	movl	8(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%eax
 	movl	%ecx,%r11d
 	addl	%r12d,%eax
 	movl	%ecx,%r12d
@@ -348,7 +348,7 @@ L$loop:
 	andl	%eax,%r12d
 	andl	%ebx,%r11d
 	movl	28(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%edx
 	movl	%ebx,%r11d
 	addl	%r12d,%edx
 	movl	%ebx,%r12d
@@ -359,7 +359,7 @@ L$loop:
 	andl	%edx,%r12d
 	andl	%eax,%r11d
 	movl	48(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ecx
 	movl	%eax,%r11d
 	addl	%r12d,%ecx
 	movl	%eax,%r12d
@@ -370,7 +370,7 @@ L$loop:
 	andl	%ecx,%r12d
 	andl	%edx,%r11d
 	movl	0(%rsi),%r10d
-	orl	%r11d,%r12d
+	addl	%r11d,%ebx
 	movl	%edx,%r11d
 	addl	%r12d,%ebx
 	movl	%edx,%r12d

--- a/generated-src/win-aarch64/crypto/fipsmodule/md5-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/md5-armv8.S
@@ -192,165 +192,165 @@ md5_blocks_loop:
 	add	w9, w9, w13               // Add constant 0x49b40821
 	add	w9, w9, w6                // Add aux function result
 	ror	w9, w9, #10               // Rotate left s=22 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 1 B=FF(B, C, D, A, 0x49b40821, s=22, M[15])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x2562             // Load lower half of constant 0xf61e2562
 	movk	x13, #0xf61e, lsl #16    // Load upper half of constant 0xf61e2562
 	add	w4, w4, w20               // Add dest value
 	add	w4, w4, w13               // Add constant 0xf61e2562
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xf61e2562, s=5, M[1])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xb340             // Load lower half of constant 0xc040b340
 	movk	x13, #0xc040, lsl #16    // Load upper half of constant 0xc040b340
 	add	w17, w17, w7              // Add dest value
 	add	w17, w17, w13             // Add constant 0xc040b340
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xc040b340, s=9, M[6])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x5a51             // Load lower half of constant 0x265e5a51
 	movk	x13, #0x265e, lsl #16    // Load upper half of constant 0x265e5a51
 	add	w8, w8, w25               // Add dest value
 	add	w8, w8, w13               // Add constant 0x265e5a51
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0x265e5a51, s=14, M[11])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xc7aa             // Load lower half of constant 0xe9b6c7aa
 	movk	x13, #0xe9b6, lsl #16    // Load upper half of constant 0xe9b6c7aa
 	add	w9, w9, w15               // Add dest value
 	add	w9, w9, w13               // Add constant 0xe9b6c7aa
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0xe9b6c7aa, s=20, M[0])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x105d             // Load lower half of constant 0xd62f105d
 	movk	x13, #0xd62f, lsl #16    // Load upper half of constant 0xd62f105d
 	add	w4, w4, w22               // Add dest value
 	add	w4, w4, w13               // Add constant 0xd62f105d
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xd62f105d, s=5, M[5])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x1453             // Load lower half of constant 0x2441453
 	movk	x13, #0x244, lsl #16     // Load upper half of constant 0x2441453
 	add	w17, w17, w16             // Add dest value
 	add	w17, w17, w13             // Add constant 0x2441453
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0x2441453, s=9, M[10])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xe681             // Load lower half of constant 0xd8a1e681
 	movk	x13, #0xd8a1, lsl #16    // Load upper half of constant 0xd8a1e681
 	add	w8, w8, w27               // Add dest value
 	add	w8, w8, w13               // Add constant 0xd8a1e681
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0xd8a1e681, s=14, M[15])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xfbc8             // Load lower half of constant 0xe7d3fbc8
 	movk	x13, #0xe7d3, lsl #16    // Load upper half of constant 0xe7d3fbc8
 	add	w9, w9, w14               // Add dest value
 	add	w9, w9, w13               // Add constant 0xe7d3fbc8
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0xe7d3fbc8, s=20, M[4])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xcde6             // Load lower half of constant 0x21e1cde6
 	movk	x13, #0x21e1, lsl #16    // Load upper half of constant 0x21e1cde6
 	add	w4, w4, w24               // Add dest value
 	add	w4, w4, w13               // Add constant 0x21e1cde6
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0x21e1cde6, s=5, M[9])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x7d6              // Load lower half of constant 0xc33707d6
 	movk	x13, #0xc337, lsl #16    // Load upper half of constant 0xc33707d6
 	add	w17, w17, w12             // Add dest value
 	add	w17, w17, w13             // Add constant 0xc33707d6
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xc33707d6, s=9, M[14])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xd87              // Load lower half of constant 0xf4d50d87
 	movk	x13, #0xf4d5, lsl #16    // Load upper half of constant 0xf4d50d87
 	add	w8, w8, w21               // Add dest value
 	add	w8, w8, w13               // Add constant 0xf4d50d87
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0xf4d50d87, s=14, M[3])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x14ed             // Load lower half of constant 0x455a14ed
 	movk	x13, #0x455a, lsl #16    // Load upper half of constant 0x455a14ed
 	add	w9, w9, w5                // Add dest value
 	add	w9, w9, w13               // Add constant 0x455a14ed
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
-	bic	x6, x8, x17               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x8, x17               // Aux function round 2 (~z & y)
 	add	w9, w8, w9                // Add X parameter round 2 B=GG(B, C, D, A, 0x455a14ed, s=20, M[8])
-	and	x13, x9, x17              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xe905             // Load lower half of constant 0xa9e3e905
 	movk	x13, #0xa9e3, lsl #16    // Load upper half of constant 0xa9e3e905
 	add	w4, w4, w26               // Add dest value
 	add	w4, w4, w13               // Add constant 0xa9e3e905
-	add	w4, w4, w6                // Add aux function result
+	and	x13, x9, x17              // Aux function round 2 (x & z)
+	add	w4, w4, w6                // Add (~z & y)
+	add	w4, w4, w13               // Add (x & z)
 	ror	w4, w4, #27               // Rotate left s=5 bits
-	bic	x6, x9, x8                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x9, x8                // Aux function round 2 (~z & y)
 	add	w4, w9, w4                // Add X parameter round 2 A=GG(A, B, C, D, 0xa9e3e905, s=5, M[13])
-	and	x13, x4, x8               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0xa3f8             // Load lower half of constant 0xfcefa3f8
 	movk	x13, #0xfcef, lsl #16    // Load upper half of constant 0xfcefa3f8
 	add	w17, w17, w3              // Add dest value
 	add	w17, w17, w13             // Add constant 0xfcefa3f8
-	add	w17, w17, w6              // Add aux function result
+	and	x13, x4, x8               // Aux function round 2 (x & z)
+	add	w17, w17, w6              // Add (~z & y)
+	add	w17, w17, w13             // Add (x & z)
 	ror	w17, w17, #23             // Rotate left s=9 bits
-	bic	x6, x4, x9                // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x4, x9                // Aux function round 2 (~z & y)
 	add	w17, w4, w17              // Add X parameter round 2 D=GG(D, A, B, C, 0xfcefa3f8, s=9, M[2])
-	and	x13, x17, x9              // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x2d9              // Load lower half of constant 0x676f02d9
 	movk	x13, #0x676f, lsl #16    // Load upper half of constant 0x676f02d9
 	add	w8, w8, w23               // Add dest value
 	add	w8, w8, w13               // Add constant 0x676f02d9
-	add	w8, w8, w6                // Add aux function result
+	and	x13, x17, x9              // Aux function round 2 (x & z)
+	add	w8, w8, w6                // Add (~z & y)
+	add	w8, w8, w13               // Add (x & z)
 	ror	w8, w8, #18               // Rotate left s=14 bits
-	bic	x6, x17, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
+	bic	x6, x17, x4               // Aux function round 2 (~z & y)
 	add	w8, w17, w8               // Add X parameter round 2 C=GG(C, D, A, B, 0x676f02d9, s=14, M[7])
-	and	x13, x8, x4               // Aux function round 2 G(x,y,z)=((x&z)|(~z&y))
-	orr	x6, x6, x13               // End aux function round 2 G(x,y,z)=((x&z)|(~z&y))
 	movz	x13, #0x4c8a             // Load lower half of constant 0x8d2a4c8a
 	movk	x13, #0x8d2a, lsl #16    // Load upper half of constant 0x8d2a4c8a
 	add	w9, w9, w11               // Add dest value
 	add	w9, w9, w13               // Add constant 0x8d2a4c8a
-	add	w9, w9, w6                // Add aux function result
+	and	x13, x8, x4               // Aux function round 2 (x & z)
+	add	w9, w9, w6                // Add (~z & y)
+	add	w9, w9, w13               // Add (x & z)
 	eor	x6, x8, x17               // Begin aux function round 3 H(x,y,z)=(x^y^z)
 	ror	w9, w9, #12               // Rotate left s=20 bits
 	movz	x10, #0x3942             // Load lower half of constant 0xfffa3942

--- a/generated-src/win-x86_64/crypto/fipsmodule/md5-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/md5-x86_64.asm
@@ -219,7 +219,7 @@ $L$loop:
 	and	r12d,ebx
 	and	r11d,ecx
 	mov	r10d,DWORD[24+rsi]
-	or	r12d,r11d
+	add	eax,r11d
 	mov	r11d,ecx
 	add	eax,r12d
 	mov	r12d,ecx
@@ -230,7 +230,7 @@ $L$loop:
 	and	r12d,eax
 	and	r11d,ebx
 	mov	r10d,DWORD[44+rsi]
-	or	r12d,r11d
+	add	edx,r11d
 	mov	r11d,ebx
 	add	edx,r12d
 	mov	r12d,ebx
@@ -241,7 +241,7 @@ $L$loop:
 	and	r12d,edx
 	and	r11d,eax
 	mov	r10d,DWORD[rsi]
-	or	r12d,r11d
+	add	ecx,r11d
 	mov	r11d,eax
 	add	ecx,r12d
 	mov	r12d,eax
@@ -252,7 +252,7 @@ $L$loop:
 	and	r12d,ecx
 	and	r11d,edx
 	mov	r10d,DWORD[20+rsi]
-	or	r12d,r11d
+	add	ebx,r11d
 	mov	r11d,edx
 	add	ebx,r12d
 	mov	r12d,edx
@@ -263,7 +263,7 @@ $L$loop:
 	and	r12d,ebx
 	and	r11d,ecx
 	mov	r10d,DWORD[40+rsi]
-	or	r12d,r11d
+	add	eax,r11d
 	mov	r11d,ecx
 	add	eax,r12d
 	mov	r12d,ecx
@@ -274,7 +274,7 @@ $L$loop:
 	and	r12d,eax
 	and	r11d,ebx
 	mov	r10d,DWORD[60+rsi]
-	or	r12d,r11d
+	add	edx,r11d
 	mov	r11d,ebx
 	add	edx,r12d
 	mov	r12d,ebx
@@ -285,7 +285,7 @@ $L$loop:
 	and	r12d,edx
 	and	r11d,eax
 	mov	r10d,DWORD[16+rsi]
-	or	r12d,r11d
+	add	ecx,r11d
 	mov	r11d,eax
 	add	ecx,r12d
 	mov	r12d,eax
@@ -296,7 +296,7 @@ $L$loop:
 	and	r12d,ecx
 	and	r11d,edx
 	mov	r10d,DWORD[36+rsi]
-	or	r12d,r11d
+	add	ebx,r11d
 	mov	r11d,edx
 	add	ebx,r12d
 	mov	r12d,edx
@@ -307,7 +307,7 @@ $L$loop:
 	and	r12d,ebx
 	and	r11d,ecx
 	mov	r10d,DWORD[56+rsi]
-	or	r12d,r11d
+	add	eax,r11d
 	mov	r11d,ecx
 	add	eax,r12d
 	mov	r12d,ecx
@@ -318,7 +318,7 @@ $L$loop:
 	and	r12d,eax
 	and	r11d,ebx
 	mov	r10d,DWORD[12+rsi]
-	or	r12d,r11d
+	add	edx,r11d
 	mov	r11d,ebx
 	add	edx,r12d
 	mov	r12d,ebx
@@ -329,7 +329,7 @@ $L$loop:
 	and	r12d,edx
 	and	r11d,eax
 	mov	r10d,DWORD[32+rsi]
-	or	r12d,r11d
+	add	ecx,r11d
 	mov	r11d,eax
 	add	ecx,r12d
 	mov	r12d,eax
@@ -340,7 +340,7 @@ $L$loop:
 	and	r12d,ecx
 	and	r11d,edx
 	mov	r10d,DWORD[52+rsi]
-	or	r12d,r11d
+	add	ebx,r11d
 	mov	r11d,edx
 	add	ebx,r12d
 	mov	r12d,edx
@@ -351,7 +351,7 @@ $L$loop:
 	and	r12d,ebx
 	and	r11d,ecx
 	mov	r10d,DWORD[8+rsi]
-	or	r12d,r11d
+	add	eax,r11d
 	mov	r11d,ecx
 	add	eax,r12d
 	mov	r12d,ecx
@@ -362,7 +362,7 @@ $L$loop:
 	and	r12d,eax
 	and	r11d,ebx
 	mov	r10d,DWORD[28+rsi]
-	or	r12d,r11d
+	add	edx,r11d
 	mov	r11d,ebx
 	add	edx,r12d
 	mov	r12d,ebx
@@ -373,7 +373,7 @@ $L$loop:
 	and	r12d,edx
 	and	r11d,eax
 	mov	r10d,DWORD[48+rsi]
-	or	r12d,r11d
+	add	ecx,r11d
 	mov	r11d,eax
 	add	ecx,r12d
 	mov	r12d,eax
@@ -384,7 +384,7 @@ $L$loop:
 	and	r12d,ecx
 	and	r11d,edx
 	mov	r10d,DWORD[rsi]
-	or	r12d,r11d
+	add	ebx,r11d
 	mov	r11d,edx
 	add	ebx,r12d
 	mov	r12d,edx


### PR DESCRIPTION
### Description of changes: 

(Equivalent to https://github.com/openssl/openssl/commit/ebe34f9a62630b45a825bc07a2e9cf52731e836e)

As suggested in https://github.com/animetosho/md5-optimisation?tab=readme-ov-file#dependency-shortcut-in-g-function, we can delay the dependency on 'x' by recognizing that ((x & z) | (y & ~z)) is equivalent to ((x & z) + (y + ~z)) in this scenario, and we can perform those additions independently, leaving our dependency on x to the final addition. This speeds it up around 5% on both platforms.

### Call-outs:
I applied the x86 patch manually, it's trivial, and the aarch64 patch applied cleanly after fixing the file name/path.

### Testing:
`ninja-build run_tests` on x86. `bssl speed -filter MD5` on x86 shows the expected speedup:

```
Before
Did 7169250 MD5 (16 bytes) operations in 1000024us (7169077.9 ops/sec): 114.7 MB/s
Did 1826500 MD5 (256 bytes) operations in 1000119us (1826282.7 ops/sec): 467.5 MB/s
Did 433000 MD5 (1350 bytes) operations in 1001295us (432440.0 ops/sec): 583.8 MB/s
Did 76000 MD5 (8192 bytes) operations in 1005792us (75562.3 ops/sec): 619.0 MB/s
Did 39000 MD5 (16384 bytes) operations in 1025281us (38038.4 ops/sec): 623.2 MB/s


After
Did 7457250 MD5 (16 bytes) operations in 1000004us (7457220.2 ops/sec): 119.3 MB/s
Did 1919000 MD5 (256 bytes) operations in 1000057us (1918890.6 ops/sec): 491.2 MB/s
Did 456000 MD5 (1350 bytes) operations in 1001377us (455373.0 ops/sec): 614.8 MB/s
Did 80000 MD5 (8192 bytes) operations in 1004118us (79671.9 ops/sec): 652.7 MB/s
Did 41000 MD5 (16384 bytes) operations in 1022055us (40115.3 ops/sec): 657.2 MB/s 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
