### PR TITLE
Mark fallible container operations as `nodiscard`

### DIFF
--- a/ssl/handoff.cc
+++ b/ssl/handoff.cc
@@ -669,8 +669,10 @@ bool SSL_apply_handback(SSL *ssl, Span<const uint8_t> handback) {
   }
   s3->session_reused = session_reused;
   hs->channel_id_negotiated = channel_id_negotiated;
-  s3->next_proto_negotiated.CopyFrom(next_proto);
-  s3->alpn_selected.CopyFrom(alpn);
+  if (!s3->next_proto_negotiated.CopyFrom(next_proto) ||
+      !s3->alpn_selected.CopyFrom(alpn)) {
+    return false;
+  }
 
   const size_t hostname_len = CBS_len(&hostname);
   if (hostname_len == 0) {


### PR DESCRIPTION
It's evidently too easy to ignore the return values of these operations. After all, ignoring allocation failures is the normal pattern in most C++ code.

Thus this change marks these functions as `nodiscard`. This does require a few CHECKs in test code, but it also catches one real instance of a problem.

Change-Id: I24432506283145fc2f459336fe1035cbca27bd4f
Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/75187
Commit-Queue: Adam Langley <agl@google.com>
Auto-Submit: Adam Langley <agl@google.com>
Reviewed-by: David Benjamin <davidben@google.com>

### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
