### PR TITLE
Wire-up rust-openssl into GitHub CI (for the time being)

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -48,4 +48,28 @@ jobs:
       - name: Run librdkafka build
         run: |
           ./tests/ci/integration/run_librdkafka_integration.sh
-          
+  rust-openssl:
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout aws-lc
+        uses: actions/checkout@v4
+        with:
+          path: aws-lc
+      - name: Checkout rust-openssl
+        uses: actions/checkout@v4
+        with:
+          repository: sfackler/rust-openssl
+          path: rust-openssl
+      - uses: dtolnay/rust-toolchain@stable
+        id: toolchain
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install bindgen-cli
+        run: cargo install --locked bindgen-cli
+      - name: Run rust-openssl integration tests
+        env:
+          RUST_OPENSSL_SRC_DIR: "${{ github.workspace }}/rust-openssl"
+        run: |
+          pushd "${GITHUB_WORKSPACE}/aws-lc"
+          ./tests/ci/integration/run_rust_openssl_integration.sh

--- a/tests/ci/integration/run_bind9_integration.sh
+++ b/tests/ci/integration/run_bind9_integration.sh
@@ -1,6 +1,8 @@
-#!/bin/bash -exu
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -exu
 
 source tests/ci/common_posix_setup.sh
 

--- a/tests/ci/integration/run_rust_openssl_integration.sh
+++ b/tests/ci/integration/run_rust_openssl_integration.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -exo pipefail
+
+source tests/ci/common_posix_setup.sh
+
+if [[ -z "${RUST_OPENSSL_SRC_DIR}" ]]; then
+    echo "RUST_OPENSSL_SRC_DIR environment variable must be set"
+    exit 1
+fi
+
+# Create build directory and navigate to it
+AWS_LC_SRC_DIR="${SRC_ROOT}"
+AWS_LC_BUILD_DIR="${SYS_ROOT}/aws-lc-build"
+AWS_LC_SHARED_INSTALL_DIR="${SYS_ROOT}/aws-lc-install-shared"
+AWS_LC_STATIC_INSTALL_DIR="${SYS_ROOT}/aws-lc-install-static"
+
+function validate_rust_openssl() {
+    OPENSSL_DIR="${1}"
+    OPENSSL_STATIC="${2}"
+    
+    # Find the path to libcrypto.so and store its directory as it can be different depending on OS distribution
+    ADDITIONAL_ENV_VARS=()
+    if [[ "${OPENSSL_STATIC}" -eq 0 ]]; then
+        LIB_DIR=$(find "${OPENSSL_DIR}" -name "libcrypto.so" -exec dirname {} \; | head -n 1)
+        ADDITIONAL_ENV_VARS+=("LD_LIBRARY_PATH=${LIB_DIR}:${LD_LIBRARY_PATH}")
+    fi
+    
+    pushd "${RUST_OPENSSL_SRC_DIR}"
+    cargo -v clean
+    env OPENSSL_DIR="${OPENSSL_DIR}" OPENSSL_STATIC="${OPENSSL_STATIC}" "${ADDITIONAL_ENV_VARS[@]}" \
+    cargo -v test -p openssl-sys --release --no-default-features "${@:3}"
+    env OPENSSL_DIR="${OPENSSL_DIR}" OPENSSL_STATIC="${OPENSSL_STATIC}" "${ADDITIONAL_ENV_VARS[@]}" \
+    cargo -v test -p openssl --release --no-default-features "${@:3}"
+    
+    popd # "${RUST_OPENSSL_SRC_DIR}"
+}
+
+AWS_LC_BUILD_ARGS=("-DBUILD_TESTING=OFF" "-DBUILD_TOOL=OFF" "-DCMAKE_BUILD_TYPE=RelWithDebInfo")
+
+aws_lc_build "${AWS_LC_SRC_DIR}" "${AWS_LC_BUILD_DIR}" "${AWS_LC_SHARED_INSTALL_DIR}" "${AWS_LC_BUILD_ARGS[@]}" -DBUILD_SHARED_LIBS=1
+aws_lc_build "${AWS_LC_SRC_DIR}" "${AWS_LC_BUILD_DIR}" "${AWS_LC_STATIC_INSTALL_DIR}" "${AWS_LC_BUILD_ARGS[@]}" -DBUILD_SHARED_LIBS=0
+
+validate_rust_openssl "${AWS_LC_SHARED_INSTALL_DIR}" 0
+validate_rust_openssl "${AWS_LC_STATIC_INSTALL_DIR}" 1
+
+validate_rust_openssl "${AWS_LC_SHARED_INSTALL_DIR}" 0 -F bindgen
+validate_rust_openssl "${AWS_LC_STATIC_INSTALL_DIR}" 1 -F bindgen

--- a/tests/ci/integration/run_strongswan_integration.sh
+++ b/tests/ci/integration/run_strongswan_integration.sh
@@ -1,6 +1,8 @@
-#!/bin/bash -exu
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -exu
 
 source tests/ci/common_posix_setup.sh
 


### PR DESCRIPTION
### Description of changes: 
Adds validation that AWS-LC will build with rust-openssl when using the bindgen feature or bindgen-cli if pointed at an AWS-LC installation directory. We will add coverage on the aws-lc-rs side specifically for handling coverage of the crate specific feature flag that toggles on `aws-lc-sys`.

### Call-outs:
Not putting this into CodeBuild right now as it would require building new docker images with Rust, and the current process is influx. Will wait for the new deployment process to be completed so we can guarantee more frequently updated rust compiler releases without having to automate that with each invocation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
