### PR TITLE
Support allowing specific unknown critical extensions

### DIFF
--- a/crypto/x509/internal.h
+++ b/crypto/x509/internal.h
@@ -344,8 +344,8 @@ struct x509_store_ctx_st {
   X509_STORE_CTX_verify_cb verify_cb;       // error callback
   X509_STORE_CTX_get_crl_fn get_crl;        // retrieve CRL
   X509_STORE_CTX_check_crl_fn check_crl;    // Check CRL validity
-  X509_STORE_CTX_verify_crit_oids
-      verify_crit_oids;  // Check custom critical oids
+  X509_STORE_CTX_verify_crit_oids_cb
+      verify_custom_crit_oids;  // Check custom critical oids
 
   // The following is built up
 
@@ -361,7 +361,7 @@ struct x509_store_ctx_st {
 
   int current_crl_score;         // score of current CRL
 
-  // Array of allowed custom critical extension oids.
+  // Stack of allowed custom critical extension oids.
   STACK_OF(ASN1_OBJECT) *custom_crit_oids;
 
   CRYPTO_EX_DATA ex_data;

--- a/crypto/x509/internal.h
+++ b/crypto/x509/internal.h
@@ -344,6 +344,8 @@ struct x509_store_ctx_st {
   X509_STORE_CTX_verify_cb verify_cb;       // error callback
   X509_STORE_CTX_get_crl_fn get_crl;        // retrieve CRL
   X509_STORE_CTX_check_crl_fn check_crl;    // Check CRL validity
+  X509_STORE_CTX_verify_crit_oids
+      verify_crit_oids;  // Check custom critical oids
 
   // The following is built up
 
@@ -358,6 +360,9 @@ struct x509_store_ctx_st {
   X509_CRL *current_crl;  // current CRL
 
   int current_crl_score;         // score of current CRL
+
+  // Array of allowed custom critical extension oids.
+  STACK_OF(ASN1_OBJECT) *custom_crit_oids;
 
   CRYPTO_EX_DATA ex_data;
 } /* X509_STORE_CTX */;

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -8279,7 +8279,6 @@ static int verify_crit_oids_callback(X509_STORE_CTX *ctx, X509 *x509,
     return 0;  // Fail if no OIDs provided
   }
   size_t known_oid_count = sk_ASN1_OBJECT_num(oids);
-  ;
   size_t unknown_ext_count = 0;
   int last_pos = X509_get_ext_by_critical(x509, 1, -1);
   while (last_pos >= 0) {

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -62,6 +62,67 @@ j2kCAwG+LLpGNmNwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBw5lmgITTEvXIj+8ls
 -----END CERTIFICATE-----
 )";
 
+static const char kX509CustomExtensionsCA[] = R"(
+-----BEGIN CERTIFICATE-----
+MIIBxzCCAW2gAwIBAgIFAQAAAAAwCgYIKoZIzj0EAwIwJjEPMA0GA1UECgwGQW1h
+em9uMRMwEQYDVQQpDAo0Mjk0OTY3Mjk2MCIYDzIwMjUwMzI5MjA0OTE5WhgPOTk5
+OTEyMzEyMzU5NTlaMCYxDzANBgNVBAoMBkFtYXpvbjETMBEGA1UEKQwKNDI5NDk2
+NzI5NjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABL3eDQzFx4cherBJdIQsxMzZ
+rCtzXBTB3f/rRMLrtjxpk2/6h3ZbE4t8MmDbwVepAKYQgT1bjPUFn+edG2U8kRej
+gYMwgYAwEgYDVR0TAQH/BAgwBgEB/wIBADBLBgNVHSMERDBCgBTMNuas7QD5hDXY
+KS7k0WDN6ckMFqEqpCgwJjEPMA0GA1UECgwGQW1hem9uMRMwEQYDVQQpDAo0Mjk0
+OTY3Mjk2MB0GA1UdDgQWBBTMNuas7QD5hDXYKS7k0WDN6ckMFjAKBggqhkjOPQQD
+AgNIADBFAiB3MJLK86+JyyoBr2s1Ugjvc7gWAHSk9OgXfyfsVmBV9gIhAPIUiYo8
+Jx+IbRyNj2WfeCbn8v3fob0wkGsKf1TSVcZ8
+-----END CERTIFICATE-----
+)";
+
+static const char kX509CustomExtensionsCert[] = R"(
+-----BEGIN CERTIFICATE-----
+MIIB6zCCAZGgAwIBAgIFAQAAAAAwCgYIKoZIzj0EAwIwJjEPMA0GA1UECgwGQW1h
+em9uMRMwEQYDVQQpDAo0Mjk0OTY3Mjk2MCIYDzIwMjUwMzI5MjA0OTE5WhgPOTk5
+OTEyMzEyMzU5NTlaMBExDzANBgNVBAoMBkFtYXpvbjBZMBMGByqGSM49AgEGCCqG
+SM49AwEHA0IABNbNswB+jmoICPKu567Odfq83s9P0N82kFYnyANgmztgHqoK7yIX
+0meBn5N9Y4m3wAmvokYeK7dU1oRSM397unmjgbwwgbkwDAYDVR0TAQH/BAIwADAO
+BgNVHQ8BAf8EBAMCB4AwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwEwFQYHK4E7gcR0
+BQEB/wQHcHJlc2VudDBLBgNVHSMERDBCgBTMNuas7QD5hDXYKS7k0WDN6ckMFqEq
+pCgwJjEPMA0GA1UECgwGQW1hem9uMRMwEQYDVQQpDAo0Mjk0OTY3Mjk2MB0GA1Ud
+DgQWBBRiexFm2K7Ou2dx4+c0LjQOsuqHJjAKBggqhkjOPQQDAgNIADBFAiAxH63Q
+eK26A9QPOkqi+5Hvrptpb9HRstSC6emJdaEB1QIhAKyhyLBPrG85QDoXrFcVZUA2
++StWnDVDGtgWM6tPz4Uw
+-----END CERTIFICATE-----
+)";
+
+static const char kX509MultipleCustomExtensionsCA[] = R"(
+-----BEGIN CERTIFICATE-----
+MIIByDCCAW2gAwIBAgIFAQAAAAAwCgYIKoZIzj0EAwIwJjEPMA0GA1UECgwGQW1h
+em9uMRMwEQYDVQQpDAo0Mjk0OTY3Mjk2MCIYDzIwMjUwMzMwMjExMzA1WhgPOTk5
+OTEyMzEyMzU5NTlaMCYxDzANBgNVBAoMBkFtYXpvbjETMBEGA1UEKQwKNDI5NDk2
+NzI5NjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABMhC2xZcc7UouUMo1xPMiq8E
+Z7DdWJq0I9nPunowEwidaif/YU6tjAPVFPmcRIhRYvZH6HWyNc0gztcfgAxa7tej
+gYMwgYAwEgYDVR0TAQH/BAgwBgEB/wIBADBLBgNVHSMERDBCgBRMh4uFf12IUZ1m
+v3WCstI0aqCBdKEqpCgwJjEPMA0GA1UECgwGQW1hem9uMRMwEQYDVQQpDAo0Mjk0
+OTY3Mjk2MB0GA1UdDgQWBBRMh4uFf12IUZ1mv3WCstI0aqCBdDAKBggqhkjOPQQD
+AgNJADBGAiEAyZK6Elt1iqVV1Rys4G8HmIE7/hRW3rbQWiNPd4FnANACIQCgbgki
+hQaJgNo+8hOTEOQZsRSaIbu+F2afe6ncp996RQ==
+-----END CERTIFICATE-----
+)";
+
+static const char kX509MultipleCustomExtensionsCert[] = R"(
+-----BEGIN CERTIFICATE-----
+MIICAjCCAaigAwIBAgIFAQAAAAAwCgYIKoZIzj0EAwIwJjEPMA0GA1UECgwGQW1h
+em9uMRMwEQYDVQQpDAo0Mjk0OTY3Mjk2MCIYDzIwMjUwMzMwMjExMzA1WhgPOTk5
+OTEyMzEyMzU5NTlaMBExDzANBgNVBAoMBkFtYXpvbjBZMBMGByqGSM49AgEGCCqG
+SM49AwEHA0IABPVuvcRmJ8fqyZferbqGWP8Kd1yHHX+4gcglS5WV9Zt7T957fhNY
+QpimdCfV+KEJji8IwBc7vOk+1Db3ulQ0dZejgdMwgdAwDAYDVR0TAQH/BAIwADAO
+BgNVHQ8BAf8EBAMCB4AwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwEwFQYHK4E7gcR0
+BQEB/wQHcHJlc2VudDAVBgcrgTuBxHQGAQH/BAdwcmVzZW50MEsGA1UdIwREMEKA
+FEyHi4V/XYhRnWa/dYKy0jRqoIF0oSqkKDAmMQ8wDQYDVQQKDAZBbWF6b24xEzAR
+BgNVBCkMCjQyOTQ5NjcyOTYwHQYDVR0OBBYEFGt+Hy7qdE2lFnnjYPGqeVvJ4uPf
+MAoGCCqGSM49BAMCA0gAMEUCIQC4aXyPOO6asCwoG1pGGmODmAEMA2tAXXNp67Oo
+hDO90wIgETGPNCQIHlvUXAfDmZdUPh+PKkv6paVhWMTXrsh19LQ=
+-----END CERTIFICATE-----
+)";
 
 std::string GetTestData(const char *path);
 
