### PR TITLE
Modify SSL to inherit ciphersuites from SSL_CTX at initialization

### DIFF
--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2172,8 +2172,7 @@ STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl) {
     return ssl->config->cipher_list->ciphers.get();
   }
 
-  return ssl->ctx && ssl->ctx->cipher_list ?
-         ssl->ctx->cipher_list->ciphers.get() : NULL;
+  return ssl->ctx->cipher_list->ciphers.get();
 }
 
 const char *SSL_get_cipher_list(const SSL *ssl, int n) {

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -693,6 +693,15 @@ SSL *SSL_new(SSL_CTX *ctx) {
           ctx->alpn_client_proto_list) ||
       !ssl->config->verify_sigalgs.CopyFrom(ctx->verify_sigalgs)) {
     return nullptr;
+      }
+
+  if (ctx->cipher_list) {
+    ssl->config->cipher_list = MakeUnique<SSLCipherPreferenceList>();
+    ssl->config->cipher_list->Init(*ctx->cipher_list.get());
+  }
+  if (ctx->tls13_cipher_list) {
+    ssl->config->tls13_cipher_list = MakeUnique<SSLCipherPreferenceList>();
+    ssl->config->tls13_cipher_list->Init(*ctx->tls13_cipher_list.get());
   }
 
   if (ctx->psk_identity_hint) {
@@ -2158,11 +2167,9 @@ STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl) {
   if (ssl == NULL) {
     return NULL;
   }
-  if (ssl->config && ssl->config->cipher_list) {
-    return ssl->config->cipher_list->ciphers.get();
-  }
 
-  return ssl->ctx->cipher_list->ciphers.get();
+  return ssl->config && ssl->config->cipher_list ?
+         ssl->config->cipher_list->ciphers.get() : NULL;
 }
 
 const char *SSL_get_cipher_list(const SSL *ssl, int n) {

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2168,8 +2168,12 @@ STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl) {
     return NULL;
   }
 
