### PR TITLE
Add MLDSA44 and MLDSA87 to OBJ_find_sigid_algs

### DIFF
--- a/crypto/obj/obj_xref.c
+++ b/crypto/obj/obj_xref.c
@@ -93,7 +93,9 @@ static const nid_triple kTriples[] = {
     // digest "undef" indicates the caller should handle this explicitly.
     {NID_rsassaPss, NID_undef, NID_rsaEncryption},
     {NID_ED25519, NID_undef, NID_ED25519},
-    {NID_MLDSA65, NID_undef, NID_MLDSA65}
+    {NID_MLDSA44, NID_undef, NID_MLDSA44},
+    {NID_MLDSA65, NID_undef, NID_MLDSA65},
+    {NID_MLDSA87, NID_undef, NID_MLDSA87},
 };
 
 int OBJ_find_sigid_algs(int sign_nid, int *out_digest_nid, int *out_pkey_nid) {


### PR DESCRIPTION
### Issues:
resolves https://github.com/aws/aws-lc/issues/2347

### Description of changes: 
Add the missing nids so that OBJ_find_sigid_algs succeeds.

### Testing:
Just manual testing. When I build s2n-tls against this fix, my ML-DSA certificate parsing tests pass without any hacky workarounds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
