### PR TITLE
Make BIO_get_mem_data a function again

### DIFF
--- a/crypto/bio/bio_mem.c
+++ b/crypto/bio/bio_mem.c
@@ -296,6 +296,10 @@ int BIO_mem_contents(const BIO *bio, const uint8_t **out_contents,
   return 1;
 }
 
+long BIO_get_mem_data(BIO *bio, char **contents) {
+  return BIO_ctrl(bio, BIO_CTRL_INFO, 0, contents);
+}
+
 int BIO_get_mem_ptr(BIO *bio, BUF_MEM **out) {
   return (int)BIO_ctrl(bio, BIO_C_GET_BUF_MEM_PTR, 0, out);
 }

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -454,8 +454,8 @@ OPENSSL_EXPORT int BIO_mem_contents(const BIO *bio,
 // WARNING: don't use this, use |BIO_mem_contents|. A negative return value
 // or zero from this function can mean either that it failed or that the
 // memory buffer is empty.
-#define BIO_get_mem_data(bio, contents) BIO_ctrl(bio, BIO_CTRL_INFO, 0, \
-                                                (char *)(contents))
+OPENSSL_EXPORT long BIO_get_mem_data(BIO *bio, char **contents);
+
 // BIO_get_mem_ptr sets |*out| to a BUF_MEM containing the current contents of
 // |bio|. It returns one on success or zero on error.
 OPENSSL_EXPORT int BIO_get_mem_ptr(BIO *bio, BUF_MEM **out);


### PR DESCRIPTION
### Description of changes: 
Can't track it down the historical reason why, but we have `BIO_get_mem_data` defined as a preprocessor macro, but BoringSSL does not. This creates an annoying compatibility issue for rust-openssl, and has forced us to implement the function properly in our aws-lc-sys crates in Rust. This redefines the function to have a concrete definition.

As a side-note, the macro was technically wrong as it was casting contents to a `char *` when it was actually `char **`, but this wasn't problematic per-se since it was being passed into a `void *` argument. If you look at the ctrl function definition you can see that it is indeed treated as a `char **` pointer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
