### PR TITLE
Check for MIPSEB in target.h

### DIFF
--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -55,6 +55,10 @@
 #elif defined(__MIPSEL__) && defined(__LP64__)
 #define OPENSSL_64_BIT
 #define OPENSSL_MIPS64
+#elif defined(__MIPSEB__) && !defined(__LP64__)
+#define OPENSSL_32_BIT
+#define OPENSSL_MIPS
+#define OPENSSL_BIG_ENDIAN
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 8
 #define OPENSSL_64_BIT
 #define OPENSSL_RISCV64


### PR DESCRIPTION
### Issues:
Addresses: 
* aws/aws-lc-rs#522

### Description of changes: 
Setup macros for big-endian MIPS in "target.h"

### Callout
A contributor informs us that the build for `mips-unknown-linux-musl` succeeds with this change: https://github.com/aws/aws-lc-rs/issues/522#issuecomment-2618841038

### Testing:
No CI testing for it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
