### PR TITLE
Increase default salt from 8 to 16 bytes for PKCS#8 & PKCS#12

### DIFF
--- a/crypto/pkcs8/internal.h
+++ b/crypto/pkcs8/internal.h
@@ -81,6 +81,7 @@ int pkcs8_pbe_decrypt(uint8_t **out, size_t *out_len, CBS *algorithm,
 #define PKCS12_KEY_ID 1
 #define PKCS12_IV_ID 2
 #define PKCS12_MAC_ID 3
+#define PKCS12_SALT_LEN 16
 
 // pkcs12_key_gen runs the PKCS#12 key derivation function as specified in
 // RFC 7292, appendix B. On success, it writes the resulting |out_len| bytes of

--- a/crypto/pkcs8/pkcs8.c
+++ b/crypto/pkcs8/pkcs8.c
@@ -456,7 +456,7 @@ int PKCS8_marshal_encrypted_private_key(CBB *out, int pbe_nid,
   // Generate a random salt if necessary.
   if (salt == NULL) {
     if (salt_len == 0) {
-      salt_len = PKCS5_SALT_LEN;
+      salt_len = PKCS12_SALT_LEN;
     }
 
     salt_buf = OPENSSL_malloc(salt_len);

--- a/crypto/pkcs8/pkcs8_x509.c
+++ b/crypto/pkcs8/pkcs8_x509.c
@@ -1056,7 +1056,7 @@ static int add_cert_safe_contents(CBB *cbb, X509 *cert,
 static int add_encrypted_data(CBB *out, int pbe_nid, const char *password,
                               size_t password_len, uint32_t iterations,
                               const uint8_t *in, size_t in_len) {
-  uint8_t salt[PKCS5_SALT_LEN];
+  uint8_t salt[PKCS12_SALT_LEN];
   if (!RAND_bytes(salt, sizeof(salt))) {
     return 0;
   }
@@ -1338,7 +1338,7 @@ PKCS12 *PKCS12_create(const char *password, const char *name,
   // TODO (CryptoAlg-2897): Update the default |md| to SHA-256 to align with
   //                        OpenSSL 3.x.
   const EVP_MD *mac_md = EVP_sha1();
-  uint8_t mac_salt[PKCS5_SALT_LEN];
+  uint8_t mac_salt[PKCS12_SALT_LEN];
   if (!CBB_flush(&auth_safe_data) ||
       !RAND_bytes(mac_salt, sizeof(mac_salt)) ||
       !pkcs12_gen_and_write_mac(
@@ -1382,7 +1382,7 @@ int PKCS12_set_mac(PKCS12 *p12, const char *password, int password_len,
     mac_iterations = 1;
   }
   if (salt_len == 0) {
-    salt_len = PKCS5_SALT_LEN;
+    salt_len = PKCS12_SALT_LEN;
   }
   // Generate |mac_salt| if |salt| is NULL and copy if NULL.
   uint8_t *mac_salt = OPENSSL_malloc(salt_len);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -511,6 +511,8 @@ OPENSSL_EXPORT int EVP_PKEY_print_params(BIO *out, const EVP_PKEY *pkey,
 // function that results in a key suitable for use in symmetric
 // cryptography.
 
+// PKCS5_SALT_LEN is a deprecated constant as used by deprecated
+// EVP_BytesToKey() which cannot change.
 #define PKCS5_SALT_LEN 8
 
 // PKCS5_PBKDF2_HMAC computes |iterations| iterations of PBKDF2 of |password|


### PR DESCRIPTION
Currently PKCS8_marshal_encrypted_private_key function uses salt
length of 8 bytes / 64 bits when no salt length is specified. Increase
this fallback default to 16 bytes / 128 bits, as recommended by NIST
SP 800-132.

Note this is for interoperability purposes. Some FIPS implementations
enforce minimum salt length of 16 bytes. Examples of such FIPS
implementations are Bouncycastle FIPS Java API and Chainguard FIPS
Provider for OpenSSL. Also future v3.6 release of OpenSSL will also
increase the default salt length to 16 bytes. A similar change has
also been submitted to BoringSSL and LibreSSL.

Keep legacy EVP_BytesToKey and PKCS5_SALT_LEN defines at 8 bytes. Add
a new internal only define PKCS12_SALT_LEN set to 16 bytes. Use
PKCS12_SALT_LEN as the fallback salt length in PKCS#8 and PKCS#12
codepaths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.