### PR TITLE
Add X509_VERIFY_PARAM_get_hostflags

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -403,6 +403,10 @@ void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
   param->hostflags = flags;
 }
 
+unsigned int X509_VERIFY_PARAM_get_hostflags(const X509_VERIFY_PARAM *param) {
+    return param->hostflags;
+}
+
 int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param, const char *email,
                                  size_t emaillen) {
   if (OPENSSL_memchr(email, '\0', emaillen) != NULL ||

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -3091,6 +3091,11 @@ OPENSSL_EXPORT int X509_VERIFY_PARAM_add1_host(X509_VERIFY_PARAM *param,
 OPENSSL_EXPORT void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
                                                     unsigned int flags);
 
+// X509_VERIFY_PARAM_get_hostflags returns |param|'s name-checking flags.
+OPENSSL_EXPORT unsigned int X509_VERIFY_PARAM_get_hostflags(
+    const X509_VERIFY_PARAM *param);
+
+
 // X509_VERIFY_PARAM_set1_email configures |param| to check for the email
 // address specified by |email|. It returns one on success and zero on error.
 // |emaillen| should be set to the length of |email|. It may be zero if |email|


### PR DESCRIPTION
### Issues:

t/V1752105287

### Description of changes: 

A recent CPython [change](https://github.com/python/cpython/commit/9752c840229fa6329d12e4a271698027363fd5ef) uses an OpenSSL symbol that we don't provide, causing relevant CI to [fail](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoicEtxdUl5RTdsWW95MmtnM0pSWjJmQU92T2RhQUJPN2VzRFdXZTdHOG1FWU1NQ2VwcGtucE92ZlA1Q3pSRHFCWW1VRTFLa3VTN1RWVC96dmsraFl5WXZwSmFha2tOTFZBOEdiWittVlRGKzlBVkRqVk5Gaz0iLCJpdlBhcmFtZXRlclNwZWMiOiJxS01SNWtSdUR0d2NvSUMvIiwibWF0ZXJpYWxTZXRTZXJpYWwiOjF9/build/488c86c9-2549-42ef-beeb-551bb8c3a261). This PR copies [that function](https://github.com/openssl/openssl/blob/8f99bcdbb80103b7cbdc4269c607142549e2d678/crypto/x509/x509_vpm.c#L408) over.

### Call-outs:

n/a

### Testing:

CI

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
