### PR TITLE
Fix CMake (< v3.20) warning

### DIFF
--- a/tool-openssl/CMakeLists.txt
+++ b/tool-openssl/CMakeLists.txt
@@ -47,14 +47,17 @@ install(TARGETS openssl
         BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-configure_file(
+file(INSTALL
     ${CMAKE_CURRENT_SOURCE_DIR}/c_rehash.sh
-    ${CMAKE_CURRENT_BINARY_DIR}/c_rehash
-    COPYONLY
+    DESTINATION
+    ${CMAKE_CURRENT_BINARY_DIR}
+    NO_SOURCE_PERMISSIONS
     FILE_PERMISSIONS
     OWNER_READ OWNER_WRITE OWNER_EXECUTE
     GROUP_READ GROUP_EXECUTE
     WORLD_READ WORLD_EXECUTE
+    RENAME
+    c_rehash
 )
 
 install(
@@ -95,14 +98,17 @@ if(BUILD_TESTING)
         x509_test.cc
     )
 
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/c_rehash_test.sh
-        ${CMAKE_CURRENT_BINARY_DIR}/c_rehash_test
-        COPYONLY
-        FILE_PERMISSIONS
-        OWNER_READ OWNER_WRITE OWNER_EXECUTE
-        GROUP_READ GROUP_EXECUTE
-        WORLD_READ WORLD_EXECUTE
+    file(INSTALL
+            ${CMAKE_CURRENT_SOURCE_DIR}/c_rehash_test.sh
+            DESTINATION
+            ${CMAKE_CURRENT_BINARY_DIR}
+            NO_SOURCE_PERMISSIONS
+            FILE_PERMISSIONS
+            OWNER_READ OWNER_WRITE OWNER_EXECUTE
+            GROUP_READ GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE
+            RENAME
+            c_rehash_test
     )
 
     target_link_libraries(tool_openssl_test boringssl_gtest_main ssl crypto)


### PR DESCRIPTION
### Description of changes:
* Use `file` instead of `configure_file` for copying scripts.
  * Fixes warning output when using older CMake versions.

### Callouts
* The `FILE_PERMISSIONS` option for [`configure_file` is only available after v3.20](https://cmake.org/cmake/help/latest/command/configure_file.html#id2). Older CMake versions produce the following warning:
```
CMake Warning (dev) at tool-openssl/CMakeLists.txt:50 (configure_file):
  configure_file called with unknown argument(s):

   FILE_PERMISSIONS
   OWNER_READ
   OWNER_WRITE
   OWNER_EXECUTE
   GROUP_READ
   GROUP_EXECUTE
   WORLD_READ
   WORLD_EXECUTE

This warning is for project developers.  Use -Wno-dev to suppress it.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
