### PR TITLE
Simplify Compiler CI jobs

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -274,6 +274,10 @@ jobs:
             compiler: 'gcc15'
           - fips: 1
             compiler: 'gcc16'
+          - fips: 1
+            compiler: 'clang20'
+          - fips: 1
+            compiler: 'clang21'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler }}
@@ -313,11 +317,19 @@ jobs:
       matrix:
         fips: [0, 1]
         compiler:
+          - 'gcc13'
           - 'gcc15'
+          - 'clang19'
           - 'clang20'
         exclude:
           - fips: 1
             compiler: 'gcc15'
+          - fips: 1
+            compiler: 'clang20'
+          - fips: 0
+            compiler: 'gcc13'
+          - fips: 0
+            compiler: 'clang19'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler }}

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -251,81 +251,102 @@ jobs:
       matrix:
         fips: [0, 1]
         compiler:
-          - ['gcc9',    1, 'gcc',   'g++']
-          - ['gcc10',   1, 'gcc',   'g++']
-          - ['gcc11',   1, 'gcc',   'g++']
-          - ['gcc12',   1, 'gcc',   'g++']
-          - ['gcc13',   1, 'gcc',   'g++']
-          - ['gcc14',   0, 'gcc',   'g++']
-          - ['gcc15',   0, 'gcc',   'g++']
-          - ['gcc16',   0, 'gcc',   'g++']
-          - ['clang14', 1, 'clang', 'clang++']
-          - ['clang15', 1, 'clang', 'clang++']
-          - ['clang16', 1, 'clang', 'clang++']
-          - ['clang17', 1, 'clang', 'clang++']
-          - ['clang18', 1, 'clang', 'clang++']
-          - ['clang19', 1, 'clang', 'clang++']
-          - ['clang20', 1, 'clang', 'clang++']
-          - ['clang21', 1, 'clang', 'clang++']
+          - 'gcc9'
+          - 'gcc10'
+          - 'gcc11'
+          - 'gcc12'
+          - 'gcc13'
+          - 'gcc14'
+          - 'gcc15'
+          - 'gcc16'
+          - 'clang14'
+          - 'clang15'
+          - 'clang16'
+          - 'clang17'
+          - 'clang18'
+          - 'clang19'
+          - 'clang20'
+          - 'clang21'
+        exclude:
+          - fips: 1
+            compiler: 'gcc14'
+          - fips: 1
+            compiler: 'gcc15'
+          - fips: 1
+            compiler: 'gcc16'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler[0] }}
+      image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler }}
     steps:
       - uses: actions/checkout@v4
-        if: matrix.fips == 0 || matrix.compiler[1] == 1
       - uses: actions/setup-go@v4
-        if: matrix.fips == 0 || matrix.compiler[1] == 1
         with:
           go-version: '>=1.18'
+      - name: Setup Clang
+        if: startsWith(matrix.compiler, 'clang')
+        run: |
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+      - name: Setup GCC
+        if: startsWith(matrix.compiler, 'gcc')
+        run: |
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
       - name: Setup Build
         if: matrix.fips == 0
         run:
-          cmake -G Ninja -B ./build -DCMAKE_C_COMPILER=${{ matrix.compiler[2] }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler[3] }} -DCMAKE_BUILD_TYPE=Release
+          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release
       - name: Setup FIPS Build
-        if: matrix.fips == 1 && matrix.compiler[1] == 1
+        if: matrix.fips == 1
         run:
-          cmake -G Ninja -B ./build -DCMAKE_C_COMPILER=${{ matrix.compiler[2] }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler[3] }} -DCMAKE_BUILD_TYPE=Release -DFIPS=1
+          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=1
       - name: Build Project
-        if: matrix.fips == 0 || matrix.compiler[1] == 1
         run: cmake --build ./build --target all
       - name: Run tests
-        if: matrix.fips == 0 || matrix.compiler[1] == 1
         run: cmake --build ./build --target run_tests
 
   pedantic-tests:
     env:
