### PR TITLE
Use unsigned return type for BN_get_minimal_width and word size tests

### DIFF
--- a/crypto/fipsmodule/bn/bn.c
+++ b/crypto/fipsmodule/bn/bn.c
@@ -218,6 +218,11 @@ unsigned BN_num_bits_word(BN_ULONG l) {
   return bits;
 }
 
+// |BN_num_bits| and |BN_num_bytes| return ints in OpenSSL. In theory, a swap
+// from OpenSSL to AWS-LC is not type-safe. However, in practice, the bit length
+// should be representable by a int due to |BN_MAX_WORDS|. The maximum bit size
+// of a BIGNUM is right-shifted by 2. If bit-sizes can be
+// represented by an int, so the byte/word size.
 unsigned BN_num_bits(const BIGNUM *bn) {
   const int width = bn_minimal_width(bn);
   if (width == 0) {
@@ -231,7 +236,7 @@ unsigned BN_num_bytes(const BIGNUM *bn) {
   return (BN_num_bits(bn) + 7) / 8;
 }
 
-int BN_get_minimal_width(const BIGNUM *bn) {
+unsigned BN_get_minimal_width(const BIGNUM *bn) {
   return bn_minimal_width(bn);
 }
 

--- a/crypto/fipsmodule/bn/bn.c
+++ b/crypto/fipsmodule/bn/bn.c
@@ -236,7 +236,9 @@ unsigned BN_num_bytes(const BIGNUM *bn) {
   return (BN_num_bits(bn) + 7) / 8;
 }
 
-unsigned BN_get_minimal_width(const BIGNUM *bn) {
+// ibmtpm performs a direct check of output to a signed value. This won't work
+// if below returns an unsigned value. Hence, the int return type.
+int BN_get_minimal_width(const BIGNUM *bn) {
   return bn_minimal_width(bn);
 }
 

--- a/crypto/fipsmodule/bn/bn_test.cc
+++ b/crypto/fipsmodule/bn/bn_test.cc
@@ -2679,6 +2679,7 @@ TEST_F(BNTest, NonMinimal) {
 
     EXPECT_EQ(4u, BN_num_bits(ten.get()));
     EXPECT_EQ(1u, BN_num_bytes(ten.get()));
+    EXPECT_EQ(1u, BN_get_minimal_width(ten.get()));
     EXPECT_FALSE(BN_is_pow2(ten.get()));
 
     bssl::UniquePtr<char> hex(BN_bn2hex(ten.get()));
@@ -2877,6 +2878,68 @@ TEST_F(BNTest, FormatWord) {
   snprintf(buf, sizeof(buf), BN_HEX_FMT2, std::numeric_limits<BN_ULONG>::max());
   EXPECT_STREQ(buf, "ffffffff");
 #endif
+}
+
+TEST_F(BNTest, GetMinimalWidth) {
+  bssl::UniquePtr<BIGNUM> bn(BN_new());
+  ASSERT_TRUE(bn);
+
+  // Zero needs 0 words
+  BN_zero(bn.get());
+  EXPECT_EQ(0u, BN_get_minimal_width(bn.get()));
+
+  // 1 needs 1 word
+  ASSERT_TRUE(BN_one(bn.get()));
+  EXPECT_EQ(1u, BN_get_minimal_width(bn.get()));
+
+  // Test negative numbers
+  ASSERT_TRUE(BN_set_word(bn.get(), 1));
+  BN_set_negative(bn.get(), 1);
+  EXPECT_EQ(1u, BN_get_minimal_width(bn.get()));
+
+  // Test powers of two
+  ASSERT_TRUE(BN_set_word(bn.get(), 1));
+  for (size_t i = 0; i < 256; i++) {
+    // For 2^i, we need ceil((i+1)/BN_BITS2) words
+    unsigned expected_words = (i + BN_BITS2) / BN_BITS2;
+    EXPECT_EQ(expected_words, BN_get_minimal_width(bn.get()))
+        << "Failed for 2^" << i;
+    ASSERT_TRUE(BN_lshift1(bn.get(), bn.get()));
+  }
+
+  // Test values near word boundaries
+  // For 32-bit: word = 32 bits
+  // For 64-bit: word = 64 bits
+  struct {
+    const char* hex;
+    unsigned expected_32bit;
+    unsigned expected_64bit;
+  } kTests[] = {
+    // 8-bit number
+    {"ff", 1, 1},
+    // 32-bit number
+    {"ffffffff", 1, 1},
+    // 33-bit number
+    {"100000000", 2, 1},
+    // 64-bit number
+    {"ffffffff00000000", 2, 1},
+    // 64-bit number
+    {"ffffffffffffffff", 2, 1},
+    // 65-bit number
+    {"10000000000000000", 3, 2},
+    // Multiple word number
+    {"ffffffffffffffffffffffffffffffff", 4, 2},
+  };
+
+  for (const auto& test : kTests) {
+    SCOPED_TRACE(test.hex);
+    HexToBIGNUM(&bn, test.hex);
+#if defined(OPENSSL_32_BIT)
+    EXPECT_EQ(test.expected_32bit, BN_get_minimal_width(bn.get()));
+#elif defined(OPENSSL_64_BIT)
+    EXPECT_EQ(test.expected_64bit, BN_get_minimal_width(bn.get()));
+#endif
+  }
 }
 
 #if defined(OPENSSL_BN_ASM_MONT) && defined(SUPPORTS_ABI_TEST)

--- a/crypto/fipsmodule/bn/bn_test.cc
+++ b/crypto/fipsmodule/bn/bn_test.cc
@@ -2679,7 +2679,6 @@ TEST_F(BNTest, NonMinimal) {
 
     EXPECT_EQ(4u, BN_num_bits(ten.get()));
     EXPECT_EQ(1u, BN_num_bytes(ten.get()));
-    EXPECT_EQ(1u, BN_get_minimal_width(ten.get()));
     EXPECT_FALSE(BN_is_pow2(ten.get()));
 
     bssl::UniquePtr<char> hex(BN_bn2hex(ten.get()));
@@ -2886,22 +2885,22 @@ TEST_F(BNTest, GetMinimalWidth) {
 
   // Zero needs 0 words
   BN_zero(bn.get());
-  EXPECT_EQ(0u, BN_get_minimal_width(bn.get()));
+  EXPECT_EQ(0, BN_get_minimal_width(bn.get()));
 
   // 1 needs 1 word
   ASSERT_TRUE(BN_one(bn.get()));
-  EXPECT_EQ(1u, BN_get_minimal_width(bn.get()));
+  EXPECT_EQ(1, BN_get_minimal_width(bn.get()));
 
   // Test negative numbers
   ASSERT_TRUE(BN_set_word(bn.get(), 1));
   BN_set_negative(bn.get(), 1);
-  EXPECT_EQ(1u, BN_get_minimal_width(bn.get()));
+  EXPECT_EQ(1, BN_get_minimal_width(bn.get()));
 
   // Test powers of two
   ASSERT_TRUE(BN_set_word(bn.get(), 1));
   for (size_t i = 0; i < 256; i++) {
     // For 2^i, we need ceil((i+1)/BN_BITS2) words
-    unsigned expected_words = (i + BN_BITS2) / BN_BITS2;
+    int expected_words = (i + BN_BITS2) / BN_BITS2;
     EXPECT_EQ(expected_words, BN_get_minimal_width(bn.get()))
         << "Failed for 2^" << i;
     ASSERT_TRUE(BN_lshift1(bn.get(), bn.get()));
@@ -2912,8 +2911,8 @@ TEST_F(BNTest, GetMinimalWidth) {
   // For 64-bit: word = 64 bits
   struct {
     const char* hex;
-    unsigned expected_32bit;
-    unsigned expected_64bit;
+    int expected_32bit;
+    int expected_64bit;
   } kTests[] = {
     // 8-bit number
     {"ff", 1, 1},

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -223,8 +223,8 @@ OPENSSL_EXPORT unsigned BN_num_bits(const BIGNUM *bn);
 OPENSSL_EXPORT unsigned BN_num_bytes(const BIGNUM *bn);
 
 // BN_get_minimal_width returns the minimal number of words needed to represent
-// |bn|.
-OPENSSL_EXPORT int BN_get_minimal_width(const BIGNUM *bn);
+// |bn|. This function can leak the size of the value encoded in |BN|.
+OPENSSL_EXPORT unsigned BN_get_minimal_width(const BIGNUM *bn);
 
 // BN_zero sets |bn| to zero.
 OPENSSL_EXPORT void BN_zero(BIGNUM *bn);

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -224,7 +224,7 @@ OPENSSL_EXPORT unsigned BN_num_bytes(const BIGNUM *bn);
 
 // BN_get_minimal_width returns the minimal number of words needed to represent
 // |bn|. This function can leak the size of the value encoded in |BN|.
-OPENSSL_EXPORT unsigned BN_get_minimal_width(const BIGNUM *bn);
+OPENSSL_EXPORT int BN_get_minimal_width(const BIGNUM *bn);
 
 // BN_zero sets |bn| to zero.
 OPENSSL_EXPORT void BN_zero(BIGNUM *bn);


### PR DESCRIPTION
### Description of changes: 

Return type of `BN_get_minimal_width()` should probably be `unsigned` as the rest of the size return functions. Take the opportunity to improve testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
