### PR TITLE
Add public wrapper to internal bn_minimal_width function

### DIFF
--- a/crypto/fipsmodule/bn/bn.c
+++ b/crypto/fipsmodule/bn/bn.c
@@ -231,6 +231,10 @@ unsigned BN_num_bytes(const BIGNUM *bn) {
   return (BN_num_bits(bn) + 7) / 8;
 }
 
+int BN_get_minimal_width(const BIGNUM *bn) {
+  return bn_minimal_width(bn);
+}
+
 void BN_zero(BIGNUM *bn) {
   bn->width = bn->neg = 0;
 }

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -222,6 +222,10 @@ OPENSSL_EXPORT unsigned BN_num_bits(const BIGNUM *bn);
 // will always fit in |int|.
 OPENSSL_EXPORT unsigned BN_num_bytes(const BIGNUM *bn);
 
+// BN_get_minimal_width returns the minimal number of words needed to represent
+// |bn|.
+OPENSSL_EXPORT int BN_get_minimal_width(const BIGNUM *bn);
+
 // BN_zero sets |bn| to zero.
 OPENSSL_EXPORT void BN_zero(BIGNUM *bn);
 


### PR DESCRIPTION
### Description of changes: 
This PR adds a public wrapper for an existing internal function bn_minimal_width. OpenSSL stores the minimal number of words needed in a field called top within the bignum struct. AWS-LC does not do this, instead we have a field called width which is a loose upper bound on this value. The new function, BN_get_minimal_width will provide us with the value of "top" for a given Bignum. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
