### PR TITLE
Add FIPS callback tests for x86 AL2023 and arm AL2/AL2023

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -262,6 +262,29 @@ batch:
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_fips_tests.sh"
 
+    - identifier: amazonlinux2_clang7x_aarch_fips_callback
+      buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2_clang-7x_latest
+        variables:
+          # AL2 Clang-7 does not support AddressSanitizer. Related ticket is linked in CryptoAlg-694.
+          # https://github.com/aws/aws-lc/pull/120#issuecomment-808439279
+          AWSLC_NO_ASM_FIPS: 0
+          AWS_LC_CI_TARGET: "tests/ci/run_fips_callback_tests.sh"
+
+    - identifier: amazonlinux2023_gcc11x_aarch_fips_callback
+      buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2023_gcc-11x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/run_fips_callback_tests.sh"
+
     - identifier: amazonlinux2023_clang15x_aarch
       buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
       env:

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -638,3 +638,12 @@ batch:
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_fips_callback_tests.sh"
 
+    - identifier: amazonlinux2023_gcc11x_x86_64_fips_callback
+      buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:amazonlinux-2023_gcc-11x_latest
+        variables:
+          AWS_LC_CI_TARGET: "tests/ci/run_fips_callback_tests.sh"


### PR DESCRIPTION
### Description of changes: 
Cover a small testing gap for an AL2023 customers that want to use the callback feature. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
