### PR TITLE
Update aws-lc-nginx.patch for nginx 1.27.4

### DIFF
--- a/tests/ci/integration/nginx_patch/aws-lc-nginx.patch
+++ b/tests/ci/integration/nginx_patch/aws-lc-nginx.patch
@@ -1,6 +1,18 @@
-diff --color=auto --color -uNr a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
---- a/src/event/ngx_event_openssl.h
-+++ b/src/event/ngx_event_openssl.h
+diff --color '--color=auto' --color -uNr a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+--- a/src/event/ngx_event_openssl.c     2025-02-05 15:06:32.000000000 +0400
++++ b/src/event/ngx_event_openssl.c     2025-02-07 10:49:09.090460910 +0400
+@@ -756,7 +756,7 @@
+             return NGX_ERROR;
+         }
+ 
+-#ifdef OPENSSL_IS_BORINGSSL
++#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+         if (sk_X509_NAME_find(list, NULL, name) > 0) {
+ #else
+         if (sk_X509_NAME_find(list, name) >= 0) {
+diff --color '--color=auto' --color -uNr a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
+--- a/src/event/ngx_event_openssl.h     2025-02-05 15:06:32.000000000 +0400
++++ b/src/event/ngx_event_openssl.h     2025-02-07 08:55:22.084613346 +0400
 @@ -25,7 +25,7 @@
  #endif
  #include <openssl/evp.h>
@@ -10,9 +22,9 @@ diff --color=auto --color -uNr a/src/event/ngx_event_openssl.h b/src/event/ngx_e
  #include <openssl/hkdf.h>
  #include <openssl/chacha.h>
  #else
-diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic.c b/src/event/quic/ngx_event_quic.c
---- a/src/event/quic/ngx_event_quic.c
-+++ b/src/event/quic/ngx_event_quic.c
+diff --color '--color=auto' --color -uNr a/src/event/quic/ngx_event_quic.c b/src/event/quic/ngx_event_quic.c
+--- a/src/event/quic/ngx_event_quic.c   2025-02-05 15:06:32.000000000 +0400
++++ b/src/event/quic/ngx_event_quic.c   2025-02-07 08:56:51.755740696 +0400
 @@ -965,7 +965,7 @@
          return NGX_DECLINED;
      }
