### PR TITLE
Bump to v1.50.1

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.50.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.50.1");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.50.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.50.1");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.50.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.50.1"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Bump version to 1.50.1. (Needed so that `aws-lc-sys` can to pick up latest s2n-bignum changes.)

### Call-outs:
#### What's Changed
* Fix GCC 4.8 docker img; Also w/ GCC 7.5 by @justsmth in https://github.com/aws/aws-lc/pull/2344
* Fix LibRdKafka CI by @smittals2 in https://github.com/aws/aws-lc/pull/2372
* Expand .clang-tidy configuration by @justsmth in https://github.com/aws/aws-lc/pull/2356
* nginx-1.28.0 aws-lc-nginx.patch by @robvanoostenrijk in https://github.com/aws/aws-lc/pull/2373
* s2n bignum import method change by @torben-hansen in https://github.com/aws/aws-lc/pull/2324
* Fix a theoretical overflow in BIO_printf by @justsmth in https://github.com/aws/aws-lc/pull/2369
* Fix tpm2-tss integration test by @justsmth in https://github.com/aws/aws-lc/pull/2370


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
