### PR TITLE
Fix a theoretical overflow in BIO_printf

### DIFF
--- a/crypto/bio/printf.c
+++ b/crypto/bio/printf.c
@@ -76,10 +76,9 @@ int BIO_printf(BIO *bio, const char *format, ...) {
   }
 
   if ((size_t) out_len >= sizeof(buf)) {
-    const int requested_len = out_len;
-    // The output was truncated. Note that vsnprintf's return value
-    // does not include a trailing NUL, but the buffer must be sized
-    // for it.
+    const size_t requested_len = (size_t)out_len;
+    // The output was truncated. Note that vsnprintf's return value does not
+    // include a trailing NUL, but the buffer must be sized for it.
     out = OPENSSL_malloc(requested_len + 1);
     out_malloced = 1;
     if (out == NULL) {
@@ -88,7 +87,7 @@ int BIO_printf(BIO *bio, const char *format, ...) {
     va_start(args, format);
     out_len = vsnprintf(out, requested_len + 1, format, args);
     va_end(args);
-    assert(out_len == requested_len);
+    assert(out_len == (int)requested_len);
   } else {
     out = buf;
   }


### PR DESCRIPTION
Found by code inspection. If vsnprintf wanted to write INT_MAX characters, allocating a INT_MAX + 1 scratch buffer will overflow. Since we always have INT_MAX < SIZE_MAX, just casting to size_t earlier avoids this.

(If the malloc implementation is unwilling to allocate INT_MAX + 1, e.g. it is forbidden to on 32-bit, that's malloc's responsibility to detect.)

Change-Id: I3c2a740ebc7ecd58464a9f63858ffcefe67f648f
Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/74247
Auto-Submit: David Benjamin <davidben@google.com>
Commit-Queue: Adam Langley <agl@google.com>
Reviewed-by: Adam Langley <agl@google.com>

### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
