### PR TITLE
Add support for more SSL BIO functions

### DIFF
--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -1035,6 +1035,7 @@ struct bio_st {
 #define BIO_C_GET_FILE_PTR 107
 #define BIO_C_SET_FILENAME 108
 #define BIO_C_SET_SSL 109
+#define BIO_C_GET_SSL 110
 #define BIO_C_SET_MD 111
 #define BIO_C_GET_MD 112
 #define BIO_C_GET_CIPHER_STATUS 113

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5112,6 +5112,34 @@ OPENSSL_EXPORT int SSL_CTX_sess_timeouts(const SSL_CTX *ctx);
 OPENSSL_EXPORT int SSL_CTX_sess_cache_full(const SSL_CTX *ctx);
 
 
+// SSL BIO methods
+
+// BIO_f_ssl returns a |BIO_METHOD| that can wrap an |SSL*| in a |BIO*|. Note
+// that this has quite different behaviour from the version in OpenSSL (notably
+// that it doesn't try to auto renegotiate).
+//
+// IMPORTANT: if you are not curl, don't use this.
+OPENSSL_EXPORT const BIO_METHOD *BIO_f_ssl(void);
+
+// BIO_set_ssl sets |ssl| as the underlying connection for |bio|, which must
+// have been created using |BIO_f_ssl|. If |take_owership| is true, |bio| will
+// call |SSL_free| on |ssl| when closed. It returns one on success or something
+// other than one on error.
+OPENSSL_EXPORT long BIO_set_ssl(BIO *bio, SSL *ssl, int take_owership);
+
+// BIO_get_ssl assigns the internal |SSL| of |bio| to |*ssl|. |*ssl| should
+// not be freed. It returns one on success or something other than one on error.
+OPENSSL_EXPORT long BIO_get_ssl(BIO *bio, SSL **ssl);
+
+// BIO_new_ssl_connect uses |ctx| to return a newly allocated BIO chain with
+// |BIO_new_ssl|, followed by a connect BIO.
+OPENSSL_EXPORT BIO *BIO_new_ssl_connect(SSL_CTX *ctx);
+
+// BIO_new_ssl returns a newly allocated SSL BIO created with |ctx|. A client
+// SSL is created if |client| is non-zero, and a server is created if otherwise.
+OPENSSL_EXPORT BIO *BIO_new_ssl(SSL_CTX *ctx, int client);
+
+
 // Deprecated functions.
 
 // SSL_library_init calls |CRYPTO_library_init| and returns one.
@@ -5508,19 +5536,6 @@ OPENSSL_EXPORT int SSL_CTX_enable_tls_channel_id(SSL_CTX *ctx);
 
 // SSL_enable_tls_channel_id calls |SSL_set_tls_channel_id_enabled|.
 OPENSSL_EXPORT int SSL_enable_tls_channel_id(SSL *ssl);
-
-// BIO_f_ssl returns a |BIO_METHOD| that can wrap an |SSL*| in a |BIO*|. Note
-// that this has quite different behaviour from the version in OpenSSL (notably
-// that it doesn't try to auto renegotiate).
-//
-// IMPORTANT: if you are not curl, don't use this.
-OPENSSL_EXPORT const BIO_METHOD *BIO_f_ssl(void);
-
-// BIO_set_ssl sets |ssl| as the underlying connection for |bio|, which must
-// have been created using |BIO_f_ssl|. If |take_owership| is true, |bio| will
-// call |SSL_free| on |ssl| when closed. It returns one on success or something
-// other than one on error.
-OPENSSL_EXPORT long BIO_set_ssl(BIO *bio, SSL *ssl, int take_owership);
 
 // SSL_get_session returns a non-owning pointer to |ssl|'s session. For
 // historical reasons, which session it returns depends on |ssl|'s state.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5116,9 +5116,9 @@ OPENSSL_EXPORT int SSL_CTX_sess_cache_full(const SSL_CTX *ctx);
 
 // BIO_f_ssl returns a |BIO_METHOD| that can wrap an |SSL*| in a |BIO*|. Note
 // that this has quite different behaviour from the version in OpenSSL (notably
-// that it doesn't try to auto renegotiate).
-//
-// IMPORTANT: if you are not curl, don't use this.
+// that it doesn't try to auto renegotiate). There is also no current support
+// for the |BIO_set_ssl*| related functions in OpenSSL or |BIO_puts| with this
+// BIO type within AWS-LC.
 OPENSSL_EXPORT const BIO_METHOD *BIO_f_ssl(void);
 
 // BIO_set_ssl sets |ssl| as the underlying connection for |bio|, which must
@@ -5133,10 +5133,18 @@ OPENSSL_EXPORT long BIO_get_ssl(BIO *bio, SSL **ssl);
 
 // BIO_new_ssl_connect uses |ctx| to return a newly allocated BIO chain with
 // |BIO_new_ssl|, followed by a connect BIO.
+//
+// Note: This allocates a |BIO| with |BIO_f_ssl| to the user, so the same
+// caveats hold true for this function as well. See |BIO_f_ssl| for more
+// details.
 OPENSSL_EXPORT BIO *BIO_new_ssl_connect(SSL_CTX *ctx);
 
 // BIO_new_ssl returns a newly allocated SSL BIO created with |ctx|. A client
 // SSL is created if |client| is non-zero, and a server is created if otherwise.
+//
+// Note: This allocates a |BIO| with |BIO_f_ssl| to the user, so the same
+// caveats hold true for this function as well. See |BIO_f_ssl| for more
+// details.
 OPENSSL_EXPORT BIO *BIO_new_ssl(SSL_CTX *ctx, int client);
 
 

--- a/ssl/bio_ssl.cc
+++ b/ssl/bio_ssl.cc
@@ -228,8 +228,7 @@ BIO *BIO_new_ssl(SSL_CTX *ctx, int client) {
   }
   if (client) {
     SSL_set_connect_state(ssl);
-  }
-  else {
+  } else {
     SSL_set_accept_state(ssl);
   }
 

--- a/ssl/bio_ssl.cc
+++ b/ssl/bio_ssl.cc
@@ -114,6 +114,14 @@ static long ssl_ctrl(BIO *bio, int cmd, long num, void *ptr) {
       bio->init = 1;
       return 1;
 
+    case BIO_C_GET_SSL:
+      if (ptr != nullptr) {
+        auto sslp = static_cast<SSL **>(ptr);
+        *sslp = ssl;
+        return 1;
+      }
+      return 0;
+
     case BIO_CTRL_GET_CLOSE:
       return bio->shutdown;
 
@@ -190,3 +198,45 @@ const BIO_METHOD *BIO_f_ssl(void) { return &ssl_method; }
 long BIO_set_ssl(BIO *bio, SSL *ssl, int take_owership) {
   return BIO_ctrl(bio, BIO_C_SET_SSL, take_owership, ssl);
 }
+
+long BIO_get_ssl(BIO *bio, SSL **ssl) {
+  return BIO_ctrl(bio, BIO_C_GET_SSL, 0, ssl);
+}
+
+BIO *BIO_new_ssl_connect(SSL_CTX *ctx) {
+  bssl::UniquePtr<BIO> con(BIO_new(BIO_s_connect()));
+  bssl::UniquePtr<BIO> ssl(BIO_new_ssl(ctx, 1));
+  if (!con || !ssl) {
+    return nullptr;
+  }
+  bssl::UniquePtr<BIO> ret(BIO_push(ssl.get(), con.get()));
+  if (!ret) {
+    return nullptr;
+  }
+
+  con.release();
+  ssl.release();
+  return ret.release();
+}
+
+BIO *BIO_new_ssl(SSL_CTX *ctx, int client) {
+  bssl::UniquePtr<BIO> ret(BIO_new(BIO_f_ssl()));
+  SSL *ssl = SSL_new(ctx);
+
+  if (!ret || !ssl) {
+    return nullptr;
+  }
+  if (client) {
+    SSL_set_connect_state(ssl);
+  }
+  else {
+    SSL_set_accept_state(ssl);
+  }
+
+  if (BIO_set_ssl(ret.get(), ssl, BIO_CLOSE) <= 0) {
+    return nullptr;
+  }
+  return ret.release();
+}
+
+


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-2926`

### Description of changes: 
Xtrabackup happens to take a dependency on some of OpenSSL's BIO_ssl methods. These are essentially helper BIOs that maintain an `SSL` within them. We have the necessary functionality available, this is just wrapping these BIOs around them.

### Call-outs:
N/A

### Testing:
Ideally we would test against the "connect" BIO created within `BIO_new_ssl_connect` with `BIO_do_connect`, but this isn't quite easy since we do not have any BIO methods that set up sockets on the server end (`BIO_s_accept`). We have other mechanisms of doing so in our `bssl` tool and `ocsp_integration_tests`, but pulling the functionality over just to test these `BIO`s seemed a bit overkill for my liking. I've given my reasoning in the test comments, if we ever do support `BIO_s_accept` we can look to update the test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
