### PR TITLE
Correct typo in malloc debug environment variable

### DIFF
--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -1658,7 +1658,7 @@ func runTest(dispatcher *shimDispatcher, statusChan chan statusMsg, test *testCa
 		if *mallocTestDebug {
 			env = append(env, "MALLOC_BREAK_ON_FAIL=1")
 		}
-		env = append(env, "_MALLOC_CHECK=1")
+		env = append(env, "MALLOC_CHECK_=1")
 	}
 
 	shim, err := newShimProcess(dispatcher, shimPath, flags, env)

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -207,7 +207,7 @@ func runTestOnce(test test, mallocNumToFail int64) (passed bool, err error) {
 		if *mallocTestDebug {
 			cmd.Env = append(cmd.Env, "MALLOC_ABORT_ON_FAIL=1")
 		}
-		cmd.Env = append(cmd.Env, "_MALLOC_CHECK=1")
+		cmd.Env = append(cmd.Env, "MALLOC_CHECK_=1")
 	}
 
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
### Description of changes: 

I don't think this is currently used for anything. While the malloc-test machinery is working atm, some errors won't be caught due to the typo. https://man7.org/linux/man-pages/man3/mallopt.3.html says it should be `MALLOC_CHECK_`.

The malloc test is sorta in a weird state. Upstream has migrated `malloc` hijack functions to `mem.c`. But not in this repo. However, the build support exists in the shape of
```
if(MALLOC_FAILURE_TESTING)
  add_definitions(-DBORINGSSL_MALLOC_FAILURE_TESTING)
endif()
```
which does nothing...

Anyway, this could be useful for something, one day, so I left all the code there. For further features, some honorary mentions one could research are `MALLOC_PERTURB_` and `mcheck()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
