### PR TITLE
nginx-1.28.0 aws-lc-nginx.patch

### DIFF
--- a/tests/ci/integration/nginx_patch/aws-lc-nginx.patch
+++ b/tests/ci/integration/nginx_patch/aws-lc-nginx.patch
@@ -1,7 +1,6 @@
-diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
-index 9ad4d177b..8dda3ffef 100644
---- a/src/event/ngx_event_openssl.h
-+++ b/src/event/ngx_event_openssl.h
+diff --color -Naur a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
+--- a/src/event/ngx_event_openssl.h	2025-04-23 15:48:54.000000000 +0400
++++ b/src/event/ngx_event_openssl.h	2025-04-26 21:53:15.697269418 +0400
 @@ -25,7 +25,7 @@
  #endif
  #include <openssl/evp.h>
@@ -11,33 +10,31 @@ index 9ad4d177b..8dda3ffef 100644
  #include <openssl/hkdf.h>
  #include <openssl/chacha.h>
  #else
-diff --git a/src/event/quic/ngx_event_quic.c b/src/event/quic/ngx_event_quic.c
-index 308597e27..8da63584a 100644
---- a/src/event/quic/ngx_event_quic.c
-+++ b/src/event/quic/ngx_event_quic.c
-@@ -965,7 +965,7 @@ ngx_quic_handle_payload(ngx_connection_t *c, ngx_quic_header_t *pkt)
+diff --color -Naur a/src/event/quic/ngx_event_quic.c b/src/event/quic/ngx_event_quic.c
+--- a/src/event/quic/ngx_event_quic.c	2025-04-23 15:48:54.000000000 +0400
++++ b/src/event/quic/ngx_event_quic.c	2025-04-26 21:38:24.905884275 +0400
+@@ -970,7 +970,7 @@
          return NGX_DECLINED;
      }
  
 -#if !defined (OPENSSL_IS_BORINGSSL)
