### PR TITLE
Fix aws-lc-rs CI test when symbols removed

### DIFF
--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -52,6 +52,11 @@ jobs:
         working-directory: ./aws-lc-rs
         run: |
           cargo test -p aws-lc-sys --features bindgen
+      - name: Delete current symbol files and headers
+        working-directory: ./aws-lc-rs
+        run: |
+          rm -rf ./aws-lc-sys/symbols/* ./aws-lc-sys/generated-include/*
+          mkdir -p ./aws-lc-sys/symbols ./aws-lc-sys/generated-include/openssl
       - name: Collect symbols
         working-directory: ./aws-lc-rs
         run: |


### PR DESCRIPTION
### Description of changes: 
* CI tests are failing when symbol are migrated to being macros due to the symbols still being listed in the symbol files.
* This change ensures that the symbol files and headers are deleted prior to their regeneration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
