### PR TITLE
Update mlkem-native

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -215,9 +215,52 @@ For Keccak and AES we are using public-domain
 code from sources and by authors listed in
 comments on top of the respective files.
 
+mlkem-native licensing
+----------------------
+
 The code in crypto/fipsmodule/ml_kem/mlkem is imported from mlkem-native
-(https://github.com/pq-code-package/mlkem-native) and carries the
-Apache 2.0 license. This license is reproduced at the bottom of this file.
+(https://github.com/pq-code-package/mlkem-native) and made available
+under the Apache-2.0 license OR the ISC license OR the MIT license.
+
+ISC license for mlkem-native content:
+
+Copyright (c) The mlkem-native project authors
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+MIT license for mlkem-native content:
+
+Copyright (c) The mlkem-native project authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+The Apache-2.0 license for mlkem-native content is reproduced at
+the bottom of this file.
 
 Licenses for support code
 -------------------------

--- a/crypto/fipsmodule/ml_kem/META.yml
+++ b/crypto/fipsmodule/ml_kem/META.yml
@@ -1,5 +1,5 @@
 name: mlkem-native
 source: pq-code-package/mlkem-native.git
 branch: main
-commit: 83d85fe224bd6cf1b75f096a2b2fa01033b3dfda
-imported-at: 2025-04-03T12:37:06+0100
+commit: 20eb37de425a06aa90aa61e8ea9c80a07f1aca7f
+imported-at: 2025-05-09T07:09:16+0100

--- a/crypto/fipsmodule/ml_kem/importer.sh
+++ b/crypto/fipsmodule/ml_kem/importer.sh
@@ -102,7 +102,7 @@ else
   SED_I=(-i)
 fi
 echo "Fixup include paths"
-sed $SED_I 's/#include "mlkem\/\([^"]*\)"/#include "\1"/' $SRC/mlkem_native_bcm.c
+sed "${SED_I[@]}" 's/#include "mlkem\/\([^"]*\)"/#include "\1"/' $SRC/mlkem_native_bcm.c
 
 echo "Remove temporary artifacts ..."
 rm -rf $TMP

--- a/crypto/fipsmodule/ml_kem/mlkem/.clang-format
+++ b/crypto/fipsmodule/ml_kem/mlkem/.clang-format
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 #
 # clang-format style file for mlkem-native
 #

--- a/crypto/fipsmodule/ml_kem/mlkem/cbmc.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/cbmc.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_CBMC_H
@@ -129,8 +129,10 @@
 
 /* Wrapper around array_bound operating on absolute values.
  *
- * Note that since the absolute bound is inclusive, but the lower
- * bound in array_bound is inclusive, we have to raise it by 1.
+ * The absolute value bound `k` is exclusive.
+ *
+ * Note that since the lower bound in array_bound is inclusive, we have to
+ * raise it by 1 here.
  */
 #define array_abs_bound(arr, lb, ub, k) \
   array_bound((arr), (lb), (ub), -((int)(k)) + 1, (k))

--- a/crypto/fipsmodule/ml_kem/mlkem/common.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/common.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_COMMON_H
 #define MLK_COMMON_H
@@ -37,15 +37,25 @@
 #define MLK_CONCAT(x1, x2) MLK_CONCAT_(x1, x2)
 
 #if defined(MLK_MULTILEVEL_BUILD)
-#define MLK_ADD_LEVEL(s) MLK_CONCAT(s, MLKEM_LVL)
+#define MLK_ADD_PARAM_SET(s) MLK_CONCAT(s, MLK_CONFIG_PARAMETER_SET)
 #else
-#define MLK_ADD_LEVEL(s) s
+#define MLK_ADD_PARAM_SET(s) s
 #endif
 
-#define MLK_NAMESPACE(s) \
-  MLK_CONCAT(MLK_CONCAT(MLK_CONFIG_NAMESPACE_PREFIX, _), s)
-#define MLK_NAMESPACE_K(s) \
-  MLK_CONCAT(MLK_CONCAT(MLK_ADD_LEVEL(MLK_CONFIG_NAMESPACE_PREFIX), _), s)
+#define MLK_NAMESPACE_PREFIX MLK_CONCAT(MLK_CONFIG_NAMESPACE_PREFIX, _)
+#define MLK_NAMESPACE_PREFIX_K \
+  MLK_CONCAT(MLK_ADD_PARAM_SET(MLK_CONFIG_NAMESPACE_PREFIX), _)
+
+/* Functions are prefixed by MLK_CONFIG_NAMESPACE.
+ *
+ * If multiple parameter sets are used, functions depending on the parameter
+ * set are additionally prefixed with 512/768/1024. See config.h.
+ *
+ * Example: If MLK_CONFIG_NAMESPACE_PREFIX is mlkem, then
+ * MLK_NAMESPACE_K(enc) becomes mlkem512_enc/mlkem768_enc/mlkem1024_enc.
+ */
+#define MLK_NAMESPACE(s) MLK_CONCAT(MLK_NAMESPACE_PREFIX, s)
+#define MLK_NAMESPACE_K(s) MLK_CONCAT(MLK_NAMESPACE_PREFIX_K, s)
 
 /* On Apple platforms, we need to emit leading underscore
  * in front of assembly symbols. We thus introducee a separate
@@ -139,6 +149,6 @@
 
 #define MLK_CONFIG_API_PARAMETER_SET MLK_CONFIG_PARAMETER_SET
 #define MLK_CONFIG_API_NAMESPACE_PREFIX \
-  MLK_ADD_LEVEL(MLK_CONFIG_NAMESPACE_PREFIX)
+  MLK_ADD_PARAM_SET(MLK_CONFIG_NAMESPACE_PREFIX)
 
 #endif /* !MLK_COMMON_H */

--- a/crypto/fipsmodule/ml_kem/mlkem/compress.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/compress.c
@@ -1,7 +1,22 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ *
+ * - [REF]
+ *   CRYSTALS-Kyber C reference implementation
+ *   Bos, Ducas, Kiltz, Lepoint, Lyubashevsky, Schanck, Schwabe, Seiler, Stehlé
+ *   https://github.com/pq-crystals/kyber/tree/main/ref
+ */
+
 #include "common.h"
 #if !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
@@ -14,7 +29,7 @@
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || (MLKEM_K == 2 || MLKEM_K == 3)
 #if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D4)
-/* Reference: `poly_compress()` in the reference implementation,
+/* Reference: `poly_compress()` in the reference implementation @[REF],
  *            for ML-KEM-{512,768}.
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
@@ -104,7 +119,7 @@ void mlk_poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
 #endif /* MLK_USE_NATIVE_POLY_COMPRESS_D10 */
 
 #if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D4)
-/* Reference: `poly_decompress()` in the reference implementation,
+/* Reference: `poly_decompress()` in the reference implementation @[REF],
  *            for ML-KEM-{512,768}. */
 MLK_INTERNAL_API
 void mlk_poly_decompress_d4(mlk_poly *r,
@@ -178,7 +193,7 @@ void mlk_poly_decompress_d10(mlk_poly *r,
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || MLKEM_K == 4
 #if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D5)
-/* Reference: `poly_compress()` in the reference implementation,
+/* Reference: `poly_compress()` in the reference implementation @[REF],
  *            for ML-KEM-1024.
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
@@ -281,7 +296,7 @@ void mlk_poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
 #endif /* MLK_USE_NATIVE_POLY_COMPRESS_D11 */
 
 #if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D5)
-/* Reference: `poly_decompress()` in the reference implementation,
+/* Reference: `poly_decompress()` in the reference implementation @[REF],
  *            for ML-KEM-1024. */
 MLK_INTERNAL_API
 void mlk_poly_decompress_d5(mlk_poly *r,
@@ -388,7 +403,7 @@ void mlk_poly_decompress_d11(mlk_poly *r,
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 4 */
 
 #if !defined(MLK_USE_NATIVE_POLY_TOBYTES)
-/* Reference: `poly_tobytes()` in the reference implementation.
+/* Reference: `poly_tobytes()` in the reference implementation @[REF].
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
  *              The reference implementation works with coefficients
@@ -434,7 +449,7 @@ void mlk_poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const mlk_poly *a)
 #endif /* MLK_USE_NATIVE_POLY_TOBYTES */
 
 #if !defined(MLK_USE_NATIVE_POLY_FROMBYTES)
-/* Reference: `poly_frombytes()` in the reference implementation. */
+/* Reference: `poly_frombytes()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
 {
@@ -462,7 +477,7 @@ void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
 }
 #endif /* MLK_USE_NATIVE_POLY_FROMBYTES */
 
-/* Reference: `poly_frommsg()` in the reference implementation.
+/* Reference: `poly_frommsg()` in the reference implementation @[REF].
  *            - We use a value barrier around the bit-selection mask to
  *              reduce the risk of compiler-introduced branches.
  *              The reference implementation contains the expression
@@ -488,7 +503,7 @@ void mlk_poly_frommsg(mlk_poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
       invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, MLKEM_Q)))
     {
       /* mlk_ct_sel_int16(MLKEM_Q_HALF, 0, b) is `Decompress_1(b != 0)`
-       * as per [FIPS 203, Eq (4.8)]. */
+       * as per @[FIPS203, Eq (4.8)]. */
 
       /* Prevent the compiler from recognizing this as a bit selection */
       uint8_t mask = mlk_value_barrier_u8(1u << j);
@@ -498,7 +513,7 @@ void mlk_poly_frommsg(mlk_poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
   mlk_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
 }
 
-/* Reference: `poly_tomsg()` in the reference implementation.
+/* Reference: `poly_tomsg()` in the reference implementation @[REF].
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
  *              The reference implementation works with coefficients

--- a/crypto/fipsmodule/ml_kem/mlkem/compress.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/compress.h
@@ -1,7 +1,22 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ *
+ * - [REF]
+ *   CRYSTALS-Kyber C reference implementation
+ *   Bos, Ducas, Kiltz, Lepoint, Lyubashevsky, Schanck, Schwabe, Seiler, Stehlé
+ *   https://github.com/pq-crystals/kyber/tree/main/ref
+ */
+
 #ifndef MLK_COMPRESS_H
 #define MLK_COMPRESS_H
 
@@ -21,7 +36,7 @@
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_1 from [FIPS 203, Eq (4.7)].
+ * Specification: Compress_1 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 
@@ -34,7 +49,7 @@
 #pragma CPROVER check disable "unsigned-overflow"
 #endif
 
-/* Reference: Embedded in poly_tomsg() in the reference implementation. */
+/* Reference: Part of poly_tomsg() in the reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d1(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -64,7 +79,7 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_4 from [FIPS 203, Eq (4.7)].
+ * Specification: Compress_4 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 /*
@@ -77,7 +92,7 @@ __contract__(
 #endif
 
 /* Reference: Embedded into `poly_compress()` in the
- *            reference implementation. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d4(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -107,12 +122,12 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo 16
  *                 to be decompressed.
  *
- * Specification: Decompress_4 from [FIPS 203, Eq (4.8)].
+ * Specification: Decompress_4 from @[FIPS203, Eq (4.8)].
  *
  ************************************************************/
 
 /* Reference: Embedded into `poly_decompress()` in the
- *            reference implementation. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d4(uint32_t u)
 __contract__(
   requires(0 <= u && u < 16)
@@ -127,7 +142,7 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_5 from [FIPS 203, Eq (4.7)].
+ * Specification: Compress_5 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 /*
@@ -140,7 +155,7 @@ __contract__(
 #endif
 
 /* Reference: Embedded into `poly_compress()` in the
- *            reference implementation. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d5(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -170,12 +185,12 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo 32
  *                 to be decompressed.
  *
- * Specification: Decompress_5 from [FIPS 203, Eq (4.8)].
+ * Specification: Decompress_5 from @[FIPS203, Eq (4.8)].
  *
  ************************************************************/
 
 /* Reference: Embedded into `poly_decompress()` in the
- *            reference implementation. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d5(uint32_t u)
 __contract__(
   requires(0 <= u && u < 32)
@@ -190,7 +205,7 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_10 from [FIPS 203, Eq (4.7)].
+ * Specification: Compress_10 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 /*
@@ -203,7 +218,7 @@ __contract__(
 #endif
 
 /* Reference: Embedded into `polyvec_compress()` in the
- *            reference implementation. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d10(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -234,12 +249,12 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo 1024
  *                 to be decompressed.
  *
- * Specification: Decompress_10 from [FIPS 203, Eq (4.8)].
+ * Specification: Decompress_10 from @[FIPS203, Eq (4.8)].
  *
  ************************************************************/
 
 /* Reference: Embedded into `polyvec_decompress()` in the
- *            reference implementation. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d10(uint32_t u)
 __contract__(
   requires(0 <= u && u < 1024)
@@ -254,7 +269,7 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_11 from [FIPS 203, Eq (4.7)].
+ * Specification: Compress_11 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 /*
@@ -267,7 +282,7 @@ __contract__(
 #endif
 
 /* Reference: Embedded into `polyvec_compress()` in the
- *            reference implementation. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d11(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -298,12 +313,12 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo 2048
  *                 to be decompressed.
  *
- * Specification: Decompress_11 from [FIPS 203, Eq (4.8)].
+ * Specification: Decompress_11 from @[FIPS203, Eq (4.8)].
  *
  ************************************************************/
 
 /* Reference: Embedded into `polyvec_decompress()` in the
- *            reference implementation. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d11(uint32_t u)
 __contract__(
   requires(0 <= u && u < 2048)
@@ -325,13 +340,13 @@ __contract__(
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_4 (Compress_4 (a))`:
- *                - ByteEncode_d: [FIPS 203, Algorithm 5],
- *                - Compress_d: [FIPS 203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_{d_v} (Compress_{d_v} (v))` appears in
- *                  [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L23],
- *                  where `d_v=4` for ML-KEM-{512,768} [FIPS 203, Table 2].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L23],
+ *                  where `d_v=4` for ML-KEM-{512,768} @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -352,13 +367,13 @@ void mlk_poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_10 (Compress_10 (a))`:
- *                - ByteEncode_d: [FIPS 203, Algorithm 5],
- *                - Compress_d: [FIPS 203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_{d_u} (Compress_{d_u} (u))` appears in
- *                  [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L22],
- *                  where `d_u=10` for ML-KEM-{512,768} [FIPS 203, Table 2].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22],
+ *                  where `d_u=10` for ML-KEM-{512,768} @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -380,13 +395,13 @@ void mlk_poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_4 (ByteDecode_4 (a))`:
- *                - ByteDecode_d: [FIPS 203, Algorithm 6],
- *                - Decompress_d: [FIPS 203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_{d_v} (ByteDecode_{d_v} (v))` appears in
- *                  [FIPS 203, Algorithm 15 (K-PKE.Decrypt), L4],
- *                  where `d_v=4` for ML-KEM-{512,768} [FIPS 203, Table 2].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L4],
+ *                  where `d_v=4` for ML-KEM-{512,768} @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -408,13 +423,13 @@ void mlk_poly_decompress_d4(mlk_poly *r,
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_10 (ByteDecode_10 (a))`:
- *                - ByteDecode_d: [FIPS 203, Algorithm 6],
- *                - Decompress_d: [FIPS 203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_{d_u} (ByteDecode_{d_u} (u))` appears in
- *                  [FIPS 203, Algorithm 15 (K-PKE.Decrypt), L3],
- *                  where `d_u=10` for ML-KEM-{512,768} [FIPS 203, Table 2].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L3],
+ *                  where `d_u=10` for ML-KEM-{512,768} @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -437,13 +452,13 @@ void mlk_poly_decompress_d10(mlk_poly *r,
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_5 (Compress_5 (a))`:
- *                - ByteEncode_d: [FIPS 203, Algorithm 5],
- *                - Compress_d: [FIPS 203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_{d_v} (Compress_{d_v} (v))` appears in
- *                  [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L23],
- *                  where `d_v=5` for ML-KEM-1024 [FIPS 203, Table 2].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L23],
+ *                  where `d_v=5` for ML-KEM-1024 @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -464,13 +479,13 @@ void mlk_poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: `ByteEncode_11 (Compress_11 (a))`:
- *                - ByteEncode_d: [FIPS 203, Algorithm 5],
- *                - Compress_d: [FIPS 203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_{d_u} (Compress_{d_u} (u))` appears in
- *                  [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L22],
- *                  where `d_u=11` for ML-KEM-1024 [FIPS 203, Table 2].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22],
+ *                  where `d_u=11` for ML-KEM-1024 @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -492,13 +507,13 @@ void mlk_poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_5 (ByteDecode_5 (a))`:
- *                - ByteDecode_d: [FIPS 203, Algorithm 6],
- *                - Decompress_d: [FIPS 203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_{d_v} (ByteDecode_{d_v} (v))` appears in
- *                  [FIPS 203, Algorithm 15 (K-PKE.Decrypt), L4],
- *                  where `d_v=5` for ML-KEM-1024 [FIPS 203, Table 2].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L4],
+ *                  where `d_v=5` for ML-KEM-1024 @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -520,13 +535,13 @@ void mlk_poly_decompress_d5(mlk_poly *r,
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_11 (ByteDecode_11 (a))`:
- *                - ByteDecode_d: [FIPS 203, Algorithm 6],
- *                - Decompress_d: [FIPS 203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_{d_u} (ByteDecode_{d_u} (u))` appears in
- *                  [FIPS 203, Algorithm 15 (K-PKE.Decrypt), L3],
- *                  where `d_u=11` for ML-KEM-1024 [FIPS 203, Table 2].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L3],
+ *                  where `d_u=11` for ML-KEM-1024 @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -549,9 +564,9 @@ void mlk_poly_decompress_d11(mlk_poly *r,
  *              - r: pointer to output byte array
  *                   (of MLKEM_POLYBYTES bytes)
  *
- * Specification: Implements ByteEncode_12 [FIPS 203, Algorithm 5].
+ * Specification: Implements ByteEncode_12 @[FIPS203, Algorithm 5].
  *                Extended to vectors as per
- *                [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -578,9 +593,9 @@ __contract__(
  *                   each coefficient unsigned and in the range
  *                   0 .. 4095
  *
- * Specification: Implements ByteDecode_12 [FIPS 203, Algorithm 6].
+ * Specification: Implements ByteDecode_12 @[FIPS203, Algorithm 6].
  *                Extended to vectors as per
- *                [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -603,12 +618,12 @@ __contract__(
  *              - const uint8_t *msg: pointer to input message
  *
  * Specification: Implements `Decompress_1 (ByteDecode_1 (a))`:
- *                - ByteDecode_d: [FIPS 203, Algorithm 6],
- *                - Decompress_d: [FIPS 203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_1 (ByteDecode_1 (w))` appears in
- *                  [FIPS 203, Algorithm 15 (K-PKE.Encrypt), L20].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Encrypt), L20].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -631,12 +646,12 @@ __contract__(
  *                Coefficients must be unsigned canonical
  *
  * Specification: Implements `ByteEncode_1 (Compress_1 (a))`:
- *                - ByteEncode_d: [FIPS 203, Algorithm 5],
- *                - Compress_d: [FIPS 203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_1 (Compress_1 (w))` appears in
- *                  [FIPS 203, Algorithm 14 (K-PKE.Decrypt), L7].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Decrypt), L7].
  *
  **************************************************/
 MLK_INTERNAL_API

--- a/crypto/fipsmodule/ml_kem/mlkem/debug.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/debug.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* NOTE: You can remove this file unless you compile with MLKEM_DEBUG. */

--- a/crypto/fipsmodule/ml_kem/mlkem/debug.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/debug.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEBUG_H
 #define MLK_DEBUG_H

--- a/crypto/fipsmodule/ml_kem/mlkem/indcpa.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/indcpa.c
@@ -1,7 +1,22 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ *
+ * - [REF]
+ *   CRYSTALS-Kyber C reference implementation
+ *   Bos, Ducas, Kiltz, Lepoint, Lyubashevsky, Schanck, Schwabe, Seiler, Stehlé
+ *   https://github.com/pq-crystals/kyber/tree/main/ref
+ */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -15,18 +30,18 @@
 #include "sampling.h"
 #include "symmetric.h"
 
-/* Level namespacing
+/* Parameter set namespacing
  * This is to facilitate building multiple instances
- * of mlkem-native (e.g. with varying security levels)
+ * of mlkem-native (e.g. with varying parameter sets)
  * within a single compilation unit. */
-#define mlk_pack_pk MLK_ADD_LEVEL(mlk_pack_pk)
-#define mlk_unpack_pk MLK_ADD_LEVEL(mlk_unpack_pk)
-#define mlk_pack_sk MLK_ADD_LEVEL(mlk_pack_sk)
-#define mlk_unpack_sk MLK_ADD_LEVEL(mlk_unpack_sk)
-#define mlk_pack_ciphertext MLK_ADD_LEVEL(mlk_pack_ciphertext)
-#define mlk_unpack_ciphertext MLK_ADD_LEVEL(mlk_unpack_ciphertext)
-#define mlk_matvec_mul MLK_ADD_LEVEL(mlk_matvec_mul)
-/* End of level namespacing */
+#define mlk_pack_pk MLK_ADD_PARAM_SET(mlk_pack_pk)
+#define mlk_unpack_pk MLK_ADD_PARAM_SET(mlk_unpack_pk)
+#define mlk_pack_sk MLK_ADD_PARAM_SET(mlk_pack_sk)
+#define mlk_unpack_sk MLK_ADD_PARAM_SET(mlk_unpack_sk)
+#define mlk_pack_ciphertext MLK_ADD_PARAM_SET(mlk_pack_ciphertext)
+#define mlk_unpack_ciphertext MLK_ADD_PARAM_SET(mlk_unpack_ciphertext)
+#define mlk_matvec_mul MLK_ADD_PARAM_SET(mlk_matvec_mul)
+/* End of parameter set namespacing */
 
 /*************************************************
  * Name:        mlk_pack_pk
@@ -41,7 +56,7 @@
  *              const uint8_t *seed: pointer to the input public seed
  *
  * Specification:
- * Implements [FIPS 203, Algorithm 13 (K-PKE.KeyGen), L19]
+ * Implements @[FIPS203, Algorithm 13 (K-PKE.KeyGen), L19]
  *
  **************************************************/
 static void mlk_pack_pk(uint8_t r[MLKEM_INDCPA_PUBLICKEYBYTES], mlk_polyvec pk,
@@ -65,7 +80,7 @@ static void mlk_pack_pk(uint8_t r[MLKEM_INDCPA_PUBLICKEYBYTES], mlk_polyvec pk,
  *                  key.
  *
  * Specification:
- * Implements [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L2-3]
+ * Implements @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L2-3]
  *
  **************************************************/
 static void mlk_unpack_pk(mlk_polyvec pk, uint8_t seed[MLKEM_SYMBYTES],
@@ -90,7 +105,7 @@ static void mlk_unpack_pk(mlk_polyvec pk, uint8_t seed[MLKEM_SYMBYTES],
  *                (secret key)
  *
  * Specification:
- * Implements [FIPS 203, Algorithm 13 (K-PKE.KeyGen), L20]
+ * Implements @[FIPS203, Algorithm 13 (K-PKE.KeyGen), L20]
  *
  **************************************************/
 static void mlk_pack_sk(uint8_t r[MLKEM_INDCPA_SECRETKEYBYTES], mlk_polyvec sk)
@@ -110,7 +125,7 @@ static void mlk_pack_sk(uint8_t r[MLKEM_INDCPA_SECRETKEYBYTES], mlk_polyvec sk)
  *                key
  *
  * Specification:
- * Implements [FIPS 203, Algorithm 15 (K-PKE.Decrypt), L5]
+ * Implements @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L5]
  *
  **************************************************/
 static void mlk_unpack_sk(mlk_polyvec sk,
@@ -131,7 +146,7 @@ static void mlk_unpack_sk(mlk_polyvec sk,
  *              mlk_poly *v: pointer to the input polynomial v
  *
  * Specification:
- * Implements [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L22-23]
+ * Implements @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22-23]
  *
  **************************************************/
 static void mlk_pack_ciphertext(uint8_t r[MLKEM_INDCPA_BYTES], mlk_polyvec b,
@@ -152,7 +167,7 @@ static void mlk_pack_ciphertext(uint8_t r[MLKEM_INDCPA_BYTES], mlk_polyvec b,
  *              - const uint8_t *c: pointer to the input serialized ciphertext
  *
  * Specification:
- * Implements [FIPS 203, Algorithm 15 (K-PKE.Decrypt), L1-4]
+ * Implements @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L1-4]
  *
  **************************************************/
 static void mlk_unpack_ciphertext(mlk_polyvec b, mlk_poly *v,
@@ -166,7 +181,7 @@ static void mlk_unpack_ciphertext(mlk_polyvec b, mlk_poly *v,
 /* This namespacing is not done at the top to avoid a naming conflict
  * with native backends, which are currently not yet namespaced. */
 #define mlk_poly_permute_bitrev_to_custom \
-  MLK_ADD_LEVEL(mlk_poly_permute_bitrev_to_custom)
+  MLK_ADD_PARAM_SET(mlk_poly_permute_bitrev_to_custom)
 
 static MLK_INLINE void mlk_poly_permute_bitrev_to_custom(int16_t data[MLKEM_N])
 __contract__(
@@ -178,7 +193,7 @@ __contract__(
   ensures(array_bound(data, 0, MLKEM_N, 0, MLKEM_Q))) { ((void)data); }
 #endif /* !MLK_USE_NATIVE_NTT_CUSTOM_ORDER */
 
-/* Reference: `gen_matrix()` in the reference implementation.
+/* Reference: `gen_matrix()` in the reference implementation @[REF].
  *            - We use a special subroutine to generate 4 polynomials
  *              at a time, to be able to leverage batched Keccak-f1600
  *              implementations. The reference implementation generates
@@ -265,7 +280,7 @@ void mlk_gen_matrix(mlk_polymat a, const uint8_t seed[MLKEM_SYMBYTES],
   }
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(seed_ext, sizeof(seed_ext));
 }
 
@@ -283,7 +298,7 @@ void mlk_gen_matrix(mlk_polymat a, const uint8_t seed[MLKEM_SYMBYTES],
  *              - mlk_polyvec vc: Mulcache for v, computed via
  *                  mlk_polyvec_mulcache_compute().
  *
- * Specification: Implements [FIPS 203, Section 2.4.7, Eq (2.12), (2.13)]
+ * Specification: Implements @[FIPS203, Section 2.4.7, Eq (2.12), (2.13)]
  *
  **************************************************/
 static void mlk_matvec_mul(mlk_polyvec out, const mlk_polymat a,
@@ -307,7 +322,7 @@ __contract__(
   }
 }
 
-/* Reference: `indcpa_keypair_derand()` in the reference implementation.
+/* Reference: `indcpa_keypair_derand()` in the reference implementation @[REF].
  *            - We use x4-batched versions of `poly_getnoise` to leverage
  *              batched x4-batched Keccak-f1600.
  *            - We use a different implementation of `gen_matrix()` which
@@ -379,7 +394,7 @@ void mlk_indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
   mlk_pack_pk(pk, pkpv, publicseed);
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
   mlk_zeroize(coins_with_domain_separator, sizeof(coins_with_domain_separator));
   mlk_zeroize(a, sizeof(a));
@@ -388,7 +403,7 @@ void mlk_indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
   mlk_zeroize(&skpv_cache, sizeof(skpv_cache));
 }
 
-/* Reference: `indcpa_enc()` in the reference implementation.
+/* Reference: `indcpa_enc()` in the reference implementation @[REF].
  *            - We use x4-batched versions of `poly_getnoise` to leverage
  *              batched x4-batched Keccak-f1600.
  *            - We use a different implementation of `gen_matrix()` which
@@ -459,7 +474,7 @@ void mlk_indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
   mlk_pack_ciphertext(c, b, &v);
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(seed, sizeof(seed));
   mlk_zeroize(&sp, sizeof(sp));
   mlk_zeroize(&sp_cache, sizeof(sp_cache));
@@ -471,7 +486,7 @@ void mlk_indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
   mlk_zeroize(&epp, sizeof(epp));
 }
 
-/* Reference: `indcpa_dec()` in the reference implementation.
+/* Reference: `indcpa_dec()` in the reference implementation @[REF].
  *            - We use a mulcache for the scalar product.
  *            - We include buffer zeroization. */
 MLK_INTERNAL_API
@@ -497,7 +512,7 @@ void mlk_indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
   mlk_poly_tomsg(m, &v);
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(&skpv, sizeof(skpv));
   mlk_zeroize(&b, sizeof(b));
   mlk_zeroize(&b_cache, sizeof(b_cache));

--- a/crypto/fipsmodule/ml_kem/mlkem/indcpa.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/indcpa.h
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ */
+
 #ifndef MLK_INDCPA_H
 #define MLK_INDCPA_H
 
@@ -23,8 +33,8 @@
  *              - const uint8_t *seed: pointer to input seed
  *              - int transposed: boolean deciding whether A or A^T is generated
  *
- * Specification: Implements [FIPS 203, Algorithm 13 (K-PKE.KeyGen), L3-7]
- *                and [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L4-8].
+ * Specification: Implements @[FIPS203, Algorithm 13 (K-PKE.KeyGen), L3-7]
+ *                and @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L4-8].
  *                The `transposed` parameter only affects internal presentation.
  *
  **************************************************/
@@ -54,7 +64,7 @@ __contract__(
  *              - const uint8_t *coins: pointer to input randomness
  *                             (of length MLKEM_SYMBYTES bytes)
  *
- * Specification: Implements [FIPS 203, Algorithm 13 (K-PKE.KeyGen)].
+ * Specification: Implements @[FIPS203, Algorithm 13 (K-PKE.KeyGen)].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -86,7 +96,7 @@ __contract__(
  *                 seed (of length MLKEM_SYMBYTES) to deterministically generate
  *                 all randomness
  *
- * Specification: Implements [FIPS 203, Algorithm 14 (K-PKE.Encrypt)].
+ * Specification: Implements @[FIPS203, Algorithm 14 (K-PKE.Encrypt)].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -116,7 +126,7 @@ __contract__(
  *              - const uint8_t *sk: pointer to input secret key
  *                                   (of length MLKEM_INDCPA_SECRETKEYBYTES)
  *
- * Specification: Implements [FIPS 203, Algorithm 15 (K-PKE.Decrypt)].
+ * Specification: Implements @[FIPS203, Algorithm 15 (K-PKE.Decrypt)].
  *
  **************************************************/
 MLK_INTERNAL_API

--- a/crypto/fipsmodule/ml_kem/mlkem/kem.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/kem.c
@@ -1,7 +1,27 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS140_3_IG]
+ *   Implementation Guidance for FIPS 140-3 and the Cryptographic Module
+ *   Validation Program National Institute of Standards and Technology
+ *   https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-ig-announcements
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ *
+ * - [REF]
+ *   CRYSTALS-Kyber C reference implementation
+ *   Bos, Ducas, Kiltz, Lepoint, Lyubashevsky, Schanck, Schwabe, Seiler, Stehlé
+ *   https://github.com/pq-crystals/kyber/tree/main/ref
+ */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -12,14 +32,14 @@
 #include "symmetric.h"
 #include "verify.h"
 
-/* Level namespacing
+/* Parameter set namespacing
  * This is to facilitate building multiple instances
  * of mlkem-native (e.g. with varying security levels)
  * within a single compilation unit. */
-#define mlk_check_pk MLK_ADD_LEVEL(mlk_check_pk)
-#define mlk_check_sk MLK_ADD_LEVEL(mlk_check_sk)
-#define mlk_check_pct MLK_ADD_LEVEL(mlk_check_pct)
-/* End of level namespacing */
+#define mlk_check_pk MLK_ADD_PARAM_SET(mlk_check_pk)
+#define mlk_check_sk MLK_ADD_PARAM_SET(mlk_check_sk)
+#define mlk_check_pct MLK_ADD_PARAM_SET(mlk_check_pct)
+/* End of parameter set namespacing */
 
 #if defined(CBMC)
 /* Redeclaration with contract needed for CBMC only */
@@ -43,11 +63,11 @@ __contract__(
  * Returns: - 0 on success
  *          - -1 on failure
  *
- * Specification: Implements [FIPS 203, Section 7.2, 'modulus check']
+ * Specification: Implements @[FIPS203, Section 7.2, 'modulus check']
  *
  **************************************************/
 
-/* Reference: Not implemented in the reference implementation. */
+/* Reference: Not implemented in the reference implementation @[REF]. */
 MLK_MUST_CHECK_RETURN_VALUE
 static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
 {
@@ -64,7 +84,7 @@ static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
   res = mlk_ct_memcmp(pk, p_reencoded, MLKEM_POLYVECBYTES) ? -1 : 0;
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(p_reencoded, sizeof(p_reencoded));
   mlk_zeroize(&p, sizeof(p));
   return res;
@@ -84,11 +104,11 @@ static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
  * Returns: - 0 on success
  *          - -1 on failure
  *
- * Specification: Implements [FIPS 203, Section 7.3, 'hash check']
+ * Specification: Implements @[FIPS203, Section 7.3, 'hash check']
  *
  **************************************************/
 
-/* Reference: Not implemented in the reference implementation. */
+/* Reference: Not implemented in the reference implementation @[REF]. */
 MLK_MUST_CHECK_RETURN_VALUE
 static int mlk_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
 {
@@ -114,7 +134,7 @@ static int mlk_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
             : 0;
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(test, sizeof(test));
   return res;
 }
@@ -128,10 +148,10 @@ __contract__(
 
 #if defined(MLK_CONFIG_KEYGEN_PCT)
 /* Specification:
- * Partially implements 'Pairwise Consistency Test' [FIPS 140-3 IG] and
- * [FIPS 203, Section 7.1, Pairwise Consistency]. */
+ * Partially implements 'Pairwise Consistency Test' @[FIPS140_3_IG, p.87] and
+ * @[FIPS203, Section 7.1, Pairwise Consistency]. */
 
-/* Reference: Not implemented in the reference implementation. */
+/* Reference: Not implemented in the reference implementation @[REF]. */
 static int mlk_check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
                          uint8_t const sk[MLKEM_INDCCA_SECRETKEYBYTES])
 {
@@ -166,7 +186,7 @@ cleanup:
   MLK_CT_TESTING_DECLASSIFY(&res, sizeof(res));
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(ct, sizeof(ct));
   mlk_zeroize(ss_enc, sizeof(ss_enc));
   mlk_zeroize(ss_dec, sizeof(ss_dec));
@@ -184,6 +204,7 @@ static int mlk_check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
 #endif /* !MLK_CONFIG_KEYGEN_PCT */
 
 /* Reference: `crypto_kem_keypair_derand()` in the reference implementation
+ *            @[REF].
  *            - We optionally include PCT which is not present in
  *              the reference code. */
 MLK_EXTERNAL_API
@@ -202,7 +223,7 @@ int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   /* Declassify public key */
   MLK_CT_TESTING_DECLASSIFY(pk, MLKEM_INDCCA_PUBLICKEYBYTES);
 
-  /* Pairwise Consistency Test (PCT) (FIPS 140-3 IPG) */
+  /* Pairwise Consistency Test (PCT) @[FIPS140_3_IG, p.87] */
   if (mlk_check_pct(pk, sk))
   {
     return -1;
@@ -211,7 +232,7 @@ int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   return 0;
 }
 
-/* Reference: `crypto_kem_keypair()` in the reference implementation
+/* Reference: `crypto_kem_keypair()` in the reference implementation @[REF]
  *            - We zeroize the stack buffer */
 MLK_EXTERNAL_API
 int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
@@ -227,12 +248,12 @@ int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   res = crypto_kem_keypair_derand(pk, sk, coins);
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(coins, sizeof(coins));
   return res;
 }
 
-/* Reference: `crypto_kem_enc_derand()` in the reference implementation
+/* Reference: `crypto_kem_enc_derand()` in the reference implementation @[REF]
  *            - We include public key check
  *            - We include stack buffer zeroization */
 MLK_EXTERNAL_API
@@ -245,7 +266,7 @@ int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   /* Will contain key, coins */
   MLK_ALIGN uint8_t kr[2 * MLKEM_SYMBYTES];
 
-  /* Specification: Implements [FIPS 203, Section 7.2, Modulus check] */
+  /* Specification: Implements @[FIPS203, Section 7.2, Modulus check] */
   if (mlk_check_pk(pk))
   {
     return -1;
@@ -263,14 +284,14 @@ int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   memcpy(ss, kr, MLKEM_SYMBYTES);
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
   mlk_zeroize(kr, sizeof(kr));
 
   return 0;
 }
 
-/* Reference: `crypto_kem_enc()` in the reference implementation
+/* Reference: `crypto_kem_enc()` in the reference implementation @[REF]
  *            - We include stack buffer zeroization */
 MLK_EXTERNAL_API
 int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
@@ -286,12 +307,12 @@ int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   res = crypto_kem_enc_derand(ct, ss, pk, coins);
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(coins, sizeof(coins));
   return res;
 }
 
-/* Reference: `crypto_kem_dec()` in the reference implementation
+/* Reference: `crypto_kem_dec()` in the reference implementation @[REF]
  *            - We include secret key check
  *            - We include stack buffer zeroization */
 MLK_EXTERNAL_API
@@ -307,7 +328,7 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
 
   const uint8_t *pk = sk + MLKEM_INDCPA_SECRETKEYBYTES;
 
-  /* Specification: Implements [FIPS 203, Section 7.3, Hash check] */
+  /* Specification: Implements @[FIPS203, Section 7.3, Hash check] */
   if (mlk_check_sk(sk))
   {
     return -1;
@@ -335,7 +356,7 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
   mlk_ct_cmov_zero(ss, kr, MLKEM_SYMBYTES, fail);
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
   mlk_zeroize(kr, sizeof(kr));
   mlk_zeroize(tmp, sizeof(tmp));

--- a/crypto/fipsmodule/ml_kem/mlkem/kem.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/kem.h
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ */
+
 #ifndef MLK_KEM_H
 #define MLK_KEM_H
 
@@ -17,15 +27,18 @@
 #include "mlkem_native.h"
 #undef MLK_CONFIG_API_NO_SUPERCOP
 
-#if MLKEM_INDCCA_SECRETKEYBYTES != MLKEM_SECRETKEYBYTES(MLKEM_LVL)
+#if MLKEM_INDCCA_SECRETKEYBYTES != \
+    MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
 #error Mismatch for SECRETKEYBYTES between kem.h and mlkem_native.h
 #endif
 
-#if MLKEM_INDCCA_PUBLICKEYBYTES != MLKEM_PUBLICKEYBYTES(MLKEM_LVL)
+#if MLKEM_INDCCA_PUBLICKEYBYTES != \
+    MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
 #error Mismatch for PUBLICKEYBYTES between kem.h and mlkem_native.h
 #endif
 
-#if MLKEM_INDCCA_CIPHERTEXTBYTES != MLKEM_CIPHERTEXTBYTES(MLKEM_LVL)
+#if MLKEM_INDCCA_CIPHERTEXTBYTES != \
+    MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
 #error Mismatch for CIPHERTEXTBYTES between kem.h and mlkem_native.h
 #endif
 
@@ -56,7 +69,7 @@
  * Returns:     - 0: On success
  *              - -1: On PCT failure (if MLK_CONFIG_KEYGEN_PCT) is enabled.
  *
- * Specification: Implements [FIPS 203, Algorithm 16, ML-KEM.KeyGen_Internal]
+ * Specification: Implements @[FIPS203, Algorithm 16, ML-KEM.KeyGen_Internal]
  *
  **************************************************/
 MLK_EXTERNAL_API
@@ -88,7 +101,7 @@ __contract__(
  * Returns:     - 0: On success
  *              - -1: On PCT failure (if MLK_CONFIG_KEYGEN_PCT) is enabled.
  *
- * Specification: Implements [FIPS 203, Algorithm 19, ML-KEM.KeyGen]
+ * Specification: Implements @[FIPS203, Algorithm 19, ML-KEM.KeyGen]
  *
  **************************************************/
 MLK_EXTERNAL_API
@@ -121,10 +134,10 @@ __contract__(
  *                 bytes)
  *
  * Returns: - 0 on success
- *          - -1 if the 'modulus check' [FIPS 203, Section 7.2]
+ *          - -1 if the 'modulus check' @[FIPS203, Section 7.2]
  *            for the public key fails.
  *
- * Specification: Implements [FIPS 203, Algorithm 17, ML-KEM.Encaps_Internal]
+ * Specification: Implements @[FIPS203, Algorithm 17, ML-KEM.Encaps_Internal]
  *
  **************************************************/
 MLK_EXTERNAL_API
@@ -158,10 +171,10 @@ __contract__(
  *                 bytes)
  *
  * Returns: - 0 on success
- *          - -1 if the 'modulus check' [FIPS 203, Section 7.2]
+ *          - -1 if the 'modulus check' @[FIPS203, Section 7.2]
  *            for the public key fails.
  *
- * Specification: Implements [FIPS 203, Algorithm 20, ML-KEM.Encaps]
+ * Specification: Implements @[FIPS203, Algorithm 20, ML-KEM.Encaps]
  *
  **************************************************/
 MLK_EXTERNAL_API
@@ -193,10 +206,10 @@ __contract__(
  *                 bytes)
  *
  * Returns: - 0 on success
- *          - -1 if the 'hash check' [FIPS 203, Section 7.3]
+ *          - -1 if the 'hash check' @[FIPS203, Section 7.3]
  *            for the secret key fails.
  *
- * Specification: Implements [FIPS 203, Algorithm 21, ML-KEM.Decaps]
+ * Specification: Implements @[FIPS203, Algorithm 21, ML-KEM.Decaps]
  *
  **************************************************/
 MLK_EXTERNAL_API

--- a/crypto/fipsmodule/ml_kem/mlkem/mlkem_native.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/mlkem_native.h
@@ -1,6 +1,15 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
  */
 
 #ifndef MLK_H
@@ -11,6 +20,11 @@
  * Public API for mlkem-native
  *
  * This header defines the public API of a single build of mlkem-native.
+ *
+ * # Examples
+ *
+ * See [examples/mlkem_native_as_code_package], [examples/multilevel_build], and
+ * [examples/multilevel_build_native] for examples of how to use this header.
  *
  * # Usage
  *
@@ -25,14 +39,14 @@
  *   The namespace prefix used for the build.
  *
  *   NOTE:
- *   For a multilevel build, you must include the 512/768/1024 suffixes
+ *   For a multi-level build, you must include the 512/768/1024 suffixes
  *   in MLK_CONFIG_API_NAMESPACE_PREFIX.
  *
  * - MLK_CONFIG_API_NO_SUPERCOP [optional]
  *
  *   By default, this header will also expose the mlkem-native API in the
  *   SUPERCOP naming convention crypto_kem_xxx. If you don't want/need this,
- *   set MLK_CONFIG_API_NO_SUPERCOP. You must set this for a multilevel build.
+ *   set MLK_CONFIG_API_NO_SUPERCOP. You must set this for a multi-level build.
  *
  * - MLK_CONFIG_API_CONSTANTS_ONLY [optional]
  *
@@ -42,19 +56,21 @@
  *   MLK_CONFIG_API_PARAMETER_SET or MLK_CONFIG_API_NAMESPACE_PREFIX,
  *   nor include a configuration.
  *
- * # Multilevel builds
+ * # Multi-level builds
  *
  * This header specifies a build of mlkem-native for a fixed security level.
  * If you need multiple builds, e.g. to build a library offering multiple
- * security levels, you need multiple instances of this header. In this case,
- * make sure to rename or #undef the header guard.
+ * security levels, you need multiple instances of this header.
+ *
+ * NOTE: In this case, you must rename or #undef the MLK_H header guard
+ *       prior to subsequent inclusions of this file.
  *
  ******************************************************************************/
 
 /******************************* Key sizes ************************************/
 
-/* Sizes of cryptographic material, per level */
-/* See mlke/common.h for the arithmetic expressions giving rise to these */
+/* Sizes of cryptographic material, per parameter set */
+/* See mlkem/common.h for the arithmetic expressions giving rise to these */
 /* check-magic: off */
 #define MLKEM512_SECRETKEYBYTES 1632
 #define MLKEM512_PUBLICKEYBYTES 800
@@ -130,7 +146,7 @@
  * Returns:     - 0: On success
  *              - -1: On PCT failure (if MLK_CONFIG_KEYGEN_PCT) is enabled.
  *
- * Specification: Implements [FIPS 203, Algorithm 16, ML-KEM.KeyGen_Internal]
+ * Specification: Implements @[FIPS203, Algorithm 16, ML-KEM.KeyGen_Internal]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE
@@ -153,7 +169,7 @@ int MLK_API_NAMESPACE(keypair_derand)(
  * Returns:     - 0: On success
  *              - -1: On PCT failure (if MLK_CONFIG_KEYGEN_PCT) is enabled.
  *
- * Specification: Implements [FIPS 203, Algorithm 19, ML-KEM.KeyGen]
+ * Specification: Implements @[FIPS203, Algorithm 19, ML-KEM.KeyGen]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE
@@ -177,10 +193,10 @@ int MLK_API_NAMESPACE(keypair)(
  *                 MLKEM_SYMBYTES bytes.
  *
  * Returns: - 0 on success
- *          - -1 if the 'modulus check' [FIPS 203, Section 7.2]
+ *          - -1 if the 'modulus check' @[FIPS203, Section 7.2]
  *            for the public key fails.
  *
- * Specification: Implements [FIPS 203, Algorithm 17, ML-KEM.Encaps_Internal]
+ * Specification: Implements @[FIPS203, Algorithm 17, ML-KEM.Encaps_Internal]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE
@@ -204,10 +220,10 @@ int MLK_API_NAMESPACE(enc_derand)(
  *                 MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
  *
  * Returns: - 0 on success
- *          - -1 if the 'modulus check' [FIPS 203, Section 7.2]
+ *          - -1 if the 'modulus check' @[FIPS203, Section 7.2]
  *            for the public key fails.
  *
- * Specification: Implements [FIPS 203, Algorithm 20, ML-KEM.Encaps]
+ * Specification: Implements @[FIPS203, Algorithm 20, ML-KEM.Encaps]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE
@@ -230,10 +246,10 @@ int MLK_API_NAMESPACE(enc)(
  *                 MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
  *
  * Returns: - 0 on success
- *          - -1 if the 'hash check' [FIPS 203, Section 7.3]
+ *          - -1 if the 'hash check' @[FIPS203, Section 7.3]
  *            for the secret key fails.
  *
- * Specification: Implements [FIPS 203, Algorithm 21, ML-KEM.Decaps]
+ * Specification: Implements @[FIPS203, Algorithm 21, ML-KEM.Decaps]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE

--- a/crypto/fipsmodule/ml_kem/mlkem/mlkem_native_bcm.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/mlkem_native_bcm.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*
@@ -24,7 +24,7 @@
  *
  * The API exposed by this file is described in mlkem_native.h.
  *
- * # Multilevel build
+ * # Multi-level build
  *
  * If you want an SCU build of mlkem-native with support for multiple security
  * levels, you need to include this file multiple times, and set
@@ -46,7 +46,7 @@
  *
  * - MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
  *   Set this option if you want to keep the directives defined in
- *   level-independent headers. This is needed for a multilevel build.
+ *   level-independent headers. This is needed for a multi-level build.
  */
 
 /* If parts of the mlkem-native source tree are not used,
@@ -76,7 +76,7 @@
  * Undefine macros from MLK_CONFIG_PARAMETER_SET-specific files
  */
 /* mlkem/common.h */
-#undef MLK_ADD_LEVEL
+#undef MLK_ADD_PARAM_SET
 #undef MLK_ASM_FN_SYMBOL
 #undef MLK_ASM_NAMESPACE
 #undef MLK_COMMON_H
@@ -92,6 +92,8 @@
 #undef MLK_MULTILEVEL_BUILD
 #undef MLK_NAMESPACE
 #undef MLK_NAMESPACE_K
+#undef MLK_NAMESPACE_PREFIX
+#undef MLK_NAMESPACE_PREFIX_K
 /* mlkem/indcpa.h */
 #undef MLK_INDCPA_H
 #undef mlk_gen_matrix
@@ -159,7 +161,6 @@
 #undef MLKEM_INDCPA_PUBLICKEYBYTES
 #undef MLKEM_INDCPA_SECRETKEYBYTES
 #undef MLKEM_K
-#undef MLKEM_LVL
 #undef MLKEM_N
 #undef MLKEM_POLYBYTES
 #undef MLKEM_POLYCOMPRESSEDBYTES_D10
@@ -217,6 +218,8 @@
 #undef MLK_SYS_BIG_ENDIAN
 #undef MLK_SYS_H
 #undef MLK_SYS_LITTLE_ENDIAN
+#undef MLK_SYS_PPC64LE
+#undef MLK_SYS_RISCV64
 #undef MLK_SYS_WINDOWS
 #undef MLK_SYS_X86_64
 #undef MLK_SYS_X86_64_AVX2

--- a/crypto/fipsmodule/ml_kem/mlkem/params.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/params.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_PARAMS_H
 #define MLK_PARAMS_H
@@ -42,7 +42,6 @@
 #define MLKEM_POLYCOMPRESSEDBYTES_D11 352
 
 #if MLKEM_K == 2
-#define MLKEM_LVL 512
 #define MLKEM_ETA1 3
 #define MLKEM_DU 10
 #define MLKEM_DV 4
@@ -50,7 +49,6 @@
 #define MLKEM_POLYCOMPRESSEDBYTES_DU MLKEM_POLYCOMPRESSEDBYTES_D10
 #define MLKEM_POLYVECCOMPRESSEDBYTES_DU (MLKEM_K * MLKEM_POLYCOMPRESSEDBYTES_DU)
 #elif MLKEM_K == 3
-#define MLKEM_LVL 768
 #define MLKEM_ETA1 2
 #define MLKEM_DU 10
 #define MLKEM_DV 4
@@ -58,7 +56,6 @@
 #define MLKEM_POLYCOMPRESSEDBYTES_DU MLKEM_POLYCOMPRESSEDBYTES_D10
 #define MLKEM_POLYVECCOMPRESSEDBYTES_DU (MLKEM_K * MLKEM_POLYCOMPRESSEDBYTES_DU)
 #elif MLKEM_K == 4
-#define MLKEM_LVL 1024
 #define MLKEM_ETA1 2
 #define MLKEM_DU 11
 #define MLKEM_DV 5

--- a/crypto/fipsmodule/ml_kem/mlkem/poly.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/poly.h
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ */
+
 #ifndef MLK_POLY_H
 #define MLK_POLY_H
 
@@ -134,7 +144,7 @@ __contract__(
  *
  * Specification: Internal normalization required in `mlk_indcpa_keypair_derand`
  *                as part of matrix-vector multiplication
- *                [FIPS 203, Algorithm 13, K-PKE.KeyGen, L18].
+ *                @[FIPS203, Algorithm 13, K-PKE.KeyGen, L18].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -164,7 +174,7 @@ __contract__(
  *            - a: Pointer to input polynomial
  *
  * Specification:
- * - Caches `b_1 * \gamma` in [FIPS 203, Algorithm 12, BaseCaseMultiply, L1]
+ * - Caches `b_1 * \gamma` in @[FIPS203, Algorithm 12, BaseCaseMultiply, L1]
  *
  ************************************************************/
 /*
@@ -192,7 +202,7 @@ __contract__(
  * Arguments:   - mlk_poly *r: pointer to input/output polynomial
  *
  * Specification: Normalizes on unsigned canoncial representatives
- *                ahead of calling [FIPS 203, Compress_d, Eq (4.7)].
+ *                ahead of calling @[FIPS203, Compress_d, Eq (4.7)].
  *                This is not made explicit in FIPS 203.
  *
  **************************************************/
@@ -225,8 +235,8 @@ __contract__(
  * not overflow. Otherwise, the behaviour of this function is undefined.
  *
  * Specification:
- * - [FIPS 203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
- * - Used in [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L21]
+ * - @[FIPS203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
+ * - Used in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L21]
  *
  ************************************************************/
 /*
@@ -254,8 +264,8 @@ __contract__(
  *            - const mlk_poly *b: Pointer to second input polynomial
  *
  * Specification:
- * - [FIPS 203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
- * - Used in [FIPS 203, Algorithm 15, K-PKE.Decrypt, L6]
+ * - @[FIPS203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
+ * - Used in @[FIPS203, Algorithm 15, K-PKE.Decrypt, L6]
  *
  **************************************************/
 /*
@@ -291,7 +301,7 @@ __contract__(
  *
  * Arguments:   - mlk_poly *p: pointer to in/output polynomial
  *
- * Specification: Implements [FIPS 203, Algorithm 9, NTT]
+ * Specification: Implements @[FIPS203, Algorithm 9, NTT]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -320,7 +330,7 @@ __contract__(
  *
  * Arguments:   - uint16_t *a: pointer to in/output polynomial
  *
- * Specification: Implements composition of [FIPS 203, Algorithm 10, NTT^{-1}]
+ * Specification: Implements composition of @[FIPS203, Algorithm 10, NTT^{-1}]
  *                and elementwise modular multiplication with a suitable
  *                Montgomery factor introduced during the base multiplication.
  *

--- a/crypto/fipsmodule/ml_kem/mlkem/poly_k.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/poly_k.h
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ */
+
 #ifndef MLK_POLY_K_H
 #define MLK_POLY_K_H
 
@@ -10,14 +20,14 @@
 #include "compress.h"
 #include "poly.h"
 
-/* Level namespacing
+/* Parameter set namespacing
  * This is to facilitate building multiple instances
- * of mlkem-native (e.g. with varying security levels)
+ * of mlkem-native (e.g. with varying parameter sets)
  * within a single compilation unit. */
-#define mlk_polyvec MLK_ADD_LEVEL(mlk_polyvec)
-#define mlk_polymat MLK_ADD_LEVEL(mlk_polymat)
-#define mlk_polyvec_mulcache MLK_ADD_LEVEL(mlk_polyvec_mulcache)
-/* End of level namespacing */
+#define mlk_polyvec MLK_ADD_PARAM_SET(mlk_polyvec)
+#define mlk_polymat MLK_ADD_PARAM_SET(mlk_polymat)
+#define mlk_polyvec_mulcache MLK_ADD_PARAM_SET(mlk_polyvec_mulcache)
+/* End of parameter set namespacing */
 
 typedef mlk_poly mlk_polyvec[MLKEM_K];
 typedef mlk_poly mlk_polymat[MLKEM_K * MLKEM_K];
@@ -37,8 +47,8 @@ typedef mlk_poly_mulcache mlk_polyvec_mulcache[MLKEM_K];
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_{d_u} (Compress_{d_u} (u))`
- *                in [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L22],
- *                with level-specific d_u defined in [FIPS 203, Table 2],
+ *                in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22],
+ *                with level-specific d_u defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DU here.
  *
  **************************************************/
@@ -74,8 +84,8 @@ __contract__(
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_{d_u} (ByteDecode_{d_u} (u))`
- *                in [FIPS 203, Algorithm 15 (K-PKE.Decrypt), L3].
- *                with level-specific d_u defined in [FIPS 203, Table 2],
+ *                in @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L3].
+ *                with level-specific d_u defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DU here.
  *
  **************************************************/
@@ -110,8 +120,8 @@ __contract__(
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_{d_v} (Compress_{d_v} (v))`
- *                in [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L23].
- *                with level-specific d_v defined in [FIPS 203, Table 2],
+ *                in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L23].
+ *                with level-specific d_v defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DV here.
  *
  **************************************************/
@@ -148,8 +158,8 @@ __contract__(
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_{d_v} (ByteDecode_{d_v} (v))`
- *                in [FIPS 203, Algorithm 15 (K-PKE.Decrypt), L4].
- *                with level-specific d_v defined in [FIPS 203, Table 2],
+ *                in @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L4].
+ *                with level-specific d_v defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DV here.
  *
  **************************************************/
@@ -183,8 +193,8 @@ __contract__(
  *                                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_{d_u} (Compress_{d_u} (u))`
- *                in [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L22].
- *                with level-specific d_u defined in [FIPS 203, Table 2],
+ *                in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22].
+ *                with level-specific d_u defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DU here.
  *
  **************************************************/
@@ -212,8 +222,8 @@ __contract__(
  *                                  (of length MLKEM_POLYVECCOMPRESSEDBYTES_DU)
  *
  * Specification: Implements `Decompress_{d_u} (ByteDecode_{d_u} (u))`
- *                in [FIPS 203, Algorithm 15 (K-PKE.Decrypt), L3].
- *                with level-specific d_u defined in [FIPS 203, Table 2],
+ *                in @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L3].
+ *                with level-specific d_u defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DU here.
  *
  **************************************************/
@@ -239,10 +249,10 @@ __contract__(
  *              - const mlk_polyvec a: pointer to input vector of polynomials
  *                  Each polynomial must have coefficients in [0,..,q-1].
  *
- * Specification: Implements ByteEncode_12 [FIPS 203, Algorithm 5].
+ * Specification: Implements ByteEncode_12 @[FIPS203, Algorithm 5].
  *                Extended to vectors as per
- *                [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
- *                and [FIPS 203, 2.4.6, Matrices and Vectors]
+ *                @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                and @[FIPS203, 2.4.6, Matrices and Vectors]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -267,10 +277,10 @@ __contract__(
  *                 normalized in [0..4095].
  *              - uint8_t *r: pointer to input byte array
  *
- * Specification: Implements ByteDecode_12 [FIPS 203, Algorithm 6].
+ * Specification: Implements ByteDecode_12 @[FIPS203, Algorithm 6].
  *                Extended to vectors as per
- *                [FIPS 203, 2.4.8 Applying Algorithms to Arrays]
- *                and [FIPS 203, 2.4.6, Matrices and Vectors]
+ *                @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                and @[FIPS203, 2.4.6, Matrices and Vectors]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -298,8 +308,8 @@ __contract__(
  * Arguments:   - mlk_polyvec r: pointer to in/output vector of polynomials
  *
  * Specification:
- * - Implements [FIPS 203, Algorithm 9, NTT]
- * - Extended to vectors as per [FIPS 203, 2.4.6, Matrices and Vectors]
+ * - Implements @[FIPS203, Algorithm 9, NTT]
+ * - Extended to vectors as per @[FIPS203, 2.4.6, Matrices and Vectors]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -329,8 +339,8 @@ __contract__(
  * Arguments:   - mlk_polyvec r: pointer to in/output vector of polynomials
  *
  * Specification:
- * - Implements [FIPS 203, Algorithm 10, NTT^{-1}]
- * - Extended to vectors as per [FIPS 203, 2.4.6, Matrices and Vectors]
+ * - Implements @[FIPS203, Algorithm 10, NTT^{-1}]
+ * - Extended to vectors as per @[FIPS203, 2.4.6, Matrices and Vectors]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -363,9 +373,9 @@ __contract__(
  *                  via mlk_polyvec_mulcache_compute().
  *
  * Specification: Implements
- *                - [FIPS 203, Section 2.4.7, Eq (2.14)]
- *                - [FIPS 203, Algorithm 11, MultiplyNTTs]
- *                - [FIPS 203, Algorithm 12, BaseCaseMultiply]
+ *                - @[FIPS203, Section 2.4.7, Eq (2.14)]
+ *                - @[FIPS203, Algorithm 11, MultiplyNTTs]
+ *                - @[FIPS203, Algorithm 12, BaseCaseMultiply]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -404,7 +414,7 @@ __contract__(
  *            - a: Pointer to input polynomial vector
  *
  * Specification:
- * - Caches `b_1 * \gamma` in [FIPS 203, Algorithm 12, BaseCaseMultiply, L1]
+ * - Caches `b_1 * \gamma` in @[FIPS203, Algorithm 12, BaseCaseMultiply, L1]
  *
  ************************************************************/
 /*
@@ -431,7 +441,7 @@ __contract__(
  * Arguments:   - mlk_polyvec r: pointer to input/output polynomial
  *
  * Specification: Normalizes on unsigned canoncial representatives
- *                ahead of calling [FIPS 203, Compress_d, Eq (4.7)].
+ *                ahead of calling @[FIPS203, Compress_d, Eq (4.7)].
  *                This is not made explicit in FIPS 203.
  *
  **************************************************/
@@ -470,8 +480,8 @@ __contract__(
  * ensures clause is required on this function.
  *
  * Specification:
- * - [FIPS 203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
- * - Used in [FIPS 203, Algorithm 14 (K-PKE.Encrypt), L19]
+ * - @[FIPS203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
+ * - Used in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L19]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -500,7 +510,7 @@ __contract__(
  *
  * Specification: Internal normalization required in `mlk_indcpa_keypair_derand`
  *                as part of matrix-vector multiplication
- *                [FIPS 203, Algorithm 13, K-PKE.KeyGen, L18].
+ *                @[FIPS203, Algorithm 13, K-PKE.KeyGen, L18].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -528,11 +538,11 @@ __contract__(
  *
  * Specification:
  * Implements 4x `SamplePolyCBD_{eta1} (PRF_{eta1} (sigma, N))`:
- * - [FIPS 203, Algorithm 8, SamplePolyCBD_eta]
- * - [FIPS 203, Eq (4.3), PRF_eta]
+ * - @[FIPS203, Algorithm 8, SamplePolyCBD_eta]
+ * - @[FIPS203, Eq (4.3), PRF_eta]
  * - `SamplePolyCBD_{eta1} (PRF_{eta1} (sigma, N))` appears in
- *   [FIPS 203, Algorithm 13, K-PKE.KeyGen, L{9, 13}]
- *   [FIPS 203, Algorithm 14, K-PKE.Encrypt, L10]
+ *   @[FIPS203, Algorithm 13, K-PKE.KeyGen, L{9, 13}]
+ *   @[FIPS203, Algorithm 14, K-PKE.Encrypt, L10]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -582,10 +592,10 @@ __contract__(
  *
  * Specification:
  * Implements `SamplePolyCBD_{eta2} (PRF_{eta2} (sigma, N))`:
- * - [FIPS 203, Algorithm 8, SamplePolyCBD_eta]
- * - [FIPS 203, Eq (4.3), PRF_eta]
+ * - @[FIPS203, Algorithm 8, SamplePolyCBD_eta]
+ * - @[FIPS203, Eq (4.3), PRF_eta]
  * - `SamplePolyCBD_{eta2} (PRF_{eta2} (sigma, N))` appears in
- *   [FIPS 203, Algorithm 14, K-PKE.Encrypt, L14]
+ *   @[FIPS203, Algorithm 14, K-PKE.Encrypt, L14]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -617,10 +627,10 @@ __contract__(
  * Implements two instances each of
  * `SamplePolyCBD_{eta1} (PRF_{eta1} (sigma, N))` and
  * `SamplePolyCBD_{eta2} (PRF_{eta2} (sigma, N))`:
- * - [FIPS 203, Algorithm 8, SamplePolyCBD_eta]
- * - [FIPS 203, Eq (4.3), PRF_eta]
+ * - @[FIPS203, Algorithm 8, SamplePolyCBD_eta]
+ * - @[FIPS203, Eq (4.3), PRF_eta]
  * - `SamplePolyCBD_{eta2} (PRF_{eta2} (sigma, N))` appears in
- *   [FIPS 203, Algorithm 14, K-PKE.Encrypt, L14]
+ *   @[FIPS203, Algorithm 14, K-PKE.Encrypt, L14]
  *
  **************************************************/
 MLK_INTERNAL_API

--- a/crypto/fipsmodule/ml_kem/mlkem/randombytes.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/randombytes.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_RANDOMBYTES_H
 #define MLK_RANDOMBYTES_H

--- a/crypto/fipsmodule/ml_kem/mlkem/sampling.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/sampling.c
@@ -1,7 +1,22 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ *
+ * - [REF]
+ *   CRYSTALS-Kyber C reference implementation
+ *   Bos, Ducas, Kiltz, Lepoint, Lyubashevsky, Schanck, Schwabe, Seiler, Stehlé
+ *   https://github.com/pq-crystals/kyber/tree/main/ref
+ */
+
 #include "common.h"
 #if !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
@@ -9,7 +24,7 @@
 #include "sampling.h"
 #include "symmetric.h"
 
-/* Reference: `rej_uniform()` in the reference implementation.
+/* Reference: `rej_uniform()` in the reference implementation @[REF].
  *            - Our signature differs from the reference implementation
  *              in that it adds the offset and always expects the base of the
  *              target buffer. This avoids shifting the buffer base in the
@@ -88,7 +103,7 @@ __contract__(
  * is provided on how many bytes of the input buffer have been consumed.
  **************************************************/
 
-/* Reference: `rej_uniform()` in the reference implementation.
+/* Reference: `rej_uniform()` in the reference implementation @[REF].
  *            - Our signature differs from the reference implementation
  *              in that it adds the offset and always expects the base of the
  *              target buffer. This avoids shifting the buffer base in the
@@ -127,7 +142,7 @@ __contract__(
   ((12 * MLKEM_N / 8 * (1 << 12) / MLKEM_Q + MLK_XOF_RATE) / MLK_XOF_RATE)
 #endif
 
-/* Reference: Does not exist in reference implementation.
+/* Reference: Does not exist in the reference implementation @[REF].
  *            - x4-batched version of `rej_uniform()` from the
  *              reference implementation, leveraging x4-batched Keccak-f1600. */
 MLK_INTERNAL_API
@@ -184,7 +199,7 @@ void mlk_poly_rej_uniform_x4(mlk_poly *vec,
   mlk_xof_x4_release(&statex);
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
 }
 
@@ -220,7 +235,7 @@ void mlk_poly_rej_uniform(mlk_poly *entry, uint8_t seed[MLKEM_SYMBYTES + 2])
   mlk_xof_release(&state);
 
   /* Specification: Partially implements
-   * [FIPS 203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
 }
 
@@ -236,7 +251,7 @@ void mlk_poly_rej_uniform(mlk_poly *entry, uint8_t seed[MLKEM_SYMBYTES + 2])
  *
  **************************************************/
 
-/* Reference: `load32_littleendian()` in the reference implementation. */
+/* Reference: `load32_littleendian()` in the reference implementation @[REF]. */
 static uint32_t mlk_load32_littleendian(const uint8_t x[4])
 {
   uint32_t r;
@@ -247,7 +262,7 @@ static uint32_t mlk_load32_littleendian(const uint8_t x[4])
   return r;
 }
 
-/* Reference: `cbd2()` in the reference implementationo. */
+/* Reference: `cbd2()` in the reference implementation @[REF]o. */
 MLK_INTERNAL_API
 void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4])
 {
@@ -288,7 +303,7 @@ void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4])
  *
  **************************************************/
 
-/* Reference: `load24_littleendian()` in the reference implementation. */
+/* Reference: `load24_littleendian()` in the reference implementation @[REF]. */
 static uint32_t mlk_load24_littleendian(const uint8_t x[3])
 {
   uint32_t r;
@@ -298,7 +313,7 @@ static uint32_t mlk_load24_littleendian(const uint8_t x[3])
   return r;
 }
 
-/* Reference: `cbd3()` in the reference implementationo. */
+/* Reference: `cbd3()` in the reference implementation @[REF]o. */
 MLK_INTERNAL_API
 void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4])
 {

--- a/crypto/fipsmodule/ml_kem/mlkem/sampling.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/sampling.h
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ */
+
 #ifndef MLK_SAMPLING_H
 #define MLK_SAMPLING_H
 
@@ -22,7 +32,7 @@
  * Arguments:   - mlk_poly *r: pointer to output polynomial
  *              - const uint8_t *buf: pointer to input byte array
  *
- * Specification: Implements [FIPS 203, Algorithm 8, SamplePolyCBD_2]
+ * Specification: Implements @[FIPS203, Algorithm 8, SamplePolyCBD_2]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -41,7 +51,7 @@ void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4]);
  * Arguments:   - mlk_poly *r: pointer to output polynomial
  *              - const uint8_t *buf: pointer to input byte array
  *
- * Specification: Implements [FIPS 203, Algorithm 8, SamplePolyCBD_3]
+ * Specification: Implements @[FIPS203, Algorithm 8, SamplePolyCBD_3]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -61,7 +71,7 @@ void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4]);
  *                Pointer consecutive array of seed buffers of size
  *                MLKEM_SYMBYTES + 2 each, plus padding for alignment.
  *
- * Specification: Implements [FIPS 203, Algorithm 7, SampleNTT]
+ * Specification: Implements @[FIPS203, Algorithm 7, SampleNTT]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -87,7 +97,7 @@ __contract__(
  *              - uint8_t *seed:       Pointer to seed buffer of size
  *                                     MLKEM_SYMBYTES + 2 each.
  *
- * Specification: Implements [FIPS 203, Algorithm 7, SampleNTT]
+ * Specification: Implements @[FIPS203, Algorithm 7, SampleNTT]
  *
  **************************************************/
 MLK_INTERNAL_API

--- a/crypto/fipsmodule/ml_kem/mlkem/symmetric.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/symmetric.h
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ */
+
 #ifndef MLK_SYMMETRIC_H
 #define MLK_SYMMETRIC_H
 
@@ -14,17 +24,17 @@
 
 /* Macros denoting FIPS 203 specific Hash functions */
 
-/* Hash function H, [FIPS 203, Section 4.1, Eq (4.4)] */
+/* Hash function H, @[FIPS203, Section 4.1, Eq (4.4)] */
 #define mlk_hash_h(OUT, IN, INBYTES) mlk_sha3_256(OUT, IN, INBYTES)
 
-/* Hash function G, [FIPS 203, Section 4.1, Eq (4.5)] */
+/* Hash function G, @[FIPS203, Section 4.1, Eq (4.5)] */
 #define mlk_hash_g(OUT, IN, INBYTES) mlk_sha3_512(OUT, IN, INBYTES)
 
-/* Hash function J, [FIPS 203, Section 4.1, Eq (4.4)] */
+/* Hash function J, @[FIPS203, Section 4.1, Eq (4.4)] */
 #define mlk_hash_j(OUT, IN, INBYTES) \
   mlk_shake256(OUT, MLKEM_SYMBYTES, IN, INBYTES)
 
-/* PRF function, [FIPS 203, Section 4.1, Eq (4.3)]
+/* PRF function, @[FIPS203, Section 4.1, Eq (4.3)]
  * Referring to (eq 4.3), `OUT` is assumed to contain `s || b`. */
 #define mlk_prf_eta(ETA, OUT, IN) \
   mlk_shake256(OUT, (ETA) * MLKEM_N / 4, IN, MLKEM_SYMBYTES + 1)

--- a/crypto/fipsmodule/ml_kem/mlkem/sys.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/sys.h
@@ -1,9 +1,26 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_SYS_H
 #define MLK_SYS_H
+
+#if !defined(MLK_CONFIG_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
+#define MLK_HAVE_INLINE_ASM
+#endif
+
+/* Try to find endianness, if not forced through CFLAGS already */
+#if !defined(MLK_SYS_LITTLE_ENDIAN) && !defined(MLK_SYS_BIG_ENDIAN)
+#if defined(__BYTE_ORDER__)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define MLK_SYS_LITTLE_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define MLK_SYS_BIG_ENDIAN
+#else
+#error "__BYTE_ORDER__ defined, but don't recognize value."
+#endif
+#endif /* __BYTE_ORDER__ */
+#endif /* !MLK_SYS_LITTLE_ENDIAN && !MLK_SYS_BIG_ENDIAN */
 
 /* Check if we're running on an AArch64 little endian system. _M_ARM64 is set by
  * MSVC. */
@@ -23,43 +40,33 @@
 #endif
 #endif /* __x86_64__ */
 
+#if defined(MLK_SYS_LITTLE_ENDIAN) && defined(__powerpc64__)
+#define MLK_SYS_PPC64LE
+#endif
+
+#if defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64
+#define MLK_SYS_RISCV64
+#endif
+
 #if defined(_WIN32)
 #define MLK_SYS_WINDOWS
 #endif
 
-#if !defined(MLK_CONFIG_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
-#define MLK_HAVE_INLINE_ASM
-#endif
-
-/* Try to find endianness, if not forced through CFLAGS already */
-#if !defined(MLK_SYS_LITTLE_ENDIAN) && !defined(MLK_SYS_BIG_ENDIAN)
-#if defined(__BYTE_ORDER__)
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define MLK_SYS_LITTLE_ENDIAN
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define MLK_SYS_BIG_ENDIAN
-#else
-#error "__BYTE_ORDER__ defined, but don't recognize value."
-#endif
-#endif /* __BYTE_ORDER__ */
-#endif /* !MLK_SYS_LITTLE_ENDIAN && !MLK_SYS_BIG_ENDIAN */
-
-/* If MLK_FORCE_AARCH64 is set, assert that we're indeed on an AArch64 system.
- */
 #if defined(MLK_FORCE_AARCH64) && !defined(MLK_SYS_AARCH64)
 #error "MLK_FORCE_AARCH64 is set, but we don't seem to be on an AArch64 system."
 #endif
 
-/* If MLK_FORCE_AARCH64_EB is set, assert that we're indeed on a big endian
- * AArch64 system. */
 #if defined(MLK_FORCE_AARCH64_EB) && !defined(MLK_SYS_AARCH64_EB)
 #error \
     "MLK_FORCE_AARCH64_EB is set, but we don't seem to be on an AArch64 system."
 #endif
 
-/* If MLK_FORCE_X86_64 is set, assert that we're indeed on an X86_64 system. */
 #if defined(MLK_FORCE_X86_64) && !defined(MLK_SYS_X86_64)
 #error "MLK_FORCE_X86_64 is set, but we don't seem to be on an X86_64 system."
+#endif
+
+#if defined(MLK_FORCE_PPC64LE) && !defined(MLK_SYS_PPC64LE)
+#error "MLK_FORCE_PPC64LE is set, but we don't seem to be on a PPC64LE system."
 #endif
 
 /*

--- a/crypto/fipsmodule/ml_kem/mlkem/verify.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/verify.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include "verify.h"
 

--- a/crypto/fipsmodule/ml_kem/mlkem/verify.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/verify.h
@@ -1,7 +1,32 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
+
+/* References
+ * ==========
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ *
+ * - [REF]
+ *   CRYSTALS-Kyber C reference implementation
+ *   Bos, Ducas, Kiltz, Lepoint, Lyubashevsky, Schanck, Schwabe, Seiler, Stehlé
+ *   https://github.com/pq-crystals/kyber/tree/main/ref
+ *
+ * - [libmceliece]
+ *   libmceliece implementation of Classic McEliece
+ *   Bernstein, Chou
+ *   https://lib.mceliece.org/
+ *
+ * - [optblocker]
+ *   PQC forum post on opt-blockers using volatile globals
+ *   Daniel J. Bernstein
+ *   https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/hqbtIGFKIpU/m/H14H0wOlBgAJ
+ */
+
 #ifndef MLK_VERIFY_H
 #define MLK_VERIFY_H
 
@@ -23,9 +48,8 @@
    We consider two approaches to implement a value barrier:
    - An empty inline asm block which marks the target value as clobbered.
    - XOR'ing with the value of a volatile global that's set to 0;
-     for a discussion / implementation of this idea, see e.g.
-     * https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/hqbtIGFKIpU/m/H14H0wOlBgAJ
-     * https://lib.mceliece.org/libmceliece-20240513/inttypes/crypto_intN.h.html
+     see @[optblocker] for a discussion of this idea, and
+     @[libmceliece, inttypes/crypto_intN.h] for an implementation.
 
    The first approach is cheap because it only prevents the compiler
    from reasoning about the value of the variable past the barrier,
@@ -130,7 +154,7 @@ __contract__(ensures(return_value == b))
  *
  **************************************************/
 
-/* Reference: Embedded in `cmov_int16()` in the reference implementation.
+/* Reference: Embedded in `cmov_int16()` in the reference implementation @[REF].
  *            - Use value barrier and shift instead of `b = -b` to
  *              convert condition into mask. */
 static MLK_INLINE uint16_t mlk_ct_cmask_nonzero_u16(uint16_t x)
@@ -151,7 +175,7 @@ __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFFFF)))
  **************************************************/
 
 /* Reference: Embedded in `verify()` and `cmov()` in the
- *            reference implementation.
+ *            reference implementation @[REF].
  *            - We include a value barrier not present in the
  *              reference implementation, to prevent the compiler
  *              from realizing that this function returns a mask. */
@@ -188,7 +212,7 @@ __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFF)))
  **************************************************/
 
 /* Reference: Embedded in polynomial compression function in the
- *            reference implementation.
+ *            reference implementation @[REF].
  *            - Used as part of signed->unsigned conversion for modular
  *              representatives to detect whether the input is negative.
  *              This happen in `mlk_poly_reduce()` here, and as part of
@@ -233,22 +257,22 @@ __contract__(ensures(return_value == ((x < 0) ? 0xFFFF : 0)))
  *
  * Specification:
  * - With `a = MLKEM_Q_HALF` and `b=0`, this essentially
- *   implements `Decompress_1` [FIPS 203, Eq (4.8)] in `mlk_poly_frommsg()`.
+ *   implements `Decompress_1` @[FIPS203, Eq (4.8)] in `mlk_poly_frommsg()`.
  * - With `a = x + MLKEM_Q`, `b = x`, and `cond` indicating whether `x`
  *   is negative, implements signed->unsigned conversion of modular
  *   representatives. Questions of representation are not considered
- *   in the specification [FIPS 203, Section 2.4.1, "The pseudocode is
+ *   in the specification @[FIPS203, Section 2.4.1, "The pseudocode is
  *   agnostic regarding how an integer modulo 𝑚 is represented in
  *   actual implementations"].
  *
  **************************************************/
 
 /* Reference: Embedded in polynomial compression function in the
- *            reference implementation.
+ *            reference implementation @[REF].
  *            - Used as part of signed->unsigned conversion for modular
  *              representatives. This happen in `mlk_poly_reduce()` here,
- *              and as part of polynomial compression functions in the
- *              reference implementation. See `mlk_poly_reduce()`.
+ *              and as part of polynomial compression functions in @[REF].
+ *              See `mlk_poly_reduce()`.
  *            - Barrier to reduce the risk of compiler-introduced branches.
  *            For `a = MLKEM_Q_HALF` and `b=0`, also embedded in
  *            `poly_frommsg()` from the reference implementation, which uses
@@ -279,7 +303,7 @@ __contract__(ensures(return_value == (cond ? a : b)))
  *
  **************************************************/
 
-/* Reference: Embedded into `cmov()` in the reference implementation.
+/* Reference: Embedded into `cmov()` in the reference implementation @[REF].
  *            - Use value barrier to get mask from condition value. */
 static MLK_INLINE uint8_t mlk_ct_sel_uint8(uint8_t a, uint8_t b, uint8_t cond)
 __contract__(ensures(return_value == (cond ? a : b)))
@@ -300,11 +324,11 @@ __contract__(ensures(return_value == (cond ? a : b)))
  *
  * Specification:
  * - Used to securely compute conditional move in
- *   [FIPS 203, Algorithm 18 (ML-KEM.Decaps_Internal, L9-11]
+ *   @[FIPS203, Algorithm 18 (ML-KEM.Decaps_Internal, L9-11]
  *
  **************************************************/
 
-/* Reference: `cmov()` in the reference implementation
+/* Reference: `cmov()` in the reference implementation @[REF]
  *            - We return `uint8_t`, not `int`.
  *            - We use an additional XOR-accumulator in the comparison loop
  *              which prevents early abort if the OR-accumulator is 0xFF.
@@ -357,11 +381,11 @@ __contract__(
  *
  * Specification:
  * - Used to securely compute conditional move in
- *   [FIPS 203, Algorithm 18 (ML-KEM.Decaps_Internal, L9-11]
+ *   @[FIPS203, Algorithm 18 (ML-KEM.Decaps_Internal, L9-11]
  *
  **************************************************/
 
-/* Reference: `cmov()` in the reference implementation.
+/* Reference: `cmov()` in the reference implementation @[REF].
  *            - We move if condition value is `0`, not `1`.
  *            - We use `mlk_ct_sel_uint8` for constant-time selection. */
 static MLK_INLINE void mlk_ct_cmov_zero(uint8_t *r, const uint8_t *x,
@@ -388,11 +412,11 @@ __contract__(
  *              size_t len:       Amount of bytes to be zeroed
  *
  * Specification: Used to implement
- * [FIPS 203, Section 3.3, Destruction of intermediate values]
+ * @[FIPS203, Section 3.3, Destruction of intermediate values]
  *
  **************************************************/
 
-/* Reference: Not present in the reference implementation. */
+/* Reference: Not present in the reference implementation @[REF]. */
 #if !defined(MLK_CONFIG_CUSTOM_ZEROIZE)
 #if defined(MLK_SYS_WINDOWS)
 #include <windows.h>

--- a/crypto/fipsmodule/ml_kem/mlkem/zetas.inc
+++ b/crypto/fipsmodule/ml_kem/mlkem/zetas.inc
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

---------

This PR re-imports the head of mlkem-native by re-running:

```
crypto/fipsmodule/ml_kem/import.sh --force
```

Notable changes:

- Licensing of mlkem-native changed from Apache-2.0 to
  `Apache-2.0 OR ISC OR MIT`. This aligns with the default
  licensing of AWS-LC under `Apache-2.0 OR ISC`.

  The LICENSE file is adjusted accordingly.

- Each source has a mini-bibliography for the citations
  used in the source file. Consistency is ensured through
  autogeneration from a main bibliography YML, which however
  is not part of the import.

  See [BIBLIOGRAPHY.yml](https://github.com/pq-code-package/mlkem-native/blob/main/BIBLIOGRAPHY.yml) and [BIBLIOGRAPHY.md](https://github.com/pq-code-package/mlkem-native/blob/main/BIBLIOGRAPHY.md) (autogenerated) in mlkem-native.

- Minor extension to mlkem/sys.h to detect PPC64 and RV64
  systems.

- Renaming of 'level' to 'parameter set' in documentation
  and identifier names. For example, the namespacing macro
  MLK_ADD_LEVEL is now MLK_ADD_PARAM_SET.

Also, the mlkem-native importer is adjusted to work on MacOS.
Due to a differences in the command line for `sed`, it previously
only worked on Linux.