### PR TITLE
fix(nix): Make sure bssl is in the PATH; workaround nix build failure…

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,42 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -50,149 +13,12 @@
         "type": "github"
       },
       "original": {
-        "id": "flake-utils",
-        "type": "indirect"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "git-hooks-nix": {
-      "inputs": {
-        "flake-compat": [
-          "nix"
-        ],
-        "gitignore": [
-          "nix"
-        ],
-        "nixpkgs": [
-          "nix",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1734279981,
-        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
-        "git-hooks-nix": "git-hooks-nix",
-        "nixfmt": "nixfmt",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-23-11": "nixpkgs-23-11",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1739307350,
-        "narHash": "sha256-R/8W3slynplgOJ1AT2lPqhEtVekEdHFZAMsKebPTJUQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "c000c16509792f452decf6ad0aea9ca91e1d8eb7",
-        "type": "github"
-      },
-      "original": {
-        "id": "nix",
-        "type": "indirect"
-      }
-    },
-    "nixfmt": {
-      "inputs": {
-        "flake-utils": "flake-utils_2"
-      },
-      "locked": {
-        "lastModified": 1736283758,
-        "narHash": "sha256-hrKhUp2V2fk/dvzTTHFqvtOg000G1e+jyIam+D4XqhA=",
-        "owner": "NixOS",
-        "repo": "nixfmt",
-        "rev": "8d4bd690c247004d90d8554f0b746b1231fe2436",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixfmt",
         "type": "github"
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1734359947,
-        "narHash": "sha256-1Noao/H+N8nFB4Beoy8fgwrcOQLVm9o4zKW1ODaqK9E=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "48d12d5e70ee91fe8481378e540433a7303dbf6a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-23-11": {
-      "locked": {
-        "lastModified": 1717159533,
-        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1739206421,
         "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
@@ -211,26 +37,10 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nix": "nix",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,20 +1,24 @@
 {
   description = "AWS-LC is a general-purpose cryptographic library";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
 
-  outputs = { self, nix, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        shells = import ./nix/devshell.nix { pkgs = pkgs; };
-
-      in rec {
-        packages.aws-lc = pkgs.stdenv.mkDerivation {
+        aws-lc = pkgs.stdenv.mkDerivation {
           src = self;
           name = "aws-lc";
           inherit system;
           nativeBuildInputs = [ pkgs.ninja pkgs.cmake pkgs.perl pkgs.go ];
+          # Workaround builds trying to write to $HOME: https://github.com/NixOS/nix/issues/670
+          preBuild = ''
+            export HOME=$PWD
+          '';
           cmakeFlags = [
             "-GNinja"
             "-DBUILD_SHARED_LIBS=ON"
@@ -24,9 +28,15 @@
             ninja run_minimal_tests
           '';
         };
+        shells = import ./nix/devshell.nix {
+          inherit pkgs;
+          inherit aws-lc;
+        };
+
+      in rec {
+        packages.aws-lc = aws-lc;
         formatter = pkgs.nixfmt;
         packages.default = packages.aws-lc;
         devShells.default = shells;
       });
 }
-

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,10 +1,18 @@
-{ pkgs }:
+{ pkgs, aws-lc }:
 pkgs.mkShell rec {
-  buildInputs = [ pkgs.cmake ];
-  packages = [ pkgs.nixfmt-classic pkgs.ninja pkgs.cmake pkgs.perl pkgs.go ];
+  buildInputs = [
+    pkgs.cmake
+    pkgs.nixfmt-classic
+    pkgs.ninja
+    pkgs.perl
+    pkgs.go
+    aws-lc
+  ];
+
   shellHook = ''
-    echo "Entering a devShell..."
-    export PS1="[awslc nix] $PS1"
+    # Set custom prompt with ANSI color
+    export PS1="\[\033[1;32m\][aws-lc]\[\033[0m\] $PS1"
+    echo -e "\033[1;32mEntering AWS-LC development shell...\033[0m"
     function clean {(set -e
       rm -rf ./build
     )}


### PR DESCRIPTION
### Issues:

none

### Description of changes: 

In some CI environments (in docker containers), the build is trying to write to $HOME, which nix intentionally unsets. This causes build failures with this error:
```
FAILED: crypto/err_data.c /tmp/nix-build-aws-lc.drv-0/source/build/crypto/err_data.c
cd /tmp/nix-build-aws-lc.drv-0/source/crypto/err && /nix/store/2xc5jh4nxvm68c67ila9p2rj3qrjgz0x-go-1.23.5/bin/go run err_data_generate.go > /tmp/nix-build-aws->
failed to initialize build cache at /homeless-shelter/.cache/go-build: mkdir /homeless-shelter: permission denied
```
By setting `$HOME` in preBuild, we can eliminate this failure.

Also, the `bssl` utility is not available in a devShell, because we're not properly importing `aws-lc`.

### Call-outs:

The build failure is blocking s2n-tls from using the upstream flake.

Reformatting both nix files with `nix fmt`.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
