### PR TITLE
No need for MacOS large/xlarge

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -37,8 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-14-large"
-          - "macos-13-large"
+          - "macos-13"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -56,8 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-14-large"
-          - "macos-13-large"
+          - "macos-13"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -75,8 +73,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-14-xlarge"
-          - "macos-13-xlarge"
+          - "macos-14"
+          - "macos-15"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -94,8 +92,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-14-xlarge"
-          - "macos-13-xlarge"
+          - "macos-14"
+          - "macos-15"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### Description of changes: 
We don't need to use the large/xlarge instances for MacOS.

### Call-outs
The following runner information can be found [here](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

| Virtual Machine | Processor (CPU) | Memory (RAM) | Storage (SSD) | Architecture | Workflow label |
|-----------------|----------------|--------------|--------------|--------------|----------------|
| macOS | 4 | 14 GB | 14 GB | Intel | macos-13 |
| macOS | 3 (M1) | 7 GB | 14 GB | arm64 | macos-latest, macos-14, macos-15 |


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
