### PR TITLE
Implement legacy callback with BIO_set_callback

### DIFF
--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -201,16 +201,16 @@ int BIO_free(BIO *bio) {
       bio->method->destroy(bio);
     }
 
-      BIO_callback_fn_ex cb = get_callback(bio);
-      if (cb != NULL) {
-        long ret = cb(bio, BIO_CB_FREE, NULL, 0, 0, 0L, 1L, NULL);
-        if (ret <= 0) {
-          if (ret >= INT_MIN) {
-            return (int)ret;
-          }
-          return INT_MIN;
+    BIO_callback_fn_ex cb = get_callback(bio);
+    if (cb != NULL) {
+      long ret = cb(bio, BIO_CB_FREE, NULL, 0, 0, 0L, 1L, NULL);
+      if (ret <= 0) {
+        if (ret >= INT_MIN) {
+          return (int)ret;
         }
+        return INT_MIN;
       }
+    }
 
 
 
@@ -244,16 +244,16 @@ int BIO_read(BIO *bio, void *buf, int len) {
     return 0;
   }
 
-    BIO_callback_fn_ex cb = get_callback(bio);
-    if (cb != NULL) {
-      long callback_ret = cb(bio, BIO_CB_READ, buf, len, 0, 0L, 1L, NULL);
-      if (callback_ret <= 0) {
-        if (callback_ret >= INT_MIN) {
-          return (int)callback_ret;
-        }
-        return INT_MIN;
+  BIO_callback_fn_ex cb = get_callback(bio);
+  if (cb != NULL) {
+    long callback_ret = cb(bio, BIO_CB_READ, buf, len, 0, 0L, 1L, NULL);
+    if (callback_ret <= 0) {
+      if (callback_ret >= INT_MIN) {
+        return (int)callback_ret;
       }
+      return INT_MIN;
     }
+  }
 
   if (!bio->init) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNINITIALIZED);
@@ -300,16 +300,16 @@ int BIO_gets(BIO *bio, char *buf, int len) {
   }
   size_t processed = 0;
 
-    BIO_callback_fn_ex cb = get_callback(bio);
-    if (cb != NULL) {
-      long callback_ret = cb(bio, BIO_CB_GETS, buf, len, 0, 0L, 1L, NULL);
-      if (callback_ret <= 0) {
-        if (callback_ret >= INT_MIN) {
-          return (int)callback_ret;
-        }
-        return INT_MIN;
+  BIO_callback_fn_ex cb = get_callback(bio);
+  if (cb != NULL) {
+    long callback_ret = cb(bio, BIO_CB_GETS, buf, len, 0, 0L, 1L, NULL);
+    if (callback_ret <= 0) {
+      if (callback_ret >= INT_MIN) {
+        return (int)callback_ret;
       }
+      return INT_MIN;
     }
+  }
 
   if (!bio->init) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNINITIALIZED);
@@ -336,16 +336,16 @@ int BIO_write(BIO *bio, const void *in, int inl) {
   }
   size_t processed = 0;
 
-    BIO_callback_fn_ex cb = get_callback(bio);
-    if (cb != NULL) {
-      long callback_ret = cb(bio, BIO_CB_WRITE, in, inl, 0, 0L, 1L, NULL);
-      if (callback_ret <= 0) {
-        if (callback_ret >= INT_MIN) {
-          return (int)callback_ret;
-        }
-        return INT_MIN;
+  BIO_callback_fn_ex cb = get_callback(bio);
+  if (cb != NULL) {
+    long callback_ret = cb(bio, BIO_CB_WRITE, in, inl, 0, 0L, 1L, NULL);
+    if (callback_ret <= 0) {
+      if (callback_ret >= INT_MIN) {
+        return (int)callback_ret;
       }
+      return INT_MIN;
     }
+  }
 
   if (!bio->init) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNINITIALIZED);
@@ -410,16 +410,16 @@ int BIO_puts(BIO *bio, const char *in) {
     return -2;
   }
 
-    BIO_callback_fn_ex cb = get_callback(bio);
-    if (cb != NULL) {
-      long callback_ret = cb(bio, BIO_CB_PUTS, in, 0, 0, 0L, 1L, NULL);
-      if (callback_ret <= 0) {
-        if (callback_ret >= INT_MIN) {
-          return (int)callback_ret;
-        }
-        return INT_MIN;
+  BIO_callback_fn_ex cb = get_callback(bio);
+  if (cb != NULL) {
+    long callback_ret = cb(bio, BIO_CB_PUTS, in, 0, 0, 0L, 1L, NULL);
+    if (callback_ret <= 0) {
+      if (callback_ret >= INT_MIN) {
+        return (int)callback_ret;
       }
+      return INT_MIN;
     }
+  }
 
 
   if (!bio->init) {
@@ -463,22 +463,22 @@ long BIO_ctrl(BIO *bio, int cmd, long larg, void *parg) {
   }
   long ret = 0;
 
-    BIO_callback_fn_ex cb = get_callback(bio);
-    if (cb != NULL) {
-      ret = cb(bio, BIO_CB_CTRL, parg, 0, cmd, larg, 1L, NULL);
-      if (ret <= 0) {
-        return ret;
-      }
+  BIO_callback_fn_ex cb = get_callback(bio);
+  if (cb != NULL) {
+    ret = cb(bio, BIO_CB_CTRL, parg, 0, cmd, larg, 1L, NULL);
+    if (ret <= 0) {
+      return ret;
     }
+  }
 
 
   ret = bio->method->ctrl(bio, cmd, larg, parg);
 
-    cb = get_callback(bio);
-    if (cb != NULL) {
-      ret = cb(bio, BIO_CB_CTRL | BIO_CB_RETURN, parg, 0, cmd, larg,
-                           ret, NULL);
-    }
+  cb = get_callback(bio);
+  if (cb != NULL) {
+    ret = cb(bio, BIO_CB_CTRL | BIO_CB_RETURN, parg, 0, cmd, larg,
+                         ret, NULL);
+  }
 
   return ret;
 }

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -82,6 +82,7 @@ static long callback_fn_wrap_ex(BIO *bio, int oper, const char *argp,
                               size_t *processed) {
   assert(bio != NULL);
   assert(bio->callback != NULL);
+  assert(bio->callback_ex == NULL);
 
   /* Strip off any BIO_CB_RETURN flag */
   int bareoper = oper & ~BIO_CB_RETURN;

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -158,12 +158,14 @@ int len, int ret) {
 
   BIO_callback_fn_ex cb = get_callback(bio);
   if (cb != NULL) {
-    ret = cb(bio, oper | BIO_CB_RETURN, buf, len, 0, 0L, ret, &processed);
+    long callback_ret = cb(bio, oper | BIO_CB_RETURN, buf, len, 0, 0L, ret, &processed);
+    if (ret > INT_MAX || ret < INT_MIN) {
+      return -1;
+    }
+    ret = (int)callback_ret;
   }
 
-  if (ret > INT_MAX || ret < INT_MIN) {
-    return -1;
-  }
+
   if (ret > 0) {
     if (processed > INT_MAX) {
       ret = -1; // Value too large to represent as int

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -227,8 +227,6 @@ int BIO_free(BIO *bio) {
       }
     }
 
-
-
     CRYPTO_free_ex_data(&g_ex_data_class, bio, &bio->ex_data);
     OPENSSL_free(bio);
   }
@@ -417,7 +415,6 @@ int BIO_puts(BIO *bio, const char *in) {
       return INT_MIN;
     }
   }
-
 
   if (!bio->init) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNINITIALIZED);

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -80,9 +80,8 @@
 static long callback_fn_wrap_ex(BIO *bio, int oper, const char *argp,
                               size_t len, int argi, long argl, int bio_ret,
                               size_t *processed) {
-  if (bio == NULL || bio->callback == NULL) {
-    return -1;
-  }
+  assert(bio != NULL);
+  assert(bio->callback != NULL);
 
   /* Strip off any BIO_CB_RETURN flag */
   int bareoper = oper & ~BIO_CB_RETURN;

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -68,13 +68,6 @@
 
 #include "../internal.h"
 
-/*
- * Helper macro for the callback to determine whether an operator expects a
- * len parameter or not
- */
-#define HAS_LEN_OPER(o)        ((o) == BIO_CB_READ || (o) == BIO_CB_WRITE || \
-(o) == BIO_CB_GETS)
-
 //   |callback_fn_wrap_ex| adapts the legacy callback interface |BIO_callback_fn| to the
 //   extended callback interface |BIO_callback_fn_ex|. This function should only be
 //   called when |callback_ex| is not available and the legacy callback is set.
@@ -95,7 +88,8 @@ static long callback_fn_wrap_ex(BIO *bio, int oper, const char *argp,
   /* Strip off any BIO_CB_RETURN flag */
   int bareoper = oper & ~BIO_CB_RETURN;
 
-  if (HAS_LEN_OPER(bareoper)) {
+  if (bareoper == BIO_CB_READ || bareoper == BIO_CB_WRITE
+    || bareoper == BIO_CB_GETS) {
     /* In this case |len| is set, and should be used instead of |argi| */
     if (len > INT_MAX)
       return -1;

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -160,7 +160,7 @@ int len, int ret) {
   BIO_callback_fn_ex cb = get_callback(bio);
   if (cb != NULL) {
     long callback_ret = cb(bio, oper | BIO_CB_RETURN, buf, len, 0, 0L, ret, &processed);
-    if (ret > INT_MAX || ret < INT_MIN) {
+    if (callback_ret > INT_MAX || callback_ret < INT_MIN) {
       return -1;
     }
     ret = (int)callback_ret;

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -68,15 +68,15 @@
 
 #include "../internal.h"
 
-//   |callback_fn_wrap_ex| adapts the legacy callback interface |BIO_callback_fn| to the
-//   extended callback interface |BIO_callback_fn_ex|. This function should only be
-//   called when |callback_ex| is not available and the legacy callback is set.
+// |callback_fn_wrap_ex| adapts the legacy callback interface |BIO_callback_fn| to the
+// extended callback interface |BIO_callback_fn_ex|. This function should only be
+// called when |callback_ex| is not available and the legacy callback is set.
 //
-//   |len| and |processed| parameters from the extended interface are ignored since
-//   they are not supported by the legacy callback interface.
+// The extended interface parameters |len| and |processed| are mapped to the legacy
+// interface parameters |argi| and |bio_ret| respectively.
 //
-//   Returns -1 on NULL |BIO| or callback, otherwise returns the result of the legacy
-//   callback.
+// Returns -1 on NULL |BIO| or callback, otherwise returns the result of the legacy
+// callback.
 static long callback_fn_wrap_ex(BIO *bio, int oper, const char *argp,
                               size_t len, int argi, long argl, int bio_ret,
                               size_t *processed) {

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -115,19 +115,17 @@ static long callback_fn_wrap_ex(BIO *bio, int oper, const char *argp,
   return ret;
 }
 
-//   |get_callback| returns the appropriate callback function for a given |BIO|, preferring
-//   the extended interface |callback_ex| over the legacy interface.
+// |get_callback| returns the appropriate callback function for a given |BIO|, preferring
+// the extended interface |callback_ex| over the legacy interface.
 //
-//   When only the legacy callback is available, it is wrapped in the extended format
-//   via |callback_fn_wrap_ex| to provide a consistent interface. The extended callback
-//   provides additional parameters for length and bytes processed tracking.
+// When only the legacy callback is available, it is wrapped in the extended format
+// via |callback_fn_wrap_ex| to provide a consistent interface. The extended callback
+// provides additional parameters for length and bytes processed tracking.
 //
-//   Returns the |callback_ex| function if available, a wrapped legacy callback if only
-//   |callback| is set, or NULL if no callbacks are set.
+// Returns the |callback_ex| function if available, a wrapped legacy callback if only
+// |callback| is set, or NULL if no callbacks are set.
 static BIO_callback_fn_ex get_callback(BIO *bio) {
-  if (bio == NULL) {
-    return NULL;
-  }
+  assert(bio != NULL);
 
   if (bio->callback_ex != NULL) {
     return bio->callback_ex;
@@ -251,7 +249,6 @@ void BIO_free_all(BIO *bio) {
 }
 
 int BIO_read(BIO *bio, void *buf, int len) {
-  int ret = 0;
 
   if (bio == NULL || bio->method == NULL || bio->method->bread == NULL) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNSUPPORTED_METHOD);
@@ -276,7 +273,7 @@ int BIO_read(BIO *bio, void *buf, int len) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNINITIALIZED);
     return -2;
   }
-  ret = bio->method->bread(bio, buf, len);
+  int ret = bio->method->bread(bio, buf, len);
 
   return handle_callback_return(bio, BIO_CB_READ, buf, len, ret);
 }
@@ -332,7 +329,7 @@ int BIO_gets(BIO *bio, char *buf, int len) {
 }
 
 int BIO_write(BIO *bio, const void *in, int inl) {
-  int ret = 0;
+
   if (bio == NULL || bio->method == NULL || bio->method->bwrite == NULL) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNSUPPORTED_METHOD);
     return -2;
@@ -356,7 +353,7 @@ int BIO_write(BIO *bio, const void *in, int inl) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_UNINITIALIZED);
     return -2;
   }
-  ret = bio->method->bwrite(bio, in, inl);
+  int ret = bio->method->bwrite(bio, in, inl);
 
   return handle_callback_return(bio, BIO_CB_WRITE, in, inl, ret);
 }

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -152,6 +152,9 @@ int len, int ret) {
     } else if (oper == BIO_CB_WRITE || oper == BIO_CB_PUTS) {
       bio->num_write += ret;
     }
+    // |callback_ex| receives the number of bytes processed via the |processed| parameter,
+    // while the legacy callback receives this information through both |argi| and |ret|.
+    // When using the legacy callback, the |processed| value will be mapped back to |ret|.
     processed = ret;
     ret = 1;
   }

--- a/crypto/bio/bio.c
+++ b/crypto/bio/bio.c
@@ -96,7 +96,7 @@ static long callback_fn_wrap_ex(BIO *bio, int oper, const char *argp,
     argi = (int)len;
   }
 
-  if (bio_ret && (oper & BIO_CB_RETURN) && bareoper != BIO_CB_CTRL) {
+  if (bio_ret > 0 && (oper & BIO_CB_RETURN) && bareoper != BIO_CB_CTRL) {
     if (*processed > INT_MAX) {
       return -1;
     }
@@ -107,7 +107,7 @@ static long callback_fn_wrap_ex(BIO *bio, int oper, const char *argp,
 
   long ret = bio->callback(bio, oper, argp, argi, argl, bio_ret);
 
-  if (ret >= 0 && (oper & BIO_CB_RETURN) && bareoper != BIO_CB_CTRL) {
+  if (ret > 0 && (oper & BIO_CB_RETURN) && bareoper != BIO_CB_CTRL) {
     *processed = (size_t)ret;
     ret = 1;
   }

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -919,15 +919,30 @@ TEST(BIOTest, FileMode) {
   expect_text_mode(bio.get());
 }
 
-// Run through the tests twice, swapping |bio1| and |bio2|, for symmetry.
-class BIOPairTest : public testing::TestWithParam<bool> {};
+// BIOPairTest: A parameterized test fixture for testing BIO pair operations
+// This test class runs each test case with four different combinations:
+//   1. Normal order (bio1->bio2) with legacy callback
+//   2. Normal order (bio1->bio2) with extended callback
+//   3. Swapped order (bio2->bio1) with legacy callback
+//   4. Swapped order (bio2->bio1) with extended callback
+//
+// Parameters:
+//   std::tuple<bool, bool>:
+//     - First bool (get<0>): Controls BIO swapping
+//       * false = normal order (bio1->bio2)
+//       * true = swapped order (bio2->bio1)
+//     - Second bool (get<1>): Controls callback type
+//       * false = legacy callback (BIO_set_callback)
+//       * true = extended callback (BIO_set_callback_ex)
+class BIOPairTest : public testing::TestWithParam<std::tuple<bool, bool>> {};
 
 TEST_P(BIOPairTest, TestPair) {
   BIO *bio1, *bio2;
   ASSERT_TRUE(BIO_new_bio_pair(&bio1, 10, &bio2, 10));
   bssl::UniquePtr<BIO> free_bio1(bio1), free_bio2(bio2);
 
-  if (GetParam()) {
+  const auto& params = GetParam();
+  if (std::get<0>(params)) { // swap_bios
     std::swap(bio1, bio2);
   }
 
@@ -1045,6 +1060,21 @@ static long bio_cb_ex(BIO *b, int oper, const char *argp, size_t len, int argi,
   return ret;
 }
 
+static long bio_cb(BIO *b, int oper, const char *argp, int argi,
+                      long argl, int ret) {
+  if (test_count_ex >= CB_TEST_COUNT) {
+    return CALL_BACK_FAILURE;
+  }
+  param_b_ex[test_count_ex] = b;
+  param_oper_ex[test_count_ex] = oper;
+  param_argp_ex[test_count_ex] = argp;
+  param_argi_ex[test_count_ex] = argi;
+  param_argl_ex[test_count_ex] = argl;
+  param_ret_ex[test_count_ex] = ret;
+  test_count_ex++;
+  return ret;
+}
+
 static void bio_callback_cleanup() {
   // These mocks are used in multiple tests and need to be reset
   test_count_ex = 0;
@@ -1066,11 +1096,28 @@ TEST_P(BIOPairTest, TestCallbacks) {
   BIO *bio1, *bio2;
   ASSERT_TRUE(BIO_new_bio_pair(&bio1, 10, &bio2, 10));
 
-  if (GetParam()) {
+  // Check the first parameter from the test tuple to determine which controls bio swapping
+  // params is a tuple<bool, bool> where:
+  //   - get<0> controls bio swapping
+  //   - get<1> controls callback type (true = extended, false = legacy)
+  const auto& params = GetParam();
+  if (std::get<0>(params)) {  // swap_bios
     std::swap(bio1, bio2);
   }
 
-  BIO_set_callback_ex(bio2, bio_cb_ex);
+  // Check the second parameter from the test tuple to determine which callback type to use
+  // params is a tuple<bool, bool> where:
+  //   - get<0> controls bio swapping
+  //   - get<1> controls callback type (true = extended, false = legacy)
+  if (std::get<1>(params)) {
+    // Use extended callback (BIO_callback_ex) which provides additional parameters:
+    // - len: size of the buffer for read/write operations
+    // - processed: pointer to store number of bytes actually processed
+    BIO_set_callback_ex(bio2, bio_cb_ex);
+  } else {
+    // Use legacy callback (BIO_callback) with basic parameters
+    BIO_set_callback(bio2, bio_cb);
+  }
 
   // Data written in one end may be read out the other.
   uint8_t buf[TEST_BUF_LEN];
@@ -1159,7 +1206,33 @@ TEST(BIOTest, InvokeConnectCallback) {
 }
 }  // namespace
 
-INSTANTIATE_TEST_SUITE_P(All, BIOPairTest, testing::Values(false, true));
+// Instantiate the parameterized test suite for BIOPairTest
+// This creates test instances for all combinations of the boolean parameters
+//
+// Parameters:
+//   First argument "All": Test suite name prefix
+//   Second argument "BIOPairTest": The test fixture class
+//   Third argument: Parameter generator using testing::Combine to create Cartesian product
+//     - First Bool(): Controls BIO swapping
+//       * false: Keep original BIO order (bio1->bio2)
+//       * true:  Swap BIOs (bio2->bio1)
+//     - Second Bool(): Controls callback type
+//       * false: Use legacy callback (BIO_set_callback)
+//       * true:  Use extended callback (BIO_set_callback_ex)
+//
+// This will generate four test combinations:
+//   1. (false, false) - Normal order, Legacy callback
+//   2. (false, true)  - Normal order, Extended callback
+//   3. (true, false)  - Swapped order, Legacy callback
+//   4. (true, true)   - Swapped order, Extended callback
+INSTANTIATE_TEST_SUITE_P(
+All,
+  BIOPairTest,
+  testing::Combine(
+      testing::Bool(),  // swap_bios
+      testing::Bool()   // use_extended_callback
+  )
+  );
 
 TEST(BIOTest, ReadWriteEx) {
   bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -1133,12 +1133,12 @@ TEST_P(BIOPairTest, TestCallbacks) {
   // The calls before the BIO operation use 1 for the BIO's return value
   ASSERT_EQ(param_ret_ex[0], 1);
 
-  // The calls after the BIO call use the return value from the BIO, which is
-  // the length of data read/written
-  ASSERT_EQ(param_ret_ex[1], TEST_DATA_WRITTEN);
+
 
   if (!std::get<1>(params)) {
-    // For old-style callback argi is used for len
+    // Legacy callback uses ret to hold data processed
+    ASSERT_EQ(param_ret_ex[1], TEST_DATA_WRITTEN);
+    // Legacy callback argi is used for len
     ASSERT_EQ(param_argi_ex[0], TEST_BUF_LEN);
     ASSERT_EQ(param_argi_ex[1], TEST_BUF_LEN);
     ASSERT_EQ(param_argl_ex[0], 0);
@@ -1147,6 +1147,8 @@ TEST_P(BIOPairTest, TestCallbacks) {
 
   // Extended callback specific verifications
   if (std::get<1>(params)) {// If using extended callback
+    // For callback_ex ret is set to 1 after setting processed
+    ASSERT_EQ(param_ret_ex[1], 1);
     // For callback_ex argi and arl are unused
     ASSERT_EQ(param_argi_ex[0], 0);
     ASSERT_EQ(param_argi_ex[1], 0);

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -1442,19 +1442,23 @@ TEST_P(BIOPairTest, TestGetsCallback) {
 
   ASSERT_EQ(param_argp_ex[0], param_argp_ex[1]);
   ASSERT_EQ(param_ret_ex[0], 1);
-  ASSERT_EQ(param_ret_ex[1], TEST_DATA_WRITTEN);
+
 
   ASSERT_EQ(param_argl_ex[0], 0);
   ASSERT_EQ(param_argl_ex[1], 0);
 
   // Old-style callback uses argi for len
   if (!use_extended_callback) {
+    // use ret for data processed
+    ASSERT_EQ(param_ret_ex[1], TEST_DATA_WRITTEN);
     ASSERT_EQ(param_argi_ex[0], TEST_BUF_LEN);
     ASSERT_EQ(param_argi_ex[1], TEST_BUF_LEN);
   }
 
   // Extended callback specific verifications
   if (use_extended_callback) {
+    // ret is set to 1 after setting processed
+    ASSERT_EQ(param_ret_ex[1], 1);
     ASSERT_EQ(param_argi_ex[0], 0);
     ASSERT_EQ(param_argi_ex[1], 0);
     ASSERT_EQ(param_len_ex[0], (size_t)TEST_BUF_LEN);

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -295,8 +295,16 @@ typedef long (*BIO_callback_fn_ex)(BIO *bio, int oper, const char *argp,
                                    size_t len, int argi, long argl, int bio_ret,
                                    size_t *processed);
 
+  // |BIO_callback_fn_ex| parameters have the following meaning:
+  //    |bio| the bio that made the call
+  //    |oper| the operation being performed, may be or'd with |BIO_CB_RETURN|
+  //    |argp| and |argl| depends on the value of oper
+  //    |argi| is used to hold len value for |BIO_CB_READ|, |BIO_CB_WRITE|, and
+  //    |BIO_CB_GETS|
+  //    |bio_ret| is the return value from the BIO method itself,
+  //    or value of processed where applicable
 typedef long (*BIO_callback_fn)(BIO *bio, int oper, const char *argp,
-    int argi, long argl, int bio_ret);
+    int argi, long argl, long bio_ret);
 
 
 // BIO_callback_ctrl allows the callback function to be manipulated. The |cmd|

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -295,6 +295,9 @@ typedef long (*BIO_callback_fn_ex)(BIO *bio, int oper, const char *argp,
                                    size_t len, int argi, long argl, int bio_ret,
                                    size_t *processed);
 
+typedef long (*BIO_callback_fn)(BIO *bio, int oper, const char *argp,
+    int argi, long argl, int bio_ret);
+
 
 // BIO_callback_ctrl allows the callback function to be manipulated. The |cmd|
 // arg will generally be |BIO_CTRL_SET_CALLBACK| but arbitrary command values
@@ -327,6 +330,9 @@ OPENSSL_EXPORT uint64_t BIO_number_written(const BIO *bio);
 
 // BIO_set_callback_ex sets the |callback_ex| for |bio|.
 OPENSSL_EXPORT void BIO_set_callback_ex(BIO *bio, BIO_callback_fn_ex callback_ex);
+
+// BIO_set_callback sets the |callback| for |bio|
+OPENSSL_EXPORT void BIO_set_callback(BIO *bio, BIO_callback_fn callback);
 
 // BIO_set_callback_arg sets the callback |arg| for |bio|.
 OPENSSL_EXPORT void BIO_set_callback_arg(BIO *bio, char *arg);
@@ -1002,6 +1008,7 @@ struct bio_st {
   // |BIO_CB_GETS|+|BIO_CB_RETURN|, |BIO_CB_CTRL|, 
   // |BIO_CB_CTRL|+|BIO_CB_RETURN|, and |BIO_CB_FREE|.
   BIO_callback_fn_ex callback_ex;
+  BIO_callback_fn callback;
   // Optional callback argument, only intended for applications use.
   char *cb_arg;
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -331,8 +331,10 @@ OPENSSL_EXPORT uint64_t BIO_number_written(const BIO *bio);
 // BIO_set_callback_ex sets the |callback_ex| for |bio|.
 OPENSSL_EXPORT void BIO_set_callback_ex(BIO *bio, BIO_callback_fn_ex callback_ex);
 
-// BIO_set_callback sets the |callback| for |bio|
-OPENSSL_EXPORT void BIO_set_callback(BIO *bio, BIO_callback_fn callback);
+// BIO_set_callback sets the legacy |callback| for |bio|. When both |callback| and
+// |callback_ex| are set, |callback_ex| will be used. Added for compatibility with
+// existing applications.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void BIO_set_callback(BIO *bio, BIO_callback_fn callback);
 
 // BIO_set_callback_arg sets the callback |arg| for |bio|.
 OPENSSL_EXPORT void BIO_set_callback_arg(BIO *bio, char *arg);
@@ -1008,7 +1010,20 @@ struct bio_st {
   // |BIO_CB_GETS|+|BIO_CB_RETURN|, |BIO_CB_CTRL|, 
   // |BIO_CB_CTRL|+|BIO_CB_RETURN|, and |BIO_CB_FREE|.
   BIO_callback_fn_ex callback_ex;
+
+  // Legacy callback function that handles the same events as |callback_ex| but without
+  // length and processed parameters.
+  // When both callbacks are set, |callback_ex| will be used.
+  // Handles |BIO_read|, |BIO_write|, |BIO_free|, |BIO_gets|, |BIO_puts|,
+  // and |BIO_ctrl| operations.
+  // Callbacks are only called with for the following events: |BIO_CB_READ|,
+  // |BIO_CB_READ|+|BIO_CB_RETURN|, |BIO_CB_WRITE|,
+  // |BIO_CB_WRITE|+|BIO_CB_RETURN|, |BIO_CB_PUTS|,
+  // |BIO_CB_PUTS|+|BIO_CB_RETURN|, |BIO_CB_GETS|,
+  // |BIO_CB_GETS|+|BIO_CB_RETURN|, |BIO_CB_CTRL|,
+  // |BIO_CB_CTRL|+|BIO_CB_RETURN|, and |BIO_CB_FREE|.
   BIO_callback_fn callback;
+
   // Optional callback argument, only intended for applications use.
   char *cb_arg;
 


### PR DESCRIPTION
### Issues:
Addresses #CRYPTOALG-3030

### Description of changes: 
Adds legacy callback to BIO meeting previous application compatibility.
Router function implemented to prefer enhanced callback but provide legacy callback if needed and available.

### Call-outs:
We now check if callback is NULL after checking if we have a callback.
Rather than calling enhanced callback directly we check with router function get_callback

### Testing:
Updated parameters for BIOPairTest to include boolean pairs enabling current enhanced callback testing to test for legacy callback.
Changed multiple tests from BIOTest to BIOPairTest for parameterized testing.
Will be adding test for get_callback in future PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