@@ -8207,4 +8268,133 @@ TEST(X509Test, Trust) {
   EXPECT_EQ(X509_V_OK, Verify(leaf.distrusted_server.get(), {root.normal.get()},
                               {intermediate.normal.get()}, {},
                               /*flags=*/0, set_server_trust));
+}
+
+// A brief validation against the |oids| expected to be done by the consumer.
+// This example simulates the consumer checking that the certificate has the
+// correct number of unknown extensions and there aren't any duplicates.
+static int verify_crit_oids_callback(X509_STORE_CTX *ctx, X509 *x509,
+                                     STACK_OF(ASN1_OBJECT) *oids) {
+  if (oids == nullptr) {
+    return 0;  // Fail if no OIDs provided
+  }
+  size_t known_oid_count = sk_ASN1_OBJECT_num(oids);
+  ;
+  size_t unknown_ext_count = 0;
+  int last_pos = X509_get_ext_by_critical(x509, 1, -1);
+  while (last_pos >= 0) {
+    const X509_EXTENSION *ext = X509_get_ext(x509, last_pos);
+    if (!X509_supported_extension(ext)) {
+      unknown_ext_count++;
+    }
+    last_pos = X509_get_ext_by_critical(x509, 1, last_pos);
+  }
+  return known_oid_count == unknown_ext_count;
+}
+
+// Helper function to set up the basic verification context
+static void SetupVerificationContext(
+    X509_STORE_CTX *ctx, const std::vector<ASN1_OBJECT *> &custom_oids = {},
+    bool set_callback = false) {
+  X509_VERIFY_PARAM *param = X509_STORE_CTX_get0_param(ctx);
+  X509_VERIFY_PARAM_set_time_posix(param, 1745884800);  // Apr 28, 2025
+
+  for (const auto &oid : custom_oids) {
+    ASSERT_TRUE(X509_STORE_CTX_add_custom_crit_oid(ctx, oid));
+  }
+
+  if (set_callback) {
+    X509_STORE_CTX_set_verify_crit_oids(ctx, verify_crit_oids_callback);
+  }
+}
+
+TEST(X509Test, X509CustomExtensions) {
+  bssl::UniquePtr<X509> cert(CertFromPEM(kX509CustomExtensionsCert));
+  ASSERT_TRUE(cert);
+  bssl::UniquePtr<X509> ca(CertFromPEM(kX509CustomExtensionsCA));
+  ASSERT_TRUE(ca);
+
+  bssl::UniquePtr<ASN1_OBJECT> custom_oid(OBJ_txt2obj("1.3.187.25204.5", 1));
+  ASSERT_TRUE(custom_oid);
+
+  // A typical call to |X509_verify_cert| without any set up would fail due to
+  // the unknown critical extensions.
+  auto typical_setup = [&](X509_STORE_CTX *ctx) {
+    SetupVerificationContext(ctx, {}, false);
+  };
+  EXPECT_EQ(X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION,
+            Verify(cert.get(), {ca.get()}, {}, {},
+                   /*flags=*/0, typical_setup));
+
+  // Unknown critical certificate extensions aren't enabled without the
+  // callback.
+  auto set_custom_ext_with_no_callback = [&](X509_STORE_CTX *ctx) {
+    SetupVerificationContext(ctx, {custom_oid.get()}, false);
+  };
+  EXPECT_EQ(X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION,
+            Verify(cert.get(), {ca.get()}, {}, {},
+                   /*flags=*/0, set_custom_ext_with_no_callback));
+
+  // Unknown critical certificate extensions aren't enabled, when only the
+  // callback is enabled, but no custom oids are set.
+  auto set_no_custom_ext_with_callback = [&](X509_STORE_CTX *ctx) {
+    SetupVerificationContext(ctx, {}, true);
+  };
+  EXPECT_EQ(X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION,
+            Verify(cert.get(), {ca.get()}, {}, {},
+                   /*flags=*/0, set_no_custom_ext_with_callback));
+
+  // This correctly sets up |ctx| with a customcritical extension and the
+  // |verify_crit_oids| callback.
+  auto set_custom_ext_with_callback = [&](X509_STORE_CTX *ctx) {
+    SetupVerificationContext(ctx, {custom_oid.get()}, true);
+  };
+  EXPECT_EQ(X509_V_OK,
+            Verify(cert.get(), {ca.get()}, {}, {}, /*flags=*/0,
+                   set_custom_ext_with_callback));
+}
+
+TEST(X509Test, X509MultipleCustomExtensions) {
+  bssl::UniquePtr<X509> cert(CertFromPEM(kX509MultipleCustomExtensionsCert));
+  ASSERT_TRUE(cert);
+  bssl::UniquePtr<X509> ca(CertFromPEM(kX509MultipleCustomExtensionsCA));
+  ASSERT_TRUE(ca);
+
+  bssl::UniquePtr<ASN1_OBJECT> custom_oid(OBJ_txt2obj("1.3.187.25204.5", 1));
+  ASSERT_TRUE(custom_oid);
+  bssl::UniquePtr<ASN1_OBJECT> custom_oid2(OBJ_txt2obj("1.3.187.25204.6", 1));
+  ASSERT_TRUE(custom_oid2);
+
+  // The result should be |X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION| since only
+  // one custom critical extension was set. Both extensions are needed since the
+  // cert contains two unknown extensions.
+  auto set_single_custom_ext = [&](X509_STORE_CTX *ctx) {
+    SetupVerificationContext(ctx, {custom_oid.get()}, true);
+  };
+  EXPECT_EQ(X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION,
+            Verify(cert.get(), {ca.get()}, {}, {},
+                   /*flags=*/0, set_single_custom_ext));
+  auto set_other_custom_ext = [&](X509_STORE_CTX *ctx) {
+    SetupVerificationContext(ctx, {custom_oid2.get()}, true);
+  };
+  EXPECT_EQ(X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION,
+            Verify(cert.get(), {ca.get()}, {}, {},
+                   /*flags=*/0, set_other_custom_ext));
+
+  // Verification should not pass if all custom critical extensions are set, but
+  // the |verify_crit_oids| callback is not configured.
+  auto only_custom_exts_set = [&](X509_STORE_CTX *ctx) {
+    SetupVerificationContext(ctx, {custom_oid.get(), custom_oid2.get()}, false);
+  };
+  EXPECT_EQ(X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION,
+            Verify(cert.get(), {ca.get()}, {}, {},
+                   /*flags=*/0, only_custom_exts_set));
+
+  // Verification should only pass if all custom critical extensions are set, and
+  // the |verify_crit_oids| callback is configured.
+  auto set_custom_exts_with_callback = [&](X509_STORE_CTX *ctx) {
+    SetupVerificationContext(ctx, {custom_oid.get(), custom_oid2.get()}, true);
+  };
+  EXPECT_EQ(X509_V_OK, Verify(cert.get(), {ca.get()}, {}, {},
+                              /*flags=*/0, set_custom_exts_with_callback));
 }

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2903,6 +2903,35 @@ OPENSSL_EXPORT int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose);
 // difference.
 OPENSSL_EXPORT int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust);
 
