### PR TITLE
Increase required CMake version to 3.5

### DIFF
--- a/.github/docker_images/gcc-4.8/Dockerfile
+++ b/.github/docker_images/gcc-4.8/Dockerfile
@@ -10,15 +10,15 @@ COPY entry.sh /
 
 WORKDIR /
 
-RUN curl -LOk "https://github.com/Kitware/CMake/releases/download/v3.6.3/cmake-3.6.3-Linux-x86_64.tar.gz"
-RUN sha256sum cmake-3.6.3-Linux-x86_64.tar.gz | grep -q "9d915d505c07d84b610e1be6242c7cad68b4b7a4090ce85ecf9cec5effa47c43"
-RUN tar -C /usr/local -xzf cmake-3.6.3-Linux-x86_64.tar.gz
-RUN rm cmake-3.6.3-Linux-x86_64.tar.gz
+RUN curl -LOk "https://github.com/Kitware/CMake/releases/download/v3.9.6/cmake-3.9.6-Linux-x86_64.tar.gz"
+RUN sha256sum cmake-3.9.6-Linux-x86_64.tar.gz | grep -q "062bf45bee36ce7c2a55ae26b8b5324720f370d420a05cba91b9448c64ffdbea"
+RUN tar -C /usr/local -xzf cmake-3.9.6-Linux-x86_64.tar.gz
+RUN rm cmake-3.9.6-Linux-x86_64.tar.gz
 RUN curl -LOk "https://go.dev/dl/go1.18.10.linux-amd64.tar.gz"
 RUN sha256sum go1.18.10.linux-amd64.tar.gz | grep -q "5e05400e4c79ef5394424c0eff5b9141cb782da25f64f79d54c98af0a37f8d49"
 RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.10.linux-amd64.tar.gz
 RUN rm go1.18.10.linux-amd64.tar.gz
 
-ENV PATH="${PATH}:/usr/local/cmake-3.6.3-Linux-x86_64/bin:/usr/local/go/bin"
+ENV PATH="${PATH}:/usr/local/cmake-3.9.6-Linux-x86_64/bin:/usr/local/go/bin"
 
 ENTRYPOINT ["/entry.sh"]

--- a/.github/docker_images/gcc-4.8/Dockerfile
+++ b/.github/docker_images/gcc-4.8/Dockerfile
@@ -10,15 +10,15 @@ COPY entry.sh /
 
 WORKDIR /
 
-RUN curl -LOk "https://github.com/Kitware/CMake/releases/download/v3.9.6/cmake-3.9.6-Linux-x86_64.tar.gz"
-RUN sha256sum cmake-3.9.6-Linux-x86_64.tar.gz | grep -q "062bf45bee36ce7c2a55ae26b8b5324720f370d420a05cba91b9448c64ffdbea"
-RUN tar -C /usr/local -xzf cmake-3.9.6-Linux-x86_64.tar.gz
-RUN rm cmake-3.9.6-Linux-x86_64.tar.gz
+RUN curl -LOk "https://github.com/Kitware/CMake/releases/download/v3.6.3/cmake-3.6.3-Linux-x86_64.tar.gz"
+RUN sha256sum cmake-3.6.3-Linux-x86_64.tar.gz | grep -q "9d915d505c07d84b610e1be6242c7cad68b4b7a4090ce85ecf9cec5effa47c43"
+RUN tar -C /usr/local -xzf cmake-3.6.3-Linux-x86_64.tar.gz
+RUN rm cmake-3.6.3-Linux-x86_64.tar.gz
 RUN curl -LOk "https://go.dev/dl/go1.18.10.linux-amd64.tar.gz"
 RUN sha256sum go1.18.10.linux-amd64.tar.gz | grep -q "5e05400e4c79ef5394424c0eff5b9141cb782da25f64f79d54c98af0a37f8d49"
 RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.10.linux-amd64.tar.gz
 RUN rm go1.18.10.linux-amd64.tar.gz
 
-ENV PATH="${PATH}:/usr/local/cmake-3.9.6-Linux-x86_64/bin:/usr/local/go/bin"
+ENV PATH="${PATH}:/usr/local/cmake-3.6.3-Linux-x86_64/bin:/usr/local/go/bin"
 
 ENTRYPOINT ["/entry.sh"]

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         cmake:
-          - { version: "3.2", url: "https://cmake.org/files/v3.2/cmake-3.2.3.tar.gz", hash: "a1ebcaf6d288eb4c966714ea457e3b9677cdfde78820d0f088712d7320850297" }
+          - { version: "3.9", url: "https://cmake.org/files/v3.9/cmake-3.9.6.tar.gz", hash: "7410851a783a41b521214ad987bb534a7e4a65e059651a2514e6ebfc8f46b218" }
           - { version: "3.28", url: "https://cmake.org/files/v3.28/cmake-3.28.1.tar.gz", hash: "15e94f83e647f7d620a140a7a5da76349fc47a1bfed66d0f5cdee8e7344079ad" }
         generator:
           - "Unix Makefiles"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         cmake:
-          - { version: "3.9", url: "https://cmake.org/files/v3.9/cmake-3.9.6.tar.gz", hash: "7410851a783a41b521214ad987bb534a7e4a65e059651a2514e6ebfc8f46b218" }
+          - { version: "3.5", url: "https://cmake.org/files/v3.5/cmake-3.5.0.tar.gz", hash: "92c83ad8a4fd6224cf6319a60b399854f55b38ebe9d297c942408b792b1a9efa" }
           - { version: "3.28", url: "https://cmake.org/files/v3.28/cmake-3.28.1.tar.gz", hash: "15e94f83e647f7d620a140a7a5da76349fc47a1bfed66d0f5cdee8e7344079ad" }
         generator:
           - "Unix Makefiles"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.9)
 
 if(POLICY CMP0091)
 cmake_policy(SET CMP0091 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.5..3.31)
 
 if(POLICY CMP0091)
 cmake_policy(SET CMP0091 NEW)


### PR DESCRIPTION
### Description of changes: 
[CMake 4.0](https://cmake.org/cmake/help/latest/release/4.0.html) is coming out soon and requires cmake_minimum_required to be at least 3.5:
> Compatibility with versions of CMake older than 3.5 has been removed. Calls to [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) that set the policy version to an older value now issue an error

The [common runtime](https://github.com/awslabs/aws-c-common/pull/1178) and [s2n-tls](https://github.com/aws/s2n-tls/issues/4899) upgraded to 3.9 last year.  

### Call-outs:
This will break any customer using CMake version less than 3.9 which was [released in November 2018](https://github.com/Kitware/CMake/releases/tag/v3.9.0)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
