### PR TITLE
Prepare for v1.49.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.48.5");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.49.0");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.48.5");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.49.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.48.5"
+#define AWSLC_VERSION_NUMBER_STRING "1.49.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Revert "Allow constructed strings in BER parsing (#2015)" by @samuel40791765 in https://github.com/aws/aws-lc/pull/2278
* Add the rehash utility to the openssl CLI tool by @smittals2 in https://github.com/aws/aws-lc/pull/2258
* Documentation on service indicator by @justsmth in https://github.com/aws/aws-lc/pull/2281
* Update patches in Ruby CI by @samuel40791765 in https://github.com/aws/aws-lc/pull/2233
* Reject DSA trailing garbage in EVP layer, add test cases by @skmcgrail in https://github.com/aws/aws-lc/pull/2289
* Add support for verifying PKCS7 signed attributes by @samuel40791765 in https://github.com/aws/aws-lc/pull/2264
* Add support for more SSL BIO functions by @samuel40791765 in https://github.com/aws/aws-lc/pull/2273
* Wire-up rust-openssl into GitHub CI (for the time being) by @skmcgrail in https://github.com/aws/aws-lc/pull/2291
* Adding detection of out-of-bound pre-bound memory read to AES-XTS tests. by @nebeid in https://github.com/aws/aws-lc/pull/2286
* AES: Add function pointer trampoline to avoid delocator issue by @hanno-becker in https://github.com/aws/aws-lc/pull/2294
* Bump mysql CI to 9.2.0 by @samuel40791765 in https://github.com/aws/aws-lc/pull/2161
* Cherrypick hardening DSA param checks from BoringSSL  by @smittals2 in https://github.com/aws/aws-lc/pull/2293

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
