### PR TITLE
Revert BIO_get_mem_data back to macro

### DIFF
--- a/crypto/bio/bio_mem.c
+++ b/crypto/bio/bio_mem.c
@@ -296,10 +296,6 @@ int BIO_mem_contents(const BIO *bio, const uint8_t **out_contents,
   return 1;
 }
 
-long BIO_get_mem_data(BIO *bio, char **contents) {
-  return BIO_ctrl(bio, BIO_CTRL_INFO, 0, contents);
-}
-
 int BIO_get_mem_ptr(BIO *bio, BUF_MEM **out) {
   return (int)BIO_ctrl(bio, BIO_C_GET_BUF_MEM_PTR, 0, out);
 }

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -1381,3 +1381,20 @@ TEST(BIOTest, TestCtrlCallback) {
   bio_callback_cleanup();
   ASSERT_EQ(BIO_free(bio), 1);
 }
+
+TEST(BIOTest, GetMemDataBackwardsCompat) {
+  bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
+  ASSERT_TRUE(bio);
+
+  const uint8_t contents[] = {0x72, 0x61, 0x63, 0x63, 0x6f, 0x6f, 0x6e};
+
+  // Write some test data
+  int write_len = BIO_write(bio.get(), contents, sizeof(contents));
+  ASSERT_EQ(sizeof(contents), (size_t)write_len);
+
+  // Yes, this is something gRPC does
+  const uint8_t *ptr = NULL;
+  long data_len = BIO_get_mem_data(bio.get(), &ptr);
+  ASSERT_EQ((size_t)data_len, sizeof(contents));
+  EXPECT_EQ(Bytes(contents, sizeof(contents)), Bytes(ptr, data_len));
+}

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.48.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.48.2");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.48.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.48.2");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.48.1"
+#define AWSLC_VERSION_NUMBER_STRING "1.48.2"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -454,8 +454,8 @@ OPENSSL_EXPORT int BIO_mem_contents(const BIO *bio,
 // WARNING: don't use this, use |BIO_mem_contents|. A negative return value
 // or zero from this function can mean either that it failed or that the
 // memory buffer is empty.
-OPENSSL_EXPORT long BIO_get_mem_data(BIO *bio, char **contents);
-
+#define BIO_get_mem_data(bio, contents) BIO_ctrl(bio, BIO_CTRL_INFO, 0, \
+                                                (char *)(contents))
 // BIO_get_mem_ptr sets |*out| to a BUF_MEM containing the current contents of
 // |bio|. It returns one on success or zero on error.
 OPENSSL_EXPORT int BIO_get_mem_ptr(BIO *bio, BUF_MEM **out);


### PR DESCRIPTION
### Call-outs:
* Reverts https://github.com/aws/aws-lc/commit/5826a075e6186ff85c4383b8f0e051d50783cc2c
* New release v1.48.2

### Testing:
* Added a test for this going-forward.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
