### PR TITLE
Ensure that AVX512 is not used on macOS

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_intel.c
+++ b/crypto/fipsmodule/cpucap/cpu_intel.c
@@ -127,7 +127,7 @@ static uint64_t OPENSSL_xgetbv(uint32_t xcr) {
 }
 
 static bool os_supports_avx512(uint64_t xcr0) {
-#if defined(__APPLE__)
+#if defined(OPENSSL_APPLE)
   // The Darwin kernel had a bug where it could corrupt the opmask registers.
   // See
   // https://community.intel.com/t5/Software-Tuning-Performance/MacOS-Darwin-kernel-bug-clobbers-AVX-512-opmask-register-state/m-p/1327259

--- a/crypto/fipsmodule/cpucap/cpu_intel.c
+++ b/crypto/fipsmodule/cpucap/cpu_intel.c
@@ -126,6 +126,22 @@ static uint64_t OPENSSL_xgetbv(uint32_t xcr) {
 #endif
 }
 
+static bool os_supports_avx512(uint64_t xcr0) {
+#if defined(__APPLE__)
+  // The Darwin kernel had a bug where it could corrupt the opmask registers.
+  // See
+  // https://community.intel.com/t5/Software-Tuning-Performance/MacOS-Darwin-kernel-bug-clobbers-AVX-512-opmask-register-state/m-p/1327259
+  // Darwin also does not initially set the XCR0 bits for AVX512, but they are
+  // set if the thread tries to use AVX512 anyway.  Thus, to safely and
+  // consistently use AVX512 on macOS we'd need to check the kernel version as
+  // well as detect AVX512 support using a macOS-specific method.  We don't
+  // bother with this, especially given Apple's transition to arm64.
+  return false;
+#else
+  return (xcr0 & 0xe6) == 0xe6;
+#endif
+}
+
 // handle_cpu_env applies the value from |in| to the CPUID values in |out[0]|
 // and |out[1]|. See the comment in |OPENSSL_cpuid_setup| about this.
 static void handle_cpu_env(uint32_t *out, const char *in) {
@@ -274,7 +290,7 @@ void OPENSSL_cpuid_setup(void) {
         ~((1u << 5) | (1u << 16) | (1u << 21) | (1u << 30) | (1u << 31));
   }
   // See Intel manual, volume 1, section 15.2.
-  if ((xcr0 & 0xe6) != 0xe6) {
+  if (!os_supports_avx512(xcr0)) {
     // Clear AVX512F. Note we don't touch other AVX512 extensions because they
     // can be used with YMM.
     extended_features[0] &= ~(1u << 16);


### PR DESCRIPTION
Change-Id: I8aa11f6c64d973ca33324687e8e61d35790cd331
Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/74127
Commit-Queue: David Benjamin <davidben@google.com>
Reviewed-by: David Benjamin <davidben@google.com>

### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