-      CC: gcc
-      CXX: g++
+      GOFLAGS: "-buildvcs=false"
     strategy:
       fail-fast: false
       matrix:
-        fips: [ 0, 1 ]
+        fips: [0, 1]
         compiler:
-          - [ 'gcc15',   0, 'gcc',   'g++' ]
-          - [ 'clang20', 1, 'clang', 'clang++' ]
+          - 'gcc15'
+          - 'clang20'
+        exclude:
+          - fips: 1
+            compiler: 'gcc15'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler[0] }}
+      image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler }}
     steps:
       - uses: actions/checkout@v4
-        if: matrix.fips == 0 || matrix.compiler[1] == 1
       - uses: actions/setup-go@v4
-        if: matrix.fips == 0 || matrix.compiler[1] == 1
         with:
           go-version: '>=1.18'
+      - name: Setup Clang
+        if: startsWith(matrix.compiler, 'clang')
+        run: |
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+      - name: Setup GCC
+        if: startsWith(matrix.compiler, 'gcc')
+        run: |
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
       - name: Setup Build
         if: matrix.fips == 0
         run:
-          cmake -G Ninja -B ./build -DCMAKE_C_COMPILER=${{ matrix.compiler[2] }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler[3] }} -DCMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-pedantic CMAKE_CXX_FLAGS=-pedantic
+          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-pedantic CMAKE_CXX_FLAGS=-pedantic
       - name: Setup FIPS Build
-        if: matrix.fips == 1 && matrix.compiler[1] == 1
+        if: matrix.fips == 1
         run:
-          cmake -G Ninja -B ./build -DCMAKE_C_COMPILER=${{ matrix.compiler[2] }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler[3] }} -DCMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-pedantic CMAKE_CXX_FLAGS=-pedantic -DFIPS=1
+          cmake -G Ninja -B ./build  -DCMAKE_BUILD_TYPE=Release -DFIPS=1 CMAKE_C_FLAGS=-pedantic CMAKE_CXX_FLAGS=-pedantic
       - name: Build Project
-        if: matrix.fips == 0 || matrix.compiler[1] == 1
         run: cmake --build ./build --target all
       - name: Run tests
-        if: matrix.fips == 0 || matrix.compiler[1] == 1
         run: cmake --build ./build --target run_tests
 
   OpenBSD:

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -244,6 +244,7 @@ jobs:
         run: cmake --build ./build --target run_tests
 
   compiler-tests:
+    name: ${{ matrix.compiler }}, FIPS=${{ matrix.fips }}
     env:
       GOFLAGS: "-buildvcs=false"
     strategy:
@@ -290,20 +291,16 @@ jobs:
         run: |
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
-      - name: Setup Build
-        if: matrix.fips == 0
+      - name: Setup ${{ (matrix.fips == 1 && '') || 'non-' }}FIPS Build
         run:
-          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release
-      - name: Setup FIPS Build
-        if: matrix.fips == 1
-        run:
-          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=1
+          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=${{matrix.fips}}
       - name: Build Project
         run: cmake --build ./build --target all
       - name: Run tests
         run: cmake --build ./build --target run_tests
 
   pedantic-tests:
+    name: pedantic - ${{ matrix.compiler }}, FIPS=${{ matrix.fips }}
     env:
       GOFLAGS: "-buildvcs=false"
     strategy:

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -164,49 +164,6 @@ jobs:
           echo ${env:SDEROOT}
           .\tests\ci\run_windows_tests.bat "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 true
 
