### PR TITLE
Migrate 3rd batch of CI jobs

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -10,36 +10,6 @@ concurrency:
 env:
   CC: gcc
 jobs:
-  nmap:
-    if: github.repository_owner == 'aws'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install OS Dependencies
-        run: |
-          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
-          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make gobject-introspection
-      - uses: actions/checkout@v3
-      - name: Run nmap build
-        run: |
-          ./tests/ci/integration/run_nmap_integration.sh
-  grpc:
-    if: github.repository_owner == 'aws'
-    env:
-      DEBIAN_FRONTEND: noninteractive
-      TZ: Etc/UTC
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:latest
-      options: --sysctl=net.ipv6.conf.all.disable_ipv6=0
-    steps:
-      - name: Install OS Dependencies
-        run: |
-          apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
-          apt-get -y --no-install-recommends install cmake gcc g++ ninja-build golang make python3 python3-sphinx autoconf libtool pkg-config git libc++-dev python3-six
-      - uses: actions/checkout@v3
-      - name: Run integration build
-        run: |
-          ./tests/ci/integration/run_grpc_integration.sh
   python-main:
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
@@ -78,62 +48,6 @@ jobs:
         env:
           FIPS: ${{ matrix.fips }}
           AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO: ${{ matrix.openssl_in_crt }}
-  bind9:
-    if: github.repository_owner == 'aws'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install OS Dependencies
-        run: |
-          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
-          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make python3 python3-pytest autoconf pkg-config libcmocka-dev liburcu-dev libuv1-dev libnghttp2-dev libcap-dev libprotobuf-c-dev protobuf-c-compiler libfstrm-dev libjemalloc-dev
-      - uses: actions/checkout@v3
-      - name: Run bind9 build
-        run: |
-          ./tests/ci/integration/run_bind9_integration.sh
-  strongswan:
-    if: github.repository_owner == 'aws'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install OS Dependencies
-        run: |
-          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
-          sudo apt-get -y --no-install-recommends install \
-          cmake gcc ninja-build golang make gperf bison flex autogen autoconf \
-          pkg-config libtool gettext libgmp-dev libsystemd-dev
-      - uses: actions/checkout@v4
-      - name: Run strongswan build
-        run: |
-          ./tests/ci/integration/run_strongswan_integration.sh
-  openvpn2-6:
-    if: github.repository_owner == 'aws'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install OS Dependencies
-        run: |
-          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
-          sudo apt-get -y --no-install-recommends install \
-          cmake gcc ninja-build golang libnl-3-dev libnl-genl-3-dev \
-          libcap-ng-dev liblz4-dev liblzo2-dev libpam-dev libcmocka-dev \
-          python3-docutils
-      - uses: actions/checkout@v4
-      - name: Run openvpn build 2.6.x
-        run: |
-          ./tests/ci/integration/run_openvpn_integration.sh release/2.6
-  openvpnMaster:
-    if: github.repository_owner == 'aws'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install OS Dependencies
-        run: |
-          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
-          sudo apt-get -y --no-install-recommends install \
-          cmake gcc ninja-build golang libnl-3-dev libnl-genl-3-dev \
-          libcap-ng-dev liblz4-dev liblzo2-dev libpam-dev libcmocka-dev \
-          python3-docutils
-      - uses: actions/checkout@v4
-      - name: Run openvpn build main
-        run: |
-          ./tests/ci/integration/run_openvpn_integration.sh master
   libevent:
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest

--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -250,7 +250,7 @@ batch:
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_ntp_integration.sh"
-          
+
     - identifier: pq_tls_integration_x86_64
       buildspec: tests/ci/codebuild/common/run_simple_target.yml
       env:

--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -321,3 +321,63 @@ batch:
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_accp_integration.sh"
+
+    - identifier: nmap_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_MEDIUM
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_nmap_integration.sh"
+
+    - identifier: grpc_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_ipv6_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_2XLARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_grpc_integration.sh"
+
+    - identifier: bind9_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_ipv6_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_MEDIUM
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_bind9_integration.sh"
+
+    - identifier: strongswan_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_ipv6_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_SMALL
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_strongswan_integration.sh"
+
+    - identifier: openvpn2_6_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_ipv6_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_MEDIUM
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_openvpn_integration.sh release/2.6"
+
+    - identifier: openvpnMaster_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_ipv6_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_MEDIUM
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_openvpn_integration.sh master"

--- a/tests/ci/codebuild/common/run_ipv6_target.yml
+++ b/tests/ci/codebuild/common/run_ipv6_target.yml
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+version: 0.2
+
+env:
+  variables:
+    GOPROXY: https://proxy.golang.org,direct
+
+phases:
+  pre_build:
+    commands:
+      - sysctl -w net.ipv6.conf.all.disable_ipv6=0
+  build:
+    commands:
+      - "./${AWS_LC_CI_TARGET}"

--- a/tests/ci/integration/run_bind9_integration.sh
+++ b/tests/ci/integration/run_bind9_integration.sh
@@ -15,7 +15,11 @@ source tests/ci/common_posix_setup.sh
 #      - BIND9_BUILD_FOLDER
 
 # Assumes script is executed from the root of aws-lc directory
-SCRATCH_FOLDER="${SRC_ROOT}/BIND9_BUILD_ROOT"
+if [ -v CODEBUILD_SRC_DIR ]; then
+  SCRATCH_FOLDER="${CODEBUILD_SCRIPT_DIR}/BIND9_BUILD_ROOT" # /codebuild/output/tmp/BIND9_BUILD_ROOT
+else
+  SCRATCH_FOLDER="${SRC_ROOT}/BIND9_BUILD_ROOT"
+fi
 BIND9_SRC_FOLDER="${SCRATCH_FOLDER}/bind9"
 BIND9_BUILD_FOLDER="${SCRATCH_FOLDER}/bind9-aws-lc"
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"


### PR DESCRIPTION
### Description of changes: 
This PR migrates jobs that require `ipv6` enabled in CodeBuild to run properly (with `nmap` being a special add-on to balance out the size of the next batch of jobs). 

The jobs to be migrated in this PR are:
  - `grpc`
  - `bind9`
  - `strongswan`
  - `openvpn2.6`
  - `openvpnMaster`
  - `nmap`

### Call-outs:
In this PR, I changed the build directory of `bind9` to resolve a character limit issue in CodeBuild.

In one of its tests, `bind9` will try to create a socket with a path deep within the build directory. Since CodeBuild's build directory is already very long, the combined socket path length will exceed the Linux limit of 108 characters. Therefore, I had to reduce the length of the build directory to mitigate this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.