### PR TITLE
Prepare v1.48.3

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.48.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.48.3");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.48.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.48.3");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.48.2"
+#define AWSLC_VERSION_NUMBER_STRING "1.48.3"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Use unsigned return type for BN_get_minimal_width and word size tests by @torben-hansen in https://github.com/aws/aws-lc/pull/2260
* Revert removal of "PEM_X509_INFO_write_bio" by @smittals2 in https://github.com/aws/aws-lc/pull/2226
* Remove no-op register move from ChaCha20_ctr32_ssse3_4x by @nebeid in https://github.com/aws/aws-lc/pull/2234
* Fix aws-lc-rs CI test when symbols removed by @justsmth in https://github.com/aws/aws-lc/pull/2262
* Add x4 batched SHAKE128 and SHAKE256 APIs by @manastasova in https://github.com/aws/aws-lc/pull/2247
* Fix aws-lc-rs CI test (again) by @justsmth in https://github.com/aws/aws-lc/pull/2268
* Minor build fixes for CMake and libssl on x86 by @skmcgrail in https://github.com/aws/aws-lc/pull/2267

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
