### PR TITLE
Enable RSA keygen becnhmarks by default

### DIFF
--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -417,8 +417,7 @@ static bool SpeedRSA(const std::string &selected) {
 }
 
 static bool SpeedRSAKeyGen(bool is_fips, const std::string &selected) {
-  // Don't run this by default because it's so slow.
-  if (selected != "RSAKeyGen") {
+  if (!selected.empty() && selected.find("RSAKeyGen") == std::string::npos) {
     return true;
   }
 


### PR DESCRIPTION
### Description of changes: 
The current filter logic in the speed tool is a bit weird. It's not possible to run all the benchmarks because RSA key gen was off by default. If you pass in the filter "RSAKeyGen" you get the keygen benchmarks and all the other RSA benchmarks. This change updates it to be treated the same as all the other benchmarks. 

The RSA key gen benchmarks are still a little weird because they override the timeout which is why they are slower and take more time. For now the canary use case is fine.

### Testing:
The CI will run this benchmark with all the libcryptos we expect to support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
