### PR TITLE
Add CMAC benchmark for AWS-LC

### DIFF
--- a/tool/ossl_bm.h
+++ b/tool/ossl_bm.h
@@ -64,6 +64,7 @@ OSSL_MAKE_DELETER(BN_CTX, BN_CTX_free)
 OSSL_MAKE_DELETER(EVP_CIPHER_CTX, EVP_CIPHER_CTX_free)
 OSSL_MAKE_DELETER(EVP_PKEY_CTX, EVP_PKEY_CTX_free)
 OSSL_MAKE_DELETER(EVP_PKEY, EVP_PKEY_free)
+OSSL_MAKE_DELETER(CMAC_CTX, CMAC_CTX_free)
 
 // OpenSSL 1.0.x has different APIs for EVP_MD_CTX and HMAC
 // We need to add more custom logic to HMAC to let it properly delete the

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -1285,7 +1285,7 @@ static bool SpeedCmacChunk(const EVP_CIPHER *cipher, std::string name,
 #if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
                CMAC_Reset(ctx.get()) &&
 #else
-               CMAC_Init(ctx.get(), nullptr, 0, nullptr, nullptr /* ENGINE */)
+               CMAC_Init(ctx.get(), nullptr, 0, nullptr, nullptr /* ENGINE */) &&
 #endif
                CMAC_Update(ctx.get(), input.get(), chunk_len) &&
                CMAC_Final(ctx.get(), digest, &out_len);


### PR DESCRIPTION
### Description of changes: 
Adds a benchmark for CMAC, OpenSSL 1.0.2 does not support CMAC. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