-  gcc-ubuntu-2004-sanity:
-    if: github.repository_owner == 'aws'
-    needs: [sanity-test-run]
-    strategy:
-      fail-fast: false
-      matrix:
-        gccversion:
-          - "10"
-        fips:
-          - "0"
-          - "1"
-    runs-on: ubuntu-22.04
-    container:
-      image: ubuntu:20.04
-    steps:
-      - run: |
-          env DEBIAN_FRONTEND=noninteractive apt-get update
-          env DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git curl cmake ninja-build \
-            gcc-${{ matrix.gccversion }} g++-${{ matrix.gccversion }}
-      - name: Install Newer Go Compiler
-        run: |
-          curl -L -o /tmp/go.tar.gz https://go.dev/dl/go1.24.2.linux-amd64.tar.gz
-          cat <<EOF >/tmp/go.tar.gz.sha256
-          68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad  /tmp/go.tar.gz
-          EOF
-          sha256sum -c /tmp/go.tar.gz.sha256
-          (cd /usr/local && tar xvf /tmp/go.tar.gz)
-      - name: Checkout
-        run: |
-          git config --global --add safe.directory '*'
-          git clone --recursive ${{ github.server_url }}/${{ github.repository }}.git .
-          git fetch origin ${{ github.sha }}
-          git checkout --recurse-submodules -b ci-job ${{ github.sha }}
-      - name: Build Project
-        run: |
-          env PATH="/usr/local/go/bin:${PATH}" \
-            CC=gcc-${{ matrix.gccversion }} CXX=g++-${{ matrix.gccversion }} \
-            cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DFIPS=${{ matrix.fips }} -GNinja
-          cmake --build build --target all
-      - name: Run Tests
-        run: |
-          cmake --build build --target run_tests
-
   clang-ubuntu-2004-sanity:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
@@ -250,151 +207,6 @@ jobs:
         run: |
           cmake --build build --target run_tests
 
-  gcc-ubuntu-2204-sanity:
-    if: github.repository_owner == 'aws'
-    needs: [sanity-test-run]
-    strategy:
-      fail-fast: false
-      matrix:
-        gccversion:
-          - "10"
-          - "11"
-          - "12"
-        fips:
-          - "0"
-          - "1"
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '>=1.18'
-      - name: Setup CMake
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          generator: Ninja
-          c-compiler: gcc-${{ matrix.gccversion }}
-          cxx-compiler: g++-${{ matrix.gccversion }}
-          options: FIPS=${{ matrix.fips }} CMAKE_BUILD_TYPE=Release
-      - name: Build Project
-        run: cmake --build ./build --target all
-      - name: Run tests
-        run: cmake --build ./build --target run_tests
-
-  gcc-ubuntu-2404-sanity:
-    if: github.repository_owner == 'aws'
-    needs: [ sanity-test-run ]
-    strategy:
-      fail-fast: false
-      matrix:
-        gccversion:
-          - "12"
-          - "13"
-          - "14"
-        fips:
-          - "0"
-          - "1"
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '>=1.18'
-      - name: Setup CMake
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          generator: Ninja
-          c-compiler: gcc-${{ matrix.gccversion }}
-          cxx-compiler: g++-${{ matrix.gccversion }}
-          options: FIPS=${{ matrix.fips }} CMAKE_BUILD_TYPE=Release
-      - name: Build Project
-        # TODO: Re-enable gcc-14/FIPS build once delocator updated
-        if: ${{ !( matrix.gccversion == '14' && matrix.fips == '1' ) }}
-        run: cmake --build ./build --target all
-      - name: Run tests
-        # TODO: Re-enable gcc-14/FIPS build once delocator updated
-        if: ${{ !( matrix.gccversion == '14' && matrix.fips == '1' ) }}
-        run: cmake --build ./build --target run_tests
-
-  gcc-14-hardened:
-    if: github.repository_owner == 'aws'
-    needs: [ sanity-test-run ]
-    strategy:
-      fail-fast: false
-      matrix:
-        gccversion:
-          - "14"
-        fips:
-          - "0"
-          - "1"
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '>=1.18'
-      - name: Setup CMake
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          generator: Ninja
-          c-compiler: gcc-${{ matrix.gccversion }}
-          cxx-compiler: g++-${{ matrix.gccversion }}
-          options: FIPS=${{ matrix.fips }} CMAKE_BUILD_TYPE=Release
-      - name: Build Project
-        # -Wno-error=hardened gives us warning but no errors if options implied by -fhardened are downgraded or disabled
-        # Ubuntu sets FORTIFY_SOURCE automatically which is one of the options implemented by hardened so this warning is
-        # generated on every compiler call.
-        # TODO: Re-enable gcc-14/FIPS build once delocator updated
-        if: ${{ !( matrix.gccversion == '14' && matrix.fips == '1' ) }}
-        run: |
-          cmake -DCMAKE_C_FLAGS='-O2 -fhardened -Wno-error=hardened' -S. -Bbuild
-          cmake --build ./build --target all
-      - name: Run tests
-        # TODO: Re-enable gcc-14/FIPS build once delocator updated
-        if: ${{ !( matrix.gccversion == '14' && matrix.fips == '1' ) }}
-        run: cmake --build ./build --target run_tests
-
-  gcc-13-pedantic:
-    if: github.repository_owner == 'aws'
-    needs: [ sanity-test-run ]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup CMake
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          generator: Ninja
-          c-compiler: gcc-13
-          cxx-compiler: g++-13
-          options: CMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-pedantic CMAKE_CXX_FLAGS=-pedantic
-      - name: Build Crypto
-        run: cmake --build ./build --target crypto
-      - name: Build SSL
-        run: cmake --build ./build --target ssl
-
-  clang-19-pedantic:
-    if: github.repository_owner == 'aws'
-    needs: [ sanity-test-run ]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install clang-19
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod u+x llvm.sh
-          sudo ./llvm.sh 19
-      - name: Setup CMake
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          generator: Ninja
-          c-compiler: clang-19
-          cxx-compiler: clang++-19
-          options: CMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-pedantic CMAKE_CXX_FLAGS=-pedantic
-      - name: Build Crypto
-        run: cmake --build ./build --target crypto
-      - name: Build SSL
-        run: cmake --build ./build --target ssl
-
   clang-ubuntu-2204-sanity:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