@@ -22,9 +34,9 @@ diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic.c b/src/event/qui
      /* OpenSSL provides read keys for an application level before it's ready */
  
      if (pkt->level == ssl_encryption_application && !c->ssl->handshaked) {
-diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic/ngx_event_quic_protection.c
---- a/src/event/quic/ngx_event_quic_protection.c
-+++ b/src/event/quic/ngx_event_quic_protection.c
+diff --color '--color=auto' --color -uNr a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic/ngx_event_quic_protection.c
+--- a/src/event/quic/ngx_event_quic_protection.c        2025-02-05 15:06:32.000000000 +0400
++++ b/src/event/quic/ngx_event_quic_protection.c        2025-02-07 10:45:30.747713969 +0400
 @@ -33,7 +33,7 @@
  
  static ngx_int_t ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out,
@@ -72,7 +84,7 @@ diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_protection.c b/sr
          break;
  
 -#ifndef OPENSSL_IS_BORINGSSL
-+#if !defined (OPENSSL_IS_BORINGSSL) && !defined (OPENSSL_IS_AWSLC)
++#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
      case TLS1_3_CK_AES_128_CCM_SHA256:
          ciphers->c = EVP_aes_128_ccm();
          ciphers->hp = EVP_aes_128_ctr();
@@ -126,7 +138,7 @@ diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_protection.c b/sr
  
  
 -#ifndef OPENSSL_IS_BORINGSSL
-+#if !defined (OPENSSL_IS_BORINGSSL) && !defined (OPENSSL_IS_AWSLC)
++#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
  
  static ngx_int_t
  ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out,
@@ -157,9 +169,9 @@ diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_protection.c b/sr
      uint32_t         cnt;
  
      if (ctx == NULL) {
-diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_protection.h b/src/event/quic/ngx_event_quic_protection.h
---- a/src/event/quic/ngx_event_quic_protection.h
-+++ b/src/event/quic/ngx_event_quic_protection.h
+diff --color '--color=auto' --color -uNr a/src/event/quic/ngx_event_quic_protection.h b/src/event/quic/ngx_event_quic_protection.h
+--- a/src/event/quic/ngx_event_quic_protection.h        2025-02-05 15:06:32.000000000 +0400
++++ b/src/event/quic/ngx_event_quic_protection.h        2025-02-07 10:46:21.868357111 +0400
 @@ -24,7 +24,7 @@
  #define NGX_QUIC_MAX_MD_SIZE          48
  
@@ -169,14 +181,16 @@ diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_protection.h b/sr
  #define ngx_quic_cipher_t             EVP_AEAD
  #define ngx_quic_crypto_ctx_t         EVP_AEAD_CTX
  #else
-diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_ssl.c b/src/event/quic/ngx_event_quic_ssl.c
---- a/src/event/quic/ngx_event_quic_ssl.c
-+++ b/src/event/quic/ngx_event_quic_ssl.c
-@@ -11,6 +11,7 @@
+diff --color '--color=auto' --color -uNr a/src/event/quic/ngx_event_quic_ssl.c b/src/event/quic/ngx_event_quic_ssl.c
+--- a/src/event/quic/ngx_event_quic_ssl.c       2025-02-05 15:06:32.000000000 +0400
++++ b/src/event/quic/ngx_event_quic_ssl.c       2025-02-07 10:48:20.179845572 +0400
+@@ -10,7 +10,8 @@
+ #include <ngx_event_quic_connection.h>
  
  
- #if defined OPENSSL_IS_BORINGSSL                                              \
-+    || defined OPENSSL_IS_AWSLC                                               \
+-#if defined OPENSSL_IS_BORINGSSL                                              \
++#if defined(OPENSSL_IS_BORINGSSL)                                             \
++    || defined(OPENSSL_IS_AWSLC)                                              \
      || defined LIBRESSL_VERSION_NUMBER                                        \
      || NGX_QUIC_OPENSSL_COMPAT
  #define NGX_QUIC_BORINGSSL_API   1
@@ -189,3 +203,27 @@ diff --color=auto --color -uNr a/src/event/quic/ngx_event_quic_ssl.c b/src/event
      if (SSL_set_quic_early_data_context(ssl_conn, p, clen) == 0) {
          ngx_log_error(NGX_LOG_INFO, c->log, 0,
                        "quic SSL_set_quic_early_data_context() failed");
+diff --color '--color=auto' --color -uNr a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
+--- a/src/http/ngx_http_request.c       2025-02-05 15:06:32.000000000 +0400
++++ b/src/http/ngx_http_request.c       2025-02-07 10:50:23.441396309 +0400
+@@ -935,7 +935,7 @@
+     sscf = ngx_http_get_module_srv_conf(cscf->ctx, ngx_http_ssl_module);
+ 
+ #if (defined TLS1_3_VERSION                                                   \
+-     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL)
++     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL && !defined OPENSSL_IS_AWSLC)
+ 
+     /*
+      * SSL_SESSION_get0_hostname() is only available in OpenSSL 1.1.1+,
+diff --color '--color=auto' --color -uNr a/src/stream/ngx_stream_ssl_module.c b/src/stream/ngx_stream_ssl_module.c
+--- a/src/stream/ngx_stream_ssl_module.c        2025-02-05 15:06:32.000000000 +0400
++++ b/src/stream/ngx_stream_ssl_module.c        2025-02-07 10:51:30.772243389 +0400
+@@ -592,7 +592,7 @@
+     sscf = ngx_stream_get_module_srv_conf(cscf->ctx, ngx_stream_ssl_module);
+ 
+ #if (defined TLS1_3_VERSION                                                   \
+-     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL)
++     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL && !defined OPENSSL_IS_AWSLC)
+ 
+     /*
+      * SSL_SESSION_get0_hostname() is only available in OpenSSL 1.1.1+,


### PR DESCRIPTION
nginx v1.27.4 fails to compile with the existing aws-lc-nginx.patch file.

This updates aws-lc-nginx.patch to allow compiling nginx v1.27.4

Tested on both Linux (Alpine) and FreeBSD.
