### PR TITLE
Improve tool-openssl compatability for x509 and verify subcommands

### DIFF
--- a/tool-openssl/crl.cc
+++ b/tool-openssl/crl.cc
@@ -17,7 +17,9 @@ static const argument_t kArguments[] = {
 
 bool CRLTool(const args_list_t &args) {
   args_map_t parsed_args;
-  if (!ParseKeyValueArguments(&parsed_args, args, kArguments)) {
+  args_list_t extra_args;
+  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool-openssl/rsa.cc
+++ b/tool-openssl/rsa.cc
@@ -17,7 +17,9 @@ static const argument_t kArguments[] = {
 // Map arguments using tool/args.cc
 bool rsaTool(const args_list_t &args) {
   args_map_t parsed_args;
-  if (!ParseKeyValueArguments(&parsed_args, args, kArguments)) {
+  args_list_t extra_args;
+  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool-openssl/s_client.cc
+++ b/tool-openssl/s_client.cc
@@ -30,8 +30,10 @@ static const argument_t kArguments[] = {
 
 bool SClientTool(const args_list_t &args) {
   std::map<std::string, std::string> args_map;
+  args_list_t extra_args;
 
-  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool-openssl/verify.cc
+++ b/tool-openssl/verify.cc
@@ -17,7 +17,9 @@ static const argument_t kArguments[] = {
     {"-untrusted", kOptionalArgument,
      "A file of untrusted certificates to be used for chain building. The "
      "file should contain one or more certificates in PEM format."},
-    { "", kOptionalArgument, "" }};
+    {"-x509_strict", kBooleanArgument,
+     "This argument is a no-op. AWS-LC is always strict."},
+    {"", kOptionalArgument, ""}};
 
 // setup_verification_store sets up an X509 certificate store for verification.
 // It configures the store with file and directory lookups. It loads the

--- a/tool-openssl/verify.cc
+++ b/tool-openssl/verify.cc
@@ -10,11 +10,14 @@
 // be a required argument. Once support for default trust stores is added,
 // make it an optional argument.
 static const argument_t kArguments[] = {
-        { "-help", kBooleanArgument, "Display option summary" },
-        { "-CAfile", kRequiredArgument, "A file of trusted certificates. The "
-                "file should contain one or more certificates in PEM format." },
-        { "", kOptionalArgument, "" }
-};
+    {"-help", kBooleanArgument, "Display option summary"},
+    {"-CAfile", kRequiredArgument,
+     "A file of trusted certificates. The "
+     "file should contain one or more certificates in PEM format."},
+    {"-untrusted", kOptionalArgument,
+     "A file of untrusted certificates to be used for chain building. The "
+     "file should contain one or more certificates in PEM format."},
+    { "", kOptionalArgument, "" }};
 
 // setup_verification_store sets up an X509 certificate store for verification.
 // It configures the store with file and directory lookups. It loads the
@@ -88,14 +91,33 @@ static int cb(int ok, X509_STORE_CTX *ctx) {
   return ok;
 }
 
-static int check(X509_STORE *ctx, const char *file) {
+static int check(X509_STORE *ctx, const char* chainfile, const char *certfile) {
+  bssl::UniquePtr<STACK_OF(X509)> chain(sk_X509_new_null());
   bssl::UniquePtr<X509> cert;
   int i = 0, ret = 0;
 
-  if (file) {
-    ScopedFILE cert_file(fopen(file, "rb"));
+  if (chainfile) {
+    ScopedFILE chain_file(fopen(chainfile, "rb"));
+    if (!chain_file) {
+      fprintf(stderr, "error %s: reading certificate failed\n", certfile);
+      return 0;
+    }
+    bssl::UniquePtr<BIO> chain_bio(BIO_new_fp(chain_file.get(), BIO_NOCLOSE));
+    while(1) {
+      bssl::UniquePtr<X509> chain_cert(PEM_read_bio_X509(chain_bio.get(), NULL, NULL, NULL));
+      if(chain_cert.get() == nullptr) {
+        break;
+      }
+      if(!sk_X509_push(chain.get(), chain_cert.release())) {
+        return 0;
+      }
+    }
+  }
+
+  if (certfile) {
+    ScopedFILE cert_file(fopen(certfile, "rb"));
     if (!cert_file) {
-      fprintf(stderr, "error %s: reading certificate failed\n", file);
+      fprintf(stderr, "error %s: reading certificate failed\n", certfile);
       return 0;
     }
     cert.reset(PEM_read_X509(cert_file.get(), nullptr, nullptr, nullptr));
@@ -112,35 +134,39 @@ static int check(X509_STORE *ctx, const char *file) {
   bssl::UniquePtr<X509_STORE_CTX> store_ctx(X509_STORE_CTX_new());
   if (store_ctx == nullptr || store_ctx.get() == nullptr) {
     fprintf(stderr, "error %s: X.509 store context allocation failed\n",
-               (file == nullptr) ? "stdin" : file);
+               (certfile == nullptr) ? "stdin" : certfile);
     return 0;
   }
 
-  if (!X509_STORE_CTX_init(store_ctx.get(), ctx, cert.get(), nullptr)) {
+  if (!X509_STORE_CTX_init(store_ctx.get(), ctx, cert.get(), chain.get())) {
     fprintf(stderr,
                "error %s: X.509 store context initialization failed\n",
-               (file == nullptr) ? "stdin" : file);
+               (certfile == nullptr) ? "stdin" : certfile);
     return 0;
   }
 
   i = X509_verify_cert(store_ctx.get());
   if (i > 0 && X509_STORE_CTX_get_error(store_ctx.get()) == X509_V_OK) {
-    fprintf(stdout, "%s: OK\n", (file == nullptr) ? "stdin" : file);
+    fprintf(stdout, "%s: OK\n", (certfile == nullptr) ? "stdin" : certfile);
     ret = 1;
   } else {
     fprintf(stderr,
                "error %s: verification failed\n",
-               (file == nullptr) ? "stdin" : file);
+               (certfile == nullptr) ? "stdin" : certfile);
   }
 
   return ret;
 }
 
 bool VerifyTool(const args_list_t &args) {
-  std::string cafile;
-  size_t i = 0;
+  args_map_t parsed_args;
+  args_list_t extra_args;
+  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments)) {
+    PrintUsage(kArguments);
+    return false;
+  }
 
-  if (args.size() == 1 && args[0] == "-help") {
+  if (parsed_args.count("-help") || parsed_args.size() == 0) {
     fprintf(stderr,
             "Usage: verify [options] [cert.pem...]\n"
             "Certificates must be in PEM format. They can be specified in one or more files.\n"
@@ -150,15 +176,7 @@ bool VerifyTool(const args_list_t &args) {
     return false;
   }
 
-  // i helps track whether input will be provided via stdin or through a file
-  if (args.size() >= 1 && args[0] == "-CAfile") {
-    cafile = args[1];
-    i += 2;
-  } else {
-    fprintf(stderr, "-CAfile must be specified. This tool does not load"
-                    " the default trust store.\n");
-    return false;
-  }
+  std::string cafile = parsed_args["-CAfile"];
 
   bssl::UniquePtr<X509_STORE> store(setup_verification_store(cafile));
   // Initialize certificate verification store
@@ -172,13 +190,15 @@ bool VerifyTool(const args_list_t &args) {
 
   int ret = 1;
 
+  const char *chain = parsed_args.count("-untrusted") ? parsed_args["-untrusted"].c_str() : NULL;
+
   // No additional file or certs provided, read from stdin
-  if (args.size() == i) {
-    ret &= check(store.get(), NULL);
+  if (extra_args.size() == 0) {
+    ret &= check(store.get(), chain, NULL);
   } else {
     // Certs provided as files
-    for (; i < args.size(); i++) {
-      ret &= check(store.get(), args[i].c_str());
+    for (size_t i = 0; i < extra_args.size(); i++) {
+      ret &= check(store.get(), chain, extra_args[i].c_str());
     }
   }
 

--- a/tool-openssl/version.cc
+++ b/tool-openssl/version.cc
@@ -10,7 +10,9 @@ static const argument_t kArguments[] = {
 
 bool VersionTool(const args_list_t &args) {
   args_map_t parsed_args;
-  if (!ParseKeyValueArguments(&parsed_args, args, kArguments)) {
+  args_list_t extra_args;
+  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -6,7 +6,6 @@
 #include <openssl/rsa.h>
 #include "internal.h"
 #include <ctime>
-#include <algorithm>
 #include <string>
 
 static const argument_t kArguments[] = {
@@ -164,6 +163,7 @@ bool X509Tool(const args_list_t &args) {
   // Check -inform has a valid value
   if(!inform.empty()) {
     if (!isStringUpperCaseEqual(inform, "DER") && !isStringUpperCaseEqual(inform, "PEM")) {
+      fprintf(stderr, "Error: '-inform' option must specify a valid encoding DER|PEM\n");
       return false;
     }
   }

--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -43,12 +43,12 @@ static bool WriteSignedCertificate(X509 *x509, bssl::UniquePtr<BIO> &output_bio,
   return true;
 }
 
-static bool isUpperCaseEqual(char a, char b) {
-  return std::toupper(a) ==  std::toupper(b);
+static bool isCharUpperCaseEqual(char a, char b) {
+  return ::toupper(a) ==  ::toupper(b);
 }
 
-static bool isUpperCaseStringsEqual(const std::string &a, const std::string &b) {
-  return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(), isUpperCaseEqual);
+static bool isStringUpperCaseEqual(const std::string &a, const std::string &b) {
+  return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(), isCharUpperCaseEqual);
 }
 
 bool LoadPrivateKeyAndSignCertificate(X509 *x509, const std::string &signkey_path) {
@@ -163,7 +163,7 @@ bool X509Tool(const args_list_t &args) {
 
   // Check -inform has a valid value
   if(!inform.empty()) {
-    if (!isUpperCaseStringsEqual(inform, "DER") && !isUpperCaseStringsEqual(inform, "PEM")) {
+    if (!isStringUpperCaseEqual(inform, "DER") && !isStringUpperCaseEqual(inform, "PEM")) {
       return false;
     }
   }
@@ -182,7 +182,7 @@ bool X509Tool(const args_list_t &args) {
 
   if (req) {
     bssl::UniquePtr<X509_REQ> csr;
-    if (!inform.empty() && isUpperCaseStringsEqual(inform, "DER")) {
+    if (!inform.empty() && isStringUpperCaseEqual(inform, "DER")) {
       csr.reset(d2i_X509_REQ_fp(in_file.get(), nullptr));
     } else {
       csr.reset(PEM_read_X509_REQ(in_file.get(), nullptr, nullptr, nullptr));
@@ -241,7 +241,7 @@ bool X509Tool(const args_list_t &args) {
   } else {
     // Parse x509 certificate from input file
     bssl::UniquePtr<X509> x509;
-    if (!inform.empty() && isUpperCaseStringsEqual(inform, "DER")) {
+    if (!inform.empty() && isStringUpperCaseEqual(inform, "DER")) {
       x509.reset(d2i_X509_fp(in_file.get(), nullptr));
     } else {
       x509.reset(PEM_read_X509(in_file.get(), nullptr, nullptr, nullptr));

--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -6,6 +6,8 @@
 #include <openssl/rsa.h>
 #include "internal.h"
 #include <ctime>
+#include <algorithm>
+#include <string>
 
 static const argument_t kArguments[] = {
   { "-help", kBooleanArgument, "Display option summary" },
@@ -41,6 +43,14 @@ static bool WriteSignedCertificate(X509 *x509, bssl::UniquePtr<BIO> &output_bio,
   return true;
 }
 
+static bool isUpperCaseEqual(char a, char b) {
+  return std::toupper(a) ==  std::toupper(b);
+}
+
+static bool isUpperCaseStringsEqual(const std::string &a, const std::string &b) {
+  return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(), isUpperCaseEqual);
+}
+
 bool LoadPrivateKeyAndSignCertificate(X509 *x509, const std::string &signkey_path) {
   ScopedFILE signkey_file(fopen(signkey_path.c_str(), "rb"));
   if (!signkey_file) {
@@ -69,7 +79,9 @@ bool IsNumeric(const std::string& str) {
 // Map arguments using tool/args.cc
 bool X509Tool(const args_list_t &args) {
   args_map_t parsed_args;
-  if (!ParseKeyValueArguments(&parsed_args, args, kArguments)) {
+  args_list_t extra_args;
+  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }
@@ -151,8 +163,7 @@ bool X509Tool(const args_list_t &args) {
 
   // Check -inform has a valid value
   if(!inform.empty()) {
-    if (inform != "DER" && inform != "PEM") {
-      fprintf(stderr, "Error: '-inform' option must specify a valid encoding DER|PEM\n");
+    if (!isUpperCaseStringsEqual(inform, "DER") && !isUpperCaseStringsEqual(inform, "PEM")) {
       return false;
     }
   }
@@ -171,7 +182,7 @@ bool X509Tool(const args_list_t &args) {
 
   if (req) {
     bssl::UniquePtr<X509_REQ> csr;
-    if (!inform.empty() && inform == "DER") {
+    if (!inform.empty() && isUpperCaseStringsEqual(inform, "DER")) {
       csr.reset(d2i_X509_REQ_fp(in_file.get(), nullptr));
     } else {
       csr.reset(PEM_read_X509_REQ(in_file.get(), nullptr, nullptr, nullptr));
@@ -230,7 +241,7 @@ bool X509Tool(const args_list_t &args) {
   } else {
     // Parse x509 certificate from input file
     bssl::UniquePtr<X509> x509;
-    if (!inform.empty() && inform == "DER") {
+    if (!inform.empty() && isUpperCaseStringsEqual(inform, "DER")) {
       x509.reset(d2i_X509_fp(in_file.get(), nullptr));
     } else {
       x509.reset(PEM_read_X509(in_file.get(), nullptr, nullptr, nullptr));

--- a/tool/args.cc
+++ b/tool/args.cc
@@ -23,10 +23,16 @@
 
 #include "internal.h"
 
-bool ParseKeyValueArguments(args_map_t *out_args,
+bool IsFlag(const std::string& arg) {
+  return arg.length() > 1 && (arg[0] == '-' || (arg.length() > 2 && arg[0] == '-' && arg[1] == '-'));
+}
+
+bool ParseKeyValueArguments(args_map_t &out_args,
+                          args_list_t &extra_args,
                           const args_list_t &args,
                           const argument_t *templates) {
-  out_args->clear();
+  out_args.clear();
+  extra_args.clear();
 
   for (size_t i = 0; i < args.size(); i++) {
     const std::string &arg = args[i];
@@ -39,30 +45,34 @@ bool ParseKeyValueArguments(args_map_t *out_args,
     }
 
     if (templ == nullptr) {
-      fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
-      return false;
+      if(IsFlag(arg)) {
+        fprintf(stderr, "Unknown flag: %s\n", arg.c_str());
+        return false;
+      }
+      extra_args.push_back(arg);
+      continue;
     }
 
-    if (out_args->find(arg) != out_args->end()) {
+    if (out_args.find(arg) != out_args.end()) {
       fprintf(stderr, "Duplicate argument: %s\n", arg.c_str());
       return false;
     }
 
     if (templ->type == kBooleanArgument) {
-      (*out_args)[arg] = "";
+      out_args[arg] = "";
     } else {
       if (i + 1 >= args.size()) {
         fprintf(stderr, "Missing argument for option: %s\n", arg.c_str());
         return false;
       }
-      (*out_args)[arg] = args[++i];
+      out_args[arg] = args[++i];
     }
   }
 
   for (size_t j = 0; templates[j].name[0] != 0; j++) {
     const argument_t *templ = &templates[j];
     if (templ->type == kRequiredArgument &&
-        out_args->find(templ->name) == out_args->end()) {
+        out_args.find(templ->name) == out_args.end()) {
       fprintf(stderr, "Missing value for required argument: %s\n", templ->name);
       return false;
     }

--- a/tool/ciphers.cc
+++ b/tool/ciphers.cc
@@ -45,9 +45,11 @@ static const argument_t kArguments[] = {
 };
 
 bool Ciphers(const std::vector<std::string> &args) {
-
   args_map_t args_map;
-  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+  args_list_t extra_args;
+
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool/client.cc
+++ b/tool/client.cc
@@ -531,8 +531,10 @@ static int verify_cb(int ok, X509_STORE_CTX *ctx)
 
 bool Client(const std::vector<std::string> &args) {
   std::map<std::string, std::string> args_map;
+  args_list_t extra_args;
 
-  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool/generate_ech.cc
+++ b/tool/generate_ech.cc
@@ -68,7 +68,9 @@ static const struct argument_t kArguments[] = {
 
 bool GenerateECH(const std::vector<std::string> &args) {
   std::map<std::string, std::string> args_map;
-  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+  args_list_t extra_args;
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool/generate_ed25519.cc
+++ b/tool/generate_ed25519.cc
@@ -36,8 +36,10 @@ static const argument_t kArguments[] = {
 
 bool GenerateEd25519Key(const std::vector<std::string> &args) {
   std::map<std::string, std::string> args_map;
+  args_list_t extra_args;
 
-  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool/genrsa.cc
+++ b/tool/genrsa.cc
@@ -33,8 +33,10 @@ static const argument_t kArguments[] = {
 
 bool GenerateRSAKey(const std::vector<std::string> &args) {
   std::map<std::string, std::string> args_map;
+  args_list_t extra_args;
 
-  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool/internal.h
+++ b/tool/internal.h
@@ -113,10 +113,16 @@ typedef struct argument_t {
 typedef std::vector<std::string> args_list_t;
 typedef std::map<std::string, std::string> args_map_t;
 
+bool IsFlag(const std::string& arg);
+
 // ParseKeyValueArguments converts the list of strings |args| ["-filter", "RSA", "-Timeout", "10"] into a map in
 // |out_args| of key value pairs {"-filter": "RSA", "-Timeout": "10"}. It uses |templates| to determine what arguments
-// are option or required.
-bool ParseKeyValueArguments(args_map_t *out_args, const args_list_t &args, const argument_t *templates);
+// are option or required. Any extra arguments that don't look like an unknown flag argument (prefixed by "-" or "--")
+// will be appended to extra_args in the order they appear in.
+bool ParseKeyValueArguments(args_map_t &out_args,
+                            args_list_t &extra_args,
+                            const args_list_t &args,
+                            const argument_t *templates);
 
 // PrintUsage prints the description from the list of templates in |templates| to stderr.
 void PrintUsage(const argument_t *templates);

--- a/tool/pkcs12.cc
+++ b/tool/pkcs12.cc
@@ -52,9 +52,10 @@ static const argument_t kArguments[] = {
 
 bool DoPKCS12(const std::vector<std::string> &args) {
   std::map<std::string, std::string> args_map;
+  args_list_t extra_args;
 
-  if (!ParseKeyValueArguments(&args_map, args, kArguments) ||
-      args_map["-dump"].empty()) {
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      args_map["-dump"].empty() || extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool/rand.cc
+++ b/tool/rand.cc
@@ -53,7 +53,10 @@ bool Rand(const std::vector<std::string> &args) {
     }
 
     std::map<std::string, std::string> args_map;
-    if (!ParseKeyValueArguments(&args_map, args_copy, kArguments)) {
+    args_list_t extra_args;
+    if (!ParseKeyValueArguments(args_map, extra_args, args_copy,
+                                kArguments) ||
+        extra_args.size() > 0) {
       PrintUsage(kArguments);
       return false;
     }

--- a/tool/server.cc
+++ b/tool/server.cc
@@ -236,8 +236,10 @@ bool Server(const std::vector<std::string> &args) {
   }
 
   std::map<std::string, std::string> args_map;
+  args_list_t extra_args;
 
-  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool/sign.cc
+++ b/tool/sign.cc
@@ -30,7 +30,9 @@ static const argument_t kArguments[] = {
 
 bool Sign(const args_list_t &args) {
   args_map_t args_map;
-  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+  args_list_t extra_args;
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2684,7 +2684,9 @@ bool Speed(const std::vector<std::string> &args) {
   EVP_MD_unstable_sha3_enable(true);
 #endif
   std::map<std::string, std::string> args_map;
-  if (!ParseKeyValueArguments(&args_map, args, kArguments)) {
+  args_list_t extra_args;
+  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+      extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }


### PR DESCRIPTION
### Description of changes: 
* OpenSSL supports passing lower-case `pem` or `der` when using the `-inform` argument to the `x509` sub-command.
* Add support for the `-untrusted` flag to the `verify` sub-command which allows for passing in a set of one or more chain certificates which may be used in the certificate chain building and validation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