@@ -405,8 +217,6 @@ jobs:
           - "11"
           - "12"
           - "13"
-          - "14"
-          - "15"
         fips:
           - "0"
           - "1"
@@ -433,67 +243,89 @@ jobs:
       - name: Run tests
         run: cmake --build ./build --target run_tests
 
-  clang-ubuntu-2404-sanity:
-    if: github.repository_owner == 'aws'
-    needs: [sanity-test-run]
+  compiler-tests:
+    env:
+      GOFLAGS: "-buildvcs=false"
     strategy:
       fail-fast: false
       matrix:
-        clangversion:
-          - "16"
-          - "17"
-          - "18"
-        fips:
-          - "0"
-          - "1"
-    runs-on: ubuntu-24.04
+        fips: [0, 1]
+        compiler:
+          - ['gcc9',    1, 'gcc',   'g++']
+          - ['gcc10',   1, 'gcc',   'g++']
+          - ['gcc11',   1, 'gcc',   'g++']
+          - ['gcc12',   1, 'gcc',   'g++']
+          - ['gcc13',   1, 'gcc',   'g++']
+          - ['gcc14',   0, 'gcc',   'g++']
+          - ['gcc15',   0, 'gcc',   'g++']
+          - ['gcc16',   0, 'gcc',   'g++']
+          - ['clang14', 1, 'clang', 'clang++']
+          - ['clang15', 1, 'clang', 'clang++']
+          - ['clang16', 1, 'clang', 'clang++']
+          - ['clang17', 1, 'clang', 'clang++']
+          - ['clang18', 1, 'clang', 'clang++']
+          - ['clang19', 1, 'clang', 'clang++']
+          - ['clang20', 1, 'clang', 'clang++']
+          - ['clang21', 1, 'clang', 'clang++']
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler[0] }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        if: matrix.fips == 0 || matrix.compiler[1] == 1
       - uses: actions/setup-go@v4
+        if: matrix.fips == 0 || matrix.compiler[1] == 1
         with:
           go-version: '>=1.18'
