### PR TITLE
Add SPARCV9 target

### DIFF
--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -49,6 +49,10 @@
 #define OPENSSL_64_BIT
 #define OPENSSL_S390X
 #define OPENSSL_BIG_ENDIAN
+#elif defined(__sparc__) && defined(_BIG_ENDIAN)
+#define OPENSSL_64_BIT
+#define OPENSSL_SPARCV9
+#define OPENSSL_BIG_ENDIAN
 #elif defined(__MIPSEL__) && !defined(__LP64__)
 #define OPENSSL_32_BIT
 #define OPENSSL_MIPS


### PR DESCRIPTION
Allow to build rustup on Solaris SPARC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.