### PR TITLE
Simplify operating system randomnness inteface 

### DIFF
--- a/crypto/rand_extra/ccrandomgeneratebytes.c
+++ b/crypto/rand_extra/ccrandomgeneratebytes.c
@@ -26,8 +26,4 @@ void CRYPTO_sysrand(uint8_t *out, size_t requested) {
   }
 }
 
-void CRYPTO_sysrand_for_seed(uint8_t *out, size_t requested) {
-  CRYPTO_sysrand(out, requested);
-}
-
 #endif

--- a/crypto/rand_extra/deterministic.c
+++ b/crypto/rand_extra/deterministic.c
@@ -50,8 +50,4 @@ void CRYPTO_sysrand(uint8_t *out, size_t requested) {
   CRYPTO_chacha_20(out, out, requested, kZeroKey, nonce, 0);
 }
 
-void CRYPTO_sysrand_for_seed(uint8_t *out, size_t requested) {
-  CRYPTO_sysrand(out, requested);
-}
-
 #endif  // OPENSSL_RAND_DETERMINISTIC

--- a/crypto/rand_extra/getentropy.c
+++ b/crypto/rand_extra/getentropy.c
@@ -41,8 +41,4 @@ void CRYPTO_sysrand(uint8_t *out, size_t requested) {
   }
 }
 
-void CRYPTO_sysrand_for_seed(uint8_t *out, size_t requested) {
-  CRYPTO_sysrand(out, requested);
-}
-
 #endif

