### PR TITLE
Bump to v1.50.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.49.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.50.0");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.49.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.50.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.49.1"
+#define AWSLC_VERSION_NUMBER_STRING "1.50.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Bump version to 1.50.0

#### What's Changed
* Remove FFDHE and SECLEVEL python test patches by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2307
* Remove unused ENABLE_DILITHIUM CMake option by @andrewhop in https://github.com/aws/aws-lc/pull/2304
* SSL_in_*_init macros by @justsmth in https://github.com/aws/aws-lc/pull/2302
* Fix link to bcm.c in FIPS.md by @justsmth in https://github.com/aws/aws-lc/pull/2309
* Test build with CMake v4.0 by @justsmth in https://github.com/aws/aws-lc/pull/2251
* Update formal verification section in README.md by @pennyannn in https://github.com/aws/aws-lc/pull/2301
* Add CI for Xtrabackup by @samuel40791765 in https://github.com/aws/aws-lc/pull/2275
* Add Libwebsockets to our CI by @smittals2 in https://github.com/aws/aws-lc/pull/2290
* Implement legacy callback with BIO_set_callback by @kingstjo in https://github.com/aws/aws-lc/pull/2285
* Import mlkem-native by @hanno-becker in https://github.com/aws/aws-lc/pull/2176
* Split out socket BIO tests by @justsmth in https://github.com/aws/aws-lc/pull/2320
* Run clang tidy by @justsmth in https://github.com/aws/aws-lc/pull/2323
* Tweaking clang-tidy config by @justsmth in https://github.com/aws/aws-lc/pull/2329
* Reinstate indefinite length and [UNIVERSAL 0] support in crypto/asn1 by @samuel40791765 in https://github.com/aws/aws-lc/pull/2306
* Implemented no-op CRYPTO_mem_ctrl by @kingstjo in https://github.com/aws/aws-lc/pull/2295
* SCRUTINICE Fixes by @smittals2 in https://github.com/aws/aws-lc/pull/2326
* Fix clang-tidy lints by @justsmth in https://github.com/aws/aws-lc/pull/2328
* Reinstate support for constructed strings in crypto/asn1 by @samuel40791765 in https://github.com/aws/aws-lc/pull/2310
* Migrate jobs from ubuntu-20.04 to ubuntu-22.04 by @skmcgrail in https://github.com/aws/aws-lc/pull/2337
* Add SecP384r1MLKEM1024 by @alexw91 in https://github.com/aws/aws-lc/pull/2327
* Test on 13.5 and 14.2 FreeBSD which are non-EOL, Fix Workflow by @skmcgrail in https://github.com/aws/aws-lc/pull/2338
* Add FIPS callback tests for x86 AL2023 and arm AL2/AL2023 by @andrewhop in https://github.com/aws/aws-lc/pull/2311
* Checkout full depth of repo for tag ci check to work on push events by @skmcgrail in https://github.com/aws/aws-lc/pull/2343
* Fix CMake (< v3.20) warning by @justsmth in https://github.com/aws/aws-lc/pull/2345
* Add MLDSA44 and MLDSA87 to OBJ_find_sigid_algs by @lrstewart in https://github.com/aws/aws-lc/pull/2348
* Bump AWSLC_API_VERSION to account for OBJ_find_sigid_algs bug by @lrstewart in https://github.com/aws/aws-lc/pull/2349
* GCC-10 & Clang-10 testing for Ubuntu-20.04 via container by @skmcgrail in https://github.com/aws/aws-lc/pull/2346


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
