### PR TITLE
Fix out-of-bound (OOB) input read in AES-XTS Decrypt in AVX-512 implementation

### DIFF
--- a/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
+++ b/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
@@ -2493,7 +2493,7 @@ ___
   vmovdqu8 	 0x40($input),%zmm2
   vmovdqu8 	 0x80($input),%zmm3
   vmovdqu8 	 0xc0($input),%zmm4
-  vmovdqu8 	 0xf0($input),%zmm5
+  vmovdqu8 	 0xf0($input),%xmm5
   add 	 \$0x100,$input
 ___
   }

--- a/crypto/fipsmodule/modes/xts_test.cc
+++ b/crypto/fipsmodule/modes/xts_test.cc
@@ -998,6 +998,27 @@ static const XTSTestCase kXTSTestCases[] = {
 };
 
 #if defined(OPENSSL_LINUX)
+static uint8_t *get_buffer_end(int pagesize) {
+  uint8_t *two_pages_p = (uint8_t *)mmap(NULL, 2*pagesize, PROT_READ|PROT_WRITE,
+                                      MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+  EXPECT_TRUE(two_pages_p != NULL) << "mmap returned NULL.";
+
+  int ret = mprotect(two_pages_p + pagesize, pagesize, PROT_NONE);
+  EXPECT_TRUE(ret == 0) << "mprotect failed.";
+
+  return two_pages_p + pagesize;
+}
+
+// Debug builds return ACCESS_INVALID_ADDRESS in the Intel SDE runs
+// of some processors when munmap is used (or after it's called).
+#if defined(NDEBUG)
+static void free_memory(uint8_t *addr, int pagesize) {
+  munmap(addr - pagesize, 2 * pagesize);
+}
+#endif
+#endif
+
+#if 0
 static uint8_t *get_buffer(int pagesize, int len) {
   uint8_t *two_pages_p = (uint8_t *)mmap(NULL, 2*pagesize, PROT_READ|PROT_WRITE,
                                       MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
@@ -1020,6 +1041,13 @@ static void free_buffer(uint8_t *addr, int pagesize, int len) {
 
 TEST(XTSTest, TestVectors) {
   unsigned test_num = 0;
+#if defined(OPENSSL_LINUX)
+  //int prev_len = 0;
+  int pagesize = sysconf(_SC_PAGE_SIZE);
+  uint8_t *in_buffer_end = get_buffer_end(pagesize);
+  uint8_t *out_buffer_end = get_buffer_end(pagesize);
+  //printf("in_end: 0x%016llx\nout_end: 0x%016llx\n", (unsigned long long)in_buffer_end, (unsigned long long)out_buffer_end);
+#endif
   for (const auto &test : kXTSTestCases) {
     test_num++;
     SCOPED_TRACE(test_num);
@@ -1039,10 +1067,20 @@ TEST(XTSTest, TestVectors) {
     int len;
     uint8_t *in_p, *out_p;
   #if defined(OPENSSL_LINUX)
-    int pagesize = sysconf(_SC_PAGE_SIZE);
+    //int pagesize = sysconf(_SC_PAGE_SIZE);
     ASSERT_GE(pagesize, (int)plaintext.size());
-    in_p = get_buffer(pagesize, plaintext.size());
-    out_p = get_buffer(pagesize, plaintext.size());
+    //in_p = get_buffer(pagesize, plaintext.size());
+    //out_p = get_buffer(pagesize, plaintext.size());
+    in_p = in_buffer_end - plaintext.size();
+    out_p = out_buffer_end - plaintext.size();
+    //printf("src: 0x%016llx\ndst: 0x%016llx\n", (unsigned long long)in_p, (unsigned long long)out_p);
+    //printf("size: %zu, diff in: %ld, diff out: %ld\n", plaintext.size(), in_buffer_end - in_p, out_buffer_end - out_p);
+    //printf("prev_len: %d\n", prev_len);
+    //fflush(stdout);
+    OPENSSL_memset(in_p, 0x00, plaintext.size());
+    OPENSSL_memset(out_p, 0x00, plaintext.size());
+    //prev_len = plaintext.size();
+    //printf("prev_len after: %d\n", prev_len);
   #else
     // Use newly-allocated buffers so ASan will catch out-of-bounds reads/writes.
     // (However, I believe this only poisons prefices not suffices)
@@ -1083,13 +1121,16 @@ TEST(XTSTest, TestVectors) {
       ASSERT_TRUE(
           EVP_DecryptUpdate(ctx.get(), in_p, &len, out_p, ciphertext.size()));
       EXPECT_EQ(Bytes(plaintext), Bytes(in_p, static_cast<size_t>(len)));
-      //std::cout << "HERE HERE!";
     }
-  #if defined(OPENSSL_LINUX) && defined(NDEBUG)
+  #if 0//defined(OPENSSL_LINUX) && defined(NDEBUG)
     free_buffer(in_p, pagesize, len);
     free_buffer(out_p, pagesize, len);
   #endif
   }
+#if defined(OPENSSL_LINUX) && defined(NDEBUG)
+  free_memory(in_buffer_end, pagesize);
+  free_memory(out_buffer_end, pagesize);
+#endif
 }
 
 // Negative test for key1 = key2

--- a/crypto/fipsmodule/modes/xts_test.cc
+++ b/crypto/fipsmodule/modes/xts_test.cc
@@ -999,14 +999,18 @@ static const XTSTestCase kXTSTestCases[] = {
 
 #if defined(OPENSSL_LINUX)
 static uint8_t *get_buffer(int pagesize, int len) {
-  uint8_t *two_pages = (uint8_t *)mmap(NULL, 2*pagesize, PROT_READ|PROT_WRITE,
+  uint8_t *two_pages_p = (uint8_t *)mmap(NULL, 2*pagesize, PROT_READ|PROT_WRITE,
                                       MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
-  EXPECT_TRUE(two_pages != NULL) << "mmap returned NULL.";
+  EXPECT_TRUE(two_pages_p != NULL) << "mmap returned NULL.";
 
-  int ret = mprotect(two_pages + pagesize, pagesize, PROT_NONE);
+  int ret = mprotect(two_pages_p + pagesize, pagesize, PROT_NONE);
   EXPECT_TRUE(ret == 0) << "mprotect failed.";
 
-  return two_pages + pagesize - len;
+  return two_pages_p + pagesize - len;
+}
+
+static void free_buffer(uint8_t *addr, int pagesize, int len) {
+  munmap(addr + len - pagesize, 2 * pagesize);
 }
 #endif
 
@@ -1038,14 +1042,15 @@ TEST(XTSTest, TestVectors) {
 
     #if defined(OPENSSL_LINUX)
       int pagesize = sysconf(_SC_PAGE_SIZE);
+      ASSERT_GE(pagesize, (int)plaintext.size());
       in_p = get_buffer(pagesize, plaintext.size());
       out_p = get_buffer(pagesize, plaintext.size());
     #else
       // Use newly-allocated buffers so ASan will catch out-of-bounds reads/writes.
       // (However, I believe this only poisons prefices not suffices)
       // ASAN doesn't catch assembly overreads.
-      std::unique_ptr<uint8_t[]> in(new uint8_t[plaintext.size()+64]);
-      std::unique_ptr<uint8_t[]> out(new uint8_t[plaintext.size()+64]);
+      std::unique_ptr<uint8_t[]> in(new uint8_t[plaintext.size()]);
+      std::unique_ptr<uint8_t[]> out(new uint8_t[plaintext.size()]);
       in_p = in.get();
       out_p = out.get();
     #endif
@@ -1075,6 +1080,11 @@ TEST(XTSTest, TestVectors) {
       ASSERT_TRUE(
           EVP_DecryptUpdate(ctx.get(), in_p, &len, out_p, ciphertext.size()));
       EXPECT_EQ(Bytes(plaintext), Bytes(in_p, static_cast<size_t>(len)));
+
+      #if defined(OPENSSL_LINUX)
+      free_buffer(in_p, pagesize, len);
+      free_buffer(out_p, pagesize, len);
+      #endif
     }
   }
 }

--- a/generated-src/linux-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
@@ -3271,7 +3271,7 @@ aes_hw_xts_decrypt_avx512:
 	vmovdqu8	64(%rdi),%zmm2
 	vmovdqu8	128(%rdi),%zmm3
 	vmovdqu8	192(%rdi),%zmm4
-	vmovdqu8	240(%rdi),%zmm5
+	vmovdqu8	240(%rdi),%xmm5
 	addq	$0x100,%rdi
 	vpxorq	%zmm9,%zmm1,%zmm1
 	vpxorq	%zmm10,%zmm2,%zmm2

--- a/generated-src/mac-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
@@ -3271,7 +3271,7 @@ L$_main_loop_run_16_amivrujEyduiFoi:
 	vmovdqu8	64(%rdi),%zmm2
 	vmovdqu8	128(%rdi),%zmm3
 	vmovdqu8	192(%rdi),%zmm4
-	vmovdqu8	240(%rdi),%zmm5
+	vmovdqu8	240(%rdi),%xmm5
 	addq	$0x100,%rdi
 	vpxorq	%zmm9,%zmm1,%zmm1
 	vpxorq	%zmm10,%zmm2,%zmm2

--- a/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
@@ -3330,7 +3330,7 @@ $L$_main_loop_run_16_amivrujEyduiFoi:
 	vmovdqu8	zmm2,ZMMWORD[64+rcx]
 	vmovdqu8	zmm3,ZMMWORD[128+rcx]
 	vmovdqu8	zmm4,ZMMWORD[192+rcx]
-	vmovdqu8	zmm5,ZMMWORD[240+rcx]
+	vmovdqu8	xmm5,XMMWORD[240+rcx]
 	add	rcx,0x100
 	vpxorq	zmm1,zmm1,zmm9
 	vpxorq	zmm2,zmm2,zmm10


### PR DESCRIPTION
### Issues:
Resolves #V1681992550

### Description of changes: 
- Fix instruction that caused out-of-bound read in the input reading of the 16x loop (which processes a batch of 16 blocks of AES, 1 block = 16 bytes). This was triggered on lengths that are in the range [16*k * (16 bytes),  (16*k +3)* (16 bytes)-1], k = 1, 2, ... The instruction was reading up to 3*16 bytes beyond the input length bound.

- The fix was inspired by the 8x loop in https://github.com/aws/aws-lc/blob/becf5785c131012bb5a64f3da6cdb117ddc0f431/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl#L2544

- The existing unit tests cover those cases but there were no explicit memory protections and ASAN doesn't instrument assembly code to check for out-of-bound reads even when the contiguous memory is explicitly poisoned.
 
### Call-outs:
N/A

### Testing:
On c6i, without the fix, the unit test segfaults
```
./crypto/crypto_test "--gtest_filter=XTSTest.*"
Note: Google Test filter = XTSTest.*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from XTSTest
[ RUN      ] XTSTest.TestVectors
Segmentation fault (core dumped)
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
