### PR TITLE
Expand .clang-tidy configuration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,54 +1,16 @@
 ---
 Checks: '
   -*,
-  bugprone-dangling-handle,
-  bugprone-integer-overflow,
-  bugprone-infinite-loop,
-  bugprone-leak,
-  bugprone-use-after-free,
-  clang-analyzer-*,
-  cppcoreguidelines-pro-bounds-constant-index,
-  security-*,
-  -clang-analyzer-optin.*,
-  -clang-analyzer-unix.Stream,
-  -clang-analyzer-cplusplus.NewDeleteLeaks
+  bugprone-*,
+  cert-*,
+  clang-analyzer,
+  concurrency-*,
+  cppcoreguidelines-*,
+  hicpp-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*
   '
 WarningsAsErrors: ''
-HeaderFilterRegex: ''
-FormatStyle: none
-
-CheckOptions:
-  - key: readability-identifier-naming.ClassCase
-    value: CamelCase
-  - key: readability-identifier-naming.ConstexprVariableCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.EnumCase
-    value: CamelCase
-  - key: readability-identifier-naming.EnumConstantCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.FunctionCase
-    value: camelBack
-  - key: readability-identifier-naming.GlobalConstantCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.StaticConstantCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.StaticVariableCase
-    value: camelBack
-  - key: readability-identifier-naming.MacroDefinitionCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.MemberCase
-    value: camelBack
-  - key: readability-identifier-naming.PrivateMemberPrefix
-    value: m_
-  - key: readability-identifier-naming.ProtectedMemberPrefix
-    value: m_
-  - key: readability-identifier-naming.PublicMemberCase
-    value: camelBack
-  - key: readability-identifier-naming.MethodCase
-    value: camelBack
-  - key: readability-identifier-naming.ParameterCase
-    value: camelBack
-  - key: readability-identifier-naming.TypeAliasCase
-    value: CamelCase
-  - key: readability-identifier-naming.VariableCase
-    value: camelBack


### PR DESCRIPTION
### Description of changes: 
* Expand the number of checks done by clang-tidy.

### Call-outs:

<details>
<summary>CLICK HERE for a dump of clang-tidy configuration: <pre>$ clang-tidy --dump-config
...
</pre></summary>

