### PR TITLE
Stop more background process that might be holding any apt locks in the EC2 test framework

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
@@ -15,7 +15,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
         variables:
-          EC2_AMI: "ami-0c29a2c5cf69b5a9c"
+          EC2_AMI: "ami-0e8c824f386e1de06"
           EC2_INSTANCE_TYPE: "c6g.2xlarge"
           ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"
           TARGET_TEST_SCRIPT: "./tests/ci/run_posix_sanitizers.sh"
@@ -28,7 +28,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
         variables:
-          EC2_AMI: "ami-0c29a2c5cf69b5a9c"
+          EC2_AMI: "ami-0e8c824f386e1de06"
           EC2_INSTANCE_TYPE: "c6g.4xlarge"
           ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"
           TARGET_TEST_SCRIPT: "./tests/ci/run_fips_tests.sh"
@@ -42,7 +42,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
         variables:
-          EC2_AMI: "ami-0c29a2c5cf69b5a9c"
+          EC2_AMI: "ami-0e8c824f386e1de06"
           EC2_INSTANCE_TYPE: "r8g.2xlarge"
           ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"
           TARGET_TEST_SCRIPT: "./tests/ci/run_posix_sanitizers.sh"
@@ -55,7 +55,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
         variables:
-          EC2_AMI: "ami-0c29a2c5cf69b5a9c"
+          EC2_AMI: "ami-0e8c824f386e1de06"
           EC2_INSTANCE_TYPE: "r8g.2xlarge"
           ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"
           TARGET_TEST_SCRIPT: "./tests/ci/run_fips_tests.sh"

--- a/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
+++ b/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
@@ -24,15 +24,41 @@ mainSteps:
             systemctl stop apt-daily.timer
             systemctl stop apt-daily-upgrade.timer
             systemctl stop unattended-upgrades.service
+            systemctl stop apt-daily-upgrade.service
+            systemctl stop unattended-upgrades.service
+            systemctl mask apt-daily.service
+            systemctl mask apt-daily-upgrade.service
+            systemctl mask unattended-upgrades.service
+            
+            # Wait for any background process to release the package locks
+            max_attempts=120; attempts=0; 
+            echo "Waiting for apt/dpkg to become available...";
+            while [ $attempts -lt $max_attempts ]; do
+                if ! lsof /var/lib/dpkg/lock-frontend >/dev/null 2>&1 && ! lsof /var/lib/dpkg/lock >/dev/null 2>&1 && ! lsof /var/lib/apt/lists/lock >/dev/null 2>&1 && ! lsof /var/cache/apt/archives/lock >/dev/null 2>&1; then
+                    if ! pgrep -f "apt|dpkg" >/dev/null 2>&1; then
+                        echo "APT/DPKG is now available.";
+                        break;
+                    fi;
+                fi;
+                echo "Waiting for package manager to release locks... (attempt $attempts)";
+                sleep 5;
+                attempts=$((attempts+1));
+            done;
+            if [ $attempts -eq $max_attempts ]; then
+                echo "ERROR: Package manager locks were not released within the timeout period.";
+                exit 1;
+            fi
+            
             export DEBIAN_FRONTEND=noninteractive
             export CPU_TYPE=$(dpkg --print-architecture)
             export SOURCE={SOURCE}
+            
             # if we have a cpu type of x86, we want linux-x86
             if [ "${CPU_TYPE}" = amd64 ]; then export CPU_ARCH=linux-x86; export AWS_CLI_PREFIX=x86_; fi
             # if we have a cpu type of arm, we want linux-aarch
             if [ "${CPU_TYPE}" = arm64 ]; then export CPU_ARCH=linux-aarch; export AWS_CLI_PREFIX=aarch; fi
+            
             # install aws-cli
-            killall apt apt-get || echo "No apt processes found"
             apt-get update
             apt-get -y remove needrestart
             apt-get -y install unzip
@@ -53,6 +79,7 @@ mainSteps:
                 exit 1
               fi
             fi
+            
             # install docker if its not already installed
             chmod +x ./tests/ci/benchmark_framework/install_docker.sh
             ./tests/ci/benchmark_framework/install_docker.sh

--- a/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
+++ b/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
@@ -37,7 +37,7 @@ mainSteps:
             apt-get -y remove needrestart
             apt-get -y install unzip
             curl "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_CLI_PREFIX}64.zip" -o "awscliv2.zip"
-            unzip awscliv2.zip
+            unzip -q awscliv2.zip
             ./aws/install
             # Check if the source code is on S3, otherwise treat the source as a PR.
             if [ "$(expr substr "$SOURCE" 1 16)" = "aws-lc-codebuild" ]; then

--- a/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
+++ b/tests/ci/cdk/cdk/ssm/general_test_run_ssm_document.yaml
@@ -22,6 +22,8 @@ mainSteps:
             shutdown -P +90
             sudo -i
             systemctl stop apt-daily.timer
+            systemctl stop apt-daily-upgrade.timer
+            systemctl stop unattended-upgrades.service
             export DEBIAN_FRONTEND=noninteractive
             export CPU_TYPE=$(dpkg --print-architecture)
             export SOURCE={SOURCE}


### PR DESCRIPTION
### Description of changes:
* Update to latest Ubuntu AMI so there are fewer things to update as well
* Check the lock and wait for it to be released before installing our dependencies
* Kill more background update processes, from the debian docs:
    * Used for downloads: /lib/systemd/system/apt-daily.timer 
    * Used for upgrades: /lib/systemd/system/apt-daily-upgrade.timer 
    * The purpose of [unattended-upgrades](https://packages.debian.org/unattended-upgrades) is to keep the computer current with the latest security (and other) updates automatically

These instance are short lived (under an hour) and don't need any updates. But these background process cause issues when our test script attempts to install the AWS CLI:
```
+ apt-get -y remove needrestart
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 1301 (python3)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
