### PR TITLE
Add null check for EVP_get_digestbyobj

### DIFF
--- a/crypto/digest_extra/digest_extra.c
+++ b/crypto/digest_extra/digest_extra.c
@@ -164,6 +164,10 @@ static const EVP_MD *cbs_to_md(const CBS *cbs) {
 }
 
 const EVP_MD *EVP_get_digestbyobj(const ASN1_OBJECT *obj) {
+  if(obj == NULL) {
+    return NULL;
+  }
+
   // Handle objects with no corresponding OID. Note we don't use |OBJ_obj2nid|
   // here to avoid pulling in the OID table.
   if (obj->nid != NID_undef) {


### PR DESCRIPTION
### Description of changes: 
Some usages of Ruby were failing internally with a NULL pointer passed to this function. Ruby OpenSSL's usage tries to parse a string and obtain an `EVP_MD` from it, but a NULL pointer is passed when an invalid string is used.
* Usage: https://github.com/ruby/openssl/blob/6dfb8dfb2b3c4a5162e38e56c4225bf3ac8e8b6f/ext/openssl/ossl_digest.c#L56  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
