### PR TITLE
MacOS-12 GH runner no longer supported

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -39,7 +39,6 @@ jobs:
         os:
           - "macos-14-large"
           - "macos-13-large"
-          - "macos-12-large"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -59,7 +58,6 @@ jobs:
         os:
           - "macos-14-large"
           - "macos-13-large"
-          - "macos-12-large"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION

### Description of changes: 
* MacOS-12 GH runner no longer supported
* See: https://github.com/actions/runner-images/issues/10721

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
