### PR TITLE
Fix ecr permissions for scrutinice

### DIFF
--- a/tests/ci/cdk/util/iam_policies.py
+++ b/tests/ci/cdk/util/iam_policies.py
@@ -217,7 +217,8 @@ def ecr_power_user_policy_in_json(ecr_repo_names):
                 "Action": [
                     "ecr:BatchGetImage",
                     "ecr:GetDownloadUrlForLayer"
-                ]
+                ],
+                "Resource": ecr_arns
             }
         ]
     }


### PR DESCRIPTION
Resolves `P195993156`

There was a minor missing line in our cdk permissions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
