### PR TITLE
Update shard_gtest to unset environment variables once all the tests are done

### DIFF
--- a/crypto/fips_callback_test.cc
+++ b/crypto/fips_callback_test.cc
@@ -147,7 +147,6 @@ TEST(FIPSCallback, PWCT) {
   ASSERT_TRUE(ed_ctx);
   EXPECT_TRUE(EVP_PKEY_keygen_init(ed_ctx.get()));
   EVP_PKEY *ed_key = nullptr;
-  EXPECT_TRUE(EVP_PKEY_keygen(ed_ctx.get(), &ed_key));
   if (broken_runtime_test != nullptr && strcmp(broken_runtime_test, "EDDSA_PWCT" ) == 0) {
     EXPECT_FALSE(EVP_PKEY_keygen(ed_ctx.get(), &ed_key));
   } else {

--- a/tests/ci/gtest_util.sh
+++ b/tests/ci/gtest_util.sh
@@ -26,5 +26,7 @@ function shard_gtest() {
           RESULT=${?}
         fi
     done
+    unset GTEST_SHARD_INDEX
+    unset GTEST_TOTAL_SHARDS
     return $RESULT
 }


### PR DESCRIPTION
### Issues:
Resolves q/2qabAwnLeC09

### Description of changes: 
Previously shard_gtest left GTEST_SHARD_INDEX and GTEST_TOTAL_SHARDS defined. Any future gtest executable that ran after shard_gtest would re-use those values and potentially skip tests in other shards besides the last one.

Identified in https://github.com/aws/aws-lc/pull/2266/files#r1993474700.

### Testing:
Previously fips_callback_test should have failed but was incorrectly skipping tests. Now the tests are running and this change fixes one issue. EVP_PKEY_keygen for ED might fail if EDDSA_PWCT is set, so keygen should only be called inside the if block to check for the correct result.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
