### PR TITLE
Implemented no-op CRYPTO_mem_ctrl

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -122,6 +122,16 @@ WEAK_SYMBOL_FUNC(void, OPENSSL_memory_free, (void *ptr))
 WEAK_SYMBOL_FUNC(size_t, OPENSSL_memory_get_size, (void *ptr))
 WEAK_SYMBOL_FUNC(void *, OPENSSL_memory_realloc, (void *ptr, size_t size))
 
+int CRYPTO_mem_ctrl(int mode) {
+  #ifdef OPENSSL_NO_CRYPTO_MDEBUG
+  // Since AWS-LC doesn't support CRYPTO_MDEBUG, always return 0
+  (void)mode;  // Silence unused parameter warning
+  return 0;
+  #else
+    #error "Must compile with OPENSSL_NO_CRYPTO_MDEBUG defined."
+  #endif
+}
+
 // Below can be customized by |CRYPTO_set_mem_functions| only once.
 static void *(*malloc_impl)(size_t, const char *, int) = NULL;
 static void *(*realloc_impl)(void *, size_t, const char *, int) = NULL;

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -122,11 +122,13 @@ WEAK_SYMBOL_FUNC(void, OPENSSL_memory_free, (void *ptr))
 WEAK_SYMBOL_FUNC(size_t, OPENSSL_memory_get_size, (void *ptr))
 WEAK_SYMBOL_FUNC(void *, OPENSSL_memory_realloc, (void *ptr, size_t size))
 
