### PR TITLE
Run clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,46 @@
+---
+Checks: '
+  -*,
+  clang-analyzer-*,
+  -clang-analyzer-optin.*,
+  -clang-analyzer-unix.Stream,
+  '
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle: none
+
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.StaticConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.StaticVariableCase
+    value: camelBack
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.MemberCase
+    value: camelBack
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.ProtectedMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.PublicMemberCase
+    value: camelBack
+  - key: readability-identifier-naming.MethodCase
+    value: camelBack
+  - key: readability-identifier-naming.ParameterCase
+    value: camelBack
+  - key: readability-identifier-naming.TypeAliasCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack

--- a/.github/workflows/clang-tidy-post.yml
+++ b/.github/workflows/clang-tidy-post.yml
@@ -1,0 +1,17 @@
+name: clang-tidy-post
+
+on:
+  workflow_run:
+    workflows: ["clang-tidy-review"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ZedThree/clang-tidy-review/post@v0.20.1
+        with:
+          lgtm_comment_body: 'Looks good to me!'
+          annotations: false
+          max_comments: 10

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,0 +1,18 @@
+name: clang-tidy-review
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+      - name: Build Project
+        run: ./util/build_compilation_database.sh
+      - uses: ZedThree/clang-tidy-review@v0.20.1
+        with:
+          split_workflow: true
+
+      - uses: ZedThree/clang-tidy-review/upload@v0.20.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,23 @@ if(BUILD_TESTING OR BUILD_LIBSSL)
   enable_language(CXX)
 endif()
 
+if(ENABLE_CLANG_TIDY)
+  find_program(CLANG_TIDY_CMD NAMES clang-tidy)
+  set(CMAKE_VERBOSE_MAKEFILE ON)
+
+  if(NOT CLANG_TIDY_CMD)
+    message(WARNING "clang-tidy is not found!")
+    set(CMAKE_CXX_CLANG_TIDY "" CACHE STRING "" FORCE)
+  else()
+    message(STATUS "clang-tidy found: ${CLANG_TIDY_CMD}")
+    set(CLANG_TIDY_EXTRA_ARGS
+            "-extra-arg=-Wno-unknown-warning-option"
+    )
+    set(CMAKE_C_CLANG_TIDY ${CLANG_TIDY_CMD} "--config-file=${AWSLC_SOURCE_DIR}/.clang-tidy")
+    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_CMD} "--config-file=${AWSLC_SOURCE_DIR}/.clang-tidy")
+  endif()
+endif()
+
 if (NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()


### PR DESCRIPTION
### Description of changes: 
* Created a .clang-tidy configuration file.
* Added an `ENABLE_CLANG_TIDY` option for out CMake build.
* Added CI workflows for clang-tidy.
  * `clang-tidy-review` performs reviews and uploads the artifacts.
  * `clang-tidy-post` posts comments to the PR.
  * These two workflow must be separate due to limited permissions on PRs originating from forks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
