### PR TITLE
Speed up sha512 on x86

### DIFF
--- a/crypto/fipsmodule/sha/internal.h
+++ b/crypto/fipsmodule/sha/internal.h
@@ -72,14 +72,14 @@ extern "C" {
 #define SHA3_MAX_BLOCKSIZE SHAKE128_BLOCKSIZE
 
 // Define state flag values for Keccak-based functions
-#define KECCAK1600_STATE_ABSORB     0 
+#define KECCAK1600_STATE_ABSORB     0
 // KECCAK1600_STATE_SQUEEZE is set when |SHAKE_Squeeze| is called.
-// It remains set while |SHAKE_Squeeze| is called repeatedly to output 
+// It remains set while |SHAKE_Squeeze| is called repeatedly to output
 // chunks of the XOF output.
-#define KECCAK1600_STATE_SQUEEZE    1  
-// KECCAK1600_STATE_FINAL is set once |SHAKE_Final| is called 
+#define KECCAK1600_STATE_SQUEEZE    1
+// KECCAK1600_STATE_FINAL is set once |SHAKE_Final| is called
 // so that |SHAKE_Squeeze| cannot be called anymore.
-#define KECCAK1600_STATE_FINAL      2 
+#define KECCAK1600_STATE_FINAL      2
 
 typedef struct keccak_st KECCAK1600_CTX;
 
@@ -287,8 +287,7 @@ OPENSSL_INLINE int sha512_avx_capable(void) {
   //  * sha512_block_data_order_avx does not seem to use SSSE3 instructions.
   // Pre-Zen AMD CPUs had slow SHLD/SHRD; Zen added the SHA extension; see the
   // discussion in sha1-586.pl.
-  return CRYPTO_is_AVX_capable() && CRYPTO_is_SSSE3_capable() &&
-         CRYPTO_is_intel_cpu();
+  return CRYPTO_is_AVX_capable() && CRYPTO_is_SSSE3_capable();
 }
 void sha512_block_data_order_avx(uint64_t state[8], const uint8_t *data,
                                  size_t num);


### PR DESCRIPTION
Enable avx version on amd, since sha-ni sha512 doesn't exist

Change-Id: I2ea4b74c7995ccae6b673adefc4b3e25d515e321
Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/73567
Reviewed-by: David Benjamin <davidben@google.com>
Commit-Queue: David Benjamin <davidben@google.com>

### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
