### PR TITLE
Remove FIPS_ENTROPY_SOURCE_JITTER_CPU macro completely

### DIFF
--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -74,11 +74,7 @@ TEST(CryptoTest, Strndup) {
 }
 
 TEST(CryptoTest, aws_lc_assert_entropy_cpu_jitter) {
-#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
   ASSERT_EQ(1, FIPS_is_entropy_cpu_jitter());
-#else
-  ASSERT_EQ(0, FIPS_is_entropy_cpu_jitter());
-#endif
 }
 
 TEST(CryptoTest, OPENSSL_hexstr2buf) {

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -277,11 +277,9 @@ static void BORINGSSL_bcm_power_on_self_test(void) {
   OPENSSL_cpuid_setup();
 #endif
 
-#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
   if (jent_entropy_init()) {
     AWS_LC_FIPS_failure("CPU Jitter entropy RNG initialization failed");
   }
-#endif
 
 #if !defined(OPENSSL_ASAN)
   // Integrity tests cannot run under ASAN because it involves reading the full

--- a/crypto/fipsmodule/self_check/fips.c
+++ b/crypto/fipsmodule/self_check/fips.c
@@ -29,11 +29,7 @@ int FIPS_mode(void) {
 }
 
 int FIPS_is_entropy_cpu_jitter(void) {
-#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
   return 1;
-#else
-  return 0;
-#endif
 }
 
 int FIPS_mode_set(int on) { return on == FIPS_mode(); }

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2427,8 +2427,9 @@ static bool SpeedSelfTest(const std::string &selected) {
   results.Print("self-test");
   return true;
 }
+#endif
 
-#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
+#if AWSLC_API_VERSION >= 34
 static bool SpeedJitter(size_t chunk_size) {
   struct rand_data *jitter_ec = jent_entropy_collector_alloc(0, JENT_FORCE_FIPS);
 
@@ -2464,7 +2465,6 @@ static bool SpeedJitter(std::string selected) {
   }
   return true;
 }
-#endif
 #endif
 
 static bool SpeedDHcheck(size_t prime_bit_length) {
@@ -3011,11 +3011,11 @@ bool Speed(const std::vector<std::string> &args) {
     if (!SpeedSelfTest(selected)) {
       return false;
     }
-#if defined(FIPS_ENTROPY_SOURCE_JITTER_CPU)
+#endif
+#if AWSLC_API_VERSION >= 34
     if (!SpeedJitter(selected)) {
       return false;
     }
-#endif
 #endif
   }
 


### PR DESCRIPTION
### Description of changes: 

`FIPS_ENTROPY_SOURCE_JITTER_CPU` ain't necessary anymore. Axe it. In the speed tool, try to stay backwards compatible and buildable with OpenSSL and its derivatives.

There is still the cmake argument `ENABLE_FIPS_ENTROPY_CPU_JITTER` left. But I'm keeping that around for build backwards compatibility - for now. In theory, we should just remove that, since it would be a build error that is easy to correct. But... Trying to be a fair citizen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
