### PR TITLE
Validate or define ARM HWCAP2_XXX macros

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_arm_linux.h
+++ b/crypto/fipsmodule/cpucap/cpu_arm_linux.h
@@ -28,14 +28,37 @@ extern "C" {
 // The cpuinfo parser lives in a header file so it may be accessible from
 // cross-platform fuzzers without adding code to those platforms normally.
 
-#define HWCAP_NEON (1 << 12)
+#if defined(HWCAP_NEON) && HWCAP_NEON != 4096
+  #error "HWCAP_NEON is defined but has wrong value (expected 4096)"
+#elif !defined(HWCAP_NEON)
+  #define HWCAP_NEON 4096
+#endif
 
 // See /usr/include/asm/hwcap.h on an ARM installation for the source of
 // these values.
-#define HWCAP2_AES (1 << 0)
-#define HWCAP2_PMULL (1 << 1)
-#define HWCAP2_SHA1 (1 << 2)
-#define HWCAP2_SHA2 (1 << 3)
+#if defined(HWCAP2_AES) && HWCAP2_AES != 1
+  #error "HWCAP2_AES is defined but has wrong value (expected 1)"
+#elif !defined(HWCAP2_AES)
+  #define HWCAP2_AES 1
+#endif
+
+#if defined(HWCAP2_PMULL) && HWCAP2_PMULL != 2
+  #error "HWCAP2_PMULL is defined but has wrong value (expected 2)"
+#elif !defined(HWCAP2_PMULL)
+  #define HWCAP2_PMULL 2
+#endif
+
+#if defined(HWCAP2_SHA1) && HWCAP2_SHA1 != 4
+  #error "HWCAP2_SHA1 is defined but has wrong value (expected 4)"
+#elif !defined(HWCAP2_SHA1)
+  #define HWCAP2_SHA1 4
+#endif
+
+#if defined(HWCAP2_SHA2) && HWCAP2_SHA2 != 8
+  #error "HWCAP2_SHA2 is defined but has wrong value (expected 8)"
+#elif !defined(HWCAP2_SHA2)
+  #define HWCAP2_SHA2 8
+#endif
 
 typedef struct {
   const char *data;

--- a/crypto/fipsmodule/cpucap/cpu_arm_linux.h
+++ b/crypto/fipsmodule/cpucap/cpu_arm_linux.h
@@ -28,36 +28,36 @@ extern "C" {
 // The cpuinfo parser lives in a header file so it may be accessible from
 // cross-platform fuzzers without adding code to those platforms normally.
 
-#if defined(HWCAP_NEON) && HWCAP_NEON != 4096
-  #error "HWCAP_NEON is defined but has wrong value (expected 4096)"
+#if defined(HWCAP_NEON) && HWCAP_NEON != (1 << 12)
+  #error "HWCAP_NEON is defined but has wrong value (expected (1 << 12))"
 #elif !defined(HWCAP_NEON)
-  #define HWCAP_NEON 4096
+  #define HWCAP_NEON (1 << 12)
 #endif
 
 // See /usr/include/asm/hwcap.h on an ARM installation for the source of
 // these values.
-#if defined(HWCAP2_AES) && HWCAP2_AES != 1
-  #error "HWCAP2_AES is defined but has wrong value (expected 1)"
+#if defined(HWCAP2_AES) && HWCAP2_AES != (1 << 0)
+  #error "HWCAP2_AES is defined but has wrong value (expected (1 << 0))"
 #elif !defined(HWCAP2_AES)
-  #define HWCAP2_AES 1
+  #define HWCAP2_AES (1 << 0)
 #endif
 
-#if defined(HWCAP2_PMULL) && HWCAP2_PMULL != 2
-  #error "HWCAP2_PMULL is defined but has wrong value (expected 2)"
+#if defined(HWCAP2_PMULL) && HWCAP2_PMULL != (1 << 1)
+  #error "HWCAP2_PMULL is defined but has wrong value (expected (1 << 1))"
 #elif !defined(HWCAP2_PMULL)
-  #define HWCAP2_PMULL 2
+  #define HWCAP2_PMULL (1 << 1)
 #endif
 
-#if defined(HWCAP2_SHA1) && HWCAP2_SHA1 != 4
-  #error "HWCAP2_SHA1 is defined but has wrong value (expected 4)"
+#if defined(HWCAP2_SHA1) && HWCAP2_SHA1 != (1 << 2)
+  #error "HWCAP2_SHA1 is defined but has wrong value (expected (1 << 2))"
 #elif !defined(HWCAP2_SHA1)
-  #define HWCAP2_SHA1 4
+  #define HWCAP2_SHA1 (1 << 2)
 #endif
 
-#if defined(HWCAP2_SHA2) && HWCAP2_SHA2 != 8
-  #error "HWCAP2_SHA2 is defined but has wrong value (expected 8)"
+#if defined(HWCAP2_SHA2) && HWCAP2_SHA2 != (1 << 3)
+  #error "HWCAP2_SHA2 is defined but has wrong value (expected (1 << 3))"
 #elif !defined(HWCAP2_SHA2)
-  #define HWCAP2_SHA2 8
+  #define HWCAP2_SHA2 (1 << 3)
 #endif
 
 typedef struct {


### PR DESCRIPTION
### Issues:
Addresses: aws/aws-lc-rs#681

### Description of changes: 
On some platforms ARM's `HWCAP2_XXX` macros might be defined in system header files, causing compilation failure due to their being redefined here.
```
.../aws-lc/crypto/fipsmodule/cpucap/cpu_arm_linux.h:35:9: error: 'HWCAP2_AES' redefined [-Werror]
     35 | #define HWCAP2_AES (1 << 0)
        |         ^~~~~~~~~~
  In file included from .../armv7ve-libreelec-linux-gnueabihf/sysroot/usr/include/bits/hwcap.h:53:9: note: this is the location of the previous definition
     53 | #define HWCAP2_AES              1
        |         ^~~~~~~~~~
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
