### PR TITLE
Enforce FIPS callback is only enabled for static builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -738,12 +738,17 @@ if(FIPS)
   endif()
 
   if(NOT BUILD_SHARED_LIBS AND NOT (NOT WIN32 AND NOT APPLE))
-    message(FATAL_ERROR "Static FIPS build of AWS-LC is suported only on Linux")
+    message(FATAL_ERROR "Static FIPS build of AWS-LC is supported only on Linux")
   endif()
 
   if(WIN32 AND CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
     message(FATAL_ERROR "Windows Debug build is not supported with FIPS, use Release or RelWithDebInfo")
   endif()
+
+  string(REGEX MATCH "(^| )-DAWSLC_FIPS_FAILURE_CALLBACK($| )" FIPS_CALLBACK_ENABLED "${CMAKE_C_FLAGS}")
+  if(FIPS_CALLBACK_ENABLED AND BUILD_SHARED_LIBS)
+    message(FATAL_ERROR "AWSLC_FIPS_FAILURE_CALLBACK only supported with the static library build of AWS-LC")
+  endif ()
 
   add_definitions(-DBORINGSSL_FIPS)
   if(FIPS_BREAK_TEST)

--- a/crypto/fips_callback_test.cc
+++ b/crypto/fips_callback_test.cc
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-#if defined(__ELF__) && defined(__GNUC__)
-
 #include <gtest/gtest.h>
 #include <openssl/crypto.h>
 #include <openssl/curve25519.h>
@@ -164,5 +162,3 @@ TEST(FIPSCallback, PWCT) {
   }
   EVP_PKEY_free(dsa_raw);
 }
-
-#endif

--- a/crypto/fips_callback_test.cc
+++ b/crypto/fips_callback_test.cc
@@ -13,12 +13,12 @@
 #include "internal.h"
 
 extern "C" {
-  OPENSSL_EXPORT void AWS_LC_fips_failure_callback(const char* message);
+  void AWS_LC_fips_failure_callback(const char* message);
 }
 
 int callback_call_count = 0;
 
-OPENSSL_EXPORT void AWS_LC_fips_failure_callback(const char* message) {
+void AWS_LC_fips_failure_callback(const char* message) {
   SCOPED_TRACE(callback_call_count);
   SCOPED_TRACE(message);
   const std::map<std::string, std::vector<std::string>> kat_failure_messages = {

--- a/crypto/fips_callback_test.cc
+++ b/crypto/fips_callback_test.cc
@@ -18,7 +18,7 @@ extern "C" {
 
 int callback_call_count = 0;
 
-void AWS_LC_fips_failure_callback(const char* message) {
+OPENSSL_EXPORT void AWS_LC_fips_failure_callback(const char* message) {
   SCOPED_TRACE(callback_call_count);
   SCOPED_TRACE(message);
   const std::map<std::string, std::vector<std::string>> kat_failure_messages = {

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1488,7 +1488,7 @@ TEST(ECTest, SmallGroupOrder) {
 #else
 // AWSLCAndroidTestRunner does not take tests that do |ASSERT_DEATH| very well.
 // GTEST issue: https://github.com/google/googletest/issues/1496.
-#if !defined(OPENSSL_ANDROID)
+#if !defined(OPENSSL_ANDROID) && !defined(AWSLC_FIPS_FAILURE_CALLBACK)
 
 TEST(ECDeathTest, SmallGroupOrderAndDie) {
   // Make a P-224 key and corrupt the group order to be small in order to fail

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -32,7 +32,11 @@ if static_linux_supported || static_openbsd_supported; then
   fips_build_and_test -DCMAKE_BUILD_TYPE=Release
 
   echo "Testing AWS-LC static breakable build with custom callback enabled"
-  run_build -DFIPS=1 -DCMAKE_C_FLAGS="-DBORINGSSL_FIPS_BREAK_TESTS -DAWSLC_FIPS_FAILURE_CALLBACK"
+  run_build -DFIPS=1 \
+    -DCMAKE_C_FLAGS="-DBORINGSSL_FIPS_BREAK_TESTS -DAWSLC_FIPS_FAILURE_CALLBACK" \
+    -DCMAKE_CXX_FLAGS="-DAWSLC_FIPS_FAILURE_CALLBACK" \
+    -DBUILD_LIBSSL=0
+  ./test_build_dir/crypto/crypto_test
   ./tests/ci/run_fips_callback_tests.sh
 
   echo "Testing AWS-LC static breakable release build"

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -34,8 +34,7 @@ if static_linux_supported || static_openbsd_supported; then
   echo "Testing AWS-LC static breakable build with custom callback enabled"
   run_build -DFIPS=1 \
     -DCMAKE_C_FLAGS="-DBORINGSSL_FIPS_BREAK_TESTS -DAWSLC_FIPS_FAILURE_CALLBACK" \
-    -DCMAKE_CXX_FLAGS="-DAWSLC_FIPS_FAILURE_CALLBACK" \
-    -DBUILD_LIBSSL=0
+    -DCMAKE_CXX_FLAGS="-DAWSLC_FIPS_FAILURE_CALLBACK"
   ./test_build_dir/crypto/crypto_test
   ./tests/ci/run_fips_callback_tests.sh
 

--- a/tool/tool.cc
+++ b/tool/tool.cc
@@ -32,10 +32,10 @@
 
 #if defined(AWSLC_FIPS_FAILURE_CALLBACK)
 extern "C" {
-  OPENSSL_EXPORT void AWS_LC_fips_failure_callback(const char* message);
+  void AWS_LC_fips_failure_callback(const char* message);
 }
 
-OPENSSL_EXPORT void AWS_LC_fips_failure_callback(const char* message) {
+void AWS_LC_fips_failure_callback(const char* message) {
     fprintf(stderr, "FIPS failure:\n%s", message);
 }
 #endif

--- a/tool/tool.cc
+++ b/tool/tool.cc
@@ -30,6 +30,16 @@
 
 #include "internal.h"
 
+#if defined(AWSLC_FIPS_FAILURE_CALLBACK)
+extern "C" {
+  OPENSSL_EXPORT void AWS_LC_fips_failure_callback(const char* message);
+}
+
+OPENSSL_EXPORT void AWS_LC_fips_failure_callback(const char* message) {
+    fprintf(stderr, "FIPS failure:\n%s", message);
+}
+#endif
+
 static bool version(const std::vector<std::string> &args) {
   printf("%s\n", AWSLC_VERSION_NUMBER_STRING);
   return true;


### PR DESCRIPTION
### Description of changes: 
Due to how shared libraries and applications load it's not possible for an application to dynamically link with AWS-LC and define it's own custom callback before AWS-LC's constructor runs which expects the callback to be defined. This change requires anyone expecting to build with the callback to statically build and link AWS-LC so their callback is defined before AWS-LC's constructor runs. 

This change also enables the call_back_test to run all the time, this test can run on any platform, platforms that don't support the callback will get the default (abort) behavior. 

This change also disables one death test if the callback is defined. Because the callback doesn't call abort the test fails. 

### Testing:
Update a test dimension to enable the callback and just run the tests like normal to ensure everything passes. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
