### PR TITLE
Bump AWSLC_API_VERSION for X509_STORE_CTX_set_verify_crit_oids

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -114,7 +114,7 @@ extern "C" {
 // A consumer may use this symbol in the preprocessor to temporarily build
 // against multiple revisions of BoringSSL at the same time. It is not
 // recommended to do so for longer than is necessary.
-#define AWSLC_API_VERSION 33
+#define AWSLC_API_VERSION 34
 
 // This string tracks the most current production release version on Github
 // https://github.com/aws/aws-lc/releases.


### PR DESCRIPTION
### Issues:
`V1726629971`

### Description of changes: 
Bump the API version so that customers like s2n-tls can know that the feature for specific unknown X509 critical extensions are supported.

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
