### PR TITLE
Ensure enabling local symbols doesn't change the module hash

### DIFF
--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -2,7 +2,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
-set -ex
+set -exo pipefail
 
 source tests/ci/common_posix_setup.sh
 

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -33,23 +33,24 @@ if static_linux_supported || static_openbsd_supported; then
 
   echo "Testing AWS-LC static breakable release build"
   run_build -DFIPS=1 -DCMAKE_C_FLAGS="-DBORINGSSL_FIPS_BREAK_TESTS"
+  ./util/fipstools/test-break-kat.sh
   export BORINGSSL_FIPS_BREAK_TEST="RSA_PWCT"
   ${BUILD_ROOT}/crypto/crypto_test --gtest_filter="RSADeathTest.KeygenFailAndDie"
   unset BORINGSSL_FIPS_BREAK_TEST
 
-  cd $SRC_ROOT
-  MODULE_HASH=$(./util/fipstools/test-break-kat.sh |\
-                    (egrep "Hash of module was:.* ([a-f0-9]*)" || true))
+  MODULE_HASH=$(go run util/fipstools/break-hash.go "${BUILD_ROOT}/util/fipstools/test_fips" ./libcrypto.so | \
+    egrep "Hash of module was:.* ([a-f0-9]*)")
 
   echo "Testing AWS-LC static breakable release build while keeping local symbols"
   echo "to check that module hash didn't change."
   run_build -DFIPS=1 -DKEEP_ASM_LOCAL_SYMBOLS=1 -DCMAKE_C_FLAGS="-DBORINGSSL_FIPS_BREAK_TESTS"
-  cd $SRC_ROOT
-  ./util/fipstools/test-break-kat.sh || grep -i hash
-  MODULE_HASH_LOCALSYMS=$(./util/fipstools/test-break-kat.sh |\
-                              (egrep "Hash of module was:.* ([a-f0-9]*)" || true))
+  MODULE_HASH_LOCALSYMS=$(go run util/fipstools/break-hash.go "${BUILD_ROOT}/util/fipstools/test_fips" ./libcrypto.so | \
+                            egrep "Hash of module was:.* ([a-f0-9]*)")
   if [ "$MODULE_HASH" == "$MODULE_HASH_LOCALSYMS" ]; then
     echo "Module hash didn't change"
+  else
+    echo "Module hashed changed with local symbols unexpectedly"
+    exit 1
   fi
 
   # These build parameters may be needed by our aws-lc-fips-sys Rust package


### PR DESCRIPTION
### Description of changes: 
The original intention of https://github.com/aws/aws-lc/pull/1005 was to ensure break-kat.go always worked with the library. https://github.com/aws/aws-lc/pull/1252 then used a side effect to get the module hash but didn't actually fail the build if the hash was different.

Turn on `pipefail` so the script exits unsuccessfully if any command fails even in a pipe. Previously if test-break-kat.sh failed the script didn't exit, instead it would continue to the grep which would also fail to find any matching string, and then the `|| true` ensured the script always continued on.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