-      - name: Setup CMake
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          generator: Ninja
-          c-compiler: clang-${{ matrix.clangversion }}
-          cxx-compiler: clang++-${{ matrix.clangversion }}
-          options: FIPS=${{ matrix.fips }} CMAKE_BUILD_TYPE=Release
+      - name: Setup Build
+        if: matrix.fips == 0
+        run:
+          cmake -G Ninja -B ./build -DCMAKE_C_COMPILER=${{ matrix.compiler[2] }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler[3] }} -DCMAKE_BUILD_TYPE=Release
+      - name: Setup FIPS Build
+        if: matrix.fips == 1 && matrix.compiler[1] == 1
+        run:
+          cmake -G Ninja -B ./build -DCMAKE_C_COMPILER=${{ matrix.compiler[2] }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler[3] }} -DCMAKE_BUILD_TYPE=Release -DFIPS=1
       - name: Build Project
+        if: matrix.fips == 0 || matrix.compiler[1] == 1
         run: cmake --build ./build --target all
       - name: Run tests
+        if: matrix.fips == 0 || matrix.compiler[1] == 1
         run: cmake --build ./build --target run_tests
 
-  clang-19-sanity:
-    if: github.repository_owner == 'aws'
-    needs: [ sanity-test-run ]
+  pedantic-tests:
+    env:
+      CC: gcc
+      CXX: g++
     strategy:
       fail-fast: false
       matrix:
-        fips:
-          - "0"
-          - "1"
-    runs-on: ubuntu-22.04
+        fips: [ 0, 1 ]
+        compiler:
+          - [ 'gcc15',   0, 'gcc',   'g++' ]
+          - [ 'clang20', 1, 'clang', 'clang++' ]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler[0] }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        if: matrix.fips == 0 || matrix.compiler[1] == 1
       - uses: actions/setup-go@v4
+        if: matrix.fips == 0 || matrix.compiler[1] == 1
         with:
           go-version: '>=1.18'
-      - name: Install clang-19
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod u+x llvm.sh
-          sudo ./llvm.sh 19
-      - name: Setup CMake
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          generator: Ninja
-          c-compiler: clang-19
-          cxx-compiler: clang++-19
-          options: FIPS=${{ matrix.fips }} CMAKE_BUILD_TYPE=Release
+      - name: Setup Build
+        if: matrix.fips == 0
+        run:
+          cmake -G Ninja -B ./build -DCMAKE_C_COMPILER=${{ matrix.compiler[2] }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler[3] }} -DCMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-pedantic CMAKE_CXX_FLAGS=-pedantic
+      - name: Setup FIPS Build
+        if: matrix.fips == 1 && matrix.compiler[1] == 1
+        run:
+          cmake -G Ninja -B ./build -DCMAKE_C_COMPILER=${{ matrix.compiler[2] }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler[3] }} -DCMAKE_BUILD_TYPE=Release CMAKE_C_FLAGS=-pedantic CMAKE_CXX_FLAGS=-pedantic -DFIPS=1
       - name: Build Project
+        if: matrix.fips == 0 || matrix.compiler[1] == 1
         run: cmake --build ./build --target all
       - name: Run tests
+        if: matrix.fips == 0 || matrix.compiler[1] == 1
         run: cmake --build ./build --target run_tests
 
   OpenBSD:

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -326,10 +326,6 @@ jobs:
             compiler: 'gcc15'
           - fips: 1
             compiler: 'clang20'
-          - fips: 0
-            compiler: 'gcc13'
-          - fips: 0
-            compiler: 'clang19'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler }}

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -269,12 +269,6 @@ jobs:
           - 'clang21'
         exclude:
           - fips: 1
