### PR TITLE
Update pairwise consistency test failures to support gracefully continiung

### DIFF
--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -550,9 +550,8 @@ int EC_KEY_generate_key_fips(EC_KEY *eckey) {
 
 #if defined(AWSLC_FIPS)
   AWS_LC_FIPS_failure("EC keygen checks failed");
-#else
-  return 0;
 #endif
+  return 0;
 }
 
 int EC_KEY_get_ex_new_index(long argl, void *argp, CRYPTO_EX_unused *unused,

--- a/crypto/fipsmodule/ml_dsa/ml_dsa_ref/sign.c
+++ b/crypto/fipsmodule/ml_dsa/ml_dsa_ref/sign.c
@@ -51,7 +51,7 @@ static int ml_dsa_keypair_pct(ml_dsa_params *params,
  *                             array of CRYPTO_SECRETKEYBYTES bytes)
  *              - const uint8_t *rnd: pointer to random seed
  *
- * Returns 0 (success)
+ * Returns 0 (success) -1 on failure or abort depending on FIPS mode
  **************************************************/
 int ml_dsa_keypair_internal(ml_dsa_params *params,
                             uint8_t *pk,
@@ -114,6 +114,7 @@ int ml_dsa_keypair_internal(ml_dsa_params *params,
   // Abort in case of PCT failure.
   if (!ml_dsa_keypair_pct(params, pk, sk)) {
     AWS_LC_FIPS_failure("ML-DSA keygen PCT failed");
+    return -1;
   }
 #endif
   return 0;
@@ -138,9 +139,9 @@ int ml_dsa_keypair(ml_dsa_params *params, uint8_t *pk, uint8_t *sk) {
   if (!RAND_bytes(seed, ML_DSA_SEEDBYTES)) {
     return -1;
   }
-  ml_dsa_keypair_internal(params, pk, sk, seed);
+  int result = ml_dsa_keypair_internal(params, pk, sk, seed);
   OPENSSL_cleanse(seed, sizeof(seed));
-  return 0;
+  return result;
 }
 
 /*************************************************

--- a/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem_ref/kem.c
@@ -59,7 +59,6 @@ int crypto_kem_keypair_derand(ml_kem_params *params,
   memcpy(sk+params->secret_key_bytes-KYBER_SYMBYTES, coins+KYBER_SYMBYTES, KYBER_SYMBYTES);
 
 #if defined(AWSLC_FIPS)
-  // Abort in case of PCT failure.
   if (keygen_pct(params, pk, sk)) {
     return -1;
   }


### PR DESCRIPTION
### Description of changes: 
Currently AWS_LC_FIPS_failure always aborts the process and it is impossible to continue after calling that function. In a future change this will be optional and AWS-LC will not abort and the overall API call should return a failure. This change updates the current pairwise consistency test spots to theoretically return a failure.

### Call-outs:
This PR does not change the behavior, if there is a PWCT failure the process still aborts.

### Testing:
With the current AWS_LC_FIPS_failure implementation it is impossible to test this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
