### PR TITLE
Fix socat test

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -48,6 +48,20 @@ jobs:
       - name: Run librdkafka build
         run: |
           ./tests/ci/integration/run_librdkafka_integration.sh
+  socat:
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-latest
+    env:
+      SHELL: /usr/bin/bash
+    steps:
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make autoconf pkg-config openssl
+      - uses: actions/checkout@v4
+      - name: Run socat integration test
+        run: |
+          ./tests/ci/integration/run_socat_integration.sh
   rust-openssl:
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest

--- a/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml
@@ -291,17 +291,6 @@ batch:
         variables:
           AWS_LC_CI_TARGET: "tests/ci/integration/run_tcpdump_integration.sh"
 
-    - identifier: socat_integration_x86_64
-      buildspec: tests/ci/codebuild/common/run_nonroot_target.yml
-      env:
-        type: LINUX_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_MEDIUM
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-22.04_gcc-12x_integration_latest
-        variables:
-          AWS_LC_CI_TARGET: "tests/ci/integration/run_socat_integration.sh"
-          LOGNAME: "postgres"
-
     - identifier: openldap_integration_x86_64
       buildspec: tests/ci/codebuild/common/run_simple_target.yml
       env:

--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -27,7 +27,8 @@ function build_and_test_socat() {
   # See: t/V1497389456.
   # socat decreased the test wait time to 3 milliseconds, which causes failures when additional warnings/logs are written.
   # Extending the wait time to 50 milliseconds is just right for us.
-  sed -i 's/MILLIs=\$((3/MILLIs=\$((50/' ./test.sh
+  # Use Perl so the command will fail if no replacement performed:
+  perl -pi -e 'BEGIN{$x=0} $x=1 if s/MICROS=\${MILLIs}000/MICROS=50000/; END{exit 1 if !$x}' ./test.sh
   # test 146 OPENSSLLISTENDSA: fails because AWS-LC doesn't support FFDH ciphersuites which are needed for DSA
   # test 216 UDP6MULTICAST_UNIDIR: known flaky test in socat with newer kernels
   # test 309 OPENSSLRENEG1: AWS-LC doesn't support renegotiation by default, it can be enabled by calling SSL_set_renegotiate_mode


### PR DESCRIPTION
### Issues:
Addresses V1753367409

### Description of changes: 
* Move socat integration test out of CodeBuild
  * The tests that were failing that involve to signals and child processes. We've had similar trouble with the libssh2 test running in CodeBuild.
* Update integration test script so it fails with script modifications are not applied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
