### PR TITLE
Don't 'dllexport' Windows symbols on static build

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -147,7 +147,7 @@ extern "C" {
 #else  // defined(BORINGSSL_SHARED_LIBRARY)
 
 #if defined(OPENSSL_WINDOWS)
-#define OPENSSL_EXPORT __declspec(dllexport)
+#define OPENSSL_EXPORT
 #else
 #define OPENSSL_EXPORT __attribute__((visibility("default")))
 #endif


### PR DESCRIPTION
### Issues:
Addresses aws/aws-lc-rs#715 

### Description of changes: 
On Windows, avoid marking exported symbols with `__declspec(dllexport)` when performing a static build.

### Call-outs:
* This is a partial revert of this PR: https://github.com/aws/aws-lc/pull/466

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
