### PR TITLE
Squelch clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,5 +11,7 @@ Checks: '
   modernize-*,
   performance-*,
   portability-*,
+  -cppcoreguidelines-macro-to-enum,
+  -cppcoreguidelines-avoid-non-const-global-variables,
   '
 WarningsAsErrors: ''

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -14,4 +14,5 @@ jobs:
           split_workflow: true
           clang_tidy_version: 19
           install_commands: /github/workspace/util/build_compilation_database.sh
+          config_file: '/github/workspace/.clang-tidy'
       - uses: ZedThree/clang-tidy-review/upload@v0.21.0


### PR DESCRIPTION
### Description of changes: 
clang-tidy is way too noisy.
* Forces the clang-tidy-review to use the configuration that we provide
* The `readibility-*` checks are not enabled.
* Silences a few other noisy checks. (Feel free to recommend others to silence.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
