### PR TITLE
Reset DTLS1_BITMAP without resorting to memset

### DIFF
--- a/ssl/dtls_method.cc
+++ b/ssl/dtls_method.cc
@@ -89,7 +89,7 @@ static bool dtls1_set_read_state(SSL *ssl, ssl_encryption_level_t level,
   }
 
   ssl->d1->r_epoch++;
-  OPENSSL_memset(&ssl->d1->bitmap, 0, sizeof(ssl->d1->bitmap));
+  ssl->d1->bitmap = DTLS1_BITMAP();
   OPENSSL_memset(ssl->s3->read_sequence, 0, sizeof(ssl->s3->read_sequence));
 
   ssl->s3->aead_read_ctx = std::move(aead_ctx);


### PR DESCRIPTION
After f94f3ed3965ea033001fb9ae006084eee408b861, there's a std::bitset in it, so memset is not guaranteed to do what we want.

There are still other problems here, and we may decide not to keep the reset at all, but fix the memset for now. See these discussions for more details:
https://boringssl-review.googlesource.com/c/boringssl/+/68027/comment/7ff3d697_a6808cee/ https://boringssl-review.googlesource.com/c/boringssl/+/68027/comment/74cabada_eadf5394/

Change-Id: I79c62d71d74a58be4ac822e0cc5a41586472a26a Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/68067
Reviewed-by: Nick Harper <nharper@chromium.org>
Commit-Queue: David Benjamin <davidben@google.com>
Reviewed-by: Bob Beck <bbe@google.com>
Auto-Submit: David Benjamin <davidben@google.com>
(cherry picked from commit 765751395cf12e5842145d56ec339a1a07a1ea53)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