-+#if !defined (OPENSSL_IS_BORINGSSL) && !defined (OPENSSL_IS_AWSLC)
++#if !defined (OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
      /* OpenSSL provides read keys for an application level before it's ready */
  
      if (pkt->level == ssl_encryption_application && !c->ssl->handshaked) {
-diff --git a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic/ngx_event_quic_protection.c
-index 3f249b36a..426a6f039 100644
---- a/src/event/quic/ngx_event_quic_protection.c
-+++ b/src/event/quic/ngx_event_quic_protection.c
-@@ -33,7 +33,7 @@ static uint64_t ngx_quic_parse_pn(u_char **pos, ngx_int_t len, u_char *mask,
+diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic/ngx_event_quic_protection.c
+--- a/src/event/quic/ngx_event_quic_protection.c	2025-04-23 15:48:54.000000000 +0400
++++ b/src/event/quic/ngx_event_quic_protection.c	2025-04-26 22:30:58.506191433 +0400
+@@ -33,7 +33,7 @@
  
  static ngx_int_t ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out,
      const u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
 -#ifndef OPENSSL_IS_BORINGSSL
-+#if !defined (OPENSSL_IS_BORINGSSL) && !defined (OPENSSL_IS_AWSLC)
++#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
  static ngx_int_t ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out,
      const u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
  #endif
-@@ -58,7 +58,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
+@@ -58,7 +58,7 @@
      switch (id) {
  
      case TLS1_3_CK_AES_128_GCM_SHA256:
@@ -46,7 +43,7 @@ index 3f249b36a..426a6f039 100644
          ciphers->c = EVP_aead_aes_128_gcm();
  #else
          ciphers->c = EVP_aes_128_gcm();
-@@ -69,7 +69,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
+@@ -69,7 +69,7 @@
          break;
  
      case TLS1_3_CK_AES_256_GCM_SHA384:
@@ -55,7 +52,7 @@ index 3f249b36a..426a6f039 100644
          ciphers->c = EVP_aead_aes_256_gcm();
  #else
          ciphers->c = EVP_aes_256_gcm();
-@@ -80,12 +80,12 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
+@@ -80,12 +80,12 @@
          break;
  
      case TLS1_3_CK_CHACHA20_POLY1305_SHA256:
@@ -70,16 +67,16 @@ index 3f249b36a..426a6f039 100644
          ciphers->hp = (const EVP_CIPHER *) EVP_aead_chacha20_poly1305();
  #else
          ciphers->hp = EVP_chacha20();
-@@ -94,7 +94,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
+@@ -94,7 +94,7 @@
          len = 32;
          break;
  
 -#ifndef OPENSSL_IS_BORINGSSL
-+#if !defined (OPENSSL_IS_BORINGSSL) && !defined (OPENSSL_IS_AWSLC)
++#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
      case TLS1_3_CK_AES_128_CCM_SHA256:
          ciphers->c = EVP_aes_128_ccm();
          ciphers->hp = EVP_aes_128_ctr();
-@@ -262,7 +262,7 @@ static ngx_int_t
+@@ -263,7 +263,7 @@
  ngx_hkdf_expand(u_char *out_key, size_t out_len, const EVP_MD *digest,
      const uint8_t *prk, size_t prk_len, const u_char *info, size_t info_len)
  {
@@ -88,7 +85,7 @@ index 3f249b36a..426a6f039 100644
  
      if (HKDF_expand(out_key, out_len, digest, prk, prk_len, info, info_len)
          == 0)
-@@ -324,7 +324,7 @@ ngx_hkdf_extract(u_char *out_key, size_t *out_len, const EVP_MD *digest,
+@@ -325,7 +325,7 @@
      const u_char *secret, size_t secret_len, const u_char *salt,
      size_t salt_len)
  {
@@ -97,7 +94,7 @@ index 3f249b36a..426a6f039 100644
  
      if (HKDF_extract(out_key, out_len, digest, secret, secret_len, salt,
                       salt_len)
-@@ -387,7 +387,7 @@ ngx_quic_crypto_init(const ngx_quic_cipher_t *cipher, ngx_quic_secret_t *s,
+@@ -388,7 +388,7 @@
      ngx_quic_md_t *key, ngx_int_t enc, ngx_log_t *log)
  {
  
@@ -106,7 +103,7 @@ index 3f249b36a..426a6f039 100644
      EVP_AEAD_CTX  *ctx;
  
      ctx = EVP_AEAD_CTX_new(cipher, key->data, key->len,
-@@ -447,7 +447,7 @@ static ngx_int_t
+@@ -448,7 +448,7 @@
  ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
      ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log)
  {
@@ -115,7 +112,7 @@ index 3f249b36a..426a6f039 100644
      if (EVP_AEAD_CTX_open(s->ctx, out->data, &out->len, out->len, nonce,
                            s->iv.len, in->data, in->len, ad->data, ad->len)
          != 1)
-@@ -467,7 +467,7 @@ ngx_int_t
+@@ -468,7 +468,7 @@
  ngx_quic_crypto_seal(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
      ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log)
  {
@@ -124,16 +121,16 @@ index 3f249b36a..426a6f039 100644
      if (EVP_AEAD_CTX_seal(s->ctx, out->data, &out->len, out->len, nonce,
                            s->iv.len, in->data, in->len, ad->data, ad->len)
          != 1)
-@@ -483,7 +483,7 @@ ngx_quic_crypto_seal(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
+@@ -484,7 +484,7 @@
  }
  
  
 -#ifndef OPENSSL_IS_BORINGSSL
-+#if !defined (OPENSSL_IS_BORINGSSL) && !defined (OPENSSL_IS_AWSLC)
++#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
  
  static ngx_int_t
  ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out,
-@@ -562,7 +562,7 @@ void
+@@ -563,7 +563,7 @@
  ngx_quic_crypto_cleanup(ngx_quic_secret_t *s)
  {
      if (s->ctx) {
@@ -142,7 +139,7 @@ index 3f249b36a..426a6f039 100644
          EVP_AEAD_CTX_free(s->ctx);
  #else
          EVP_CIPHER_CTX_free(s->ctx);
-@@ -578,7 +578,7 @@ ngx_quic_crypto_hp_init(const EVP_CIPHER *cipher, ngx_quic_secret_t *s,
+@@ -579,7 +579,7 @@
  {
      EVP_CIPHER_CTX  *ctx;
  
@@ -151,7 +148,7 @@ index 3f249b36a..426a6f039 100644
      if (cipher == (EVP_CIPHER *) EVP_aead_chacha20_poly1305()) {
          /* no EVP interface */
          s->hp_ctx = NULL;
-@@ -614,7 +614,7 @@ ngx_quic_crypto_hp(ngx_quic_secret_t *s, u_char *out, u_char *in,
+@@ -615,7 +615,7 @@
  
      ctx = s->hp_ctx;
  
@@ -160,10 +157,9 @@ index 3f249b36a..426a6f039 100644
      uint32_t         cnt;
  
      if (ctx == NULL) {
-diff --git a/src/event/quic/ngx_event_quic_protection.h b/src/event/quic/ngx_event_quic_protection.h
-index c09456f53..8c5d97f0c 100644
---- a/src/event/quic/ngx_event_quic_protection.h
-+++ b/src/event/quic/ngx_event_quic_protection.h
+diff --color -Naur a/src/event/quic/ngx_event_quic_protection.h b/src/event/quic/ngx_event_quic_protection.h
+--- a/src/event/quic/ngx_event_quic_protection.h	2025-04-23 15:48:54.000000000 +0400
++++ b/src/event/quic/ngx_event_quic_protection.h	2025-04-26 21:55:34.479043252 +0400
 @@ -24,7 +24,7 @@
  #define NGX_QUIC_MAX_MD_SIZE          48
  
@@ -173,10 +169,9 @@ index c09456f53..8c5d97f0c 100644
  #define ngx_quic_cipher_t             EVP_AEAD
  #define ngx_quic_crypto_ctx_t         EVP_AEAD_CTX
  #else
-diff --git a/src/event/quic/ngx_event_quic_ssl.c b/src/event/quic/ngx_event_quic_ssl.c
-index ba0b5929f..a306d60d3 100644
---- a/src/event/quic/ngx_event_quic_ssl.c
-+++ b/src/event/quic/ngx_event_quic_ssl.c
+diff --color -Naur a/src/event/quic/ngx_event_quic_ssl.c b/src/event/quic/ngx_event_quic_ssl.c
+--- a/src/event/quic/ngx_event_quic_ssl.c	2025-04-23 15:48:54.000000000 +0400
++++ b/src/event/quic/ngx_event_quic_ssl.c	2025-04-26 22:38:34.152015187 +0400
 @@ -11,6 +11,7 @@
  
  
@@ -185,7 +180,7 @@ index ba0b5929f..a306d60d3 100644
      || defined LIBRESSL_VERSION_NUMBER                                        \
      || NGX_QUIC_OPENSSL_COMPAT
  #define NGX_QUIC_BORINGSSL_API   1
-@@ -583,7 +584,7 @@ ngx_quic_init_connection(ngx_connection_t *c)
+@@ -583,7 +584,7 @@
          return NGX_ERROR;
      }
  
@@ -194,31 +189,27 @@ index ba0b5929f..a306d60d3 100644
      if (SSL_set_quic_early_data_context(ssl_conn, p, clen) == 0) {
          ngx_log_error(NGX_LOG_INFO, c->log, 0,
                        "quic SSL_set_quic_early_data_context() failed");
-diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
-index ceac8d307..c1ea40f7f 100644
---- a/src/http/ngx_http_request.c
-+++ b/src/http/ngx_http_request.c
-@@ -935,7 +935,8 @@ ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
+diff --color -Naur a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
+--- a/src/http/ngx_http_request.c	2025-04-23 15:48:54.000000000 +0400
++++ b/src/http/ngx_http_request.c	2025-04-26 21:38:47.476172719 +0400
+@@ -935,7 +935,7 @@
      sscf = ngx_http_get_module_srv_conf(cscf->ctx, ngx_http_ssl_module);
  
  #if (defined TLS1_3_VERSION                                                   \
 -     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL)
-+     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL     \
-+     && !defined OPENSSL_IS_AWSLC)
++     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL && !defined OPENSSL_IS_AWSLC) 
  
      /*
       * SSL_SESSION_get0_hostname() is only available in OpenSSL 1.1.1+,
-diff --git a/src/stream/ngx_stream_ssl_module.c b/src/stream/ngx_stream_ssl_module.c
-index 2f1b99624..844aa90e7 100644
---- a/src/stream/ngx_stream_ssl_module.c
-+++ b/src/stream/ngx_stream_ssl_module.c
-@@ -592,7 +592,8 @@ ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
+diff --color -Naur a/src/stream/ngx_stream_ssl_module.c b/src/stream/ngx_stream_ssl_module.c
+--- a/src/stream/ngx_stream_ssl_module.c	2025-04-23 15:48:54.000000000 +0400
++++ b/src/stream/ngx_stream_ssl_module.c	2025-04-26 21:55:53.449285719 +0400
+@@ -592,7 +592,7 @@
      sscf = ngx_stream_get_module_srv_conf(cscf->ctx, ngx_stream_ssl_module);
  
  #if (defined TLS1_3_VERSION                                                   \
 -     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL)
-+     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL     \
-+     && !defined OPENSSL_IS_AWSLC)
++     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL && !defined OPENSSL_IS_AWSLC)
  
      /*
       * SSL_SESSION_get0_hostname() is only available in OpenSSL 1.1.1+,


### PR DESCRIPTION
### Description of changes: 

Updated integrations aws-lc-nginx.patch against nginx 1.28.0

### Testing:

Successful build of nginx 1.28.0 against AWS-LC 1.50.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.