### PR TITLE
Display X509 fingerprint after hash

### DIFF
--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -304,6 +304,14 @@ bool X509Tool(const args_list_t &args) {
       BIO_printf(output_bio.get(), "\n");
     }
 
+    if (subject_hash) {
+      BIO_printf(output_bio.get(), "%08x\n", X509_subject_name_hash(x509.get()));
+    }
+
+    if(subject_hash_old) {
+      BIO_printf(output_bio.get(), "%08x\n", X509_subject_name_hash_old(x509.get()));
+    }
+
     if (fingerprint) {
       unsigned int out_len;
       unsigned char md[EVP_MAX_MD_SIZE];
@@ -319,14 +327,6 @@ bool X509Tool(const args_list_t &args) {
         BIO_printf(output_bio.get(), "%02X%c", md[j], (j + 1 == (int)out_len)
                                                       ? '\n' : ':');
       }
-    }
-
-    if (subject_hash) {
-      BIO_printf(output_bio.get(), "%08x\n", X509_subject_name_hash(x509.get()));
-    }
-
-    if(subject_hash_old) {
-      BIO_printf(output_bio.get(), "%08x\n", X509_subject_name_hash_old(x509.get()));
     }
 
     if (dates) {

--- a/tool-openssl/x509_test.cc
+++ b/tool-openssl/x509_test.cc
@@ -474,6 +474,16 @@ TEST_F(X509ComparisonTest, X509ToolCompareFingerprintOpenSSL) {
   ASSERT_EQ(tool_output_str, openssl_output_str);
 }
 
+// Test against OpenSSL output "openssl x509 -in file -fingerprint -subject_hash -subject_hash_old"
+TEST_F(X509ComparisonTest, X509ToolCompareHashFingerprintOpenSSL) {
+  std::string tool_command = std::string(tool_executable_path)       + " x509 -subject_hash -fingerprint -noout -in " + in_path + " > " + out_path_tool;
+  std::string openssl_command = std::string(openssl_executable_path) + " x509 -subject_hash -fingerprint -noout -in " + in_path + " > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+
+  ASSERT_EQ(tool_output_str, openssl_output_str);
+}
+
 // Test against OpenSSL output "openssl x509 -in file -noout -subject -fingerprint"
 TEST_F(X509ComparisonTest, X509ToolCompareSubjectFingerprintOpenSSL) {
   std::string tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -noout -subject -fingerprint > " + out_path_tool;


### PR DESCRIPTION
### Description of changes: 
The X509 tool should output the has subject-hash before the fingerprint.

### Call-outs:
Previous output comparison:
```
❯ openssl x509 -subject_hash -fingerprint -noout -in test.pem
b7d05793
SHA1 Fingerprint=EC:B8:70:11:AA:0C:7F:45:0A:86:EE:A4:AA:CA:8A:81:84:9B:72:00

❯ ~/lib/AWS-LC-DEBUG-INSTALL/bin/openssl x509 -subject_hash -fingerprint -noout -in test.pem
SHA1 Fingerprint=EC:B8:70:11:AA:0C:7F:45:0A:86:EE:A4:AA:CA:8A:81:84:9B:72:00
b7d05793
```

### Testing:
With this change comparison:
```
❯ openssl x509 -subject_hash -fingerprint -noout -in test.pem
b7d05793
SHA1 Fingerprint=EC:B8:70:11:AA:0C:7F:45:0A:86:EE:A4:AA:CA:8A:81:84:9B:72:00

❯ ~/lib/AWS-LC-DEBUG-INSTALL/bin/openssl x509 -subject_hash -fingerprint -noout -in test.pem
b7d05793
SHA1 Fingerprint=EC:B8:70:11:AA:0C:7F:45:0A:86:EE:A4:AA:CA:8A:81:84:9B:72:00
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
