### PR TITLE
Make ASN1_get_object a direct call

### DIFF
--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -63,9 +63,9 @@
 #include <openssl/err.h>
 #include <openssl/mem.h>
 
+#include "../bytestring/internal.h"
 #include "../internal.h"
 #include "internal.h"
-#include "../bytestring/internal.h"
 
 
 // Cross-module errors from crypto/x509/i2d_pr.c.
@@ -114,9 +114,21 @@ OPENSSL_DECLARE_ERROR_REASON(ASN1, UNSUPPORTED_TYPE)
 
 static void asn1_put_length(unsigned char **pp, int length);
 
-int asn1_get_object_maybe_indefinite(const unsigned char **inp, long *out_len,
-                                     int *out_tag, int *out_class, long in_len,
-                                     int indefinite_ok) {
+// |ASN1_get_object| parses an ASN.1 header, including tag, class, and length
+// information. The tag number is written to |*out_tag|. The class is written to
+// |*out_class|. If the tag is not indefinite, the content length is written to
+// |*out_len|. If the tag indicates the indefinite form, |*out_len| is set to 0.
+// |inp| is advanced past the header in the input buffer.
+//
+// Indefinite-length encoding and universal tags are always allowed to align
+// with OpenSSL behavior.
+//
+// The return value may have the following bits set:
+//   * 0x80: error occurred while parsing.
+//   * 0x20: the encoding is constructed, not primitive.
+//   * 0x01: indefinite-length constructed encoding.
+int ASN1_get_object(const unsigned char **inp, long *out_len, int *out_tag,
+                    int *out_class, long in_len) {
   if (in_len < 0) {
     OPENSSL_PUT_ERROR(ASN1, ASN1_R_HEADER_TOO_LONG);
     return 0x80;
@@ -137,8 +149,8 @@ int asn1_get_object_maybe_indefinite(const unsigned char **inp, long *out_len,
   int ber_found_temp;
   if (!cbs_get_any_asn1_element(&cbs, &body, &tag, &header_len, &ber_found_temp,
                                 &indefinite, /*ber_ok=*/1,
-                                /*universal_tag_ok=*/indefinite_ok) ||
-      (indefinite && !indefinite_ok) || !CBS_skip(&body, header_len) ||
+                                /*universal_tag_ok=*/1) ||
+      !CBS_skip(&body, header_len) ||
       // Bound the length to comfortably fit in an int. Lengths in this
       // module often switch between int and long without overflow checks.
       CBS_len(&body) > INT_MAX / 2) {
@@ -166,12 +178,6 @@ int asn1_get_object_maybe_indefinite(const unsigned char **inp, long *out_len,
   *out_tag = tag_number;
   *out_class = tag_class;
   return constructed;
-}
-
-int ASN1_get_object(const unsigned char **inp, long *out_len, int *out_tag,
-                    int *out_class, long in_len) {
-  return asn1_get_object_maybe_indefinite(inp, out_len, out_tag, out_class, in_len,
-    /*indefinite_ok=*/1);
 }
 
 // class 0 is constructed constructed == 2 for indefinite length constructed

--- a/crypto/asn1/internal.h
+++ b/crypto/asn1/internal.h
@@ -217,21 +217,6 @@ void asn1_type_cleanup(ASN1_TYPE *a);
 // ASN.1 PrintableString, and zero otherwise.
 int asn1_is_printable(uint32_t value);
 
-// asn1_get_object_maybe_indefinite parses an ASN.1 header, including tag, class,
-// and length information. The tag number is written to |*out_tag|. The class is
-// written to |*out_class|. If the tag is not indefinite, the content length is
-// written to |*out_len|. |inp| is advanced past the header in the input buffer.
-//
-// If |indefinite_ok| is non-zero, indefinite-length encoding and universal tags
-// are allowed, otherwise these will produce errors.
-//
-// The return value may have the following bits set:
-//   * 0x80: error occurred while parsing.
-//   * 0x20: the encoding is constructed, not primitive.
-//   * 0x01: indefinite-length constructed encoding.
-int asn1_get_object_maybe_indefinite(const unsigned char **inp, long *out_len, int *out_tag,
-                        int *out_class, long in_len, int indefinite_ok);
-
 // asn1_bit_string_length returns the number of bytes in |str| and sets
 // |*out_padding_bits| to the number of padding bits.
 //


### PR DESCRIPTION
### Description of changes: 
https://github.com/aws/aws-lc/commit/eafd9404887d5982dd647bd4f914664281130060 made all calls to ASN1 parsers able to parse indefinite length BER. This work to do this was easier thanks to https://github.com/aws/aws-lc/commit/cfe86a3830d5212099b2284a964be066c653dcbc, but this also removes the need for the divergent logic in `asn1_get_object_maybe_indefinite`. 

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
