### PR TITLE
Prepare for release v.1.48.4

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.48.3");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.48.4");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.48.3");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.48.4");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.48.3"
+#define AWSLC_VERSION_NUMBER_STRING "1.48.4"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
https://github.com/aws/aws-lc/releases/edit/untagged-64078f9fa7b969a1a3e7

## What's Changed
* Make AWS_LC_fips_failure_callback optional in builds with AWSLC_FIPS_FAILURE_CALLBACK by @andrewhop in https://github.com/aws/aws-lc/pull/2266


**Full Changelog**: https://github.com/aws/aws-lc/compare/v1.48.3...v1.48.4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
