### PR TITLE
CI: Bump fuzzing instance size on ARM

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_fuzzing_omnibus.yaml
@@ -22,7 +22,7 @@ batch:
       env:
         type: ARM_CONTAINER
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
+        compute-type: BUILD_GENERAL1_XLARGE
         image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-aarch:amazonlinux-2023_clang-15x_sanitizer_latest
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_fuzz_tests.sh"


### PR DESCRIPTION
Fuzzing on ARM is taking 80-90 minutes. This is to try bumping the instance size to make things faster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
