### PR TITLE
Fix tpm2-tss integration test

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1574,6 +1574,10 @@ void X509_STORE_CTX_set_chain(X509_STORE_CTX *ctx, STACK_OF(X509) *sk) {
   ctx->untrusted = sk;
 }
 
+void X509_STORE_CTX_set0_untrusted(X509_STORE_CTX *ctx, STACK_OF(X509) *sk) {
+  X509_STORE_CTX_set_chain(ctx, sk);
+}
+
 STACK_OF(X509) *X509_STORE_CTX_get0_untrusted(X509_STORE_CTX *ctx) {
   return ctx->untrusted;
 }

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -4986,6 +4986,10 @@ OPENSSL_EXPORT void X509_STORE_set_check_crl(
 OPENSSL_EXPORT void X509_STORE_CTX_set_chain(X509_STORE_CTX *ctx,
                                              STACK_OF(X509) *sk);
 
+// X509_STORE_CTX_set0_untrusted is an alias for  |X509_STORE_CTX_set_chain|.
+OPENSSL_EXPORT void X509_STORE_CTX_set0_untrusted(X509_STORE_CTX *ctx,
+                                                  STACK_OF(X509) *sk);
+
 // The following flags do nothing. The corresponding non-standard options have
 // been removed.
 #define X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT 0

--- a/tests/ci/integration/tpm2_tools_patch/aws-lc-tpm2-tools.patch
+++ b/tests/ci/integration/tpm2_tools_patch/aws-lc-tpm2-tools.patch
@@ -1,3 +1,15 @@
+From dea6a384d56f631eba23188f57dd4e4d84c10657 Mon Sep 17 00:00:00 2001
+From: Justin W Smith <justsmth@amazon.com>
+Date: Fri, 25 Apr 2025 21:19:12 +0000
+Subject: [PATCH] AWS-LC Support
+
+---
+ lib/tpm2_identity_util.c      | 2 +-
+ lib/tpm2_openssl.c            | 4 ++--
+ tools/misc/tpm2_checkquote.c  | 2 +-
+ tools/tpm2_getekcertificate.c | 4 ++--
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
 diff --git a/lib/tpm2_identity_util.c b/lib/tpm2_identity_util.c
 index fbf1e938..2c6448d3 100644
 --- a/lib/tpm2_identity_util.c
@@ -12,7 +24,7 @@ index fbf1e938..2c6448d3 100644
          LOG_ERR("Failed EVP_PKEY_CTX_set0_rsa_oaep_label");
          free(newlabel);
 diff --git a/lib/tpm2_openssl.c b/lib/tpm2_openssl.c
-index 516d8b63..48d75c7b 100644
+index d2f07a7c..ca1a6b40 100644
 --- a/lib/tpm2_openssl.c
 +++ b/lib/tpm2_openssl.c
 @@ -36,7 +36,7 @@ int tpm2_openssl_halgid_from_tpmhalg(TPMI_ALG_HASH algorithm) {
@@ -34,10 +46,10 @@ index 516d8b63..48d75c7b 100644
  #endif
      /*
 diff --git a/tools/misc/tpm2_checkquote.c b/tools/misc/tpm2_checkquote.c
-index e5f8ef41..10847523 100644
+index 498dffbc..d5bef7af 100644
 --- a/tools/misc/tpm2_checkquote.c
 +++ b/tools/misc/tpm2_checkquote.c
-@@ -80,7 +80,7 @@ static bool verify(void) {
+@@ -110,7 +110,7 @@ static bool verify(void) {
          return false;
      }
  
@@ -46,3 +58,28 @@ index e5f8ef41..10847523 100644
  #if OPENSSL_VERSION_MAJOR < 3
      if (ctx.halg == TPM2_ALG_SM3_256) {
          ret = EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2);
+diff --git a/tools/tpm2_getekcertificate.c b/tools/tpm2_getekcertificate.c
+index 79d859c7..fb525c63 100644
+--- a/tools/tpm2_getekcertificate.c
++++ b/tools/tpm2_getekcertificate.c
+@@ -519,7 +519,7 @@ static bool retrieve_web_endorsement_certificate(char *uri) {
+      * should not be used - Used only on platforms with older CA certificates.
+      */
+     if (ctx.SSL_NO_VERIFY) {
+-        rc = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
++        rc = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+         if (rc != CURLE_OK) {
+             LOG_ERR("curl_easy_setopt for CURLOPT_SSL_VERIFYPEER failed: %s",
+                     curl_easy_strerror(rc));
+@@ -564,7 +564,7 @@ static bool retrieve_web_endorsement_certificate(char *uri) {
+         goto out_easy_cleanup;
+     }
+ 
+-    rc = curl_easy_setopt(curl, CURLOPT_FAILONERROR, true);
++    rc = curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+     if (rc != CURLE_OK) {
+         LOG_ERR("curl_easy_setopt for CURLOPT_FAILONERROR failed: %s",
+                 curl_easy_strerror(rc));
+-- 
+2.43.0
+

--- a/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
+++ b/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
@@ -1,17 +1,18 @@
-From e867fd70195c99a5d2d0f39f8bc7d4641304a53a Mon Sep 17 00:00:00 2001
+From 6eb70474d5767afc3a9111cfbfab8ed83f673d87 Mon Sep 17 00:00:00 2001
 From: Justin W Smith <justsmth@amazon.com>
-Date: Thu, 11 Jul 2024 09:49:35 -0400
-Subject: [PATCH] aws-lc-tpm2-tss.patch
+Date: Fri, 25 Apr 2025 21:18:07 +0000
+Subject: [PATCH] AWS-LC support
 
 ---
- configure.ac                     | 6 ------
- src/tss2-esys/esys_crypto_ossl.c | 2 +-
- src/tss2-fapi/ifapi_curl.c       | 6 +++---
- test/unit/fapi-eventlog.c        | 8 +++++---
- 4 files changed, 9 insertions(+), 13 deletions(-)
+ configure.ac                            | 6 ------
+ src/tss2-esys/esys_crypto_ossl.c        | 2 +-
+ src/tss2-fapi/ifapi_curl.c              | 8 ++++----
+ src/tss2-fapi/ifapi_verify_cert_chain.c | 2 +-
+ test/unit/fapi-eventlog.c               | 8 +++++---
+ 5 files changed, 11 insertions(+), 15 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index eb6051ea..7051e51c 100644
+index 6cc3efc8..9029383d 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -189,12 +189,6 @@ AS_IF([test "x$enable_esys" = xyes],
@@ -41,10 +42,10 @@ index 15e534ce..75043897 100644
          goto_error(r, TSS2_ESYS_RC_GENERAL_FAILURE,
                     "Could not set RSA label.", cleanup);
 diff --git a/src/tss2-fapi/ifapi_curl.c b/src/tss2-fapi/ifapi_curl.c
-index 18f4a9ff..d68450b8 100644
+index 75e81141..79f77fdf 100644
 --- a/src/tss2-fapi/ifapi_curl.c
 +++ b/src/tss2-fapi/ifapi_curl.c
-@@ -88,13 +88,13 @@ get_crl_from_cert(X509 *cert, X509_CRL **crl)
+@@ -88,13 +88,13 @@ ifapi_get_crl_from_cert(X509 *cert, X509_CRL **crl)
      int curl_rc;
  
      *crl = NULL;
@@ -60,7 +61,7 @@ index 18f4a9ff..d68450b8 100644
              {
                  GENERAL_NAME *gen_name = sk_GENERAL_NAME_value(distpoint->name.fullname, j);
                  ASN1_IA5STRING *asn1_str = gen_name->d.uniformResourceIdentifier;
-@@ -171,7 +171,7 @@ ifapi_curl_verify_ek_cert(
+@@ -179,7 +179,7 @@ ifapi_curl_verify_ek_cert(
      X509_STORE_CTX *ctx = NULL;
      X509_CRL *crl_intermed = NULL;
      X509_CRL *crl_ek = NULL;
@@ -69,6 +70,28 @@ index 18f4a9ff..d68450b8 100644
      size_t ui;
      AUTHORITY_INFO_ACCESS *info = NULL;
      ASN1_IA5STRING *uri = NULL;
+@@ -463,7 +463,7 @@ ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
+         goto out_easy_cleanup;
+     }
+ 
+-    rc = curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
++    rc = curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+     if (rc != CURLE_OK) {
+         LOG_ERROR("curl_easy_setopt for CURLOPT_FOLLOWLOCATION failed: %s",
+                   curl_easy_strerror(rc));
+diff --git a/src/tss2-fapi/ifapi_verify_cert_chain.c b/src/tss2-fapi/ifapi_verify_cert_chain.c
+index b495e512..c741c8ad 100644
+--- a/src/tss2-fapi/ifapi_verify_cert_chain.c
++++ b/src/tss2-fapi/ifapi_verify_cert_chain.c
+@@ -64,7 +64,7 @@ char* get_issuer_url(X509 *cert) {
+     AUTHORITY_INFO_ACCESS *info = X509_get_ext_d2i(cert, NID_info_access, NULL, NULL);
+     if (!info) return NULL;
+ 
+-    for (int i = 0; i < sk_ACCESS_DESCRIPTION_num(info); i++) {
++    for (size_t i = 0; i < sk_ACCESS_DESCRIPTION_num(info); i++) {
+         ACCESS_DESCRIPTION *ad = sk_ACCESS_DESCRIPTION_value(info, i);
+         if (OBJ_obj2nid(ad->method) == NID_ad_ca_issuers && ad->location->type == GEN_URI) {
+             ASN1_IA5STRING *uri = ad->location->d.uniformResourceIdentifier;
 diff --git a/test/unit/fapi-eventlog.c b/test/unit/fapi-eventlog.c
 index 3b859e39..796894ee 100644
 --- a/test/unit/fapi-eventlog.c


### PR DESCRIPTION
### Issues:
Resolves V1753330919

### Description of changes: 
* Add support for [OpenSSL's X509_STORE_CTX_set0_untrusted](https://github.com/openssl/openssl/blob/1c1c9dc11b574c7e034c553aef2c9472ecafca80/crypto/x509/x509_vfy.c#L2711-L2714)
* Update tpm2-tss patch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
