### PR TITLE
Remove FFDHE and SECLEVEL python test patches

### DIFF
--- a/tests/ci/integration/python_patch/3.12/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/3.12/aws-lc-cpython.patch
@@ -23,23 +23,6 @@ index f3960be..ffd360b 100644
  
  PROTOCOLS = sorted(ssl._PROTOCOL_NAMES)
  HOST = socket_helper.HOST
-@@ -167,7 +168,7 @@ def is_ubuntu():
-     except FileNotFoundError:
-         return False
- 
--if is_ubuntu():
-+if is_ubuntu() and not Py_OPENSSL_IS_AWSLC:
-     def seclevel_workaround(*ctxs):
-         """"Lower security level to '1' and allow all ciphers for TLS 1.0/1"""
-         for ctx in ctxs:
-@@ -3954,6 +3958,7 @@ def test_no_legacy_server_connect(self):
-                                    sni_name=hostname)
- 
-     @unittest.skipIf(Py_DEBUG_WIN32, "Avoid mixing debug/release CRT on Windows")
-+    @unittest.skipIf(Py_OPENSSL_IS_AWSLC, "AWS-LC doesn't support (FF)DHE")
-     def test_dh_params(self):
-         # Check we can get a connection with ephemeral Diffie-Hellman
-         client_context, server_context, hostname = testing_context()
 @@ -4313,7 +4318,10 @@ def test_session_handling(self):
                                   'Session refers to a different SSLContext.')
  

--- a/tests/ci/integration/python_patch/3.13/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/3.13/aws-lc-cpython.patch
@@ -23,23 +23,6 @@ index 7fdd2be..7d8839f 100644
  
  PROTOCOLS = sorted(ssl._PROTOCOL_NAMES)
  HOST = socket_helper.HOST
-@@ -177,7 +178,7 @@ def is_ubuntu():
-     except FileNotFoundError:
-         return False
- 
--if is_ubuntu():
-+if is_ubuntu() and not Py_OPENSSL_IS_AWSLC:
-     def seclevel_workaround(*ctxs):
-         """"Lower security level to '1' and allow all ciphers for TLS 1.0/1"""
-         for ctx in ctxs:
-@@ -4061,6 +4062,7 @@ def test_no_legacy_server_connect(self):
-                                    sni_name=hostname)
- 
-     @unittest.skipIf(Py_DEBUG_WIN32, "Avoid mixing debug/release CRT on Windows")
-+    @unittest.skipIf(Py_OPENSSL_IS_AWSLC, "AWS-LC doesn't support (FF)DHE")
-     def test_dh_params(self):
-         # Check we can get a connection with ephemeral Diffie-Hellman
-         client_context, server_context, hostname = testing_context()
 @@ -4424,14 +4426,14 @@ def test_session_handling(self):
      def test_psk(self):
          psk = bytes.fromhex('deadbeef')

--- a/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
@@ -2,31 +2,6 @@ diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
 index 0e50d09..f4b7b3c 100644
 --- a/Lib/test/test_ssl.py
 +++ b/Lib/test/test_ssl.py
-@@ -41,6 +41,7 @@
- from ssl import Purpose, TLSVersion, _TLSContentType, _TLSMessageType, _TLSAlertType
- 
- Py_DEBUG_WIN32 = support.Py_DEBUG and sys.platform == 'win32'
-+Py_OPENSSL_IS_AWSLC = "AWS-LC" in ssl.OPENSSL_VERSION
- 
- PROTOCOLS = sorted(ssl._PROTOCOL_NAMES)
- HOST = socket_helper.HOST
-@@ -174,7 +175,7 @@ def is_ubuntu():
-     except FileNotFoundError:
-         return False
- 
--if is_ubuntu():
-+if is_ubuntu() and not Py_OPENSSL_IS_AWSLC:
-     def seclevel_workaround(*ctxs):
-         """"Lower security level to '1' and allow all ciphers for TLS 1.0/1"""
-         for ctx in ctxs:
-@@ -4001,6 +4002,7 @@ def test_no_legacy_server_connect(self):
-                                    sni_name=hostname)
- 
-     @unittest.skipIf(Py_DEBUG_WIN32, "Avoid mixing debug/release CRT on Windows")
-+    @unittest.skipIf(Py_OPENSSL_IS_AWSLC, "AWS-LC doesn't support (FF)DHE")
-     def test_dh_params(self):
-         # Check we can get a connection with ephemeral Diffie-Hellman
-         client_context, server_context, hostname = testing_context()
 @@ -4443,14 +4445,14 @@ def server_callback(identity):
              self.assertEqual(identity, client_identity)
              return psk


### PR DESCRIPTION
### Description of changes: 

Two recent upstream CPython PRs removed the need for patching around our lack of support for [FFDHE TLS ciphersuites](https://github.com/python/cpython/pull/131051) and [non-0 `SECLEVEL` values](https://github.com/python/cpython/pull/131739).

### Call-outs:
n/a

### Testing:
- local
- CI

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
