### PR TITLE
Prepare v1.52.0 release

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.51.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.52.0");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.51.2");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.52.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.51.2"
+#define AWSLC_VERSION_NUMBER_STRING "1.52.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Fix prefix build when path has spaces by @justsmth in https://github.com/aws/aws-lc/pull/2400
* Prepare v1.51.2 by @justsmth in https://github.com/aws/aws-lc/pull/2401
* Set OPENSSL_NO_EXTERNAL_PSK_TLS13 to indicate lack of TLS 1.3 PSK by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2399
* BIO datagram functions by @justsmth in https://github.com/aws/aws-lc/pull/2321
* Reject NewSessionTicket messages with empty tickets in TLS 1.3 by @justsmth in https://github.com/aws/aws-lc/pull/2367
* Ensure that AVX512 is not used on macOS by @justsmth in https://github.com/aws/aws-lc/pull/2363
* Fix socket test issues by @torben-hansen in https://github.com/aws/aws-lc/pull/2404
* Remove python CI patch for main by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2407
* Remove xmlsec patch by @smittals2 in https://github.com/aws/aws-lc/pull/2405
* Fix clang tidy ci by @justsmth in https://github.com/aws/aws-lc/pull/2375
* Mark fallible container operations as `nodiscard` by @justsmth in https://github.com/aws/aws-lc/pull/2366
* Remove extra va_end in err_add_error_vdata by @justsmth in https://github.com/aws/aws-lc/pull/2364
* Check for QUIC in SSL_process_quic_post_handshake by @justsmth in https://github.com/aws/aws-lc/pull/2365
* Add missing symbols for Unbound by @nhatnghiho in https://github.com/aws/aws-lc/pull/2352
* Update mlkem-native by @hanno-becker in https://github.com/aws/aws-lc/pull/2406
* CI for iOS by @justsmth in https://github.com/aws/aws-lc/pull/2389
* Squelch clang-tidy by @justsmth in https://github.com/aws/aws-lc/pull/2414
* Clang-tidy is still noisy by @justsmth in https://github.com/aws/aws-lc/pull/2417
* Add back two rules for clang-tidy by @smittals2 in https://github.com/aws/aws-lc/pull/2418
* Implement BIO_dump by @kingstjo in https://github.com/aws/aws-lc/pull/2331
* Make ASN1_get_object a direct call by @samuel40791765 in https://github.com/aws/aws-lc/pull/2332
* Add Python 3.9 CI patch by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2415
* Rework memory BIOs and implement BIO_seek by @nhatnghiho in https://github.com/aws/aws-lc/pull/2380
* ML-DSA: ASN.1 Module - add parsing of BOTH private key format by @jakemas in https://github.com/aws/aws-lc/pull/2416
* Detection of unused results by @justsmth in https://github.com/aws/aws-lc/pull/2411
* Fix gtest_util.sh failure detection by @justsmth in https://github.com/aws/aws-lc/pull/2423
* Remove unused docs/configs by @torben-hansen in https://github.com/aws/aws-lc/pull/2427
* ML-DSA: Add ML-DSA keyGen to break-kat.go by @jakemas in https://github.com/aws/aws-lc/pull/2422
* Fix CI for mingw by @justsmth in https://github.com/aws/aws-lc/pull/2428
* Bump AWSLC_API_VERSION for X509_STORE_CTX_set_verify_crit_oids by @samuel40791765 in https://github.com/aws/aws-lc/pull/2426
* Revert "Rework memory BIOs and implement BIO_seek (#2380)" by @samuel40791765 in https://github.com/aws/aws-lc/pull/2432
* Resolve SSL_PRIVATE_METHOD and certificate slots functionality by @skmcgrail in https://github.com/aws/aws-lc/pull/2429

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
