### PR TITLE
Remove no-op register move from ChaCha20_ctr32_ssse3_4x

### DIFF
--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -705,7 +705,6 @@ ChaCha20_ctr32_ssse3_4x:
 	_CET_ENDBR
 	mov		%rsp,%r9		# frame pointer
 .cfi_def_cfa_register	r9
-	mov		%r10,%r11
 ___
 $code.=<<___;
 	sub		\$0x140+$xframe,%rsp

--- a/generated-src/linux-x86_64/crypto/chacha/chacha-x86_64.S
+++ b/generated-src/linux-x86_64/crypto/chacha/chacha-x86_64.S
@@ -465,7 +465,6 @@ ChaCha20_ctr32_ssse3_4x:
 _CET_ENDBR
 	movq	%rsp,%r9
 .cfi_def_cfa_register	r9
-	movq	%r10,%r11
 	subq	$0x140+8,%rsp
 	movdqa	.Lsigma(%rip),%xmm11
 	movdqu	(%rcx),%xmm15

--- a/generated-src/mac-x86_64/crypto/chacha/chacha-x86_64.S
+++ b/generated-src/mac-x86_64/crypto/chacha/chacha-x86_64.S
@@ -459,7 +459,6 @@ _ChaCha20_ctr32_ssse3_4x:
 _CET_ENDBR
 	movq	%rsp,%r9
 
-	movq	%r10,%r11
 	subq	$0x140+8,%rsp
 	movdqa	L$sigma(%rip),%xmm11
 	movdqu	(%rcx),%xmm15

--- a/generated-src/win-x86_64/crypto/chacha/chacha-x86_64.asm
+++ b/generated-src/win-x86_64/crypto/chacha/chacha-x86_64.asm
@@ -509,7 +509,6 @@ $L$SEH_begin_ChaCha20_ctr32_ssse3_4x:
 _CET_ENDBR
 	mov	r9,rsp
 
-	mov	r11,r10
 	sub	rsp,0x140+168
 	movaps	XMMWORD[(-168)+r9],xmm6
 	movaps	XMMWORD[(-152)+r9],xmm7


### PR DESCRIPTION
r11 does not have anything in it yet, and r10 is never read. This is a remnant of the ia32cap dispatch that we missed in
f5e0c8f92a22679b0cd8d24d0d670769c1cc07f3.

Bug: 673
Change-Id: I5cc179401418aee6479b4a38ae1c09f68ec40238 Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/68291
Commit-Queue: David Benjamin <davidben@google.com>
Reviewed-by: Bob Beck <bbe@google.com>
(cherry picked from commit [03d1b7c544851d9f44df1e9ff21839742e08c819](https://github.com/google/boringssl/commit/03d1b7c544851d9f44df1e9ff21839742e08c819))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.