-            compiler: 'gcc14'
-          - fips: 1
-            compiler: 'gcc15'
-          - fips: 1
-            compiler: 'gcc16'
-          - fips: 1
             compiler: 'clang20'
           - fips: 1
             compiler: 'clang21'

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -331,6 +331,10 @@ if(FIPS_DELOCATE)
   set_target_properties(bcm_c_generated_asm PROPERTIES COMPILE_OPTIONS "-S")
   set_target_properties(bcm_c_generated_asm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+  if (CLANG AND (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER "19.99.99"))
+    set_target_properties(bcm_c_generated_asm PROPERTIES COMPILE_OPTIONS "-Wno-unused-command-line-argument")
+  endif()
+
   set(TARGET "")
   if(CMAKE_ASM_COMPILER_TARGET)
     set(TARGET "--target=${CMAKE_ASM_COMPILER_TARGET}")

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -331,6 +331,7 @@ if(FIPS_DELOCATE)
   set_target_properties(bcm_c_generated_asm PROPERTIES COMPILE_OPTIONS "-S")
   set_target_properties(bcm_c_generated_asm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+  # Clang 20+ warns when both "-S" and "-c" are used as options to the compiler.
   if (CLANG AND (CMAKE_ASM_COMPILER_ID MATCHES "Clang" OR CMAKE_ASM_COMPILER MATCHES "clang") AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER "19.99.99"))
     set_target_properties(bcm_c_generated_asm PROPERTIES COMPILE_OPTIONS "-Wno-unused-command-line-argument")
   endif()

--- a/tests/docker_images/gcc/15.1.0/Dockerfile
+++ b/tests/docker_images/gcc/15.1.0/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+# This release of Ubuntu provides GCC versions 4.8 and 7.5
+# * 4.8: /usr/bin/gcc-4.8
+# * 7.5: /usr/bin/gcc
+FROM gcc:15.1.0
+
+SHELL ["/bin/bash", "-c"]
+
+RUN  apt-get update
+RUN  apt-get install -y ca-certificates cmake curl sudo build-essential gdb
+RUN  apt-get install -y git golang-go ninja-build
+RUN  apt-get install -f
+
+ENV GOCACHE /tmp
+
+CMD ["/bin/bash"]

--- a/tests/docker_images/gcc/build_images.sh
+++ b/tests/docker_images/gcc/build_images.sh
@@ -18,7 +18,10 @@ if ! docker buildx inspect ${BUILDER_NAME}; then
 fi
 
 ## GCC-4.8
-docker buildx build --platform linux/amd64 -t aws-lc:gcc-4.8 "${SCRIPT_DIR}"/4.8 --load
+#docker buildx build --platform linux/amd64 -t aws-lc:gcc-4.8 "${SCRIPT_DIR}"/4.8 --load
+
+## GCC-15.1.0
+docker buildx build --platform linux/amd64 -t aws-lc:gcc-15.1.0 "${SCRIPT_DIR}"/15.1.0 --load
 
 docker buildx rm ${BUILDER_NAME}
 

--- a/third_party/googletest/include/gtest/gtest-printers.h
+++ b/third_party/googletest/include/gtest/gtest-printers.h
@@ -460,7 +460,9 @@ GTEST_API_ void PrintTo(wchar_t wc, ::std::ostream* os);
 
 GTEST_API_ void PrintTo(char32_t c, ::std::ostream* os);
 inline void PrintTo(char16_t c, ::std::ostream* os) {
-  PrintTo(ImplicitCast_<char32_t>(c), os);
+  // TODO(b/418738869): Incorrect for values not representing valid codepoints.Add commentMore actions
+  // Also see https://github.com/google/googletest/issues/4762.
+  PrintTo(static_cast<char32_t>(c), os);
 }
 #ifdef __cpp_char8_t
 inline void PrintTo(char8_t c, ::std::ostream* os) {

--- a/util/fipstools/test_fips.c
+++ b/util/fipstools/test_fips.c
@@ -62,23 +62,45 @@ int main(int argc, char **argv) {
   printf("Module version: %" PRIu32 "\n", module_version);
 #endif //BORINGSSL_FIPS_140_3
 
-  static const uint8_t kAESKey[16] = "BoringCrypto Key";
-  static const uint8_t kPlaintext[64] =
-      "BoringCryptoModule FIPS KAT Encryption and Decryption Plaintext!";
-  static const DES_cblock kDESKey1 = {"BCMDESK1"};
-  static const DES_cblock kDESKey2 = {"BCMDESK2"};
-  static const DES_cblock kDESKey3 = {"BCMDESK3"};
-  static const DES_cblock kDESIV = {"BCMDESIV"};
+  static const uint8_t kAESKey[16] = {'B', 'o', 'r', 'i', 'n', 'g', 'C', 'r',
+                                      'y', 'p', 't', 'o', ' ', 'K', 'e', 'y'};
+
+  static const uint8_t kPlaintext[64] = {
+      'B', 'o', 'r', 'i', 'n', 'g', 'C', 'r', 'y', 'p', 't', 'o', 'M',
+      'o', 'd', 'u', 'l', 'e', ' ', 'F', 'I', 'P', 'S', ' ', 'K', 'A',
+      'T', ' ', 'E', 'n', 'c', 'r', 'y', 'p', 't', 'i', 'o', 'n', ' ',
+      'a', 'n', 'd', ' ', 'D', 'e', 'c', 'r', 'y', 'p', 't', 'i', 'o',
+      'n', ' ', 'P', 'l', 'a', 'i', 'n', 't', 'e', 'x', 't', '!'};
+
+  static const DES_cblock kDESKey1 = {{'B', 'C', 'M', 'D', 'E', 'S', 'K', '1'}};
+
+  static const DES_cblock kDESKey2 = {{'B', 'C', 'M', 'D', 'E', 'S', 'K', '2'}};
+
+  static const DES_cblock kDESKey3 = {{'B', 'C', 'M', 'D', 'E', 'S', 'K', '3'}};
+
+  static const DES_cblock kDESIV = {{'B', 'C', 'M', 'D', 'E', 'S', 'I', 'V'}};
   static const uint8_t kPlaintextSHA256[32] = {
       0x37, 0xbd, 0x70, 0x53, 0x72, 0xfc, 0xd4, 0x03, 0x79, 0x70, 0xfb,
       0x06, 0x95, 0xb1, 0x2a, 0x82, 0x48, 0xe1, 0x3e, 0xf2, 0x33, 0xfb,
       0xef, 0x29, 0x81, 0x22, 0x45, 0x40, 0x43, 0x70, 0xce, 0x0f};
-  const uint8_t kDRBGEntropy[48] =
-      "DBRG Initial Entropy                            ";
-  const uint8_t kDRBGPersonalization[18] = "BCMPersonalization";
-  const uint8_t kDRBGAD[16] = "BCM DRBG AD     ";
-  const uint8_t kDRBGEntropy2[48] =
-      "DBRG Reseed Entropy                             ";
+  const uint8_t kDRBGEntropy[48] = {
+      'D', 'B', 'R', 'G', ' ', 'I', 'n', 'i', 't', 'i', 'a', 'l',
+      ' ', 'E', 'n', 't', 'r', 'o', 'p', 'y', ' ', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '};
+
+  const uint8_t kDRBGPersonalization[18] = {'B', 'C', 'M', 'P', 'e', 'r',
+                                            's', 'o', 'n', 'a', 'l', 'i',
+                                            'z', 'a', 't', 'i', 'o', 'n'};
+
+  const uint8_t kDRBGAD[16] = {'B', 'C', 'M', ' ', 'D', 'R', 'B', 'G',
+                               ' ', 'A', 'D', ' ', ' ', ' ', ' ', ' '};
+
+  const uint8_t kDRBGEntropy2[48] = {
+      'D', 'B', 'R', 'G', ' ', 'R', 'e', 's', 'e', 'e', 'd', ' ',
+      'E', 'n', 't', 'r', 'o', 'p', 'y', ' ', ' ', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '};
 
   AES_KEY aes_key;
   uint8_t aes_iv[16];


### PR DESCRIPTION
### Description of changes: 
* Simplify CI for testing various compilers by using prepared Docker images for each.
* Fix build failures affecting GCC 15/16 and Clang 21.

### Call-outs:
* The FIPS build appears to be failing with Clang 20/21.
  * Clang 20/21 warn when both `-S` and `-c` are used together as options to the compiler.  This is potentially related to the FIPS built failure. (?)
* GCC 16 and Clang 21 are not yet released, but thought it would be useful to proactively build against them in our CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