-int CRYPTO_mem_ctrl(int mode) {
-  #ifdef OPENSSL_NO_CRYPTO_MDEBUG
-  // Since AWS-LC doesn't support CRYPTO_MDEBUG, always return 0
-  (void)mode;  // Silence unused parameter warning
-  return 0;
+// Control function for crypto memory debugging Always returns 0 in AWS-LC
+// |mode| Unused parameter AWS-LC doesn't support |CRYPTO_MDEBUG|
+// Always returns 0
+int CRYPTO_mem_ctrl(const int mode) {
+  #if defined (OPENSSL_NO_CRYPTO_MDEBUG)
+    (void)mode;  // Silence unused parameter warning
+    return 0;
   #else
     #error "Must compile with OPENSSL_NO_CRYPTO_MDEBUG defined."
   #endif

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -125,7 +125,7 @@ WEAK_SYMBOL_FUNC(void *, OPENSSL_memory_realloc, (void *ptr, size_t size))
 // Control function for crypto memory debugging Always returns 0 in AWS-LC
 // |mode| Unused parameter AWS-LC doesn't support |CRYPTO_MDEBUG|
 // Always returns 0
-int CRYPTO_mem_ctrl(const int mode) {
+int CRYPTO_mem_ctrl(int mode) {
   #if defined (OPENSSL_NO_CRYPTO_MDEBUG)
     (void)mode;  // Silence unused parameter warning
     return 0;

--- a/docs/porting/functionality-differences.md
+++ b/docs/porting/functionality-differences.md
@@ -296,6 +296,17 @@ libcrypto is the portion of OpenSSL for performing general-purpose cryptography,
 
 Older and less common usages of `EVP_PKEY` have been removed. For example, signing and verifying with `EVP_PKEY_DSA`  is not supported. More details on specific features can be found in the corresponding [header documentation](https://github.com/aws/aws-lc/tree/main/include/openssl).
 
+Memory debugging functionality between AWS-LC and OpenSSL 1.1.1u:
+
+|Function |OpenSSL 1.1.1 |AWS-LC |
+|--- |--- |--- |
+|CRYPTO_mem_ctrl() |X | |
+|CRYPTO_mem_leaks() |X | |
+|CRYPTO_mem_leaks_fp() |X | |
+|CRYPTO_mem_leaks_cb() |X | |
+
+Note: AWS-LC defines OPENSSL_NO_CRYPTO_MDEBUG by default.
+
 **When migrating to AWS-LC, it is important to understand the specific libcrypto components your application is reliant on from OpenSSL. For example, there may be underlying differences when consuming** **X509 certificate verification** **from AWS-LC.** <ins>**Migrators to AWS-LC are expected to understand their intended use cases and have tests surrounding functionality they are dependent on.**</ins> AWS-LC provides test coverage for functional and cryptographic correctness, along with compliance with standards like PKCS and X509. Different cryptographic libraries may implement some behavior by convention that is not standardized and thus is not guaranteed to work the same way in AWS-LC. Customers are responsible for writing their own tests to determine whether they are affected by these kinds of differences, and AWS-LC will publish a list of known differences in the future.
 
 **If you have a valid use case for any missing functionality or if anything is not clarified in our documentation, feel free to [cut an issue](https://github.com/aws/aws-lc/issues/new?assignees=&labels=&projects=&template=general-issue.md&title=) or create a PR to let us know.**
@@ -838,8 +849,22 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>Returns NULL.</span></p>
   </td>
  </tr>
+<tr>
+ <td>
+  <p><span>Memory Debugging</span></p>
+ </td>
+ <td>
+  <p><span>crypto.h</span></p>
+ </td>
+ <td>
+  <p><span>CRYPTO_mem_ctrl</span></p>
+ </td>
+<td>
+<p><span>Returns 0.</span></p>
+</td>
+</tr>
  <tr>
-  <td rowspan=13>
+  <td rowspan=14>
   <p><span>Miscellaneous</span></p>
   </td>
   <td rowspan=5>
@@ -1020,4 +1045,21 @@ Older and less common usages of `EVP_PKEY` have been removed. For example, signi
   <p><span>Returns zero.</span></p>
   </td>
  </tr>
+<tr>
+<td>
+<p>
+<span>
+        <a href="https://github.com/aws/aws-lc/blob/412be9d1bb4f9d2f962dba1beac41249dbacdb55/include/openssl/x509.h#L5097">
+            x509.h
+        </a>
+    </span>
+</p>
+</td>
+<td>
+  <p><span>X509_TRUST_cleanup</span></p>
+  </td>
+  <td>
+  <p><span>Does nothing.</span></p>
+  </td>
+</tr>
 </table>

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -217,7 +217,7 @@ OPENSSL_EXPORT void OPENSSL_cleanup(void);
 // |BORINGSSL_FIPS| and zero otherwise.
 OPENSSL_EXPORT int FIPS_mode_set(int on);
 
-// |CRYPTO_mem_ctrl| intentionally does nothing and returns 0.
+// CRYPTO_mem_ctrl intentionally does nothing and returns 0.
 // AWS-LC defines |OPENSSL_NO_CRYPTO_MDEBUG| by default.
 // These are related to memory debugging functionalities provided by OpenSSL,
 // but are not supported in AWS-LC.

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -175,11 +175,6 @@ OPENSSL_EXPORT unsigned long OpenSSL_version_num(void);
 
 OPENSSL_EXPORT unsigned long awslc_api_version_num(void);
 
-// |CRYPTO_mem_ctrl| intentionally does nothing.
-// AWS-LC does not support the related
-// memory debugging with |OPENSSL_NO_CRYPTO_MDEBUG| defined.
-OPENSSL_EXPORT OPENSSL_DEPRECATED int CRYPTO_mem_ctrl(int mode);
-
 // CRYPTO_malloc_init returns one.
 OPENSSL_EXPORT int CRYPTO_malloc_init(void);
 
@@ -221,6 +216,12 @@ OPENSSL_EXPORT void OPENSSL_cleanup(void);
 // FIPS_mode_set returns one if |on| matches whether BoringSSL was built with
 // |BORINGSSL_FIPS| and zero otherwise.
 OPENSSL_EXPORT int FIPS_mode_set(int on);
+
+// |CRYPTO_mem_ctrl| intentionally does nothing and returns 0.
+// AWS-LC defines |OPENSSL_NO_CRYPTO_MDEBUG| by default.
+// These are related to memory debugging functionalities provided by OpenSSL,
+// but are not supported in AWS-LC.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int CRYPTO_mem_ctrl(int mode);
 
 #if defined(BORINGSSL_FIPS_140_3)
 

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -175,6 +175,11 @@ OPENSSL_EXPORT unsigned long OpenSSL_version_num(void);
 
 OPENSSL_EXPORT unsigned long awslc_api_version_num(void);
 
+// |CRYPTO_mem_ctrl| intentionally does nothing.
+// AWS-LC does not support the related
+// memory debugging with |OPENSSL_NO_CRYPTO_MDEBUG| defined.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int CRYPTO_mem_ctrl(int mode);
+
 // CRYPTO_malloc_init returns one.
 OPENSSL_EXPORT int CRYPTO_malloc_init(void);
 


### PR DESCRIPTION
### Issues:
Addresses #CryptoAlg-2905

### Description of changes: 
Applications requiring CRYPTO_mem_ctrl can now build successfully. However, we define `OPENSSL_NO_CRYPTO_MDEBUG` in AWS-LC, which disables this functionality. As a result, the implemented function intentionally does nothing.

### Call-outs:
We've added a defensive compilation error that will trigger if `OPENSSL_NO_CRYPTO_MDEBUG` is removed in the future. This will allow us to fully implement the function if needed.

### Testing:
No testing is required for this intentional no-operation function. This approach is consistent with OpenSSL 1.1.1's handling of `OPENSSL_NO_CRYPTO_MDEBUG`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
