### PR TITLE
Verify leaf certificate public key rather then leaving it to the caller

### DIFF
--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -4875,10 +4875,10 @@ TEST(X509Test, SignatureVerification) {
                    {intermediate.bad_key_type.get()}, {}));
 
   // Bad keys in the leaf are rejected.
-  EXPECT_EQ(X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY,
+  EXPECT_EQ(X509_R_UNABLE_TO_GET_CERTS_PUBLIC_KEY,
             Verify(leaf.bad_key.get(), {root.valid.get()},
                    {intermediate.valid.get()}, {}));
-  EXPECT_EQ(X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY,
+  EXPECT_EQ(X509_R_UNABLE_TO_GET_CERTS_PUBLIC_KEY,
             Verify(leaf.bad_key_type.get(), {root.valid.get()},
                    {intermediate.valid.get()}, {}));
 

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -4874,11 +4874,13 @@ TEST(X509Test, SignatureVerification) {
             Verify(leaf.valid.get(), {root.valid.get()},
                    {intermediate.bad_key_type.get()}, {}));
 
-  // Bad keys in the leaf are ignored. The leaf's key is used by the caller.
-  EXPECT_EQ(X509_V_OK, Verify(leaf.bad_key.get(), {root.valid.get()},
-                              {intermediate.valid.get()}, {}));
-  EXPECT_EQ(X509_V_OK, Verify(leaf.bad_key_type.get(), {root.valid.get()},
-                              {intermediate.valid.get()}, {}));
+  // Bad keys in the leaf are rejected.
+  EXPECT_EQ(X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY,
+            Verify(leaf.bad_key.get(), {root.valid.get()},
+                   {intermediate.valid.get()}, {}));
+  EXPECT_EQ(X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY,
+            Verify(leaf.bad_key_type.get(), {root.valid.get()},
+                   {intermediate.valid.get()}, {}));
 
   // At the time we go to verify signatures, it is possible that we have a
   // single-element certificate chain with a certificate that isn't self-signed.

--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -179,7 +179,7 @@ const char *X509_verify_cert_error_string(long err) {
       return "Invalid certificate verification context";
     case X509_V_ERR_STORE_LOOKUP:
       return "Issuer certificate lookup error";
-    case X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY:
+    case X509_R_UNABLE_TO_GET_CERTS_PUBLIC_KEY:
       return "Unable to get leaf certificate's public key";
 
     default:

--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -179,6 +179,8 @@ const char *X509_verify_cert_error_string(long err) {
       return "Invalid certificate verification context";
     case X509_V_ERR_STORE_LOOKUP:
       return "Issuer certificate lookup error";
+    case X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY:
+      return "Unable to get leaf certificate's public key";
 
     default:
       return "unknown certificate verification error";

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1432,10 +1432,10 @@ static int internal_verify(X509_STORE_CTX *ctx) {
   // has a public key we actually support. Otherwise
   // we shouldn't consider the certificate okay.
   //
-  // This covers situtations like invalid curves or points.
+  // This covers situations like invalid curves or points.
   EVP_PKEY *pkey = X509_get0_pubkey(xs);
   if(pkey == NULL) {
-    ctx->error = X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY;
+    ctx->error = X509_R_UNABLE_TO_GET_CERTS_PUBLIC_KEY;
     ctx->current_cert = xi;
     ok = 0;
     goto end;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1427,6 +1427,20 @@ static int internal_verify(X509_STORE_CTX *ctx) {
       xs = sk_X509_value(ctx->chain, n);
     }
   }
+
+  // Check that the final certificate subject (leaf)
+  // has a public key we actually support. Otherwise
+  // we shouldn't consider the certificate okay.
+  //
+  // This covers situtations like invalid curves or points.
+  EVP_PKEY *pkey = X509_get0_pubkey(xs);
+  if(pkey == NULL) {
+    ctx->error = X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY;
+    ctx->current_cert = xi;
+    ok = 0;
+    goto end;
+  }
+
   ok = 1;
 end:
   return ok;

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2736,7 +2736,7 @@ OPENSSL_EXPORT void X509_STORE_CTX_set_cert(X509_STORE_CTX *c, X509 *x);
 #define X509_V_ERR_EE_KEY_TOO_SMALL 68
 #define X509_V_ERR_CA_KEY_TOO_SMALL 69
 #define X509_V_ERR_CA_MD_TOO_WEAK 70
-#define X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY 71
+#define X509_R_UNABLE_TO_GET_CERTS_PUBLIC_KEY 71
 
 // X509_STORE_CTX_get_error, after |X509_verify_cert| returns, returns
 // |X509_V_OK| if verification succeeded or an |X509_V_ERR_*| describing why

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -2736,6 +2736,7 @@ OPENSSL_EXPORT void X509_STORE_CTX_set_cert(X509_STORE_CTX *c, X509 *x);
 #define X509_V_ERR_EE_KEY_TOO_SMALL 68
 #define X509_V_ERR_CA_KEY_TOO_SMALL 69
 #define X509_V_ERR_CA_MD_TOO_WEAK 70
+#define X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY 71
 
 // X509_STORE_CTX_get_error, after |X509_verify_cert| returns, returns
 // |X509_V_OK| if verification succeeded or an |X509_V_ERR_*| describing why
@@ -3086,7 +3087,7 @@ OPENSSL_EXPORT int X509_VERIFY_PARAM_add1_host(X509_VERIFY_PARAM *param,
 // X509_CHECK_FLAG_NO_WILDCARDS disables wildcard matching for DNS names.
 #define X509_CHECK_FLAG_NO_WILDCARDS 0x2
 
-// X509_CHECK_FLAG_NEVER_CHECK_SUBJECT constrains host name patterns passed to |X509_check_host|
+// X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS constrains host name patterns passed to |X509_check_host|
 // starting with '.' to only match a single label / subdomain.
 //
 // For example, by default the host name '.example.com' would match a certificate DNS name like

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -1586,6 +1586,9 @@ int SSL_alert_from_verify_result(long result) {
     case X509_V_ERR_INVALID_PURPOSE:
       return SSL_AD_UNSUPPORTED_CERTIFICATE;
 
+    case X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY:
+      return SSL_AD_UNSUPPORTED_CERTIFICATE;
+
     default:
       return SSL_AD_CERTIFICATE_UNKNOWN;
   }

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -1584,9 +1584,7 @@ int SSL_alert_from_verify_result(long result) {
       return SSL_AD_HANDSHAKE_FAILURE;
 
     case X509_V_ERR_INVALID_PURPOSE:
-      return SSL_AD_UNSUPPORTED_CERTIFICATE;
-
-    case X509_V_ERR_UNABLE_TO_DECODE_LEAF_PUBLIC_KEY:
+    case X509_R_UNABLE_TO_GET_CERTS_PUBLIC_KEY:
       return SSL_AD_UNSUPPORTED_CERTIFICATE;
 
     default:


### PR DESCRIPTION
OpenSSL's behavior when performing X509 certificate validation is to build the up certificate chain, verify the extensions of the constructed chain, etc, finally proceeding with handling the subjectPublicKeyInfo algorithm and parameters inheritance as appropriate through the chain when applicable per [rfc5280](https://www.rfc-editor.org/rfc/inline-errata/rfc5280.html). This process will cause OpenSSL to reject certificates when encountering public keys that it doesn't understand, for example unknown / unsupported EC curve names, invalid curve points etc. This includes intermediate and root certificates with such public keys (which would need to be usable to validate the issuer signatures on subjects in the chain etc), but also includes the leaf certificate as it's public key is parsed to determine if it inherits parameters etc.

For AWS-LC this parameter inheritance is not supported (as it was removed by BoringSSL from which we forked), particularly because for key types like EC we only support specific named curves and no custom parameters. So this step of key inheritance does not occur. This means that the certificate subject public keys are not used until validating the issuer signatures through the chain. Root and intermediate certificates with public keys that are not parseable / supported are then rejected at this step, except for the leaf certificate. There was a comment left by BoringSSL in the tests to indicate that the subject public key (for which the EVP_PKEY may be NULL if it was not parseable) is left to be validated by the caller invoking `X509_verify_cert`. This means that such a leaf certificate passes validated (correctly validated through the constructed chain, reasonably well formed etc), but still might not actually be useable. But such certificates would have never returned successfully by `X509_verify_cert` if using OpenSSL. This PR realigns AWS-LC to behave similarly to OpenSSL by checking the final leaf certificate for the user, and verifying that it contains a supported public key type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
