### PR TITLE
Prepare for release v.1.48.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.47.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.48.0");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.47.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.48.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.47.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.48.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
https://github.com/aws/aws-lc/releases/edit/untagged-aef9ee5aee62c3242f30

## What's Changed
* Remove BORINGSSL_FIPS_BREAK_FFC_DH by @andrewhop in https://github.com/aws/aws-lc/pull/2216
* Increase required CMake version to 3.5 by @andrewhop in https://github.com/aws/aws-lc/pull/2219
* Coverity Fix by @smittals2 in https://github.com/aws/aws-lc/pull/2236
* Check pagesize is non-negative in AES-XTS test by @nebeid in https://github.com/aws/aws-lc/pull/2237
* Don't 'dllexport' Windows symbols on static build by @justsmth in https://github.com/aws/aws-lc/pull/2238
* Update to using Clang 18 on Windows by @justsmth in https://github.com/aws/aws-lc/pull/2240
* Enforce FIPS callback is only enabled for static builds by @andrewhop in https://github.com/aws/aws-lc/pull/2241


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
