### PR TITLE
Avoid mixing SSE and AVX in XTS-mode AVX512 implementation

### DIFF
--- a/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
+++ b/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
@@ -1598,7 +1598,7 @@ ___
   vmovdqu8 	 %zmm1,($output)
   vmovdqu 	 %xmm2,0x40($output)
   add 	 \$0x50,$output
-  movdqa 	 %xmm2,%xmm8
+  vmovdqa 	 %xmm2,%xmm8
   vextracti32x4 	 \$0x1,%zmm10,%xmm0
   and 	 \$0xf,$length
   je 	 .L_ret_${rndsuffix}

--- a/generated-src/linux-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
@@ -428,7 +428,7 @@ aes_hw_xts_encrypt_avx512:
 	vmovdqu8	%zmm1,(%rsi)
 	vmovdqu	%xmm2,64(%rsi)
 	addq	$0x50,%rsi
-	movdqa	%xmm2,%xmm8
+	vmovdqa	%xmm2,%xmm8
 	vextracti32x4	$0x1,%zmm10,%xmm0
 	andq	$0xf,%rdx
 	je	.L_ret_hEgxyDlCngwrfFe

--- a/generated-src/mac-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
@@ -428,7 +428,7 @@ L$_remaining_num_blocks_is_5_hEgxyDlCngwrfFe:
 	vmovdqu8	%zmm1,(%rsi)
 	vmovdqu	%xmm2,64(%rsi)
 	addq	$0x50,%rsi
-	movdqa	%xmm2,%xmm8
+	vmovdqa	%xmm2,%xmm8
 	vextracti32x4	$0x1,%zmm10,%xmm0
 	andq	$0xf,%rdx
 	je	L$_ret_hEgxyDlCngwrfFe

--- a/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
@@ -447,7 +447,7 @@ $L$_remaining_num_blocks_is_5_hEgxyDlCngwrfFe:
 	vmovdqu8	ZMMWORD[rdx],zmm1
 	vmovdqu	XMMWORD[64+rdx],xmm2
 	add	rdx,0x50
-	movdqa	xmm8,xmm2
+	vmovdqa	xmm8,xmm2
 	vextracti32x4	xmm0,zmm10,0x1
 	and	r8,0xf
 	je	NEAR $L$_ret_hEgxyDlCngwrfFe


### PR DESCRIPTION
### Issues:

P192842055

### Description of changes: 

Define the set `S = [i*128+80,i*128+80+15], i=1,2,3,...,` . The set of inputs with lengths from `S`, on the XTS encrypt path using the AVX512 implementation, a bimodal performance occurred. We have observed more than 80% drop in performance.

The graph depicts AWS-LC (blue) and AWS-LC-FIPS-2024 (orange), showing the pattern.

![Screenshot 2025-01-24 at 6 29 13 PM](https://github.com/user-attachments/assets/db3b7dff-4967-45b3-96ce-40178e897729)

This is caused by mixing SSE and AVX instructions in the AVX512 implementation. In particular, for lengths in `S`, the path `L_remaining_num_blocks_is_5_` is taken. This path contains a single move `movdqa`, an SSE instruction:
```
  .L_remaining_num_blocks_is_5_${rndsuffix}:
  vmovdqu8 	 ($input),%zmm1
  vmovdqu 	 0x40($input),%xmm2

  [...]

  vmovdqu8 	 %zmm1,($output)
  vmovdqu 	 %xmm2,0x40($output)
  add 	 \$0x50,$output
  movdqa 	 %xmm2,%xmm8
  vextracti32x4 	 \$0x1,%zmm10,%xmm0
  [...]
```

It's perhaps a less known fact that mixing SSE and AVX instruction can lead to severe performance issues. See e.g. Agner Fog's manual Section 9.12 "Transitions between VEX and non-VEX modes" (at time of writing page 132 in https://www.agner.org/optimize/microarchitecture.pdf):

> The transitions B → C, C → B and C → A take approximately 70 clock cycles each on the Sandy Bridge

That appears to be true on our test CPU (Sapphire Rapids) from the c7i instance family. Although, page Section 12.10 in Agner's does state:

> The severe penalty for mixing 256-bit VEX code with 128-bit non-VEX code in early processors (see chapter 9.12 page 134) is no longer found in the Ice Lake

Sapphire Rapids is not Ice Lake, but is newer though. So, that's slightly confusing. Nonetheless, to recover performance, a fix should simply be to use the VEX instruction instead of the non-VEX i.e. `vmovdqa`.

Before:
```
$ ./tool/bssl speed -filter AES-256-XTS -chunks 206,207,208,209
Did 27399500 AES-256-XTS encrypt (206 bytes) operations in 1000006us (27399335.6 ops/sec): 5644.3 MB/s
Did 28754500 AES-256-XTS encrypt (207 bytes) operations in 1000002us (28754442.5 ops/sec): 5952.2 MB/s
Did 5494000 AES-256-XTS encrypt (208 bytes) operations in 1000024us (5493868.1 ops/sec): 1142.7 MB/s
Did 5346750 AES-256-XTS encrypt (209 bytes) operations in 1000030us (5346589.6 ops/sec): 1117.4 MB/s
```

After:
```
$ ./tool/bssl speed -filter AES-256-XTS -chunks 206,207,208,209
Did 27859000 AES-256-XTS encrypt (206 bytes) operations in 1000015us (27858582.1 ops/sec): 5738.9 MB/s
Did 27360500 AES-256-XTS encrypt (207 bytes) operations in 1000007us (27360308.5 ops/sec): 5663.6 MB/s
Did 33774750 AES-256-XTS encrypt (208 bytes) operations in 1000003us (33774648.7 ops/sec): 7025.1 MB/s
Did 27810000 AES-256-XTS encrypt (209 bytes) operations in 1000004us (27809888.8 ops/sec): 5812.3 MB/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
