### PR TITLE
Cherry-pick support for CMake 4.0 to fips-2024-09-27

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         cmake:
-          - { version: "3.2", url: "https://cmake.org/files/v3.2/cmake-3.2.3.tar.gz", hash: "a1ebcaf6d288eb4c966714ea457e3b9677cdfde78820d0f088712d7320850297" }
+          - { version: "3.5", url: "https://cmake.org/files/v3.5/cmake-3.5.0.tar.gz", hash: "92c83ad8a4fd6224cf6319a60b399854f55b38ebe9d297c942408b792b1a9efa" }
           - { version: "3.28", url: "https://cmake.org/files/v3.28/cmake-3.28.1.tar.gz", hash: "15e94f83e647f7d620a140a7a5da76349fc47a1bfed66d0f5cdee8e7344079ad" }
         generator:
           - "Unix Makefiles"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5..3.31)
 
 if(POLICY CMP0091)
 cmake_policy(SET CMP0091 NEW)


### PR DESCRIPTION
### Description of changes: 
This code does not modify the FIPS boundary.

Cherry-picks:
* https://github.com/aws/aws-lc/commit/2c1b35b8feeebb4038688d5c04dc0a48421ce06b (#2219)
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
