### PR TITLE
Make install_shared_and_static test more robust

### DIFF
--- a/tests/ci/run_install_shared_and_static.sh
+++ b/tests/ci/run_install_shared_and_static.sh
@@ -44,7 +44,7 @@ function install_aws_lc() {
     rm -rf "${BUILD_DIR:?}"
     sync
 
-    ${CMAKE_COMMAND} -H${AWS_LC_DIR} -B${BUILD_DIR} -GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF -D${BUILD_SHARED_LIBS} --fresh
+    ${CMAKE_COMMAND} --fresh -H${AWS_LC_DIR} -B${BUILD_DIR} -GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF -D${BUILD_SHARED_LIBS}
     ${CMAKE_COMMAND} --build ${BUILD_DIR} --target install
 }
 
@@ -97,15 +97,15 @@ build_myapp() {
     local EXPECT_USE_LIB_TYPE=$3 # (".so" or ".a") which types of libssl and libcrypto are expected to be used
 
     echo "Build Parameters:"
-    echo "BUILD_SHARED_LIBS: \${BUILD_SHARED_LIBS}"
-    echo "AWS_LC_INSTALL_DIR: \${AWS_LC_INSTALL_DIR}"
-    echo "EXPECT_USE_LIB_TYPE: \${EXPECT_USE_LIB_TYPE}"
+    echo "BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}"
+    echo "AWS_LC_INSTALL_DIR: ${AWS_LC_INSTALL_DIR}"
+    echo "EXPECT_USE_LIB_TYPE: ${EXPECT_USE_LIB_TYPE}"
 
     local BUILD_DIR=${SCRATCH_DIR}/build
     rm -rf "${BUILD_DIR:?}"
     sync
 
-    cmake -H${MYAPP_SRC_DIR} -B${BUILD_DIR} -GNinja -D${BUILD_SHARED_LIBS} -DCMAKE_PREFIX_PATH=${SCRATCH_DIR}/${AWS_LC_INSTALL_DIR} --fresh
+    cmake --fresh -H${MYAPP_SRC_DIR} -B${BUILD_DIR} -GNinja -D${BUILD_SHARED_LIBS} -DCMAKE_PREFIX_PATH=${SCRATCH_DIR}/${AWS_LC_INSTALL_DIR}
     cmake --build ${BUILD_DIR}
     ldd ${BUILD_DIR}/myapp
 

--- a/tests/ci/run_install_shared_and_static.sh
+++ b/tests/ci/run_install_shared_and_static.sh
@@ -122,7 +122,7 @@ test_lib_use() {
     local LDD_OUTPUT=$(ldd ${APP})
     echo "${LDD_OUTPUT}" | grep "${LIB_NAME}" || echo "No matches found"
 
-    if ldd ${APP} | grep -q ${LIB_NAME}.so; then
+    if echo "${LDD_OUTPUT}" | grep -q ${LIB_NAME}.so; then
         local ACTUAL_USE_LIB_TYPE=.so
     else
         local ACTUAL_USE_LIB_TYPE=.a

--- a/tests/ci/run_install_shared_and_static.sh
+++ b/tests/ci/run_install_shared_and_static.sh
@@ -119,6 +119,9 @@ test_lib_use() {
     local LIB_NAME=$2 # name of lib that app should be using, without file extension
     local EXPECT_USE_LIB_TYPE=$3 # (".so" or ".a") expected type of lib that app should be using
 
+    local LDD_OUTPUT=$(ldd ${APP})
+    echo "${LDD_OUTPUT}" | grep "${LIB_NAME}" || echo "No matches found"
+
     if ldd ${APP} | grep -q ${LIB_NAME}.so; then
         local ACTUAL_USE_LIB_TYPE=.so
     else

--- a/tests/ci/run_install_shared_and_static.sh
+++ b/tests/ci/run_install_shared_and_static.sh
@@ -6,7 +6,7 @@ set -exo pipefail
 
 source tests/ci/common_posix_setup.sh
 
-export CMAKE_BUILD_PARALLEL_LEVEL=${NUM_CPU_THREADS}
+export CMAKE_BUILD_PARALLEL_LEVEL=1
 
 # Set up environment.
 
@@ -29,6 +29,7 @@ ROOT=$(realpath ${AWS_LC_DIR}/..)
 SCRATCH_DIR=${ROOT}/SCRATCH_AWSLC_INSTALL_SHARED_AND_STATIC
 mkdir -p ${SCRATCH_DIR}
 rm -rf "${SCRATCH_DIR:?}"/*
+sync
 
 function fail() {
     echo "test failure: $1"
@@ -41,7 +42,9 @@ function install_aws_lc() {
 
     local BUILD_DIR=${SCRATCH_DIR}/build
     rm -rf "${BUILD_DIR:?}"
-    ${CMAKE_COMMAND} -H${AWS_LC_DIR} -B${BUILD_DIR} -GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF -D${BUILD_SHARED_LIBS}
+    sync
+
+    ${CMAKE_COMMAND} -H${AWS_LC_DIR} -B${BUILD_DIR} -GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF -D${BUILD_SHARED_LIBS} --fresh
     ${CMAKE_COMMAND} --build ${BUILD_DIR} --target install
 }
 
@@ -61,6 +64,7 @@ install_aws_lc install-both BUILD_SHARED_LIBS=ON
 MYAPP_SRC_DIR=${SCRATCH_DIR}/myapp-src
 rm -rf "${MYAPP_SRC_DIR:?}"
 mkdir -p ${MYAPP_SRC_DIR}
+sync
 
 cat <<EOF > ${MYAPP_SRC_DIR}/mylib.c
 #include <openssl/ssl.h>
@@ -92,10 +96,16 @@ build_myapp() {
     local AWS_LC_INSTALL_DIR=$2 # which install dir should be used
     local EXPECT_USE_LIB_TYPE=$3 # (".so" or ".a") which types of libssl and libcrypto are expected to be used
 
+    echo "Build Parameters:"
+    echo "BUILD_SHARED_LIBS: \${BUILD_SHARED_LIBS}"
+    echo "AWS_LC_INSTALL_DIR: \${AWS_LC_INSTALL_DIR}"
+    echo "EXPECT_USE_LIB_TYPE: \${EXPECT_USE_LIB_TYPE}"
+
     local BUILD_DIR=${SCRATCH_DIR}/build
     rm -rf "${BUILD_DIR:?}"
+    sync
 
-    cmake -H${MYAPP_SRC_DIR} -B${BUILD_DIR} -GNinja -D${BUILD_SHARED_LIBS} -DCMAKE_PREFIX_PATH=${SCRATCH_DIR}/${AWS_LC_INSTALL_DIR}
+    cmake -H${MYAPP_SRC_DIR} -B${BUILD_DIR} -GNinja -D${BUILD_SHARED_LIBS} -DCMAKE_PREFIX_PATH=${SCRATCH_DIR}/${AWS_LC_INSTALL_DIR} --fresh
     cmake --build ${BUILD_DIR}
     ldd ${BUILD_DIR}/myapp
 
@@ -137,6 +147,7 @@ build_myapp BUILD_SHARED_LIBS=OFF install-both .a # myapp should use libssl.a/li
 # ------------------------------------------------------- #
 rm -rf "${MYAPP_SRC_DIR:?}"
 mkdir -p ${MYAPP_SRC_DIR}
+sync
 
 cat <<EOF > ${MYAPP_SRC_DIR}/static_constructor_test.c
 #include <stdint.h>


### PR DESCRIPTION
### Issues:
`P198393553`

### Description of changes: 
Making the test more robust to prevent flaky behavior: 
1. Add more logging
2. Use sync to force file state after delete operations
3. use --fresh with CMAKE to prevent using any cache 
4. Turn off parallel CMAKE build

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
