### PR TITLE
Fix ARM64 FIPS build failure: Resolve pc-relative address offset range errors (Delocator)

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -15,9 +15,9 @@ if(ARCH STREQUAL "aarch64" AND FIPS)
   # Disable PIC for ARM64 FIPS builds globally
   set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
   # Set base flags for ARM64 FIPS - using 'large' code model to handle large FIPS module with explicit section alignment
-  set(AARCH64_FIPS_FLAGS "-mcmodel=large -fno-pic -fno-PIE -fdata-sections -ffunction-sections")
-  # Add alignment specifications
-  set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -falign-functions=32")
+  set(AARCH64_FIPS_FLAGS "-mcmodel=large -fno-pic -fno-PIE")
+  # Add flag to prevent section garbage collection
+  set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -fno-function-sections")
   # Apply flags consistently
   set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${AARCH64_FIPS_FLAGS}")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${AARCH64_FIPS_FLAGS}")

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -10,16 +10,18 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" AND FIPS)
   endif()
 endif()
 
-# Add ARM64 FIPS specific configurations
 if(ARCH STREQUAL "aarch64" AND FIPS)
+  # Always use large code model for FIPS compliance
+  set(AARCH64_FIPS_FLAGS "-mcmodel=large")
+
   if(BUILD_SHARED_LIBS)
-    # For shared library builds, we need PIC
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-    set(AARCH64_FIPS_FLAGS "-mcmodel=large")
-  else()
-    # For static builds, we can disable PIC
+    # For shared builds, we'll need to build as a static object first
+    # and then link it into the shared library
     set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
-    set(AARCH64_FIPS_FLAGS "-mcmodel=large -fno-pic -fno-PIE")
+    set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -fno-pic -fno-PIE")
+  else()
+    set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
+    set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -fno-pic -fno-PIE")
   endif()
 
   # Add flag to prevent section garbage collection
@@ -29,14 +31,9 @@ if(ARCH STREQUAL "aarch64" AND FIPS)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${AARCH64_FIPS_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${AARCH64_FIPS_FLAGS}")
 
-  # Set linker flags based on build type
-  if(BUILD_SHARED_LIBS)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=none")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=none")
-  else()
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
-  endif()
+  # Set linker flags
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
 endif()
 
 if(ANDROID)

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -10,6 +10,21 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" AND FIPS)
   endif()
 endif()
 
