### PR TITLE
SSL_in_*_init macros

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1774,6 +1774,13 @@ OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl);
 
 // Connection information.
 
+// SSL_in_connect_init returns 1 if |ssl| is a client and has a pending
+// handshake. Otherwise, it returns 0.
+# define SSL_in_connect_init(a)          (SSL_in_init(a) && !SSL_is_server(a))
+// SSL_in_accept_init returns 1 if |ssl| is a server and has a pending
+// handshake. Otherwise, it returns 0.
+# define SSL_in_accept_init(a)           (SSL_in_init(a) && SSL_is_server(a))
+
 // SSL_is_init_finished returns one if |ssl| has completed its initial handshake
 // and has no pending handshake. It returns zero otherwise.
 OPENSSL_EXPORT int SSL_is_init_finished(const SSL *ssl);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1776,10 +1776,11 @@ OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_get_ciphers(const SSL *ssl);
 
 // SSL_in_connect_init returns 1 if |ssl| is a client and has a pending
 // handshake. Otherwise, it returns 0.
-# define SSL_in_connect_init(a)          (SSL_in_init(a) && !SSL_is_server(a))
+OPENSSL_EXPORT int SSL_in_connect_init(const SSL *ssl);
+
 // SSL_in_accept_init returns 1 if |ssl| is a server and has a pending
 // handshake. Otherwise, it returns 0.
-# define SSL_in_accept_init(a)           (SSL_in_init(a) && SSL_is_server(a))
+OPENSSL_EXPORT int SSL_in_accept_init(const SSL *ssl);
 
 // SSL_is_init_finished returns one if |ssl| has completed its initial handshake
 // and has no pending handshake. It returns zero otherwise.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -6178,6 +6178,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 #define SSL_set_tmp_ecdh SSL_set_tmp_ecdh
 #define SSL_set_tmp_rsa SSL_set_tmp_rsa
 #define SSL_total_renegotiations SSL_total_renegotiations
+#define SSL_in_connect_init SSL_in_connect_init
+#define SSL_in_accept_init SSL_in_accept_init
 
 #endif  // !defined(BORINGSSL_PREFIX)
 

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -3062,6 +3062,14 @@ int SSL_can_release_private_key(const SSL *ssl) {
   return !ssl->s3->hs || ssl->s3->hs->can_release_private_key;
 }
 
+int SSL_in_connect_init(const SSL *ssl) {
+  return SSL_in_init(ssl) && !SSL_is_server(ssl);
+}
+
+int SSL_in_accept_init(const SSL *ssl) {
+  return SSL_in_init(ssl) && SSL_is_server(ssl);
+}
+
 int SSL_is_init_finished(const SSL *ssl) { return !SSL_in_init(ssl); }
 
 int SSL_in_init(const SSL *ssl) {


### PR DESCRIPTION
### Description of changes: 
Provide functions `SSL_in_connect_init` and `SSL_in_accept_init`.

### Call-outs:
Function definitions match OpenSSL macros: https://github.com/openssl/openssl/blob/a3fc812c0c78e2f5db8b9d45bddaff62dfc958ae/include/openssl/ssl.h#L1071-L1073

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
