### PR TITLE
Check pagesize is non-negative in AES-XTS test

### DIFF
--- a/crypto/fipsmodule/modes/xts_test.cc
+++ b/crypto/fipsmodule/modes/xts_test.cc
@@ -1018,6 +1018,7 @@ TEST(XTSTest, TestVectors) {
   unsigned test_num = 0;
 #if defined(OPENSSL_LINUX)
   int pagesize = sysconf(_SC_PAGE_SIZE);
+  ASSERT_GE(pagesize, 0);
   uint8_t *in_buffer_end = get_buffer_end(pagesize);
   uint8_t *out_buffer_end = get_buffer_end(pagesize);
 #endif


### PR DESCRIPTION
### Issues:
Addresses #P206132928

### Description of changes: 
Coverity signaled that pagesize is passed to `mprotect()` without ensuring it's non-negative.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
