### PR TITLE
Lower-case internal function names and correct env variable

### DIFF
--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -357,7 +357,7 @@ static void rand_state_initialize(struct rand_thread_local_state *state) {
 // |RAND_USE_USER_PRED_RESISTANCE| or |RAND_NO_USER_PRED_RESISTANCE|. The former
 // cause the content of |user_pred_resistance| to be mixed in as prediction
 // resistance. The latter ensures that |user_pred_resistance| is not used.
-static void RAND_bytes_core(
+static void rand_bytes_core(
   struct rand_thread_local_state *state,
   uint8_t *out, size_t out_len,
   const uint8_t user_pred_resistance[RAND_PRED_RESISTANCE_LEN],
@@ -464,7 +464,7 @@ static void RAND_bytes_core(
   CRYPTO_MUTEX_unlock_read(&state->state_clear_lock);
 }
 
-static void RAND_bytes_private(uint8_t *out, size_t out_len,
+static void rand_bytes_private(uint8_t *out, size_t out_len,
   const uint8_t user_pred_resistance[RAND_PRED_RESISTANCE_LEN],
   int use_user_pred_resistance) {
 
@@ -491,7 +491,7 @@ static void RAND_bytes_private(uint8_t *out, size_t out_len,
     thread_local_list_add_node(state);
   }
 
-  RAND_bytes_core(state, out, out_len, user_pred_resistance,
+  rand_bytes_core(state, out, out_len, user_pred_resistance,
     use_user_pred_resistance);
 
   FIPS_service_indicator_unlock_state();
@@ -501,7 +501,7 @@ static void RAND_bytes_private(uint8_t *out, size_t out_len,
 int RAND_bytes_with_user_prediction_resistance(uint8_t *out, size_t out_len,
   const uint8_t user_pred_resistance[RAND_PRED_RESISTANCE_LEN]) {
   
-  RAND_bytes_private(out, out_len, user_pred_resistance,
+  rand_bytes_private(out, out_len, user_pred_resistance,
     RAND_USE_USER_PRED_RESISTANCE);
   return 1;
 }
@@ -509,7 +509,7 @@ int RAND_bytes_with_user_prediction_resistance(uint8_t *out, size_t out_len,
 int RAND_bytes(uint8_t *out, size_t out_len) {
 
   static const uint8_t kZeroPredResistance[RAND_PRED_RESISTANCE_LEN] = {0};
-  RAND_bytes_private(out, out_len, kZeroPredResistance,
+  rand_bytes_private(out, out_len, kZeroPredResistance,
     RAND_NO_USER_PRED_RESISTANCE);
   return 1;
 }

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -87,7 +87,8 @@
   },
   {
     "comment": "Run RAND test suite without fork detection",
-    "cmd": ["crypto/crypto_test", "BORINGSSL_IGNORE_FORK_DETECTION=1", "--gtest_filter=RandTest.*:-RandTest.Fork"],
+    "cmd": ["crypto/crypto_test", "--gtest_filter=RandTest.*:-RandTest.Fork"],
+    "env": ["BORINGSSL_IGNORE_FORK_DETECTION=1"],
     "skip_valgrind": true
   },
   {


### PR DESCRIPTION
### Description of changes: 

Use lower-case for internal function  names and set env variables to the env variable field.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