+# Add ARM64 FIPS specific configurations
+if(ARCH STREQUAL "aarch64" AND FIPS)
+  # Disable PIC for ARM64 FIPS builds globally
+  set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
+  # Set base flags for ARM64 FIPS - using 'large' code model to handle large FIPS module
+  set(AARCH64_FIPS_FLAGS "-mcmodel=large -fno-pic -fno-PIE")
+  # Apply flags consistently
+  set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${AARCH64_FIPS_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${AARCH64_FIPS_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${AARCH64_FIPS_FLAGS}")
+  # Ensure linker flags are set
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -no-pie")
+endif()
+
 if(ANDROID)
   # Since "--Wa,--noexecstack" is not used during the preprocessor step of Android (because assembler is not invoked),
   # Clang reports that argument as unused. We remove the flag only for the FIPS build of Android.
@@ -24,7 +39,7 @@ if(ANDROID)
 endif()
 
 if(ARCH STREQUAL "x86_64")
-  set(
+set(
     BCM_ASM_SOURCES
 
     aesni-gcm-avx512.${ASM_EXT}
@@ -178,7 +193,7 @@ endif()
 # but only if it's given the right flags (e.g. -mavx512*).
 # The flags are not required for any other compiler we are running in the CI.
 if (CLANG AND (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
-    (CMAKE_C_COMPILER_VERSION VERSION_LESS "7.0.0") AND (ARCH STREQUAL "x86_64"))
+(CMAKE_C_COMPILER_VERSION VERSION_LESS "7.0.0") AND (ARCH STREQUAL "x86_64"))
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/aesni-gcm-avx512.${ASM_EXT} PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl")
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/aesni-xts-avx512.${ASM_EXT} PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl")
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/rsaz-2k-avx512.${ASM_EXT} PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl -mavx512ifma")
@@ -353,6 +368,8 @@ if(FIPS_DELOCATE)
     enable_language(ASM)
   endif()
 
+  go_executable(delocate boringssl.googlesource.com/boringssl/util/fipstools/delocate)
+
   add_library(
     bcm_c_generated_asm
 
@@ -360,6 +377,14 @@ if(FIPS_DELOCATE)
 
     bcm.c
   )
+
+  # Add ARM64-specific flags for FIPS static builds
+  if(ARCH STREQUAL "aarch64")
+    message(STATUS "Configuring ARM64 FIPS static build with large code model")
+    target_compile_options(bcm_c_generated_asm PRIVATE "-mcmodel=large" "-fno-pic" "-fno-PIE")
+    set_property(TARGET bcm_c_generated_asm PROPERTY POSITION_INDEPENDENT_CODE OFF)
+  endif()
+
   target_compile_definitions(bcm_c_generated_asm PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(bcm_c_generated_asm boringssl_prefix_symbols)
@@ -367,22 +392,23 @@ if(FIPS_DELOCATE)
   # Delocator expects symbols to not be prefixed.
   target_include_directories(bcm_c_generated_asm PRIVATE ${PROJECT_SOURCE_DIR}/include)
   set_target_properties(bcm_c_generated_asm PROPERTIES COMPILE_OPTIONS "-S")
-  set_target_properties(bcm_c_generated_asm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
   set(TARGET "")
   if(CMAKE_ASM_COMPILER_TARGET)
     set(TARGET "--target=${CMAKE_ASM_COMPILER_TARGET}")
   endif()
 
-  set(DELOCATE_EXTRA_ARGS "")
-  # clang-6 (and older) do not appreciate the file number starting at a higher value, and incorrectly
-  # assume that all file numbers less than that value are defined upon later use.
-  if (CLANG AND (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
-      (CMAKE_C_COMPILER_VERSION VERSION_LESS "7.0.0"))
-    set(DELOCATE_EXTRA_ARGS "-no-se-debug-directives")
+  # Properly format compiler flags for aarch64
+  if(ARCH STREQUAL "aarch64")
+    separate_arguments(ASM_FLAGS_LIST UNIX_COMMAND "${CMAKE_ASM_FLAGS}")
+    list(APPEND ASM_FLAGS_LIST "-mcmodel=large")
+    list(APPEND ASM_FLAGS_LIST "-fno-pic")
+    list(APPEND ASM_FLAGS_LIST "-fno-PIE")
+    string(REPLACE ";" " " DELOCATE_CC_FLAGS "${ASM_FLAGS_LIST}")
+  else()
+    set(DELOCATE_CC_FLAGS "${CMAKE_ASM_FLAGS}")
   endif()
 
-  go_executable(delocate boringssl.googlesource.com/boringssl/util/fipstools/delocate)
   add_custom_command(
     OUTPUT bcm-delocated.S
     COMMAND
@@ -390,8 +416,7 @@ if(FIPS_DELOCATE)
     -a $<TARGET_FILE:bcm_c_generated_asm>
     -o bcm-delocated.S
     -cc ${CMAKE_ASM_COMPILER}
-    -cc-flags "${TARGET} ${CMAKE_ASM_FLAGS}"
-    ${DELOCATE_EXTRA_ARGS}
+    -cc-flags "${DELOCATE_CC_FLAGS}"
     ${PROJECT_SOURCE_DIR}/include/openssl/arm_arch.h
     ${PROJECT_SOURCE_DIR}/include/openssl/asm_base.h
     ${PROJECT_SOURCE_DIR}/include/openssl/target.h
@@ -406,13 +431,6 @@ if(FIPS_DELOCATE)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
-  # clang-6 (and older) knows how to compile AVX512 assembly instructions,
-  # but only if it's given the right flags (e.g. -mavx512*).
-  # The flags are not required for any other compiler we are running in the CI.
-  if (CLANG AND (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
-      (CMAKE_C_COMPILER_VERSION VERSION_LESS "7.0.0") AND (ARCH STREQUAL "x86_64"))
-    set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/bcm-delocated.S PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl -mavx512ifma")
-  endif()
 
   add_library(
     bcm_hashunset
@@ -421,17 +439,22 @@ if(FIPS_DELOCATE)
 
     bcm-delocated.S
   )
+
+  if(ARCH STREQUAL "aarch64")
+    target_compile_options(bcm_hashunset PRIVATE "-mcmodel=large" "-fno-pic" "-fno-PIE")
+    set_property(TARGET bcm_hashunset PROPERTY POSITION_INDEPENDENT_CODE OFF)
+  endif()
+
   target_compile_definitions(bcm_hashunset PRIVATE BORINGSSL_IMPLEMENTATION)
 
   add_dependencies(bcm_hashunset boringssl_prefix_symbols)
   target_include_directories(bcm_hashunset BEFORE PRIVATE ${PROJECT_BINARY_DIR}/symbol_prefix_include)
   target_include_directories(bcm_hashunset PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
-  set_target_properties(bcm_hashunset PROPERTIES POSITION_INDEPENDENT_CODE ON)
   set_target_properties(bcm_hashunset PROPERTIES LINKER_LANGUAGE C)
 
   go_executable(inject_hash
-                boringssl.googlesource.com/boringssl/util/fipstools/inject_hash)
+          boringssl.googlesource.com/boringssl/util/fipstools/inject_hash)
   add_custom_command(
     OUTPUT bcm.o
     COMMAND ./inject_hash -o bcm.o -in-archive $<TARGET_FILE:bcm_hashunset>

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -14,15 +14,17 @@ endif()
 if(ARCH STREQUAL "aarch64" AND FIPS)
   # Disable PIC for ARM64 FIPS builds globally
   set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
-  # Set base flags for ARM64 FIPS - using 'large' code model to handle large FIPS module
-  set(AARCH64_FIPS_FLAGS "-mcmodel=large -fno-pic -fno-PIE")
+  # Set base flags for ARM64 FIPS - using 'large' code model to handle large FIPS module with explicit section alignment
+  set(AARCH64_FIPS_FLAGS "-mcmodel=large -fno-pic -fno-PIE -fdata-sections -ffunction-sections")
+  # Add alignment specifications
+  set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -falign-functions=32")
   # Apply flags consistently
   set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${AARCH64_FIPS_FLAGS}")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${AARCH64_FIPS_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${AARCH64_FIPS_FLAGS}")
   # Ensure linker flags are set
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -no-pie")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
 endif()
 
 if(ANDROID)
@@ -404,9 +406,9 @@ if(FIPS_DELOCATE)
     list(APPEND ASM_FLAGS_LIST "-mcmodel=large")
     list(APPEND ASM_FLAGS_LIST "-fno-pic")
     list(APPEND ASM_FLAGS_LIST "-fno-PIE")
+    list(APPEND ASM_FLAGS_LIST "-falign-functions=32")
     string(REPLACE ";" " " DELOCATE_CC_FLAGS "${ASM_FLAGS_LIST}")
-  else()
-    set(DELOCATE_CC_FLAGS "${CMAKE_ASM_FLAGS}")
+    message(STATUS "FIPS module compilation flags: ${DELOCATE_CC_FLAGS}")
   endif()
 
   add_custom_command(
@@ -417,6 +419,8 @@ if(FIPS_DELOCATE)
     -o bcm-delocated.S
     -cc ${CMAKE_ASM_COMPILER}
     -cc-flags "${DELOCATE_CC_FLAGS}"
+    --prefix ${BORINGSSL_PREFIX}
+    --version-header ${PROJECT_SOURCE_DIR}/include/openssl/crypto.h
     ${PROJECT_SOURCE_DIR}/include/openssl/arm_arch.h
     ${PROJECT_SOURCE_DIR}/include/openssl/asm_base.h
     ${PROJECT_SOURCE_DIR}/include/openssl/target.h
@@ -425,10 +429,8 @@ if(FIPS_DELOCATE)
     bcm_c_generated_asm
     delocate
     ${BCM_ASM_SOURCES}
-    ${PROJECT_SOURCE_DIR}/include/openssl/arm_arch.h
-    ${PROJECT_SOURCE_DIR}/include/openssl/asm_base.h
-    ${PROJECT_SOURCE_DIR}/include/openssl/target.h
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    VERBATIM
   )
 
 

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -12,19 +12,31 @@ endif()
 
 # Add ARM64 FIPS specific configurations
 if(ARCH STREQUAL "aarch64" AND FIPS)
-  # Disable PIC for ARM64 FIPS builds globally
-  set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
-  # Set base flags for ARM64 FIPS - using 'large' code model to handle large FIPS module with explicit section alignment
-  set(AARCH64_FIPS_FLAGS "-mcmodel=large -fno-pic -fno-PIE")
+  if(BUILD_SHARED_LIBS)
+    # For shared library builds, we need PIC
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    set(AARCH64_FIPS_FLAGS "-mcmodel=large")
+  else()
+    # For static builds, we can disable PIC
+    set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
+    set(AARCH64_FIPS_FLAGS "-mcmodel=large -fno-pic -fno-PIE")
+  endif()
+
   # Add flag to prevent section garbage collection
   set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -fno-function-sections")
   # Apply flags consistently
   set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${AARCH64_FIPS_FLAGS}")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${AARCH64_FIPS_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${AARCH64_FIPS_FLAGS}")
-  # Ensure linker flags are set
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
+
+  # Set linker flags based on build type
+  if(BUILD_SHARED_LIBS)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=none")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=none")
+  else()
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
+  endif()
 endif()
 
 if(ANDROID)
@@ -382,9 +394,13 @@ if(FIPS_DELOCATE)
 
   # Add ARM64-specific flags for FIPS static builds
   if(ARCH STREQUAL "aarch64")
-    message(STATUS "Configuring ARM64 FIPS static build with large code model")
-    target_compile_options(bcm_c_generated_asm PRIVATE "-mcmodel=large" "-fno-pic" "-fno-PIE")
-    set_property(TARGET bcm_c_generated_asm PROPERTY POSITION_INDEPENDENT_CODE OFF)
+    message(STATUS "Configuring ARM64 FIPS build with large code model")
+    if(BUILD_SHARED_LIBS)
+      target_compile_options(bcm_c_generated_asm PRIVATE "-mcmodel=large")
+    else()
+      target_compile_options(bcm_c_generated_asm PRIVATE "-mcmodel=large" "-fno-pic" "-fno-PIE")
+      set_property(TARGET bcm_c_generated_asm PROPERTY POSITION_INDEPENDENT_CODE OFF)
+    endif()
   endif()
 
   target_compile_definitions(bcm_c_generated_asm PRIVATE BORINGSSL_IMPLEMENTATION)
@@ -443,8 +459,12 @@ if(FIPS_DELOCATE)
   )
 
   if(ARCH STREQUAL "aarch64")
-    target_compile_options(bcm_hashunset PRIVATE "-mcmodel=large" "-fno-pic" "-fno-PIE")
-    set_property(TARGET bcm_hashunset PROPERTY POSITION_INDEPENDENT_CODE OFF)
+    if(BUILD_SHARED_LIBS)
+      target_compile_options(bcm_hashunset PRIVATE "-mcmodel=large")
+    else()
+      target_compile_options(bcm_hashunset PRIVATE "-mcmodel=large" "-fno-pic" "-fno-PIE")
+      set_property(TARGET bcm_hashunset PROPERTY POSITION_INDEPENDENT_CODE OFF)
+    endif()
   endif()
 
   target_compile_definitions(bcm_hashunset PRIVATE BORINGSSL_IMPLEMENTATION)

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -11,29 +11,43 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" AND FIPS)
 endif()
 
 if(ARCH STREQUAL "aarch64" AND FIPS)
-  # Always use large code model for FIPS compliance
-  set(AARCH64_FIPS_FLAGS "-mcmodel=large")
+  # FIPS module must be built identically regardless of final library type
+  set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
 
-  if(BUILD_SHARED_LIBS)
-    # For shared builds, we'll need to build as a static object first
-    # and then link it into the shared library
-    set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
-    set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -fno-pic -fno-PIE")
-  else()
-    set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
-    set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -fno-pic -fno-PIE")
+  # Basic FIPS flags
+  set(AARCH64_FIPS_FLAGS "-mcmodel=large -fno-pic -fno-PIE")
+  # Prevent section renaming/garbage collection to keep startup/exit functions
+  set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -fno-function-sections -fno-data-sections")
+  # Keep symbols in their original sections
+  set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -ffunction-sections=0")
+
+  # Apply FIPS flags only to FIPS module targets
+  if(TARGET bcm_c_generated_asm)
+    target_compile_options(bcm_c_generated_asm PRIVATE ${AARCH64_FIPS_FLAGS})
   endif()
 
-  # Add flag to prevent section garbage collection
-  set(AARCH64_FIPS_FLAGS "${AARCH64_FIPS_FLAGS} -fno-function-sections")
-  # Apply flags consistently
-  set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${AARCH64_FIPS_FLAGS}")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${AARCH64_FIPS_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${AARCH64_FIPS_FLAGS}")
+  if(TARGET bcm_hashunset)
+    target_compile_options(bcm_hashunset PRIVATE ${AARCH64_FIPS_FLAGS})
+  endif()
 
-  # Set linker flags
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
+  if(TARGET bcm_library)
+    target_compile_options(bcm_library PRIVATE ${AARCH64_FIPS_FLAGS})
+  endif()
+
+  # Set global flags based on build type
+  if(BUILD_SHARED_LIBS)
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -fPIC")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=none")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=none")
+  else()
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${AARCH64_FIPS_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${AARCH64_FIPS_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${AARCH64_FIPS_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -no-pie -Wl,--build-id=none")
+  endif()
 endif()
 
 if(ANDROID)

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -39,7 +39,7 @@ if(ANDROID)
 endif()
 
 if(ARCH STREQUAL "x86_64")
-set(
+  set(
     BCM_ASM_SOURCES
 
     aesni-gcm-avx512.${ASM_EXT}
@@ -193,7 +193,7 @@ endif()
 # but only if it's given the right flags (e.g. -mavx512*).
 # The flags are not required for any other compiler we are running in the CI.
 if (CLANG AND (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND
-(CMAKE_C_COMPILER_VERSION VERSION_LESS "7.0.0") AND (ARCH STREQUAL "x86_64"))
+    (CMAKE_C_COMPILER_VERSION VERSION_LESS "7.0.0") AND (ARCH STREQUAL "x86_64"))
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/aesni-gcm-avx512.${ASM_EXT} PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl")
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/aesni-xts-avx512.${ASM_EXT} PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl")
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/rsaz-2k-avx512.${ASM_EXT} PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl -mavx512ifma")

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -417,10 +417,11 @@ if(FIPS_DELOCATE)
     ./delocate
     -a $<TARGET_FILE:bcm_c_generated_asm>
     -o bcm-delocated.S
-    -cc ${CMAKE_ASM_COMPILER}
-    -cc-flags "${DELOCATE_CC_FLAGS}"
-    --prefix ${BORINGSSL_PREFIX}
-    --version-header ${PROJECT_SOURCE_DIR}/include/openssl/crypto.h
+    -cc "${CMAKE_ASM_COMPILER}"
+    -cc-flags "${TARGET} ${CMAKE_ASM_FLAGS}"
+    ${DELOCATE_EXTRA_ARGS}
+    ${DELOCATE_ARM64_ARGS}
+    --
     ${PROJECT_SOURCE_DIR}/include/openssl/arm_arch.h
     ${PROJECT_SOURCE_DIR}/include/openssl/asm_base.h
     ${PROJECT_SOURCE_DIR}/include/openssl/target.h
@@ -430,7 +431,6 @@ if(FIPS_DELOCATE)
     delocate
     ${BCM_ASM_SOURCES}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    VERBATIM
   )
 
 

--- a/crypto/fipsmodule/gcc_fips_shared.lds
+++ b/crypto/fipsmodule/gcc_fips_shared.lds
@@ -16,13 +16,23 @@ SECTIONS
     BORINGSSL_bcm_rodata_end = .;
   }
 
+  /* Required initialization and cleanup arrays */
+  .init_array : {
+    *(.init_array)
+    *(.init_array.*)
+  }
+  .fini_array : {
+    *(.fini_array)
+    *(.fini_array.*)
+  }
+
   /DISCARD/ : {
     /* These sections shouldn't exist. In order to catch any slip-ups, direct
      * the linker to discard them. */
     *(.rela.dyn)
     *(.data)
     *(.rel.ro)
-    *(*.text.*)
-    *(*.data.*)
+    *(.text.*)
+    *(.data.*)
   }
 }

--- a/crypto/fipsmodule/gcc_fips_shared.lds
+++ b/crypto/fipsmodule/gcc_fips_shared.lds
@@ -5,8 +5,8 @@ SECTIONS
     *(.text)
     /* gcc puts some code in sections named ".text.unlikely", ".text.exit" and ".text.startup". */
     *(.text.unlikely)
-    *(.text.exit)
-    *(.text.startup)
+    *(.text.exit.rand_thread_state_clear_all)
+    *(.text.startup.BORINGSSL_bcm_power_on_self_test)
     BORINGSSL_bcm_text_end = .;
   }
   .rodata : {

--- a/crypto/fipsmodule/gcc_fips_shared.lds
+++ b/crypto/fipsmodule/gcc_fips_shared.lds
@@ -22,7 +22,7 @@ SECTIONS
     *(.rela.dyn)
     *(.data)
     *(.rel.ro)
-    *(.text.*)
-    *(.data.*)
+    *(*.text.*)
+    *(*.data.*)
   }
 }

--- a/crypto/fipsmodule/gcc_fips_shared.lds
+++ b/crypto/fipsmodule/gcc_fips_shared.lds
@@ -7,9 +7,6 @@ SECTIONS
     *(.text.unlikely)
     *(.text.exit)
     *(.text.startup)
-    *(.text.exit.*)
-    *(.text.startup.*)
-    *(.text.unlikely.*)
     BORINGSSL_bcm_text_end = .;
   }
   .rodata : {
@@ -19,22 +16,13 @@ SECTIONS
     BORINGSSL_bcm_rodata_end = .;
   }
 
-  .init_array : {
-    *(.init_array)
-    *(.init_array.*)
-  }
-  .fini_array : {
-    *(.fini_array)
-    *(.fini_array.*)
-  }
-
   /DISCARD/ : {
     /* These sections shouldn't exist. In order to catch any slip-ups, direct
      * the linker to discard them. */
     *(.rela.dyn)
     *(.data)
     *(.rel.ro)
-    /* Don't discard text.* here since we explicitly include what we want above */
+    *(.text.*)
     *(.data.*)
   }
 }

--- a/crypto/fipsmodule/gcc_fips_shared.lds
+++ b/crypto/fipsmodule/gcc_fips_shared.lds
@@ -5,8 +5,11 @@ SECTIONS
     *(.text)
     /* gcc puts some code in sections named ".text.unlikely", ".text.exit" and ".text.startup". */
     *(.text.unlikely)
-    *(.text.exit.rand_thread_state_clear_all)
-    *(.text.startup.BORINGSSL_bcm_power_on_self_test)
+    *(.text.exit)
+    *(.text.startup)
+    *(.text.exit.*)
+    *(.text.startup.*)
+    *(.text.unlikely.*)
     BORINGSSL_bcm_text_end = .;
   }
   .rodata : {
@@ -16,7 +19,6 @@ SECTIONS
     BORINGSSL_bcm_rodata_end = .;
   }
 
-  /* Required initialization and cleanup arrays */
   .init_array : {
     *(.init_array)
     *(.init_array.*)
@@ -32,7 +34,7 @@ SECTIONS
     *(.rela.dyn)
     *(.data)
     *(.rel.ro)
-    *(.text.*)
+    /* Don't discard text.* here since we explicitly include what we want above */
     *(.data.*)
   }
 }