```
---
Checks:          'clang-diagnostic-*,clang-analyzer-*, -*, bugprone-*, cert-*, clang-analyzer, concurrency-*, cppcoreguidelines-*, hicpp-*, misc-*, modernize-*, performance-*, portability-*, readability-* '
WarningsAsErrors: ''
HeaderFileExtensions:
  - ''
  - h
  - hh
  - hpp
  - hxx
ImplementationFileExtensions:
  - c
  - cc
  - cpp
  - cxx
HeaderFilterRegex: ''
ExcludeHeaderFilterRegex: ''
FormatStyle:     none
User:            justsmth
CheckOptions:
  bugprone-argument-comment.CommentBoolLiterals: '0'
  bugprone-argument-comment.CommentCharacterLiterals: '0'
  bugprone-argument-comment.CommentFloatLiterals: '0'
  bugprone-argument-comment.CommentIntegerLiterals: '0'
  bugprone-argument-comment.CommentNullPtrs: '0'
  bugprone-argument-comment.CommentStringLiterals: '0'
  bugprone-argument-comment.CommentUserDefinedLiterals: '0'
  bugprone-argument-comment.IgnoreSingleArgument: '0'
  bugprone-argument-comment.StrictMode: '0'
  bugprone-assert-side-effect.AssertMacros: assert,NSAssert,NSCAssert
  bugprone-assert-side-effect.CheckFunctionCalls: 'false'
  bugprone-assert-side-effect.IgnoredFunctions: __builtin_expect
  bugprone-dangling-handle.HandleClasses: 'std::basic_string_view;std::experimental::basic_string_view;std::span'
  bugprone-easily-swappable-parameters.IgnoredParameterNames: '"";iterator;Iterator;begin;Begin;end;End;first;First;last;Last;lhs;LHS;rhs;RHS'
  bugprone-easily-swappable-parameters.IgnoredParameterTypeSuffixes: 'bool;Bool;_Bool;it;It;iterator;Iterator;inputit;InputIt;forwardit;ForwardIt;bidirit;BidirIt;constiterator;const_iterator;Const_Iterator;Constiterator;ConstIterator;RandomIt;randomit;random_iterator;ReverseIt;reverse_iterator;reverse_const_iterator;ConstReverseIterator;Const_Reverse_Iterator;const_reverse_iterator;Constreverseiterator;constreverseiterator'
  bugprone-easily-swappable-parameters.MinimumLength: '2'
  bugprone-easily-swappable-parameters.ModelImplicitConversions: 'true'
  bugprone-easily-swappable-parameters.NamePrefixSuffixSilenceDissimilarityTreshold: '1'
  bugprone-easily-swappable-parameters.QualifiersMix: 'false'
  bugprone-easily-swappable-parameters.SuppressParametersUsedTogether: 'true'
  bugprone-empty-catch.AllowEmptyCatchForExceptions: ''
  bugprone-empty-catch.IgnoreCatchWithKeywords: '@TODO;@FIXME'
  bugprone-exception-escape.FunctionsThatShouldNotThrow: ''
  bugprone-exception-escape.IgnoredExceptions: ''
  bugprone-implicit-widening-of-multiplication-result.IgnoreConstantIntExpr: 'false'
  bugprone-implicit-widening-of-multiplication-result.IncludeStyle: llvm
  bugprone-implicit-widening-of-multiplication-result.UseCXXHeadersInCppSources: 'true'
  bugprone-implicit-widening-of-multiplication-result.UseCXXStaticCastsInCppSources: 'true'
  bugprone-lambda-function-name.IgnoreMacros: 'false'
  bugprone-misplaced-widening-cast.CheckImplicitCasts: 'false'
  bugprone-narrowing-conversions.IgnoreConversionFromTypes: ''
  bugprone-narrowing-conversions.PedanticMode: 'false'
  bugprone-narrowing-conversions.WarnOnEquivalentBitWidth: 'true'
  bugprone-narrowing-conversions.WarnOnFloatingPointNarrowingConversion: 'true'
  bugprone-narrowing-conversions.WarnOnIntegerNarrowingConversion: 'true'
  bugprone-narrowing-conversions.WarnOnIntegerToFloatingPointNarrowingConversion: 'true'
  bugprone-narrowing-conversions.WarnWithinTemplateInstantiation: 'false'
  bugprone-non-zero-enum-to-bool-conversion.EnumIgnoreList: ''
  bugprone-not-null-terminated-result.WantToUseSafeFunctions: 'true'
  bugprone-optional-value-conversion.OptionalTypes: '::std::optional;::absl::optional;::boost::optional'
  bugprone-optional-value-conversion.ValueMethods: '::value$;::get$'
  bugprone-pointer-arithmetic-on-polymorphic-object.IgnoreInheritedVirtualFunctions: 'false'
  bugprone-reserved-identifier.AggressiveDependentMemberLookup: 'false'
  bugprone-reserved-identifier.AllowedIdentifiers: ''
  bugprone-reserved-identifier.Invert: 'false'
  bugprone-signal-handler.AsyncSafeFunctionSet: POSIX
  bugprone-signed-char-misuse.CharTypdefsToIgnore: ''
  bugprone-signed-char-misuse.DiagnoseSignedUnsignedCharComparisons: 'true'
  bugprone-sizeof-expression.WarnOnOffsetDividedBySizeOf: 'true'
  bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant: 'true'
  bugprone-sizeof-expression.WarnOnSizeOfConstant: 'true'
  bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression: 'false'
  bugprone-sizeof-expression.WarnOnSizeOfPointer: 'false'
  bugprone-sizeof-expression.WarnOnSizeOfPointerToAggregate: 'true'
  bugprone-sizeof-expression.WarnOnSizeOfThis: 'true'
  bugprone-string-constructor.LargeLengthThreshold: '8388608'
  bugprone-string-constructor.StringNames: '::std::basic_string;::std::basic_string_view'
  bugprone-string-constructor.WarnOnLargeLength: 'true'
  bugprone-stringview-nullptr.IncludeStyle: llvm
  bugprone-suspicious-enum-usage.StrictMode: 'false'
  bugprone-suspicious-missing-comma.MaxConcatenatedTokens: '5'
  bugprone-suspicious-missing-comma.RatioThreshold: '0.200000'
  bugprone-suspicious-missing-comma.SizeThreshold: '5'
  bugprone-suspicious-string-compare.StringCompareLikeFunctions: ''
  bugprone-suspicious-string-compare.WarnOnImplicitComparison: 'true'
  bugprone-suspicious-string-compare.WarnOnLogicalNotComparison: 'false'
  bugprone-suspicious-stringview-data-usage.AllowedCallees: ''
  bugprone-suspicious-stringview-data-usage.StringViewTypes: '::std::basic_string_view;::llvm::StringRef'
  bugprone-tagged-union-member-count.CountingEnumPrefixes: ''
  bugprone-tagged-union-member-count.CountingEnumSuffixes: count
  bugprone-tagged-union-member-count.EnableCountingEnumHeuristic: 'true'
  bugprone-tagged-union-member-count.StrictMode: 'false'
  bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit: '16'
  bugprone-unchecked-optional-access.IgnoreSmartPointerDereference: 'false'
  bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField: 'true'
  bugprone-unsafe-functions.CustomFunctions: ''
  bugprone-unsafe-functions.ReportDefaultFunctions: 'true'
  bugprone-unsafe-functions.ReportMoreUnsafeFunctions: 'true'
  bugprone-unused-local-non-trivial-variable.ExcludeTypes: ''
  bugprone-unused-local-non-trivial-variable.IncludeTypes: '::std::.*mutex;::std::future;::std::basic_string;::std::basic_regex;::std::basic_istringstream;::std::basic_stringstream;::std::bitset;::std::filesystem::path'
  bugprone-unused-return-value.AllowCastToVoid: 'false'
  bugprone-unused-return-value.CheckedFunctions: '^::std::async$;^::std::launder$;^::std::remove$;^::std::remove_if$;^::std::unique$;^::std::unique_ptr::release$;^::std::basic_string::empty$;^::std::vector::empty$;^::std::back_inserter$;^::std::distance$;^::std::find$;^::std::find_if$;^::std::inserter$;^::std::lower_bound$;^::std::make_pair$;^::std::map::count$;^::std::map::find$;^::std::map::lower_bound$;^::std::multimap::equal_range$;^::std::multimap::upper_bound$;^::std::set::count$;^::std::set::find$;^::std::setfill$;^::std::setprecision$;^::std::setw$;^::std::upper_bound$;^::std::vector::at$;^::bsearch$;^::ferror$;^::feof$;^::isalnum$;^::isalpha$;^::isblank$;^::iscntrl$;^::isdigit$;^::isgraph$;^::islower$;^::isprint$;^::ispunct$;^::isspace$;^::isupper$;^::iswalnum$;^::iswprint$;^::iswspace$;^::isxdigit$;^::memchr$;^::memcmp$;^::strcmp$;^::strcoll$;^::strncmp$;^::strpbrk$;^::strrchr$;^::strspn$;^::strstr$;^::wcscmp$;^::access$;^::bind$;^::connect$;^::difftime$;^::dlsym$;^::fnmatch$;^::getaddrinfo$;^::getopt$;^::htonl$;^::htons$;^::iconv_open$;^::inet_addr$;^::isascii$;^::isatty$;^::mmap$;^::newlocale$;^::openat$;^::pathconf$;^::pthread_equal$;^::pthread_getspecific$;^::pthread_mutex_trylock$;^::readdir$;^::readlink$;^::recvmsg$;^::regexec$;^::scandir$;^::semget$;^::setjmp$;^::shm_open$;^::shmget$;^::sigismember$;^::strcasecmp$;^::strsignal$;^::ttyname$'
  bugprone-unused-return-value.CheckedReturnTypes: '^::std::error_code$;^::std::error_condition$;^::std::errc$;^::std::expected$;^::boost::system::error_code$'
  cert-arr39-c.WarnOnOffsetDividedBySizeOf: 'true'
  cert-arr39-c.WarnOnSizeOfCompareToConstant: 'false'
  cert-arr39-c.WarnOnSizeOfConstant: 'false'
  cert-arr39-c.WarnOnSizeOfIntegerExpression: 'false'
  cert-arr39-c.WarnOnSizeOfPointer: 'false'
  cert-arr39-c.WarnOnSizeOfPointerToAggregate: 'false'
  cert-arr39-c.WarnOnSizeOfThis: 'false'
  cert-ctr56-cpp.IgnoreInheritedVirtualFunctions: 'false'
  cert-dcl16-c.IgnoreMacros: 'true'
  cert-dcl16-c.NewSuffixes: 'L;LL;LU;LLU'
  cert-dcl37-c.AggressiveDependentMemberLookup: 'false'
  cert-dcl37-c.AllowedIdentifiers: ''
  cert-dcl37-c.Invert: 'false'
  cert-dcl51-cpp.AggressiveDependentMemberLookup: 'false'
  cert-dcl51-cpp.AllowedIdentifiers: ''
  cert-dcl51-cpp.Invert: 'false'
  cert-err09-cpp.CheckThrowTemporaries: 'true'
  cert-err09-cpp.MaxSize: '18446744073709551615'
  cert-err09-cpp.WarnOnLargeObjects: 'false'
  cert-err33-c.AllowCastToVoid: 'true'
  cert-err33-c.CheckedFunctions: '^::aligned_alloc;^::asctime_s;^::at_quick_exit;^::atexit;^::bsearch;^::bsearch_s;^::btowc;^::c16rtomb;^::c32rtomb;^::calloc;^::clock;^::cnd_broadcast;^::cnd_init;^::cnd_signal;^::cnd_timedwait;^::cnd_wait;^::ctime_s;^::fclose;^::fflush;^::fgetc;^::fgetpos;^::fgets;^::fgetwc;^::fopen;^::fopen_s;^::fprintf;^::fprintf_s;^::fputc;^::fputs;^::fputwc;^::fputws;^::fread;^::freopen;^::freopen_s;^::fscanf;^::fscanf_s;^::fseek;^::fsetpos;^::ftell;^::fwprintf;^::fwprintf_s;^::fwrite;^::fwscanf;^::fwscanf_s;^::getc;^::getchar;^::getenv;^::getenv_s;^::gets_s;^::getwc;^::getwchar;^::gmtime;^::gmtime_s;^::localtime;^::localtime_s;^::malloc;^::mbrtoc16;^::mbrtoc32;^::mbsrtowcs;^::mbsrtowcs_s;^::mbstowcs;^::mbstowcs_s;^::memchr;^::mktime;^::mtx_init;^::mtx_lock;^::mtx_timedlock;^::mtx_trylock;^::mtx_unlock;^::printf_s;^::putc;^::putwc;^::raise;^::realloc;^::remove;^::rename;^::scanf;^::scanf_s;^::setlocale;^::setvbuf;^::signal;^::snprintf;^::snprintf_s;^::sprintf;^::sprintf_s;^::sscanf;^::sscanf_s;^::strchr;^::strerror_s;^::strftime;^::strpbrk;^::strrchr;^::strstr;^::strtod;^::strtof;^::strtoimax;^::strtok;^::strtok_s;^::strtol;^::strtold;^::strtoll;^::strtoul;^::strtoull;^::strtoumax;^::strxfrm;^::swprintf;^::swprintf_s;^::swscanf;^::swscanf_s;^::thrd_create;^::thrd_detach;^::thrd_join;^::thrd_sleep;^::time;^::timespec_get;^::tmpfile;^::tmpfile_s;^::tmpnam;^::tmpnam_s;^::tss_create;^::tss_get;^::tss_set;^::ungetc;^::ungetwc;^::vfprintf;^::vfprintf_s;^::vfscanf;^::vfscanf_s;^::vfwprintf;^::vfwprintf_s;^::vfwscanf;^::vfwscanf_s;^::vprintf_s;^::vscanf;^::vscanf_s;^::vsnprintf;^::vsnprintf_s;^::vsprintf;^::vsprintf_s;^::vsscanf;^::vsscanf_s;^::vswprintf;^::vswprintf_s;^::vswscanf;^::vswscanf_s;^::vwprintf_s;^::vwscanf;^::vwscanf_s;^::wcrtomb;^::wcschr;^::wcsftime;^::wcspbrk;^::wcsrchr;^::wcsrtombs;^::wcsrtombs_s;^::wcsstr;^::wcstod;^::wcstof;^::wcstoimax;^::wcstok;^::wcstok_s;^::wcstol;^::wcstold;^::wcstoll;^::wcstombs;^::wcstombs_s;^::wcstoul;^::wcstoull;^::wcstoumax;^::wcsxfrm;^::wctob;^::wctrans;^::wctype;^::wmemchr;^::wprintf_s;^::wscanf;^::wscanf_s'
  cert-err33-c.CheckedReturnTypes: '^::std::error_code$;^::std::error_condition$;^::std::errc$;^::std::expected$;^::boost::system::error_code$'
  cert-err61-cpp.CheckThrowTemporaries: 'true'
  cert-err61-cpp.MaxSize: '18446744073709551615'
  cert-err61-cpp.WarnOnLargeObjects: 'false'
  cert-int09-c.AllowExplicitSequentialInitialValues: 'true'
  cert-int09-c.AllowExplicitZeroFirstInitialValue: 'true'
  cert-msc24-c.CustomFunctions: ''
  cert-msc24-c.ReportDefaultFunctions: 'true'
  cert-msc24-c.ReportMoreUnsafeFunctions: 'true'
  cert-msc32-c.DisallowedSeedTypes: 'time_t,std::time_t'
  cert-msc33-c.CustomFunctions: ''
  cert-msc33-c.ReportDefaultFunctions: 'true'
  cert-msc33-c.ReportMoreUnsafeFunctions: 'true'
  cert-msc51-cpp.DisallowedSeedTypes: 'time_t,std::time_t'
  cert-msc54-cpp.AsyncSafeFunctionSet: POSIX
  cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField: 'false'
  cert-oop57-cpp.MemCmpNames: ''
  cert-oop57-cpp.MemCpyNames: ''
  cert-oop57-cpp.MemSetNames: ''
  cert-sig30-c.AsyncSafeFunctionSet: POSIX
  cert-str34-c.CharTypdefsToIgnore: ''
  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: 'false'
  concurrency-mt-unsafe.FunctionSet: any
  cppcoreguidelines-avoid-c-arrays.AllowStringArrays: 'false'
  cppcoreguidelines-avoid-do-while.IgnoreMacros: 'false'
  cppcoreguidelines-avoid-magic-numbers.IgnoreAllFloatingPointValues: 'false'
  cppcoreguidelines-avoid-magic-numbers.IgnoreBitFieldsWidths: 'true'
  cppcoreguidelines-avoid-magic-numbers.IgnorePowersOf2IntegerValues: 'false'
  cppcoreguidelines-avoid-magic-numbers.IgnoreTypeAliases: 'false'
  cppcoreguidelines-avoid-magic-numbers.IgnoreUserDefinedLiterals: 'false'
  cppcoreguidelines-avoid-magic-numbers.IgnoredFloatingPointValues: '1.0;100.0;'
  cppcoreguidelines-avoid-magic-numbers.IgnoredIntegerValues: '1;2;3;4;'
  cppcoreguidelines-avoid-non-const-global-variables.AllowInternalLinkage: 'false'
  cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal: 'false'
  cppcoreguidelines-explicit-virtual-functions.FinalSpelling: final
  cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors: 'false'
  cppcoreguidelines-explicit-virtual-functions.IgnoreTemplateInstantiations: 'false'
  cppcoreguidelines-explicit-virtual-functions.OverrideSpelling: override
  cppcoreguidelines-init-variables.IncludeStyle: llvm
  cppcoreguidelines-init-variables.MathHeader: '<math.h>'
  cppcoreguidelines-macro-usage.AllowedRegexp: '^DEBUG_*'
  cppcoreguidelines-macro-usage.CheckCapsOnly: 'false'
  cppcoreguidelines-macro-usage.IgnoreCommandLineMacros: 'true'
  cppcoreguidelines-narrowing-conversions.IgnoreConversionFromTypes: ''
  cppcoreguidelines-narrowing-conversions.PedanticMode: 'false'
  cppcoreguidelines-narrowing-conversions.WarnOnEquivalentBitWidth: 'true'
  cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion: 'true'
  cppcoreguidelines-narrowing-conversions.WarnOnIntegerNarrowingConversion: 'true'
  cppcoreguidelines-narrowing-conversions.WarnOnIntegerToFloatingPointNarrowingConversion: 'true'
  cppcoreguidelines-narrowing-conversions.WarnWithinTemplateInstantiation: 'false'
  cppcoreguidelines-no-malloc.Allocations: '::malloc;::calloc'
  cppcoreguidelines-no-malloc.Deallocations: '::free'
  cppcoreguidelines-no-malloc.Reallocations: '::realloc'
  cppcoreguidelines-no-suspend-with-lock.LockGuards: '::std::unique_lock;::std::scoped_lock;::std::shared_lock;::std::lock_guard'
  cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'true'
  cppcoreguidelines-non-private-member-variables-in-classes.IgnorePublicMemberVariables: 'false'
  cppcoreguidelines-owning-memory.LegacyResourceConsumers: '::free;::realloc;::freopen;::fclose'
  cppcoreguidelines-owning-memory.LegacyResourceProducers: '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
  cppcoreguidelines-pro-bounds-constant-array-index.GslHeader: ''
  cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle: llvm
  cppcoreguidelines-pro-type-const-cast.StrictMode: 'false'
  cppcoreguidelines-pro-type-member-init.IgnoreArrays: 'false'
  cppcoreguidelines-pro-type-member-init.UseAssignment: 'false'
  cppcoreguidelines-pro-type-static-cast-downcast.StrictMode: 'true'
  cppcoreguidelines-rvalue-reference-param-not-moved.AllowPartialMove: 'false'
  cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreNonDeducedTemplateTypes: 'false'
  cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreUnnamedParams: 'false'
  cppcoreguidelines-special-member-functions.AllowImplicitlyDeletedCopyOrMove: 'false'
  cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions: 'false'
  cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted: 'false'
  cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: 'false'
  cppcoreguidelines-use-default-member-init.IgnoreMacros: 'true'
  cppcoreguidelines-use-default-member-init.UseAssignment: 'false'
  google-readability-braces-around-statements.ShortStatementLines: '1'
  google-readability-function-size.StatementThreshold: '800'
  google-readability-namespace-comments.ShortNamespaceLines: '10'
  google-readability-namespace-comments.SpacesBeforeComments: '2'
  hicpp-avoid-c-arrays.AllowStringArrays: 'false'
  hicpp-braces-around-statements.ShortStatementLines: '0'
  hicpp-deprecated-headers.CheckHeaderFile: 'false'
  hicpp-function-size.BranchThreshold: none
  hicpp-function-size.LineThreshold: none
  hicpp-function-size.NestingThreshold: none
  hicpp-function-size.ParameterThreshold: none
  hicpp-function-size.StatementThreshold: '800'
  hicpp-function-size.VariableThreshold: none
  hicpp-ignored-remove-result.AllowCastToVoid: 'true'
  hicpp-member-init.IgnoreArrays: 'false'
  hicpp-member-init.UseAssignment: 'false'
  hicpp-move-const-arg.CheckMoveToConstRef: 'true'
  hicpp-move-const-arg.CheckTriviallyCopyableMove: 'true'
  hicpp-multiway-paths-covered.WarnOnMissingElse: 'false'
  hicpp-no-malloc.Allocations: '::malloc;::calloc'
  hicpp-no-malloc.Deallocations: '::free'
  hicpp-no-malloc.Reallocations: '::realloc'
  hicpp-signed-bitwise.IgnorePositiveIntegerLiterals: 'false'
  hicpp-special-member-functions.AllowImplicitlyDeletedCopyOrMove: 'false'
  hicpp-special-member-functions.AllowMissingMoveFunctions: 'false'
  hicpp-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted: 'false'
  hicpp-special-member-functions.AllowSoleDefaultDtor: 'false'
  hicpp-uppercase-literal-suffix.IgnoreMacros: 'true'
  hicpp-uppercase-literal-suffix.NewSuffixes: ''
  hicpp-use-auto.MinTypeNameLength: '5'
  hicpp-use-auto.RemoveStars: 'false'
  hicpp-use-emplace.ContainersWithPush: '::std::stack;::std::queue;::std::priority_queue'
  hicpp-use-emplace.ContainersWithPushBack: '::std::vector;::std::list;::std::deque'
  hicpp-use-emplace.ContainersWithPushFront: '::std::forward_list;::std::list;::std::deque'
  hicpp-use-emplace.EmplacyFunctions: 'vector::emplace_back;vector::emplace;deque::emplace;deque::emplace_front;deque::emplace_back;forward_list::emplace_after;forward_list::emplace_front;list::emplace;list::emplace_back;list::emplace_front;set::emplace;set::emplace_hint;map::emplace;map::emplace_hint;multiset::emplace;multiset::emplace_hint;multimap::emplace;multimap::emplace_hint;unordered_set::emplace;unordered_set::emplace_hint;unordered_map::emplace;unordered_map::emplace_hint;unordered_multiset::emplace;unordered_multiset::emplace_hint;unordered_multimap::emplace;unordered_multimap::emplace_hint;stack::emplace;queue::emplace;priority_queue::emplace'
  hicpp-use-emplace.IgnoreImplicitConstructors: 'false'
  hicpp-use-emplace.SmartPointers: '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
  hicpp-use-emplace.TupleMakeFunctions: '::std::make_pair;::std::make_tuple'
  hicpp-use-emplace.TupleTypes: '::std::pair;::std::tuple'
  hicpp-use-equals-default.IgnoreMacros: 'true'
  hicpp-use-equals-delete.IgnoreMacros: 'true'
  hicpp-use-noexcept.ReplacementString: ''
  hicpp-use-noexcept.UseNoexceptFalse: 'true'
  hicpp-use-nullptr.IgnoredTypes: 'std::_CmpUnspecifiedParam::;^std::__cmp_cat::__unspec'
  hicpp-use-nullptr.NullMacros: 'NULL'
  hicpp-use-override.AllowOverrideAndFinal: 'false'
  hicpp-use-override.FinalSpelling: final
  hicpp-use-override.IgnoreDestructors: 'false'
  hicpp-use-override.IgnoreTemplateInstantiations: 'false'
  hicpp-use-override.OverrideSpelling: override
  llvm-else-after-return.WarnOnConditionVariables: 'false'
  llvm-else-after-return.WarnOnUnfixable: 'false'
  llvm-qualified-auto.AddConstToQualified: 'false'
  misc-const-correctness.AnalyzeReferences: 'true'
  misc-const-correctness.AnalyzeValues: 'true'
  misc-const-correctness.TransformPointersAsValues: 'false'
  misc-const-correctness.TransformReferences: 'true'
  misc-const-correctness.TransformValues: 'true'
  misc-const-correctness.WarnPointersAsValues: 'false'
  misc-coroutine-hostile-raii.RAIITypesList: 'std::lock_guard;std::scoped_lock'
  misc-coroutine-hostile-raii.SafeAwaitableList: ''
  misc-header-include-cycle.IgnoredFilesList: ''
  misc-include-cleaner.DeduplicateFindings: 'true'
  misc-include-cleaner.IgnoreHeaders: ''
  misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'false'
  misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables: 'false'
  misc-throw-by-value-catch-by-reference.CheckThrowTemporaries: 'true'
  misc-throw-by-value-catch-by-reference.MaxSize: '18446744073709551615'
  misc-throw-by-value-catch-by-reference.WarnOnLargeObjects: 'false'
  misc-uniqueptr-reset-release.IncludeStyle: llvm
  misc-unused-parameters.IgnoreVirtual: 'false'
  misc-unused-parameters.StrictMode: 'false'
  misc-use-internal-linkage.FixMode: UseStatic
  modernize-avoid-bind.PermissiveParameterList: 'false'
  modernize-avoid-c-arrays.AllowStringArrays: 'false'
  modernize-deprecated-headers.CheckHeaderFile: 'false'
  modernize-loop-convert.IncludeStyle: llvm
  modernize-loop-convert.MakeReverseRangeFunction: ''
  modernize-loop-convert.MakeReverseRangeHeader: ''
  modernize-loop-convert.MaxCopySize: '16'
  modernize-loop-convert.MinConfidence: reasonable
  modernize-loop-convert.NamingStyle: CamelCase
  modernize-loop-convert.UseCxx20ReverseRanges: 'true'
  modernize-make-shared.IgnoreDefaultInitialization: 'true'
  modernize-make-shared.IgnoreMacros: 'true'
  modernize-make-shared.IncludeStyle: llvm
  modernize-make-shared.MakeSmartPtrFunction: 'std::make_shared'
  modernize-make-shared.MakeSmartPtrFunctionHeader: '<memory>'
  modernize-make-unique.IgnoreDefaultInitialization: 'true'
  modernize-make-unique.IgnoreMacros: 'true'
  modernize-make-unique.IncludeStyle: llvm
  modernize-make-unique.MakeSmartPtrFunction: 'std::make_unique'
  modernize-make-unique.MakeSmartPtrFunctionHeader: '<memory>'
  modernize-min-max-use-initializer-list.IgnoreNonTrivialTypes: 'true'
  modernize-min-max-use-initializer-list.IgnoreTrivialTypesOfSizeAbove: '32'
  modernize-min-max-use-initializer-list.IncludeStyle: llvm
  modernize-pass-by-value.IncludeStyle: llvm
  modernize-pass-by-value.ValuesOnly: 'false'
  modernize-raw-string-literal.DelimiterStem: lit
  modernize-raw-string-literal.ReplaceShorterLiterals: 'false'
  modernize-replace-auto-ptr.IncludeStyle: llvm
  modernize-replace-disallow-copy-and-assign-macro.MacroName: DISALLOW_COPY_AND_ASSIGN
  modernize-replace-random-shuffle.IncludeStyle: llvm
  modernize-type-traits.IgnoreMacros: 'false'
  modernize-use-auto.MinTypeNameLength: '5'
  modernize-use-auto.RemoveStars: 'false'
  modernize-use-bool-literals.IgnoreMacros: 'true'
  modernize-use-default-member-init.IgnoreMacros: 'true'
  modernize-use-default-member-init.UseAssignment: 'false'
  modernize-use-designated-initializers.IgnoreMacros: 'true'
  modernize-use-designated-initializers.IgnoreSingleElementAggregates: 'true'
  modernize-use-designated-initializers.RestrictToPODTypes: 'false'
  modernize-use-designated-initializers.StrictCStandardCompliance: 'true'
  modernize-use-designated-initializers.StrictCppStandardCompliance: 'true'
  modernize-use-emplace.ContainersWithPush: '::std::stack;::std::queue;::std::priority_queue'
  modernize-use-emplace.ContainersWithPushBack: '::std::vector;::std::list;::std::deque'
  modernize-use-emplace.ContainersWithPushFront: '::std::forward_list;::std::list;::std::deque'
  modernize-use-emplace.EmplacyFunctions: 'vector::emplace_back;vector::emplace;deque::emplace;deque::emplace_front;deque::emplace_back;forward_list::emplace_after;forward_list::emplace_front;list::emplace;list::emplace_back;list::emplace_front;set::emplace;set::emplace_hint;map::emplace;map::emplace_hint;multiset::emplace;multiset::emplace_hint;multimap::emplace;multimap::emplace_hint;unordered_set::emplace;unordered_set::emplace_hint;unordered_map::emplace;unordered_map::emplace_hint;unordered_multiset::emplace;unordered_multiset::emplace_hint;unordered_multimap::emplace;unordered_multimap::emplace_hint;stack::emplace;queue::emplace;priority_queue::emplace'
  modernize-use-emplace.IgnoreImplicitConstructors: 'false'
  modernize-use-emplace.SmartPointers: '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
  modernize-use-emplace.TupleMakeFunctions: '::std::make_pair;::std::make_tuple'
  modernize-use-emplace.TupleTypes: '::std::pair;::std::tuple'
  modernize-use-equals-default.IgnoreMacros: 'true'
  modernize-use-equals-delete.IgnoreMacros: 'true'
  modernize-use-integer-sign-comparison.EnableQtSupport: 'false'
  modernize-use-integer-sign-comparison.IncludeStyle: llvm
  modernize-use-nodiscard.ReplacementString: '[[nodiscard]]'
  modernize-use-noexcept.ReplacementString: ''
  modernize-use-noexcept.UseNoexceptFalse: 'true'
  modernize-use-nullptr.IgnoredTypes: 'std::_CmpUnspecifiedParam::;^std::__cmp_cat::__unspec'
  modernize-use-nullptr.NullMacros: 'NULL'
  modernize-use-override.AllowOverrideAndFinal: 'false'
  modernize-use-override.FinalSpelling: final
  modernize-use-override.IgnoreDestructors: 'false'
  modernize-use-override.IgnoreTemplateInstantiations: 'false'
  modernize-use-override.OverrideSpelling: override
  modernize-use-ranges.IncludeStyle: llvm
  modernize-use-ranges.UseReversePipe: 'false'
  modernize-use-std-format.FormatHeader: '<format>'
  modernize-use-std-format.IncludeStyle: llvm
  modernize-use-std-format.ReplacementFormatFunction: 'std::format'
  modernize-use-std-format.StrFormatLikeFunctions: 'absl::StrFormat'
  modernize-use-std-format.StrictMode: 'false'
  modernize-use-std-numbers.DiffThreshold: '0.001'
  modernize-use-std-numbers.IncludeStyle: llvm
  modernize-use-std-print.FprintfLikeFunctions: '::fprintf;absl::FPrintF'
  modernize-use-std-print.IncludeStyle: llvm
  modernize-use-std-print.PrintHeader: '<print>'
  modernize-use-std-print.PrintfLikeFunctions: '::printf;absl::PrintF'
  modernize-use-std-print.ReplacementPrintFunction: 'std::print'
  modernize-use-std-print.ReplacementPrintlnFunction: 'std::println'
  modernize-use-std-print.StrictMode: 'false'
  modernize-use-transparent-functors.SafeMode: 'false'
  modernize-use-using.IgnoreExternC: 'false'
  modernize-use-using.IgnoreMacros: 'true'
  performance-enum-size.EnumIgnoreList: ''
  performance-faster-string-find.StringLikeClasses: '::std::basic_string;::std::basic_string_view'
  performance-for-range-copy.AllowedTypes: ''
  performance-for-range-copy.WarnOnAllAutoCopies: 'false'
  performance-inefficient-string-concatenation.StrictMode: 'false'
  performance-inefficient-vector-operation.EnableProto: 'false'
  performance-inefficient-vector-operation.VectorLikeClasses: '::std::vector'
  performance-move-const-arg.CheckMoveToConstRef: 'true'
  performance-move-const-arg.CheckTriviallyCopyableMove: 'true'
  performance-no-automatic-move.AllowedTypes: ''
  performance-type-promotion-in-math-fn.IncludeStyle: llvm
  performance-unnecessary-copy-initialization.AllowedTypes: ''
  performance-unnecessary-copy-initialization.ExcludedContainerTypes: ''
  performance-unnecessary-value-param.AllowedTypes: ''
  performance-unnecessary-value-param.IncludeStyle: llvm
  portability-restrict-system-includes.Includes: '*'
  portability-simd-intrinsics.Std: ''
  portability-simd-intrinsics.Suggest: 'false'
  readability-avoid-const-params-in-decls.IgnoreMacros: 'true'
  readability-avoid-return-with-void-value.IgnoreMacros: 'true'
  readability-avoid-return-with-void-value.StrictMode: 'true'
  readability-braces-around-statements.ShortStatementLines: '0'
  readability-const-return-type.IgnoreMacros: 'true'
  readability-container-data-pointer.IgnoredContainers: ''
  readability-container-size-empty.ExcludedComparisonTypes: '::std::array'
  readability-else-after-return.WarnOnConditionVariables: 'true'
  readability-else-after-return.WarnOnUnfixable: 'true'
  readability-enum-initial-value.AllowExplicitSequentialInitialValues: 'true'
  readability-enum-initial-value.AllowExplicitZeroFirstInitialValue: 'true'
  readability-function-cognitive-complexity.DescribeBasicIncrements: 'true'
  readability-function-cognitive-complexity.IgnoreMacros: 'false'
  readability-function-cognitive-complexity.Threshold: '25'
  readability-function-size.BranchThreshold: none
  readability-function-size.LineThreshold: none
  readability-function-size.NestingThreshold: none
  readability-function-size.ParameterThreshold: none
  readability-function-size.StatementThreshold: '800'
  readability-function-size.VariableThreshold: none
  readability-identifier-length.IgnoredExceptionVariableNames: '^[e]$'
  readability-identifier-length.IgnoredLoopCounterNames: '^[ijk_]$'
  readability-identifier-length.IgnoredParameterNames: '^[n]$'
  readability-identifier-length.IgnoredVariableNames: ''
  readability-identifier-length.MinimumExceptionNameLength: '2'
  readability-identifier-length.MinimumLoopCounterNameLength: '2'
  readability-identifier-length.MinimumParameterNameLength: '3'
  readability-identifier-length.MinimumVariableNameLength: '3'
  readability-identifier-naming.AggressiveDependentMemberLookup: 'false'
  readability-identifier-naming.CheckAnonFieldInParent: 'false'
  readability-identifier-naming.GetConfigPerFile: 'true'
  readability-identifier-naming.IgnoreFailedSplit: 'false'
  readability-identifier-naming.IgnoreMainLikeFunctions: 'false'
  readability-implicit-bool-conversion.AllowIntegerConditions: 'false'
  readability-implicit-bool-conversion.AllowPointerConditions: 'false'
  readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: 'false'
  readability-inconsistent-declaration-parameter-name.IgnoreMacros: 'true'
  readability-inconsistent-declaration-parameter-name.Strict: 'false'
  readability-magic-numbers.IgnoreAllFloatingPointValues: 'false'
  readability-magic-numbers.IgnoreBitFieldsWidths: 'true'
  readability-magic-numbers.IgnorePowersOf2IntegerValues: 'false'
  readability-magic-numbers.IgnoreTypeAliases: 'false'
  readability-magic-numbers.IgnoreUserDefinedLiterals: 'false'
  readability-magic-numbers.IgnoredFloatingPointValues: '1.0;100.0;'
  readability-magic-numbers.IgnoredIntegerValues: '1;2;3;4;'
  readability-operators-representation.BinaryOperators: ''
  readability-operators-representation.OverloadedOperators: ''
  readability-qualified-auto.AddConstToQualified: 'true'
  readability-redundant-casting.IgnoreMacros: 'true'
  readability-redundant-casting.IgnoreTypeAliases: 'false'
  readability-redundant-declaration.IgnoreMacros: 'true'
  readability-redundant-member-init.IgnoreBaseInCopyConstructors: 'false'
  readability-redundant-smartptr-get.IgnoreMacros: 'true'
  readability-redundant-string-init.StringNames: '::std::basic_string_view;::std::basic_string'
  readability-simplify-boolean-expr.ChainedConditionalAssignment: 'false'
  readability-simplify-boolean-expr.ChainedConditionalReturn: 'false'
  readability-simplify-boolean-expr.IgnoreMacros: 'false'
  readability-simplify-boolean-expr.SimplifyDeMorgan: 'true'
  readability-simplify-boolean-expr.SimplifyDeMorganRelaxed: 'false'
  readability-simplify-subscript-expr.Types: '::std::basic_string;::std::basic_string_view;::std::vector;::std::array;::std::span'
  readability-static-accessed-through-instance.NameSpecifierNestingThreshold: '3'
  readability-string-compare.StringLikeClasses: '::std::basic_string;::std::basic_string_view'
  readability-suspicious-call-argument.Abbreviation: 'true'
  readability-suspicious-call-argument.Abbreviations: 'str=string;lst=list;arr=array;num=number;ptr=pointer;i=index;ln=line;cpy=copy;src=source;dest=destination;val=value;idx=index;vec=vector;wdth=width;nr=number;elem=element;srv=server;pos=position;cl=client;stmt=statement;len=length;buf=buffer;dist=distancedst=distance;hght=height;var=variable;addr=address;col=column;attr=attribute;cnt=count;ref=reference'
  readability-suspicious-call-argument.Dice: 'true'
  readability-suspicious-call-argument.DiceDissimilarBelow: '60'
  readability-suspicious-call-argument.DiceSimilarAbove: '70'
  readability-suspicious-call-argument.Equality: 'true'
  readability-suspicious-call-argument.JaroWinkler: 'true'
  readability-suspicious-call-argument.JaroWinklerDissimilarBelow: '75'
  readability-suspicious-call-argument.JaroWinklerSimilarAbove: '85'
  readability-suspicious-call-argument.Levenshtein: 'true'
  readability-suspicious-call-argument.LevenshteinDissimilarBelow: '50'
  readability-suspicious-call-argument.LevenshteinSimilarAbove: '66'
  readability-suspicious-call-argument.MinimumIdentifierNameLength: '3'
  readability-suspicious-call-argument.Prefix: 'true'
  readability-suspicious-call-argument.PrefixDissimilarBelow: '25'
  readability-suspicious-call-argument.PrefixSimilarAbove: '30'
  readability-suspicious-call-argument.Substring: 'true'
  readability-suspicious-call-argument.SubstringDissimilarBelow: '40'
  readability-suspicious-call-argument.SubstringSimilarAbove: '50'
  readability-suspicious-call-argument.Suffix: 'true'
  readability-suspicious-call-argument.SuffixDissimilarBelow: '25'
  readability-suspicious-call-argument.SuffixSimilarAbove: '30'
  readability-uniqueptr-delete-release.PreferResetCall: 'false'
  readability-uppercase-literal-suffix.IgnoreMacros: 'true'
  readability-uppercase-literal-suffix.NewSuffixes: ''
  readability-use-std-min-max.IncludeStyle: llvm
SystemHeaders:   false
...
```

</details>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
