### PR TITLE
s2n-bignum build should use boringssl_prefix_symbols_asm.h

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -320,13 +320,13 @@ function(s2n_asm_cpreprocess dest src)
   string(REGEX REPLACE "[ ]+" ";" CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS}")
 
   if(BORINGSSL_PREFIX)
-    set(S2N_BIGNUM_PREFIX_INCLUDE "--include=${AWSLC_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h")
+    set(S2N_BIGNUM_PREFIX_INCLUDE "--include=${AWSLC_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h")
   endif()
 
   add_custom_command(
           OUTPUT ${dest}
           COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
-          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${S2N_BIGNUM_DIR}/${src} -I${S2N_BIGNUM_INCLUDE_DIR} ${S2N_BIGNUM_PREFIX_INCLUDE} -DS2N_BN_HIDE_SYMBOLS | tr \"\;\" \"\\n\" > ${dest}
+          COMMAND ${CMAKE_ASM_COMPILER} ${TARGET} ${CMAKE_ASM_FLAGS} -E ${S2N_BIGNUM_DIR}/${src} -I${AWSLC_BINARY_DIR}/symbol_prefix_include -I${S2N_BIGNUM_INCLUDE_DIR} ${S2N_BIGNUM_PREFIX_INCLUDE} -DS2N_BN_HIDE_SYMBOLS | tr \"\;\" \"\\n\" > ${dest}
           DEPENDS
           ${S2N_BIGNUM_DIR}/${src}
           WORKING_DIRECTORY .


### PR DESCRIPTION
### Related:
* https://github.com/aws/aws-lc-rs/pull/729

### Description of changes: 
MacOS assembly required the use of `boringssl_prefix_symbols_asm.h`

### Call-outs:
* For other platforms this is [equivalent to `boringssl_prefix_symbols.h`](https://github.com/aws/aws-lc-rs/blob/main/aws-lc-sys/generated-include/openssl/boringssl_prefix_symbols_asm.h#L15-L17)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
