### PR TITLE
Remove unused CMake options for break tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,9 +751,6 @@ if(FIPS)
   endif ()
 
   add_definitions(-DBORINGSSL_FIPS)
-  if(FIPS_BREAK_TEST)
-    add_definitions("-DBORINGSSL_FIPS_BREAK_${FIPS_BREAK_TEST}=1")
-  endif()
   # The FIPS integrity check does not work for ASan and MSan builds.
   if(NOT ASAN AND NOT MSAN)
     if(BUILD_SHARED_LIBS)

--- a/crypto/fipsmodule/FIPS.md
+++ b/crypto/fipsmodule/FIPS.md
@@ -39,7 +39,7 @@ The AWS-LC-FIPS v2.0 module uses passive entropy by default and the specific ent
 
 ## Breaking known-answer and continuous tests
 
-Each known-answer test (KAT) uses a unique, random input value. `util/fipstools/break-kat.go` contains a listing of those values and can be used to corrupt a given test in a binary. Since changes to the KAT input values will invalidate the integrity test, `BORINGSSL_FIPS_BREAK_TESTS` can be defined in `fips_break_tests.h` to disable it for the purposes of testing.
+Each known-answer test (KAT) uses a unique, random input value. `util/fipstools/break-kat.go` contains a listing of those values and can be used to corrupt a given test in a binary. Since changes to the KAT input values will invalidate the integrity test, `BORINGSSL_FIPS_BREAK_TESTS` can be defined using CMake CMAKE_C_FLAGS to disable it for the purposes of testing.
 
 Some FIPS tests cannot be broken by replacing a known string in the binary. For those, when `BORINGSSL_FIPS_BREAK_TESTS` is defined, the environment variable `BORINGSSL_FIPS_BREAK_TEST` can be set to one of a number of values in order to break the corresponding test:
 


### PR DESCRIPTION
### Description of changes: 
Setting the CMake option FIPS_BREAK_TEST to something like FFC_DH would result in defining `BORINGSSL_FIPS_BREAK_FFC_DH=1` which used to be how the break tests were broken. break-kat.go replaced all of that and all the code using the definitions were removed. https://github.com/aws/aws-lc/commit/913af96d029e0c80e8d573af6ddbbfd798ed98c5 removed the last legacy usage of it.

The correct way to test breaking AWS-LC is outlined in FIPS.md:
1. Compile with `BORINGSSL_FIPS_BREAK_TESTS` defined
2. Run break-kat.go to break a certain CAST

This also removes the note about fips_break_tests.h since that file doesn't exist anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