-  return ssl->config && ssl->config->cipher_list ?
-         ssl->config->cipher_list->ciphers.get() : NULL;
+  if (ssl->config && ssl->config->cipher_list) {
+    return ssl->config->cipher_list->ciphers.get();
+  }
+
+  return ssl->ctx && ssl->ctx->cipher_list ?
+         ssl->ctx->cipher_list->ciphers.get() : NULL;
 }
 
 const char *SSL_get_cipher_list(const SSL *ssl, int n) {

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -693,7 +693,7 @@ SSL *SSL_new(SSL_CTX *ctx) {
           ctx->alpn_client_proto_list) ||
       !ssl->config->verify_sigalgs.CopyFrom(ctx->verify_sigalgs)) {
     return nullptr;
-      }
+  }
 
   if (ctx->cipher_list) {
     ssl->config->cipher_list = MakeUnique<SSLCipherPreferenceList>();

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -2821,6 +2821,49 @@ TEST(SSLTest, FindingCipher) {
   ASSERT_FALSE(cipher3);
 }
 
+TEST(SSLTest, CheckSSLCipherInheritance) {
+  // This configures SSL_CTX objects with default TLS 1.2 and 1.3 ciphersuites
+  bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL_CTX> server_ctx =
+          CreateContextWithTestCertificate(TLS_method());
+  ASSERT_TRUE(client_ctx);
+  ASSERT_TRUE(server_ctx);
+
+  ASSERT_TRUE(SSL_CTX_set_min_proto_version(client_ctx.get(), TLS1_2_VERSION));
+  ASSERT_TRUE(SSL_CTX_set_max_proto_version(client_ctx.get(), TLS1_3_VERSION));
+  ASSERT_TRUE(SSL_CTX_set_min_proto_version(server_ctx.get(), TLS1_2_VERSION));
+  ASSERT_TRUE(SSL_CTX_set_max_proto_version(server_ctx.get(), TLS1_3_VERSION));
+
+  ASSERT_TRUE(SSL_CTX_set_ciphersuites(client_ctx.get(), "TLS_AES_128_GCM_SHA256"));
+  ASSERT_TRUE(SSL_CTX_set_ciphersuites(server_ctx.get(), "TLS_AES_128_GCM_SHA256"));
+  ASSERT_TRUE(SSL_CTX_set_cipher_list(client_ctx.get(), "TLS_RSA_WITH_AES_128_CBC_SHA"));
+  ASSERT_TRUE(SSL_CTX_set_cipher_list(server_ctx.get(), "TLS_RSA_WITH_AES_128_CBC_SHA"));
+
+  bssl::UniquePtr<SSL> client, server;
+  ASSERT_TRUE(CreateClientAndServer(&client, &server, client_ctx.get(), server_ctx.get()));
+
+  // Modify CTX ciphersuites
+  ASSERT_TRUE(SSL_CTX_set_ciphersuites(client_ctx.get(), "TLS_AES_256_GCM_SHA384"));
+  ASSERT_TRUE(SSL_CTX_set_ciphersuites(server_ctx.get(), "TLS_AES_256_GCM_SHA384"));
+  ASSERT_TRUE(SSL_CTX_set_cipher_list(client_ctx.get(), "TLS_RSA_WITH_AES_256_CBC_SHA"));
+  ASSERT_TRUE(SSL_CTX_set_cipher_list(server_ctx.get(), "TLS_RSA_WITH_AES_256_CBC_SHA"));
+
+  // Ensure SSL object inherits initial CTX ciphersuites
+  STACK_OF(SSL_CIPHER) *client_ciphers = SSL_get_ciphers(client.get());
+  STACK_OF(SSL_CIPHER) *server_ciphers = SSL_get_ciphers(server.get());
+  ASSERT_TRUE(client_ciphers);
+  ASSERT_TRUE(server_ciphers);
+  const SSL_CIPHER *tls13_cipher = SSL_get_cipher_by_value(TLS1_3_CK_AES_128_GCM_SHA256 & 0xFFFF);
+  const SSL_CIPHER *tls12_cipher = SSL_get_cipher_by_value(TLS1_CK_RSA_WITH_AES_128_SHA & 0xFFFF);
+  ASSERT_TRUE(tls13_cipher);
+  ASSERT_TRUE(tls12_cipher);
+
+  ASSERT_TRUE(sk_SSL_CIPHER_find_awslc(client_ciphers, NULL, tls12_cipher));
+  ASSERT_TRUE(sk_SSL_CIPHER_find_awslc(client_ciphers, NULL, tls13_cipher));
+  ASSERT_TRUE(sk_SSL_CIPHER_find_awslc(server_ciphers, NULL, tls12_cipher));
+  ASSERT_TRUE(sk_SSL_CIPHER_find_awslc(server_ciphers, NULL, tls13_cipher));  
+}
+
 TEST(SSLTest, SSLGetCiphersReturnsTLS13Default) {
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
   bssl::UniquePtr<SSL_CTX> server_ctx =

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -2853,6 +2853,8 @@ TEST(SSLTest, CheckSSLCipherInheritance) {
   STACK_OF(SSL_CIPHER) *server_ciphers = SSL_get_ciphers(server.get());
   ASSERT_TRUE(client_ciphers);
   ASSERT_TRUE(server_ciphers);
+  ASSERT_EQ(sk_SSL_CIPHER_num(client_ciphers), 2u);
+  ASSERT_EQ(sk_SSL_CIPHER_num(server_ciphers), 2u);
   const SSL_CIPHER *tls13_cipher = SSL_get_cipher_by_value(TLS1_3_CK_AES_128_GCM_SHA256 & 0xFFFF);
   const SSL_CIPHER *tls12_cipher = SSL_get_cipher_by_value(TLS1_CK_RSA_WITH_AES_128_SHA & 0xFFFF);
   ASSERT_TRUE(tls13_cipher);


### PR DESCRIPTION
### Description of changes: 
This is a follow up to https://github.com/aws/aws-lc/commit/154f9986bc18f8f0e6126157a3abc84230456f77. 
These changes initialize the SSL object with configured ciphersuites from the parent SSL_CTX object at initialization. Now both SSL and SSL_CTX objects will have their own copy of ciphersuites. 

We inherited the behavior of defaulting to SSL_CTX ciphersuites when none are set on SSL from BoringSSL. OpenSSL does things differently and copies the ciphersuites to SSL at init. This behavioral difference is aligned in this PR. 

### Testing:
A test to ensure changes to SSL_CTX don't impact SSL configurations and we correctly inherit ciphersuites. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
