### PR TITLE
Update to using Clang 18 on Windows

### DIFF
--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -56,7 +56,7 @@ jobs:
         uses: KyleMayes/install-llvm-action@v2
         id: clang
         with:
-          version: 17
+          version: 18
           env: true
       - name: Setup CMake
         uses: threeal/cmake-action@v1.3.0


### PR DESCRIPTION
### Issues:
Addresses CI failure: https://github.com/aws/aws-lc/actions/runs/13661696749/job/38194107977?pr=2239#step:6:65
```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\yvals_core.h:927:1: error: static assertion failed: error STL1000: Unexpected compiler version, expected Clang 18.0.0 or newer.
  927 | _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 18.0.0 or newer.");
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Description of changes: 
* Use Clang v18 for `windows-latest` (i.e `windows-2025`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
