### PR TITLE
Check for QUIC in SSL_process_quic_post_handshake

### DIFF
--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -968,7 +968,7 @@ static int ssl_do_post_handshake(SSL *ssl, const SSLMessage &msg) {
 int SSL_process_quic_post_handshake(SSL *ssl) {
   ssl_reset_error_state(ssl);
 
-  if (ssl->quic_method == nullptr || SSL_in_init(ssl)) {
+  if (ssl->quic_method == nullptr || (SSL_in_init(ssl) != 0)) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
     return 0;
   }

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -968,7 +968,7 @@ static int ssl_do_post_handshake(SSL *ssl, const SSLMessage &msg) {
 int SSL_process_quic_post_handshake(SSL *ssl) {
   ssl_reset_error_state(ssl);
 
-  if (SSL_in_init(ssl)) {
+  if (ssl->quic_method == nullptr || SSL_in_init(ssl)) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
     return 0;
   }


### PR DESCRIPTION
This function doesn't make sense for non-QUIC SSLs.

Change-Id: I3fc08a01f45d8c4e36e449675aecc98ce296abe1
Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/73127
Auto-Submit: David Benjamin <davidben@google.com>
Commit-Queue: David Benjamin <davidben@google.com>
Reviewed-by: Nick Harper <nharper@chromium.org>

### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
