### PR TITLE
Remove unused ENABLE_DILITHIUM CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ endif()
 option(BUILD_TESTING "Build all test targets for AWS-LC" ON)
 option(BUILD_LIBSSL "Build libssl for AWS-LC" ON)
 option(BUILD_TOOL "Build bssl tool for AWS-LC" ON)
-option(ENABLE_DILITHIUM "Enable Dilithium signatures in the EVP API" OFF)
 option(DISABLE_PERL "Disable Perl for AWS-LC" OFF)
 option(DISABLE_GO "Disable Go for AWS-LC" OFF)
 option(ENABLE_FIPS_ENTROPY_CPU_JITTER "Enable FIPS entropy source: CPU Jitter" OFF)
@@ -168,11 +167,6 @@ endif()
 
 if(NOT PERL_EXECUTABLE OR NOT GO_EXECUTABLE)
   set(GENERATE_CODE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/generated-src")
-endif()
-
-
-if(ENABLE_DILITHIUM)
-  add_definitions(-DENABLE_DILITHIUM)
 endif()
 
 if(USE_CUSTOM_LIBCXX)

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -23,7 +23,6 @@ function build_aws_lc_fips {
   run_build \
       -DCMAKE_INSTALL_PREFIX="${install_dir}/aws-lc-fips" \
       -DFIPS=1 \
-      -DENABLE_DILITHIUM=ON \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DBUILD_SHARED_LIBS=1 \
       -DBUILD_TESTING=OFF \
@@ -45,7 +44,6 @@ function build_aws_lc_branch {
     cmake -GNinja \
         -DCMAKE_INSTALL_PREFIX="${install_dir}/aws-lc-${branch}" \
         -DFIPS=1 \
-        -DENABLE_DILITHIUM=ON \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DBUILD_SHARED_LIBS=1
     ninja install
@@ -83,7 +81,7 @@ build_openssl_no_debug $openssl_3_2_branch
 build_openssl_no_debug $openssl_master_branch
 build_boringssl
 
-run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DCMAKE_C_STANDARD=11 -DENABLE_DILITHIUM=ON -DBENCHMARK_LIBS="\
+run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DCMAKE_C_STANDARD=11 -DBENCHMARK_LIBS="\
 aws-lc-fips-2021:${install_dir}/aws-lc-fips-2021-10-20;\
 aws-lc-fips-2022:${install_dir}/aws-lc-fips-2022-11-02;\
 aws-lc-fips-2024:${install_dir}/aws-lc-fips-2024-09-27;\

--- a/tests/ci/run_posix_sanitizers.sh
+++ b/tests/ci/run_posix_sanitizers.sh
@@ -7,7 +7,7 @@ set -exo pipefail
 source tests/ci/common_posix_setup.sh
 
 build_type=Release
-cflags=("-DCMAKE_BUILD_TYPE=${build_type}" "-DENABLE_DILITHIUM=ON")
+cflags=("-DCMAKE_BUILD_TYPE=${build_type}")
 if [ $(uname -p) == "aarch64" ]; then
   # BoringSSL provides two sets tests: the C/C++ tests and the blackbox tests.
   # Details: https://github.com/google/boringssl/blob/master/BUILDING.md

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -7,38 +7,35 @@ set -exo pipefail
 source tests/ci/common_posix_setup.sh
 
 echo "Testing AWS-LC in debug mode."
-build_and_test -DENABLE_DILITHIUM=ON
+build_and_test
 echo "Testing c_rehash script executes."
 test_c_rehash
 
 echo "Testing AWS-LC in release mode."
-build_and_test -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
-
-echo "Testing AWS-LC with Dilithium3 disabled."
-build_and_test -DENABLE_DILITHIUM=OFF
+build_and_test -DCMAKE_BUILD_TYPE=Release
 
 echo "Testing AWS-LC small compilation."
-build_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+build_and_test -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release
 
 echo "Testing AWS-LC with libssl off."
-build_and_test -DBUILD_LIBSSL=OFF -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+build_and_test -DBUILD_LIBSSL=OFF -DCMAKE_BUILD_TYPE=Release
 
 echo "Testing AWS-LC in no asm mode."
-build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+build_and_test -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release
 
 echo "Testing building shared lib."
-build_and_test -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+build_and_test -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 
 echo "Testing with a SysGenId."
 TEST_SYSGENID_PATH=$(mktemp)
 dd if=/dev/zero of="${TEST_SYSGENID_PATH}" bs=1 count=4096
-build_and_test -DTEST_SYSGENID_PATH="${TEST_SYSGENID_PATH}" -DENABLE_DILITHIUM=ON
+build_and_test -DTEST_SYSGENID_PATH="${TEST_SYSGENID_PATH}"
 
 echo "Testing with pre-generated assembly code."
-build_and_test -DDISABLE_PERL=ON -DENABLE_DILITHIUM=ON
+build_and_test -DDISABLE_PERL=ON
 
 echo "Testing building with AArch64 Data-Independent Timing (DIT) on."
-build_and_test -DENABLE_DATA_INDEPENDENT_TIMING=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+build_and_test -DENABLE_DATA_INDEPENDENT_TIMING=ON -DCMAKE_BUILD_TYPE=Release
 
 # Lightly verify that uncommon build options does not break the build. Fist
 # define a list of typical build options to verify the special build option with
@@ -46,10 +43,10 @@ build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "
 
 ## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
 for build_option in "${build_options_to_test[@]}"; do
-  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON -DENABLE_DILITHIUM=ON
+  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
 done
 
 ## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
 for build_option in "${build_options_to_test[@]}"; do
-  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON -DENABLE_DILITHIUM=ON
+  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON
 done


### PR DESCRIPTION
### Description of changes: 
Dilithium (really ML-DSA) is always enabled in AWS-LC now. No C or C++ files used the ENABLE_DILITHIUM define.

### Call-outs:
Any customers or automated builds of AWS-LC that define the CMake option will not be broken by this. They will get a small message and the build will continue:

```
CMake Warning:
  Manually-specified variables were not used by the project:

    ENABLE_DILITHIUM


-- Build files have been written to: ~/aws-lc/build
```

This will also save some CI time by reducing the total number of builds in the posix tests by 1. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
