### PR TITLE
Remove access() call from Snapsafe detection

### DIFF
--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "../delocate.h"
 

--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -32,7 +32,7 @@ static void do_aws_snapsafe_init(void) {
 
   *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
 
-  int fd_gcc = open(CRYPTO_get_sysgenid_path(), O_RDONLY);
+  int fd_sgc = open(CRYPTO_get_sysgenid_path(), O_RDONLY);
   if (fd_sgc == -1) {
     if (errno == ENOENT) {
       *snapsafety_state_bss_get() = SNAPSAFETY_STATE_NOT_SUPPORTED;

--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -33,7 +33,7 @@ static void do_aws_snapsafe_init(void) {
 
   *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
   int fd_sgc = open(CRYPTO_get_sysgenid_path(), O_RDONLY);
-  if (fd_sgc <= 0) {
+  if (fd_sgc < 0) {
     return;
   }
 

--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "../delocate.h"
 
@@ -23,13 +24,16 @@ DEFINE_BSS_GET(int, snapsafety_state)
 
 static void do_aws_snapsafe_init(void) {
   *sgc_addr_bss_get() = NULL;
-  *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
+  *snapsafety_state_bss_get() = SNAPSAFETY_STATE_NOT_SUPPORTED;
 
+  struct stat buff;
+  if (stat(CRYPTO_get_sysgenid_path(), &buff) != 0) {
+    return;
+  }
+
+  *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
   int fd_sgc = open(CRYPTO_get_sysgenid_path(), O_RDONLY);
-  if (fd_sgc == -1) {
-    if (errno == ENOENT) {
-      *snapsafety_state_bss_get() = SNAPSAFETY_STATE_NOT_SUPPORTED;
-    }
+  if (fd_sgc != 0) {
     return;
   }
 

--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -24,13 +24,13 @@ DEFINE_BSS_GET(int, snapsafety_state)
 static void do_aws_snapsafe_init(void) {
   *snapsafety_state_bss_get() = SNAPSAFETY_STATE_NOT_SUPPORTED;
   *sgc_addr_bss_get() = NULL;
+  if (stat(CRYPTO_get_sysgenid_path()) < 0) {
+    return;
+  }
 
+  *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
   int fd_sgc = open(CRYPTO_get_sysgenid_path(), O_RDONLY);
   if (fd_sgc == -1) {
-    if (errno == EACCES) {
-      return;
-    }
-    *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
     return;
   }
 

--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -23,16 +23,20 @@ DEFINE_BSS_GET(volatile uint32_t *, sgc_addr)
 DEFINE_BSS_GET(int, snapsafety_state)
 
 static void do_aws_snapsafe_init(void) {
-  *snapsafety_state_bss_get() = SNAPSAFETY_STATE_NOT_SUPPORTED;
+  // *snapsafety_state_bss_get() = SNAPSAFETY_STATE_NOT_SUPPORTED;
   *sgc_addr_bss_get() = NULL;
-  struct stat fileData;
-  if (stat(CRYPTO_get_sysgenid_path(), &fileData) < 0) {
-    return;
-  }
+  // struct stat fileData;
+  // if (stat(CRYPTO_get_sysgenid_path(), &fileData) < 0) {
+  //   return;
+  // }
 
   *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
-  int fd_sgc = open(CRYPTO_get_sysgenid_path(), O_RDONLY);
+
+  int fd_gcc = open(CRYPTO_get_sysgenid_path(), O_RDONLY);
   if (fd_sgc == -1) {
+    if (errno == ENOENT) {
+      *snapsafety_state_bss_get() = SNAPSAFETY_STATE_NOT_SUPPORTED;
+    }
     return;
   }
 
@@ -47,7 +51,6 @@ static void do_aws_snapsafe_init(void) {
   close(fd_sgc);
 
   if (addr == MAP_FAILED) {
-    *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
     return;
   }
 

--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -33,7 +33,7 @@ static void do_aws_snapsafe_init(void) {
 
   *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
   int fd_sgc = open(CRYPTO_get_sysgenid_path(), O_RDONLY);
-  if (fd_sgc != 0) {
+  if (fd_sgc <= 0) {
     return;
   }
 

--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -24,7 +24,8 @@ DEFINE_BSS_GET(int, snapsafety_state)
 static void do_aws_snapsafe_init(void) {
   *snapsafety_state_bss_get() = SNAPSAFETY_STATE_NOT_SUPPORTED;
   *sgc_addr_bss_get() = NULL;
-  if (stat(CRYPTO_get_sysgenid_path()) < 0) {
+  struct stat fileData;
+  if (stat(CRYPTO_get_sysgenid_path(), &fileData) < 0) {
     return;
   }
 

--- a/crypto/fipsmodule/rand/snapsafe_detect.c
+++ b/crypto/fipsmodule/rand/snapsafe_detect.c
@@ -9,7 +9,6 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/mman.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #include "../delocate.h"
 
@@ -23,13 +22,7 @@ DEFINE_BSS_GET(volatile uint32_t *, sgc_addr)
 DEFINE_BSS_GET(int, snapsafety_state)
 
 static void do_aws_snapsafe_init(void) {
-  // *snapsafety_state_bss_get() = SNAPSAFETY_STATE_NOT_SUPPORTED;
   *sgc_addr_bss_get() = NULL;
-  // struct stat fileData;
-  // if (stat(CRYPTO_get_sysgenid_path(), &fileData) < 0) {
-  //   return;
-  // }
-
   *snapsafety_state_bss_get() = SNAPSAFETY_STATE_FAILED_INITIALISE;
 
   int fd_sgc = open(CRYPTO_get_sysgenid_path(), O_RDONLY);


### PR DESCRIPTION
### Description of changes: 
This change uses stat() instead of access() to check for the existence of the Sysgenid device. This is more accurate to ascertain whether the device exists on a machine. access() could fail for various other reasons such as missing permissions. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
