### PR TITLE
Fix PRNG model test

### DIFF
--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
@@ -151,7 +151,7 @@ static void tree_jitter_drbg_maybe_get_pred_resistance(
 
   if (tree_jitter_drbg->is_global == 0 &&
       tree_jitter_drbg->ube_protection != 1) {
-    CRYPTO_sysrand_for_seed(pred_resistance, RAND_PRED_RESISTANCE_LEN);
+    CRYPTO_sysrand(pred_resistance, RAND_PRED_RESISTANCE_LEN);
     *pred_resistance_len = RAND_PRED_RESISTANCE_LEN;
   }
 }

--- a/crypto/rand_extra/getrandom_fillin.h
+++ b/crypto/rand_extra/getrandom_fillin.h
@@ -16,6 +16,7 @@
 #define OPENSSL_HEADER_CRYPTO_RAND_GETRANDOM_FILLIN_H
 
 #include <openssl/base.h>
+#include "internal.h"
 
 
 #if defined(OPENSSL_RAND_URANDOM)

--- a/crypto/rand_extra/urandom_test.cc
+++ b/crypto/rand_extra/urandom_test.cc
@@ -24,6 +24,7 @@
 #include "../ube/snapsafe_detect.h"
 
 #if defined(OPENSSL_RAND_URANDOM) && \
+    defined(OPENSSL_X86_64) && \
     !defined(BORINGSSL_SHARED_LIBRARY) && \
     !defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE) && \
     defined(USE_NR_getrandom) && !defined(AWSLC_SNAPSAFE_TESTING)


### PR DESCRIPTION
### Description of changes: 

The PRNG model has been disabled for a while in the RAGDOLL branch. This PR fixes the PRNG model test for the new implementation. It only captures system calls, so it was pretty straightforward to model the correct flow. Some changes were required to capture the real trace due to Jitter Entropy and other stuff... This should all be explained in inline comments in the source code. Few details below.

The following assumption is no longer true

> It's assumed that any arguments to open(2) are constants in read-only memory

because of system calls originating from Jitter Entropy. This requires a bit more care when parsing the filename argument to `open/openat`. Take the opportunity to simplify the string handling a bit by changing to c++ native std strings.

When reading registers through ptrace, sometimes they are sign-extended(?). Need to cater for that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
