### PR TITLE
Prepare v1.52.1

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5296,7 +5296,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.52.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.52.1");
 }
 
 #else
@@ -5339,6 +5339,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.52.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.52.1");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.52.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.52.1"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Increase default salt from 8 to 16 bytes for PKCS#8 & PKCS#12 by @xnox in https://github.com/aws/aws-lc/pull/2409
* fix(nix): Make sure bssl is in the PATH; workaround nix build failure… by @dougch in https://github.com/aws/aws-lc/pull/2431
* Fix path-has-spaces test by @justsmth in https://github.com/aws/aws-lc/pull/2436
* Create pre-production stage for CI pipeline by @nhatnghiho in https://github.com/aws/aws-lc/pull/2282
* Fix CI cross-mingw by @justsmth in https://github.com/aws/aws-lc/pull/2437
* Display X509 fingerprint after hash by @justsmth in https://github.com/aws/aws-lc/pull/2444

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