+// X509_STORE_CTX_add_custom_crit_oid adds |oid| to the list of "known"
+// critical extension OIDs in |ctx|. Typical OpenSSL/AWS-LC behavior returns
+// an error if there are any unknown critical extensions present within the
+// certificates being validated. This function lets users to specify custom
+// OIDs of any critical extensions that are within the certificates being
+// validated, that they wish to allow.
+//
+// To properly consume this feature, the callback mechanism with
+// |X509_STORE_CTX_set_verify_crit_oids| must be set. See its specific
+// documentation for more details.
+OPENSSL_EXPORT int X509_STORE_CTX_add_custom_crit_oid(X509_STORE_CTX *ctx,
+                                                      ASN1_OBJECT *oid);
+
+// X509_STORE_CTX_verify_crit_oids is the callback signature for
+// |X509_STORE_CTX_set_verify_crit_oids|. |ctx| is the context being used,
+// |x509| represents the current certificate being validated, and |oids|
+// represents the stack of custom OIDs that have been set by
+// |X509_STORE_CTX_add_custom_crit_oid|.
+typedef int (*X509_STORE_CTX_verify_crit_oids)(X509_STORE_CTX *ctx, X509 *x509,
+                                               STACK_OF(ASN1_OBJECT) *oids);
+
+// X509_STORE_CTX_set_verify_crit_oids sets the |verify_crit_oids| callback
+// function for |ctx|. Consumers should be performing additional validation
+// against the custom extension oids after or during the handshake with
+// |X509_STORE_CTX_set_verify_crit_oids|. This callback forces users to validate
+// their custom OIDs when processing unknown custom critical extensions.
+OPENSSL_EXPORT void X509_STORE_CTX_set_verify_crit_oids(
+    X509_STORE_CTX *ctx, X509_STORE_CTX_verify_crit_oids verify_crit_oids);
+
 
 // Verification parameters
 //

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2903,12 +2903,12 @@ OPENSSL_EXPORT int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose);
 // difference.
 OPENSSL_EXPORT int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust);
 
