### PR TITLE
Update EVP_PKEY ED keygen to use an internal function that can return the result of the PWCT

### DIFF
--- a/crypto/fipsmodule/curve25519/curve25519.c
+++ b/crypto/fipsmodule/curve25519/curve25519.c
@@ -32,6 +32,12 @@
 #include "../cpucap/internal.h"
 #include "internal.h"
 
+#if defined(NDEBUG)
+#define CHECK(x) (void) (x)
+#else
+#define CHECK(x) assert(x)
+#endif
+
 const uint8_t RFC8032_DOM2_PREFIX[DOM2_PREFIX_SIZE] = {
     'S', 'i', 'g', 'E', 'd', '2', '5', '5', '1', '9', ' ',
     'n', 'o', ' ', 'E', 'd', '2', '5', '5', '1', '9', ' ',
@@ -166,7 +172,7 @@ void ED25519_keypair(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
   // The existing public function is void, ED25519_keypair_internal can only
   // fail if the PWCT fails and we're in a callback build where AWS_LC_FIPS_failure
   // doesn't abort on FIPS failure.
-  assert(ED25519_keypair_internal(out_public_key, out_private_key));
+  CHECK(ED25519_keypair_internal(out_public_key, out_private_key));
 }
 
 int ED25519_sign(uint8_t out_sig[ED25519_SIGNATURE_LEN],

--- a/crypto/fipsmodule/curve25519/curve25519.c
+++ b/crypto/fipsmodule/curve25519/curve25519.c
@@ -112,7 +112,7 @@ void ED25519_keypair_from_seed(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
     ED25519_PUBLIC_KEY_LEN);
 }
 
-static void ed25519_keypair_pct(uint8_t public_key[ED25519_PUBLIC_KEY_LEN],
+static int ed25519_keypair_pct(uint8_t public_key[ED25519_PUBLIC_KEY_LEN],
   uint8_t private_key[ED25519_PRIVATE_KEY_LEN]) {
 #if defined(AWSLC_FIPS)
   uint8_t msg[16] = {16};
@@ -121,17 +121,20 @@ static void ed25519_keypair_pct(uint8_t public_key[ED25519_PUBLIC_KEY_LEN],
     // This should never happen and static analysis will say that ED25519_sign_no_self_test
     // always returns 1
     AWS_LC_FIPS_failure("Ed25519 keygen PCT failed");
+    return 0;
   }
   if (boringssl_fips_break_test("EDDSA_PWCT")) {
     msg[0] = ~msg[0];
   }
   if (ED25519_verify_no_self_test(msg, 16, out_sig, public_key) != 1) {
     AWS_LC_FIPS_failure("Ed25519 keygen PCT failed");
+    return 0;
   }
 #endif
+  return 1;
 }
 
-void ED25519_keypair(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
+int ED25519_keypair_internal(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
   uint8_t out_private_key[ED25519_PRIVATE_KEY_LEN]) {
   // We have to avoid the self tests and digest function in ed25519_keypair_pct
   // from updating the service indicator.
@@ -149,10 +152,21 @@ void ED25519_keypair(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
   ED25519_keypair_from_seed(out_public_key, out_private_key, seed);
   OPENSSL_cleanse(seed, ED25519_SEED_LEN);
 
-  ed25519_keypair_pct(out_public_key, out_private_key);
+  int result = ed25519_keypair_pct(out_public_key, out_private_key);
 
   FIPS_service_indicator_unlock_state();
-  FIPS_service_indicator_update_state();
+  if (result) {
+    FIPS_service_indicator_update_state();
+  }
+  return result;
+}
+
+void ED25519_keypair(uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
+  uint8_t out_private_key[ED25519_PRIVATE_KEY_LEN]) {
+  // The existing public function is void, ED25519_keypair_internal can only
+  // fail if the PWCT fails and we're in a callback build where AWS_LC_FIPS_failure
+  // doesn't abort on FIPS failure.
+  assert(ED25519_keypair_internal(out_public_key, out_private_key));
 }
 
 int ED25519_sign(uint8_t out_sig[ED25519_SIGNATURE_LEN],

--- a/crypto/fipsmodule/curve25519/internal.h
+++ b/crypto/fipsmodule/curve25519/internal.h
@@ -40,6 +40,10 @@ typedef enum {
 #define MAX_DOM2_SIZE \
   (DOM2_PREFIX_SIZE + DOM2_F_SIZE + DOM2_C_SIZE + MAX_DOM2_CONTEXT_SIZE)
 
+int ED25519_keypair_internal(
+    uint8_t out_public_key[ED25519_PUBLIC_KEY_LEN],
+    uint8_t out_private_key[ED25519_PRIVATE_KEY_LEN]);
+
 int ed25519_sign_internal(
     ed25519_algorithm_t alg,
     uint8_t out_sig[ED25519_SIGNATURE_LEN],

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -5,6 +5,7 @@
 set -exo pipefail
 
 source tests/ci/common_posix_setup.sh
+source tests/ci/gtest_util.sh
 
 function static_linux_supported() {
   if [[ ("$(uname -s)" == 'Linux'*) && (("$(uname -p)" == 'x86_64'*) || ("$(uname -p)" == 'aarch64'*)) ]]; then
@@ -35,7 +36,7 @@ if static_linux_supported || static_openbsd_supported; then
   run_build -DFIPS=1 \
     -DCMAKE_C_FLAGS="-DBORINGSSL_FIPS_BREAK_TESTS -DAWSLC_FIPS_FAILURE_CALLBACK" \
     -DCMAKE_CXX_FLAGS="-DAWSLC_FIPS_FAILURE_CALLBACK"
-  ./test_build_dir/crypto/crypto_test
+  shard_gtest ./test_build_dir/crypto/crypto_test
   ./tests/ci/run_fips_callback_tests.sh
 
   echo "Testing AWS-LC static breakable release build"


### PR DESCRIPTION
### Description of changes: 
`ED25519_keypair` has always been void, this used to be okay because it was infallible. Now it can fail due to the PWCT failing. Usually if that happened the process would abort which is the default (and only approved) behavior of `AWS_LC_FIPS_failure`. However, if AWS-LC is built with the callback and that callback doesn't abort it is possible for `EVP_PKEY_keygen` to continue. Changes:
 * `EVP_PKEY_keygen` now detects this failure and return the error to the caller
 * `ED25519_keypair` doesn't increment the service indicator if the PWCT fails

### Testing:
I updated the fips_callback_test to use the EVP API for ED and check the return value

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