--- a/crypto/rand_extra/internal.h
+++ b/crypto/rand_extra/internal.h
@@ -21,9 +21,7 @@ extern "C" {
 #endif
 
 // Functions:
-// CRYPTO_init_sysrand
 // CRYPTO_sysrand
-// CRYPTO_sysrand_for_seed
 // CRYPTO_sysrand_if_available
 // are the operating system entropy source interface used in the randomness
 // generation implementation.
@@ -32,17 +30,11 @@ extern "C" {
 // system.
 OPENSSL_EXPORT void CRYPTO_sysrand(uint8_t *buf, size_t len);
 
-// CRYPTO_sysrand_for_seed fills |len| bytes at |buf| with entropy from the
-// operating system. It may draw from the |GRND_RANDOM| pool on Android,
-// depending on the vendor's configuration.
-OPENSSL_EXPORT void CRYPTO_sysrand_for_seed(uint8_t *buf, size_t len);
-
 #if defined(OPENSSL_RAND_URANDOM)
 // CRYPTO_sysrand_if_available fills |len| bytes at |buf| with entropy from the
 // operating system, or early /dev/urandom data, and returns 1, _if_ the entropy
-// pool is initialized or if getrandom() is not available and not in FIPS mode.
-// Otherwise it will not block and will instead fill |buf| with all zeros and
-// return 0.
+// pool is initialized or if getrandom() is not available. Otherwise it will not
+// block and will instead fill |buf| with all zeros and return 0.
 int CRYPTO_sysrand_if_available(uint8_t *buf, size_t len);
 #else
 OPENSSL_INLINE int CRYPTO_sysrand_if_available(uint8_t *buf, size_t len) {

--- a/crypto/rand_extra/internal.h
+++ b/crypto/rand_extra/internal.h
@@ -37,14 +37,6 @@ OPENSSL_EXPORT void CRYPTO_sysrand(uint8_t *buf, size_t len);
 // depending on the vendor's configuration.
 OPENSSL_EXPORT void CRYPTO_sysrand_for_seed(uint8_t *buf, size_t len);
 
-#if defined(OPENSSL_RAND_URANDOM) || defined(OPENSSL_RAND_WINDOWS)
-// CRYPTO_init_sysrand initializes long-lived resources needed to draw entropy
-// from the operating system.
-void CRYPTO_init_sysrand(void);
-#else
-OPENSSL_INLINE void CRYPTO_init_sysrand(void) {}
-#endif  // defined(OPENSSL_RAND_URANDOM) || defined(OPENSSL_RAND_WINDOWS)
-
 #if defined(OPENSSL_RAND_URANDOM)
 // CRYPTO_sysrand_if_available fills |len| bytes at |buf| with entropy from the
 // operating system, or early /dev/urandom data, and returns 1, _if_ the entropy

--- a/crypto/rand_extra/urandom.c
+++ b/crypto/rand_extra/urandom.c
@@ -463,13 +463,6 @@ void CRYPTO_sysrand(uint8_t *out, size_t requested) {
   }
 }
 
-void CRYPTO_sysrand_for_seed(uint8_t *out, size_t requested) {
-  if (!fill_with_entropy(out, requested, /*block=*/1, /*seed=*/1)) {
-    perror("entropy fill failed");
-    abort();
-  }
-}
-
 int CRYPTO_sysrand_if_available(uint8_t *out, size_t requested) {
   if (fill_with_entropy(out, requested, /*block=*/0, /*seed=*/0)) {
     return 1;

--- a/crypto/rand_extra/urandom.c
+++ b/crypto/rand_extra/urandom.c
@@ -455,10 +455,6 @@ static int fill_with_entropy(uint8_t *out, size_t len, int block, int seed) {
   return 1;
 }
 
-void CRYPTO_init_sysrand(void) {
-  CRYPTO_once(&initialize_random_flavor_once, init_random_flavor_once);
-}
-
 // CRYPTO_sysrand puts |requested| random bytes into |out|.
 void CRYPTO_sysrand(uint8_t *out, size_t requested) {
   if (!fill_with_entropy(out, requested, /*block=*/1, /*seed=*/0)) {

--- a/crypto/rand_extra/windows.c
+++ b/crypto/rand_extra/windows.c
@@ -84,9 +84,4 @@ void CRYPTO_sysrand(uint8_t *out, size_t requested) {
 }
 
 #endif  // WINAPI_PARTITION_APP && !WINAPI_PARTITION_DESKTOP
-
-void CRYPTO_sysrand_for_seed(uint8_t *out, size_t requested) {
-  CRYPTO_sysrand(out, requested);
-}
-
 #endif  // OPENSSL_RAND_WINDOWS

--- a/crypto/rand_extra/windows.c
+++ b/crypto/rand_extra/windows.c
@@ -37,8 +37,6 @@ OPENSSL_MSVC_PRAGMA(warning(pop))
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
     !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 
-void CRYPTO_init_sysrand(void) {}
-
 void CRYPTO_sysrand(uint8_t *out, size_t requested) {
   while (requested > 0) {
     ULONG output_bytes_this_pass = ULONG_MAX;
@@ -60,6 +58,7 @@ void CRYPTO_sysrand(uint8_t *out, size_t requested) {
 // See: https://learn.microsoft.com/en-us/windows/win32/seccng/processprng
 typedef BOOL (WINAPI *ProcessPrngFunction)(PBYTE pbData, SIZE_T cbData);
 static ProcessPrngFunction g_processprng_fn = NULL;
+static CRYPTO_once_t once = CRYPTO_ONCE_INIT;
 
 static void init_processprng(void) {
   HMODULE hmod = LoadLibraryW(L"bcryptprimitives");
@@ -72,13 +71,10 @@ static void init_processprng(void) {
   }
 }
 
-void CRYPTO_init_sysrand(void) {
-  static CRYPTO_once_t once = CRYPTO_ONCE_INIT;
-  CRYPTO_once(&once, init_processprng);
-}
-
 void CRYPTO_sysrand(uint8_t *out, size_t requested) {
-  CRYPTO_init_sysrand();
+
+  CRYPTO_once(&once, init_processprng);
+
   // On non-UWP configurations, use ProcessPrng instead of BCryptGenRandom
   // to avoid accessing resources that may be unavailable inside the
   // Chromium sandbox. See https://crbug.com/74242

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2988,7 +2988,6 @@ bool Speed(const std::vector<std::string> &args) {
 #endif
 #if defined(INTERNAL_TOOL)
        !SpeedRandom(CRYPTO_sysrand, "CRYPTO_sysrand", selected) ||
-       !SpeedRandom(CRYPTO_sysrand_for_seed, "CRYPTO_sysrand_for_seed", selected) ||
        !SpeedHashToCurve(selected) ||
        !SpeedTrustToken("TrustToken-Exp1-Batch1", TRUST_TOKEN_experiment_v1(), 1, selected) ||
        !SpeedTrustToken("TrustToken-Exp1-Batch10", TRUST_TOKEN_experiment_v1(), 10, selected) ||


### PR DESCRIPTION
### Description of changes: 

`CRYPTO_init_sysrand` is not necessary as a standalone function. `CRYPTO_pre_sandbox_init` were the only real consumer and that no longer uses it. That pre-sandbox configuration is now just handled by calling the high-level interface instead, that doesn't require remembering to add now features that have kernel touch points.

`CRYPTO_sysrand_for_seed` is always just a wrapper around `CRYPTO_sysrand` and, therefore, is redundant. `CRYPTO_sysrand_for_seed` was inherited from upstream that had other requirements. Mainly some FIPS stuff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
