### PR TITLE
Set OPENSSL_NO_EXTERNAL_PSK_TLS13 to indicate lack of TLS 1.3 PSK

### DIFF
--- a/include/openssl/opensslconf.h
+++ b/include/openssl/opensslconf.h
@@ -53,9 +53,10 @@ extern "C" {
 #define OPENSSL_NO_MD2
 #define OPENSSL_NO_MDC2
 #define OPENSSL_NO_OCB
-// OPENSSL_NO_PSK_TLS13 indicates lack of support for external
-// PSK authentication in TLS >= 1.3
-#define OPENSSL_NO_PSK_TLS13
+// OPENSSL_NO_EXTERNAL_PSK_TLS13 indicates lack of support for external
+// PSK authentication in TLS >= 1.3. AWS-LC intentionally omits support
+// for this due to security conerns outlined in RFC 9258.
+#define OPENSSL_NO_EXTERNAL_PSK_TLS13
 #define OPENSSL_NO_RC2
 #define OPENSSL_NO_RC5
 #define OPENSSL_NO_RFC3779

--- a/include/openssl/opensslconf.h
+++ b/include/openssl/opensslconf.h
@@ -53,6 +53,9 @@ extern "C" {
 #define OPENSSL_NO_MD2
 #define OPENSSL_NO_MDC2
 #define OPENSSL_NO_OCB
+// OPENSSL_NO_PSK_TLS13 indicates lack of support for external
+// PSK authentication in TLS >= 1.3
+#define OPENSSL_NO_PSK_TLS13
 #define OPENSSL_NO_RC2
 #define OPENSSL_NO_RC5
 #define OPENSSL_NO_RFC3779

--- a/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
@@ -1,29 +1,33 @@
+diff --git a/Lib/ssl.py b/Lib/ssl.py
+index 05df4ad..7e3c4cb 100644
+--- a/Lib/ssl.py
++++ b/Lib/ssl.py
+@@ -116,7 +116,7 @@
+ 
+ from _ssl import (
+     HAS_SNI, HAS_ECDH, HAS_NPN, HAS_ALPN, HAS_SSLv2, HAS_SSLv3, HAS_TLSv1,
+-    HAS_TLSv1_1, HAS_TLSv1_2, HAS_TLSv1_3, HAS_PSK, HAS_PHA
++    HAS_TLSv1_1, HAS_TLSv1_2, HAS_TLSv1_3, HAS_PSK, HAS_PSK_TLS13, HAS_PHA
+ )
+ from _ssl import _DEFAULT_CIPHERS, _OPENSSL_API_VERSION
+ 
 diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
-index 0e50d09..f4b7b3c 100644
+index 395b2ef..c168224 100644
 --- a/Lib/test/test_ssl.py
 +++ b/Lib/test/test_ssl.py
-@@ -4443,14 +4445,14 @@ def server_callback(identity):
-             self.assertEqual(identity, client_identity)
-             return psk
-
--        client_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-+        client_context, server_context, _ = testing_context()
-+
-         client_context.check_hostname = False
-         client_context.verify_mode = ssl.CERT_NONE
-         client_context.minimum_version = ssl.TLSVersion.TLSv1_3
-         client_context.set_ciphers('PSK')
-         client_context.set_psk_client_callback(client_callback)
-
--        server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-         server_context.minimum_version = ssl.TLSVersion.TLSv1_3
-         server_context.set_ciphers('PSK')
-         server_context.set_psk_server_callback(server_callback, identity_hint)
+@@ -4488,6 +4488,7 @@ def server_callback(identity):
+ 
+     @requires_tls_version('TLSv1_3')
+     @unittest.skipUnless(ssl.HAS_PSK, 'TLS-PSK disabled on this OpenSSL build')
++    @unittest.skipUnless(ssl.HAS_PSK_TLS13, 'TLS 1.3 PSK disabled on this OpenSSL build')
+     def test_psk_tls1_3(self):
+         psk = bytes.fromhex('deadbeef')
+         identity_hint = 'identity-hint'
 diff --git a/Modules/Setup b/Modules/Setup
-index cd1cf24..53bcc4c 100644
+index a066982..3d7fbc3 100644
 --- a/Modules/Setup
 +++ b/Modules/Setup
-@@ -208,11 +208,11 @@ PYTHONPATH=$(COREPYTHONPATH)
+@@ -213,11 +213,11 @@ PYTHONPATH=$(COREPYTHONPATH)
  #_hashlib _hashopenssl.c $(OPENSSL_INCLUDES) $(OPENSSL_LDFLAGS) -lcrypto
  
  # To statically link OpenSSL:
@@ -40,3 +44,20 @@ index cd1cf24..53bcc4c 100644
  
  # The _tkinter module.
  #
+diff --git a/Modules/_ssl.c b/Modules/_ssl.c
+index 97a29f4..3f2f55e 100644
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -6626,6 +6626,12 @@ sslmodule_init_constants(PyObject *m)
+     addbool(m, "HAS_PSK", 1);
+ #endif
+ 
++#ifdef OPENSSL_NO_PSK_TLS13
++    addbool(m, "HAS_PSK_TLS13", 0);
++#else
++    addbool(m, "HAS_PSK_TLS13", 1);
++#endif
++
+ #ifdef SSL_VERIFY_POST_HANDSHAKE
+     addbool(m, "HAS_PHA", 1);
+ #else

--- a/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
@@ -52,7 +52,7 @@ index 97a29f4..3f2f55e 100644
      addbool(m, "HAS_PSK", 1);
  #endif
  
-+#ifdef OPENSSL_NO_PSK_TLS13
++#ifdef OPENSSL_NO_EXTERNAL_PSK_TLS13
 +    addbool(m, "HAS_PSK_TLS13", 0);
 +#else
 +    addbool(m, "HAS_PSK_TLS13", 1);


### PR DESCRIPTION
### Description of changes: 

Due to [security concerns](https://www.rfc-editor.org/rfc/rfc9258.html#section-1), neither AWS-LC [nor BoringSSL](https://issues.chromium.org/issues/369963041) support external (i.e. non-session-resumption, established out of band) PSKs in TLS 1.3. This PR proposes a "configuration" flag to indicate this limitation to consumers, much as we did with `OPENSSL_NO_TLS_PHA` in 0aebf17.

### Call-outs:

Other cryptography libraries do not set this macro; it's unique to us.

### Testing:

- CI w/ new patch set

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
