### PR TITLE
Clang-tidy is still noisy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,15 +1,7 @@
 ---
 Checks: '
   -*,
-  bugprone-*,
-  cert-*,
-  clang-analyzer,
-  concurrency-*,
-  cppcoreguidelines-*,
-  hicpp-*,
-  misc-*,
-  modernize-*,
-  performance-*,
+  clang-analyzer-*,
   portability-*,
   '
 WarningsAsErrors: ''


### PR DESCRIPTION


### Description of changes:
Clang-tidy is still way too noisy. This makes a more aggressive cut.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