-// X509_STORE_CTX_add_custom_crit_oid adds |oid| to the list of "known"
-// critical extension OIDs in |ctx|. Typical OpenSSL/AWS-LC behavior returns
-// an error if there are any unknown critical extensions present within the
-// certificates being validated. This function lets users to specify custom
-// OIDs of any critical extensions that are within the certificates being
-// validated, that they wish to allow.
+// X509_STORE_CTX_add_custom_crit_oid adds |oid| to the list of "known" critical
+// extension OIDs in |ctx|. Typical OpenSSL/AWS-LC behavior returns an error if
+// there are any unknown critical extensions present within the certificates
+// being validated. This function lets users specify custom OIDs of any critical
+// extensions that are within the certificates being validated, that they wish
+// to allow.
 //
 // To properly consume this feature, the callback mechanism with
 // |X509_STORE_CTX_set_verify_crit_oids| must be set. See its specific
@@ -2919,10 +2919,12 @@ OPENSSL_EXPORT int X509_STORE_CTX_add_custom_crit_oid(X509_STORE_CTX *ctx,
 // X509_STORE_CTX_verify_crit_oids is the callback signature for
 // |X509_STORE_CTX_set_verify_crit_oids|. |ctx| is the context being used,
 // |x509| represents the current certificate being validated, and |oids|
-// represents the stack of custom OIDs that have been set by
+// is a stack of |ASN1_OBJECT|s representing unknown critical extension
+// OIDs that were found in |x509| and match those previously registered via
 // |X509_STORE_CTX_add_custom_crit_oid|.
-typedef int (*X509_STORE_CTX_verify_crit_oids)(X509_STORE_CTX *ctx, X509 *x509,
-                                               STACK_OF(ASN1_OBJECT) *oids);
+typedef int (*X509_STORE_CTX_verify_crit_oids_cb)(X509_STORE_CTX *ctx,
+                                                  X509 *x509,
+                                                  STACK_OF(ASN1_OBJECT) *oids);
 
 // X509_STORE_CTX_set_verify_crit_oids sets the |verify_crit_oids| callback
 // function for |ctx|. Consumers should be performing additional validation
@@ -2930,7 +2932,8 @@ typedef int (*X509_STORE_CTX_verify_crit_oids)(X509_STORE_CTX *ctx, X509 *x509,
 // |X509_STORE_CTX_set_verify_crit_oids|. This callback forces users to validate
 // their custom OIDs when processing unknown custom critical extensions.
 OPENSSL_EXPORT void X509_STORE_CTX_set_verify_crit_oids(
-    X509_STORE_CTX *ctx, X509_STORE_CTX_verify_crit_oids verify_crit_oids);
+    X509_STORE_CTX *ctx,
+    X509_STORE_CTX_verify_crit_oids_cb verify_custom_crit_oids);
 
 
 // Verification parameters


### PR DESCRIPTION
### Issues:
Resolves `V1726629971`

### Description of changes: 
As of today, AWS-LC returns an error as part of verification if there are any critical extensions present in the certificate being validated. There have been asks to set a custom OID on the issued certificates to ensure that additional validation is performed by customers after or during the handshake. The intention is to prevent accidental mis-use of these certificates without that extra validation.

To support this, we've decided to add two new APIs for this use case. 
1. `X509_STORE_CTX_add_custom_crit_oid` adds  an oid as an `ASN1_OBJECT` to the list of "known" critical extension OIDs in `ctx`. Typical OpenSSL/AWS-LC behavior returns an error if there are any unknown critical extensions present within the certificates being validated. This function lets users specify custom OIDs of any critical extensions that are within the certificates being validated, that they wish to allow. The callback mechanism enabled with `X509_STORE_CTX_set_verify_crit_oids` must be set for this feature to enabled.

2. `X509_STORE_CTX_set_verify_crit_oids` enables the `X509_STORE_CTX_verify_crit_oids_cb` with `X509_STORE_CTX`. Consumers should be performing additional validation against the custom extension oids after or during the handshake. This callback forces users to validate their custom OIDs when processing unknown custom critical extensions. The `X509_STORE_CTX_verify_crit_oids_cb` callback function gives the user the current certificate being validated as `x509` and a stack of `ASN1_OBJECT`s representing unknown critical extension OIDs that were found in `x509` and match those previously registered via`|X509_STORE_CTX_add_custom_crit_oid` as  `oids`.

This should not effect any existing consumers of `X509_verify_cert`. Any existence of an unknown critical extension will still cause the entire verification to be aborted. Only consumers that have enabled the callback and set specific OIDs with `ASN1_OBJECT` can circumvent the check and trigger the verification to pass.



### Testing:
Test certs were generated by the team asking for this feature. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
