### PR TITLE
Add more build options to match callback build

### DIFF
--- a/crypto/fipsmodule/self_check/self_check.c
+++ b/crypto/fipsmodule/self_check/self_check.c
@@ -437,7 +437,7 @@ err:
 // actually exercised, in FIPS mode. (In non-FIPS mode these tests are only run
 // when requested by |BORINGSSL_self_test|.)
 
-OPENSSL_NOINLINE static int boringssl_self_test_rsa(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_rsa(void) {
   int ret = 0;
   uint8_t output[256];
 
@@ -536,7 +536,7 @@ err:
   return ret;
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_ecc(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_ecc(void) {
   int ret = 0;
   EC_KEY *ec_key = NULL;
   EC_POINT *ec_point_in = NULL;
@@ -662,7 +662,7 @@ err:
   return ret;
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_ffdh(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_ffdh(void) {
   int ret = 0;
   DH *dh = NULL;
   DH *fb_dh = NULL;
@@ -809,7 +809,7 @@ err:
   return ret;
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_ml_kem(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_ml_kem(void) {
   int ret = 0;
 
   static const uint8_t kKeyGenEKSeed[MLKEM512_KEYGEN_SEED_LEN] = {
@@ -1503,7 +1503,7 @@ err:
   return ret;
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_ml_dsa(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_ml_dsa(void) {
   int ret = 0;
 
   // Examples kMLDSAKeyGenSeed, kMLDSAKeyGenPublicKey, kMLDSAKeyGenPrivateKey from
@@ -2308,7 +2308,7 @@ OPENSSL_NOINLINE static int boringssl_self_test_ml_dsa(void) {
     return ret;
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_eddsa(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_eddsa(void) {
   int ret = 0;
 
   static const uint8_t kEd25519PrivateKey[ED25519_PRIVATE_KEY_SEED_LEN] = {
@@ -2371,7 +2371,7 @@ err:
   return ret;
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_hasheddsa(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_hasheddsa(void) {
   int ret = 0;
 
   static const uint8_t kEd25519PrivateKey[ED25519_PRIVATE_KEY_SEED_LEN] = {
@@ -2555,7 +2555,7 @@ int boringssl_self_test_sha256(void) {
                     "SHA-256 KAT");
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_sha512(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_sha512(void) {
   static const uint8_t kInput[16] = {
       0x21, 0x25, 0x12, 0xf8, 0xd2, 0xad, 0x83, 0x22,
       0x78, 0x1c, 0x6c, 0x4d, 0x69, 0xa9, 0xda, 0xa1,
@@ -2596,7 +2596,7 @@ int boringssl_self_test_hmac_sha256(void) {
                     "HMAC-SHA-256 KAT");
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_hkdf_sha256(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_hkdf_sha256(void) {
   static const uint8_t kHKDF_ikm_tc1[] = {
       0x58, 0x3e, 0xa3, 0xcf, 0x8f, 0xcf, 0xc8, 0x08, 0x73, 0xcc, 0x7b, 0x88,
       0x00, 0x9d, 0x4a, 0xed, 0x07, 0xd8, 0xd8, 0x88, 0xae, 0x98, 0x76, 0x8d,
@@ -2625,7 +2625,7 @@ OPENSSL_NOINLINE static int boringssl_self_test_hkdf_sha256(void) {
                     "HKDF-SHA-256 KAT");
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_sha3_256(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_sha3_256(void) {
   // From: SHA3_256ShortMsg.txt
   // Len = 128
   // Msg = d83c721ee51b060c5a41438a8221e040
@@ -2647,7 +2647,7 @@ OPENSSL_NOINLINE static int boringssl_self_test_sha3_256(void) {
                     "SHA3-256 KAT");
 }
 
-OPENSSL_NOINLINE static int boringssl_self_test_fast(void) {
+static OPENSSL_NOINLINE int boringssl_self_test_fast(void) {
   static const uint8_t kAESKey[16] = {'B', 'o', 'r', 'i', 'n', 'g', 'C', 'r',
                                       'y', 'p', 't', 'o', ' ', 'K', 'e', 'y'};
   // Older versions of the gcc release build on ARM will optimize out the

--- a/crypto/fipsmodule/self_check/self_check.c
+++ b/crypto/fipsmodule/self_check/self_check.c
@@ -437,7 +437,7 @@ err:
 // actually exercised, in FIPS mode. (In non-FIPS mode these tests are only run
 // when requested by |BORINGSSL_self_test|.)
 
-static int boringssl_self_test_rsa(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_rsa(void) {
   int ret = 0;
   uint8_t output[256];
 
@@ -536,7 +536,7 @@ err:
   return ret;
 }
 
-static int boringssl_self_test_ecc(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_ecc(void) {
   int ret = 0;
   EC_KEY *ec_key = NULL;
   EC_POINT *ec_point_in = NULL;
@@ -662,7 +662,7 @@ err:
   return ret;
 }
 
-static int boringssl_self_test_ffdh(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_ffdh(void) {
   int ret = 0;
   DH *dh = NULL;
   DH *fb_dh = NULL;
@@ -809,7 +809,7 @@ err:
   return ret;
 }
 
-static int boringssl_self_test_ml_kem(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_ml_kem(void) {
   int ret = 0;
 
   static const uint8_t kKeyGenEKSeed[MLKEM512_KEYGEN_SEED_LEN] = {
@@ -1503,7 +1503,7 @@ err:
   return ret;
 }
 
-static int boringssl_self_test_ml_dsa(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_ml_dsa(void) {
   int ret = 0;
 
   // Examples kMLDSAKeyGenSeed, kMLDSAKeyGenPublicKey, kMLDSAKeyGenPrivateKey from
@@ -2308,7 +2308,7 @@ static int boringssl_self_test_ml_dsa(void) {
     return ret;
 }
 
-static int boringssl_self_test_eddsa(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_eddsa(void) {
   int ret = 0;
 
   static const uint8_t kEd25519PrivateKey[ED25519_PRIVATE_KEY_SEED_LEN] = {
@@ -2371,7 +2371,7 @@ err:
   return ret;
 }
 
-static int boringssl_self_test_hasheddsa(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_hasheddsa(void) {
   int ret = 0;
 
   static const uint8_t kEd25519PrivateKey[ED25519_PRIVATE_KEY_SEED_LEN] = {
@@ -2555,7 +2555,7 @@ int boringssl_self_test_sha256(void) {
                     "SHA-256 KAT");
 }
 
-static int boringssl_self_test_sha512(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_sha512(void) {
   static const uint8_t kInput[16] = {
       0x21, 0x25, 0x12, 0xf8, 0xd2, 0xad, 0x83, 0x22,
       0x78, 0x1c, 0x6c, 0x4d, 0x69, 0xa9, 0xda, 0xa1,
@@ -2596,7 +2596,7 @@ int boringssl_self_test_hmac_sha256(void) {
                     "HMAC-SHA-256 KAT");
 }
 
-static int boringssl_self_test_hkdf_sha256(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_hkdf_sha256(void) {
   static const uint8_t kHKDF_ikm_tc1[] = {
       0x58, 0x3e, 0xa3, 0xcf, 0x8f, 0xcf, 0xc8, 0x08, 0x73, 0xcc, 0x7b, 0x88,
       0x00, 0x9d, 0x4a, 0xed, 0x07, 0xd8, 0xd8, 0x88, 0xae, 0x98, 0x76, 0x8d,
@@ -2625,7 +2625,7 @@ static int boringssl_self_test_hkdf_sha256(void) {
                     "HKDF-SHA-256 KAT");
 }
 
-static int boringssl_self_test_sha3_256(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_sha3_256(void) {
   // From: SHA3_256ShortMsg.txt
   // Len = 128
   // Msg = d83c721ee51b060c5a41438a8221e040
@@ -2647,7 +2647,7 @@ static int boringssl_self_test_sha3_256(void) {
                     "SHA3-256 KAT");
 }
 
-static int boringssl_self_test_fast(void) {
+OPENSSL_NOINLINE static int boringssl_self_test_fast(void) {
   static const uint8_t kAESKey[16] = {'B', 'o', 'r', 'i', 'n', 'g', 'C', 'r',
                                       'y', 'p', 't', 'o', ' ', 'K', 'e', 'y'};
   // Older versions of the gcc release build on ARM will optimize out the

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -248,7 +248,7 @@ extern "C" {
 #define OPENSSL_INLINE static inline OPENSSL_UNUSED
 #endif
 
-#if defined(OPENSSL_WINDOS)
+#if defined(OPENSSL_WINDOWS)
 #define OPENSSL_NOINLINE __declspec(noinline)
 #else
 #define OPENSSL_NOINLINE __attribute__((noinline))

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -248,6 +248,12 @@ extern "C" {
 #define OPENSSL_INLINE static inline OPENSSL_UNUSED
 #endif
 
+#if defined(OPENSSL_WINDOS)
+#define OPENSSL_NOINLINE __declspec(noinline)
+#else
+#define OPENSSL_NOINLINE __attribute__((noinline))
+#endif
+
 // ossl_ssize_t is a signed type which is large enough to fit the size of any
 // valid memory allocation. We prefer using |size_t|, but sometimes we need a
 // signed type for OpenSSL API compatibility. This type can be used in such

--- a/tests/ci/run_fips_callback_tests.sh
+++ b/tests/ci/run_fips_callback_tests.sh
@@ -71,7 +71,7 @@ function run_all_break_tests() {
 
 echo "Testing AWS-LC static breakable build with custom callback and Jitter enabled"
 build_and_test -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_BUILD_SHARED_LIBS=OFF \
+  -DBUILD_SHARED_LIBS=OFF \
   -DFIPS=1 \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_INSTALL_INCLUDEDIR=include \
@@ -87,7 +87,7 @@ run_all_break_tests
 
 echo "Testing AWS-LC static build with custom callback and Jitter enabled"
 build_and_test -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_BUILD_SHARED_LIBS=OFF \
+  -DBUILD_SHARED_LIBS=OFF \
   -DFIPS=1 \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_INSTALL_INCLUDEDIR=include \

--- a/tests/ci/run_fips_callback_tests.sh
+++ b/tests/ci/run_fips_callback_tests.sh
@@ -70,9 +70,15 @@ function run_all_break_tests() {
 }
 
 echo "Testing AWS-LC static breakable build with custom callback and Jitter enabled"
-build_and_test -DFIPS=1 \
-  -DCMAKE_C_FLAGS="-DBORINGSSL_FIPS_BREAK_TESTS -DAWSLC_FIPS_FAILURE_CALLBACK" \
+build_and_test -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_SHARED_LIBS=OFF \
+  -DFIPS=1 \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_INSTALL_INCLUDEDIR=include \
+  -DCMAKE_INSTALL_BINDIR=bin \
+  -DCMAKE_C_FLAGS="-ggdb -DBORINGSSL_FIPS_BREAK_TESTS -DAWSLC_FIPS_FAILURE_CALLBACK" \
   -DCMAKE_CXX_FLAGS="-DAWSLC_FIPS_FAILURE_CALLBACK" \
+  -DBUILD_TESTING=ON -DBUILD_LIBSSL=ON \
   -DENABLE_FIPS_ENTROPY_CPU_JITTER=1
 
 maybe_run_fips_tests
@@ -80,9 +86,15 @@ maybe_run_fips_break_tests
 run_all_break_tests
 
 echo "Testing AWS-LC static build with custom callback and Jitter enabled"
-build_and_test -DFIPS=1 \
-  -DCMAKE_C_FLAGS="-DAWSLC_FIPS_FAILURE_CALLBACK" \
+build_and_test -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_SHARED_LIBS=OFF \
+  -DFIPS=1 \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_INSTALL_INCLUDEDIR=include \
+  -DCMAKE_INSTALL_BINDIR=bin \
+  -DCMAKE_C_FLAGS="-ggdb -DAWSLC_FIPS_FAILURE_CALLBACK" \
   -DCMAKE_CXX_FLAGS="-DAWSLC_FIPS_FAILURE_CALLBACK" \
+  -DBUILD_TESTING=ON -DBUILD_LIBSSL=ON \
   -DENABLE_FIPS_ENTROPY_CPU_JITTER=1
 
 maybe_run_fips_tests


### PR DESCRIPTION
### Resolves
CryptoAlg-2437

### Description of changes: 
Mirror more of the build options to make sure we catch any build issues early in GitHub. Adding the release with debug issue raised an issue with break-kat.go failing with: `Test input value was still found after erasing it. Second copy?`. This happens because the function which contains the test vectors are inlined into two functions which results in two copies of the data. This only appears to happen with GCC 7.3.1. This change fixes that by marking all of the tests as no inline. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
