### PR TITLE
Prepare for v1.49.1

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.49.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.49.1");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.49.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.49.1");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.49.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.49.1"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* FIPS Integrity Hash Tooling by @skmcgrail in https://github.com/aws/aws-lc/pull/2296
* Add more build options to match callback build by @andrewhop in https://github.com/aws/aws-lc/pull/2279
* Add req to OpenSSL CLI tool by @smittals2 in https://github.com/aws/aws-lc/pull/2284
* Turn on better logging for EC2 test framework by @andrewhop in https://github.com/aws/aws-lc/pull/2298




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
