### PR TITLE
Add CI for Xtrabackup

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -493,3 +493,13 @@ batch:
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_ruby_integration.sh ruby_3_4 ruby_3_3 ruby_3_2"
           FIPS: 1
+
+    - identifier: xtrabackup_integration_x86_64
+      buildspec: tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/integration/run_xtrabackup_integration.sh"

--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x_integration/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x_integration/Dockerfile
@@ -26,9 +26,11 @@ RUN set -ex && \
     lcov \
     libcap-dev \
     libcurl4-openssl-dev \
+    libev-dev \
     libevent-dev \
     libfstrm-dev \
     libftdi-dev \
+    libgcrypt20-dev \
     libglib2.0-dev \
     libgmp-dev \
     libini-config-dev \
@@ -45,8 +47,9 @@ RUN set -ex && \
     libnl-genl-3-dev \
     libpam-dev \
     libpcre3-dev  \
-    libpsl-dev \
+    libprocps-dev \
     libprotobuf-c-dev \
+    libpsl-dev \
     libssl-dev \
     libsystemd-dev \
     liburcu-dev \
@@ -67,7 +70,8 @@ RUN set -ex && \
     python3-sphinx \
     ruby \
     uthash-dev \
-    uuid-dev && \
+    uuid-dev \
+    vim-common && \
     pip3 install gcovr && \
     apt-get autoremove --purge -y && \
     apt-get clean && \

--- a/tests/ci/integration/run_xtrabackup_integration.sh
+++ b/tests/ci/integration/run_xtrabackup_integration.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -exu
+
+source tests/ci/common_posix_setup.sh
+
+# This directory is specific to the docker image used. Use -DDOWNLOAD_BOOST=1 -DWITH_BOOST=<directory>
+# with mySQL to download a compatible boost version locally.
+BOOST_INSTALL_FOLDER=/home/dependencies/boost
+
+# Set up environment.
+
+# SYS_ROOT
+#  |
+#  - SRC_ROOT(aws-lc)
+#  |
+#  - SCRATCH_FOLDER
+#    |
+#    - AWS_LC_BUILD_FOLDER
+#    - AWS_LC_INSTALL_FOLDER
+#    - XTRABACKUP_BUILD_FOLDER
+
+# Assumes script is executed from the root of aws-lc directory
+SCRATCH_FOLDER=${SYS_ROOT}/"XTRABACKUP_BUILD_ROOT"
+XTRABACKUP_SRC_FOLDER="${SCRATCH_FOLDER}/percona-xtrabackup"
+XTRABACKUP_BUILD_FOLDER="${SCRATCH_FOLDER}/xtrabackup-aws-lc"
+AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
+AWS_LC_INSTALL_FOLDER="${XTRABACKUP_SRC_FOLDER}/aws-lc-install"
+
+mkdir -p ${SCRATCH_FOLDER}
+rm -rf "${SCRATCH_FOLDER:?}"/*
+cd ${SCRATCH_FOLDER}
+
+function xtrabackup_build() {
+  cmake ${XTRABACKUP_SRC_FOLDER} -GNinja -DWITH_SSL=system -DCMAKE_PREFIX_PATH=${AWS_LC_INSTALL_FOLDER} "-B${XTRABACKUP_BUILD_FOLDER}" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  time ninja -C ${XTRABACKUP_BUILD_FOLDER}
+  ls -R ${XTRABACKUP_BUILD_FOLDER}
+}
+
+git clone --recurse-submodules https://github.com/percona/percona-xtrabackup.git ${XTRABACKUP_SRC_FOLDER} --depth 1
+mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${XTRABACKUP_BUILD_FOLDER}
+ls
+
+aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=1
+
+pushd ${XTRABACKUP_SRC_FOLDER}
+xtrabackup_build
+popd
+
+ldd "${XTRABACKUP_BUILD_FOLDER}/bin/xtrabackup" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libcrypto.so" || exit 1
+ldd "${XTRABACKUP_BUILD_FOLDER}/bin/xtrabackup" | grep "${AWS_LC_INSTALL_FOLDER}/lib/libssl.so" || exit 1


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-2926`

### Description of changes: 
We've added support for Xtrabackup in https://github.com/aws/aws-lc/pull/2273, this ensures that the build doesn't break.

### Call-outs:
N/A

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