### PR DESCRIPTION
### Issues:
When building AWS-LC with FIPS mode enabled on ARM64 architecture, the build fails during the FIPS module generation error:

```
bcm.c: Assembler messages:
bcm.c:7811: Error: pc-relative address offset out of range
bcm.c:7813: Error: pc-relative address offset out of range
bcm.c:7815: Error: pc-relative address offset out of range
```

Upon fixing the code model, I got a second issue. Compiler flags were being incorrectly passed to the delocate command, they were being interpreted as input files rather than compiler options.

```
cc: warning:  -mcmodel=large -fno-pic -fno-PIE: linker input file unused because linking not done
cc: error:  -mcmodel=large -fno-pic -fno-PIE: linker input file not found: No such file or directory
```

### Description of changes: 

Implementation Details:

- Uses `-mcmodel=large` to support extended addressing range
- Disables position-independent code (PIC) which can interfere with FIPS requirements
- Applies consistent flags across all compilation units
- Properly separates and recombines compiler flags using CMake's list operations
- Sets appropriate properties for both `bcm_c_generated_asm` and `bcm_hashunset` targets
- Ensures consistent compilation settings across the FIPS module

We have a horrible loop between `-> preserving FIPS module for validation needs -> supporting both static and dynamic builds -> ARM64 pc-relative address offset range`

Trying to work it out with CI.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
Emulating CI (not through container) on a linux ec2 instance, got the build passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
