### PR TITLE
Update mlkem-native to v1

### DIFF
--- a/crypto/fipsmodule/ml_kem/META.yml
+++ b/crypto/fipsmodule/ml_kem/META.yml
@@ -1,5 +1,5 @@
 name: mlkem-native
 source: pq-code-package/mlkem-native.git
-branch: main
-commit: 20eb37de425a06aa90aa61e8ea9c80a07f1aca7f
-imported-at: 2025-05-09T07:09:16+0100
+branch: v1.0.0
+commit: 048fc2a7a7b4ba0ad4c989c1ac82491aa94d5bfa
+imported-at: 2025-06-04T13:38:24+0100

--- a/crypto/fipsmodule/ml_kem/ml_kem.c
+++ b/crypto/fipsmodule/ml_kem/ml_kem.c
@@ -5,8 +5,6 @@
 
 // Include level-independent code
 #define MLK_CONFIG_FILE "../mlkem_native_config.h"
-#define MLK_CONFIG_FIPS202_CUSTOM_HEADER "../fips202_glue.h"
-#define MLK_CONFIG_FIPS202X4_CUSTOM_HEADER "../fips202x4_glue.h"
 #define MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
 
 // MLKEM-512

--- a/crypto/fipsmodule/ml_kem/mlkem/common.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/common.h
@@ -46,7 +46,7 @@
 #define MLK_NAMESPACE_PREFIX_K \
   MLK_CONCAT(MLK_ADD_PARAM_SET(MLK_CONFIG_NAMESPACE_PREFIX), _)
 
-/* Functions are prefixed by MLK_CONFIG_NAMESPACE.
+/* Functions are prefixed by MLK_CONFIG_NAMESPACE_PREFIX.
  *
  * If multiple parameter sets are used, functions depending on the parameter
  * set are additionally prefixed with 512/768/1024. See config.h.
@@ -100,6 +100,7 @@
 #endif
 
 #if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)
+#include MLK_CONFIG_ARITH_BACKEND_FILE
 /* Include to enforce consistency of API and implementation,
  * and conduct sanity checks on the backend.
  *
@@ -108,10 +109,10 @@
 #if defined(MLK_CHECK_APIS) && !defined(__ASSEMBLER__)
 #include "native/api.h"
 #endif
-#include MLK_CONFIG_ARITH_BACKEND_FILE
 #endif /* MLK_CONFIG_USE_NATIVE_BACKEND_ARITH */
 
 #if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)
+#include MLK_CONFIG_FIPS202_BACKEND_FILE
 /* Include to enforce consistency of API and implementation,
  * and conduct sanity checks on the backend.
  *
@@ -120,7 +121,6 @@
 #if defined(MLK_CHECK_APIS) && !defined(__ASSEMBLER__)
 #include "fips202/native/api.h"
 #endif
-#include MLK_CONFIG_FIPS202_BACKEND_FILE
 #endif /* MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 
 #if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)

--- a/crypto/fipsmodule/ml_kem/mlkem/mlkem_native.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/mlkem_native.h
@@ -23,7 +23,7 @@
  *
  * # Examples
  *
- * See [examples/mlkem_native_as_code_package], [examples/multilevel_build], and
+ * See [examples/basic], [examples/multilevel_build], and
  * [examples/multilevel_build_native] for examples of how to use this header.
  *
  * # Usage

--- a/crypto/fipsmodule/ml_kem/mlkem/mlkem_native_bcm.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/mlkem_native_bcm.c
@@ -8,11 +8,6 @@
  *          Do not modify it directly.
  */
 
-/*
- * Monolithic compilation unit bundling all compilation units within
- * mlkem-native
- */
-
 /******************************************************************************
  *
  * Single compilation unit (SCU) for fixed-level build of mlkem-native
@@ -29,18 +24,21 @@
  * If you want an SCU build of mlkem-native with support for multiple security
  * levels, you need to include this file multiple times, and set
  * MLK_CONFIG_MULTILEVEL_WITH_SHARED and MLK_CONFIG_MULTILEVEL_NO_SHARED
- * appropriately. This is exemplified in examples/monolithic_build_multilevel.
+ * appropriately. This is exemplified in examples/monolithic_build_multilevel
+ * and examples/monolithic_build_multilevel_native.
  *
  * # Configuration
  *
- * - MLK_CONFIG_MONOBUILD_CUSTOM_FIPS202
+ * The following options from the mlkem-native configuration are relevant:
+ *
+ * - MLK_CONFIG_FIPS202_CUSTOM_HEADER
  *   Set this option if you use a custom FIPS202 implementation.
  *
- * - MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH
+ * - MLK_CONFIG_USE_NATIVE_BACKEND_ARITH
  *   Set this option if you want to include the native arithmetic backends
  *   in your build.
  *
- * - MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202
+ * - MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *   Set this option if you want to include the native FIPS202 backends
  *   in your build.
  *
@@ -54,11 +52,11 @@
  *
  * Example:
  * ```bash
- * unifdef -UMLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH mlkem_native_monobuild.c
+ * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native.c
  * ```
  */
 
-#include "sys.h"
+#include "common.h"
 
 #include "compress.c"
 #include "debug.c"
@@ -72,42 +70,20 @@
 
 
 
+/* Macro #undef's
+ *
+ * The following undefines macros from headers
+ * included by the source files imported above.
+ *
+ * This is to allow building and linking multiple builds
+ * of mlkem-native for varying parameter sets through concatenation
+ * of this file, as if the files had been compiled separately.
+ * If this is not relevant to you, you may remove the following.
+ */
+
 /*
  * Undefine macros from MLK_CONFIG_PARAMETER_SET-specific files
  */
-/* mlkem/common.h */
-#undef MLK_ADD_PARAM_SET
-#undef MLK_ASM_FN_SYMBOL
-#undef MLK_ASM_NAMESPACE
-#undef MLK_COMMON_H
-#undef MLK_CONCAT
-#undef MLK_CONCAT_
-#undef MLK_CONFIG_API_NAMESPACE_PREFIX
-#undef MLK_CONFIG_API_PARAMETER_SET
-#undef MLK_EMPTY_CU
-#undef MLK_EXTERNAL_API
-#undef MLK_FIPS202X4_HEADER_FILE
-#undef MLK_FIPS202_HEADER_FILE
-#undef MLK_INTERNAL_API
-#undef MLK_MULTILEVEL_BUILD
-#undef MLK_NAMESPACE
-#undef MLK_NAMESPACE_K
-#undef MLK_NAMESPACE_PREFIX
-#undef MLK_NAMESPACE_PREFIX_K
-/* mlkem/indcpa.h */
-#undef MLK_INDCPA_H
-#undef mlk_gen_matrix
-#undef mlk_indcpa_dec
-#undef mlk_indcpa_enc
-#undef mlk_indcpa_keypair_derand
-/* mlkem/kem.h */
-#undef MLK_CONFIG_API_NO_SUPERCOP
-#undef MLK_KEM_H
-#undef crypto_kem_dec
-#undef crypto_kem_enc
-#undef crypto_kem_enc_derand
-#undef crypto_kem_keypair
-#undef crypto_kem_keypair_derand
 /* mlkem/mlkem_native.h */
 #undef CRYPTO_BYTES
 #undef CRYPTO_CIPHERTEXTBYTES
@@ -148,7 +124,40 @@
 #undef crypto_kem_enc_derand
 #undef crypto_kem_keypair
 #undef crypto_kem_keypair_derand
-/* mlkem/params.h */
+/* mlkem/src/common.h */
+#undef MLK_ADD_PARAM_SET
+#undef MLK_ASM_FN_SYMBOL
+#undef MLK_ASM_NAMESPACE
+#undef MLK_COMMON_H
+#undef MLK_CONCAT
+#undef MLK_CONCAT_
+#undef MLK_CONFIG_API_NAMESPACE_PREFIX
+#undef MLK_CONFIG_API_PARAMETER_SET
+#undef MLK_EMPTY_CU
+#undef MLK_EXTERNAL_API
+#undef MLK_FIPS202X4_HEADER_FILE
+#undef MLK_FIPS202_HEADER_FILE
+#undef MLK_INTERNAL_API
+#undef MLK_MULTILEVEL_BUILD
+#undef MLK_NAMESPACE
+#undef MLK_NAMESPACE_K
+#undef MLK_NAMESPACE_PREFIX
+#undef MLK_NAMESPACE_PREFIX_K
+/* mlkem/src/indcpa.h */
+#undef MLK_INDCPA_H
+#undef mlk_gen_matrix
+#undef mlk_indcpa_dec
+#undef mlk_indcpa_enc
+#undef mlk_indcpa_keypair_derand
+/* mlkem/src/kem.h */
+#undef MLK_CONFIG_API_NO_SUPERCOP
+#undef MLK_KEM_H
+#undef crypto_kem_dec
+#undef crypto_kem_enc
+#undef crypto_kem_enc_derand
+#undef crypto_kem_keypair
+#undef crypto_kem_keypair_derand
+/* mlkem/src/params.h */
 #undef MLKEM_DU
 #undef MLKEM_DV
 #undef MLKEM_ETA1
@@ -177,7 +186,7 @@
 #undef MLKEM_SYMBYTES
 #undef MLKEM_UINT12_LIMIT
 #undef MLK_PARAMS_H
-/* mlkem/poly_k.h */
+/* mlkem/src/poly_k.h */
 #undef MLK_POLY_K_H
 #undef mlk_poly_compress_du
 #undef mlk_poly_compress_dv
@@ -201,7 +210,7 @@
 #undef mlk_polyvec_reduce
 #undef mlk_polyvec_tobytes
 #undef mlk_polyvec_tomont
-/* mlkem/sys.h */
+/* mlkem/src/sys.h */
 #undef MLK_ALIGN
 #undef MLK_ALIGN_UP
 #undef MLK_ALWAYS_INLINE
@@ -219,6 +228,7 @@
 #undef MLK_SYS_H
 #undef MLK_SYS_LITTLE_ENDIAN
 #undef MLK_SYS_PPC64LE
+#undef MLK_SYS_RISCV32
 #undef MLK_SYS_RISCV64
 #undef MLK_SYS_WINDOWS
 #undef MLK_SYS_X86_64
@@ -228,7 +238,7 @@
 /*
  * Undefine macros from MLK_CONFIG_PARAMETER_SET-generic files
  */
-/* mlkem/compress.h */
+/* mlkem/src/compress.h */
 #undef MLK_COMPRESS_H
 #undef mlk_poly_compress_d10
 #undef mlk_poly_compress_d11
@@ -242,7 +252,7 @@
 #undef mlk_poly_frommsg
 #undef mlk_poly_tobytes
 #undef mlk_poly_tomsg
-/* mlkem/debug.h */
+/* mlkem/src/debug.h */
 #undef MLK_DEBUG_H
 #undef mlk_assert
 #undef mlk_assert_abs_bound
@@ -251,7 +261,7 @@
 #undef mlk_assert_bound_2d
 #undef mlk_debug_check_assert
 #undef mlk_debug_check_bounds
-/* mlkem/poly.h */
+/* mlkem/src/poly.h */
 #undef MLK_INVNTT_BOUND
 #undef MLK_NTT_BOUND
 #undef MLK_POLY_H
@@ -262,15 +272,15 @@
 #undef mlk_poly_reduce
 #undef mlk_poly_sub
 #undef mlk_poly_tomont
-/* mlkem/randombytes.h */
+/* mlkem/src/randombytes.h */
 #undef MLK_RANDOMBYTES_H
-/* mlkem/sampling.h */
+/* mlkem/src/sampling.h */
 #undef MLK_SAMPLING_H
 #undef mlk_poly_cbd2
 #undef mlk_poly_cbd3
 #undef mlk_poly_rej_uniform
 #undef mlk_poly_rej_uniform_x4
-/* mlkem/symmetric.h */
+/* mlkem/src/symmetric.h */
 #undef MLK_SYMMETRIC_H
 #undef MLK_XOF_RATE
 #undef mlk_hash_g
@@ -290,11 +300,11 @@
 #undef mlk_xof_x4_init
 #undef mlk_xof_x4_release
 #undef mlk_xof_x4_squeezeblocks
-/* mlkem/verify.h */
+/* mlkem/src/verify.h */
 #undef MLK_USE_ASM_VALUE_BARRIER
 #undef MLK_VERIFY_H
 #undef mlk_ct_opt_blocker_u64
-/* mlkem/cbmc.h */
+/* mlkem/src/cbmc.h */
 #undef MLK_CBMC_H
 #undef __contract__
 #undef __loop__

--- a/crypto/fipsmodule/ml_kem/mlkem/poly.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/poly.c
@@ -9,7 +9,7 @@
  * - [NeonNTT]
  *   Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1
  *   Becker, Hwang, Kannwischer, Yang, Yang
- *   https://tches.iacr.org/index.php/TCHES/article/view/9295
+ *   https://eprint.iacr.org/2021/986
  *
  * - [REF]
  *   CRYSTALS-Kyber C reference implementation
@@ -283,12 +283,6 @@ MLK_INTERNAL_API
 void mlk_poly_mulcache_compute(mlk_poly_mulcache *x, const mlk_poly *a)
 {
   mlk_poly_mulcache_compute_native(x->coeffs, a->coeffs);
-  /*
-   * This bound is true for the AArch64 and AVX2 implementations,
-   * but not needed in the higher level bounds reasoning.
-   * It is thus omitted from the spec but checked here nonetheless.
-   */
-  mlk_assert_abs_bound(x, MLKEM_N / 2, MLKEM_Q);
 }
 #endif /* MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE */
 

--- a/crypto/fipsmodule/ml_kem/mlkem/poly.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/poly.h
@@ -44,7 +44,7 @@ typedef struct
 typedef struct
 {
   int16_t coeffs[MLKEM_N >> 1];
-} mlk_poly_mulcache;
+} MLK_ALIGN mlk_poly_mulcache;
 
 /*************************************************
  * Name:        mlk_cast_uint16_to_int16

--- a/crypto/fipsmodule/ml_kem/mlkem/poly_k.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/poly_k.c
@@ -14,7 +14,7 @@
  * - [NeonNTT]
  *   Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1
  *   Becker, Hwang, Kannwischer, Yang, Yang
- *   https://tches.iacr.org/index.php/TCHES/article/view/9295
+ *   https://eprint.iacr.org/2021/986
  *
  * - [REF]
  *   CRYSTALS-Kyber C reference implementation

--- a/crypto/fipsmodule/ml_kem/mlkem/sampling.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/sampling.c
@@ -262,7 +262,7 @@ static uint32_t mlk_load32_littleendian(const uint8_t x[4])
   return r;
 }
 
-/* Reference: `cbd2()` in the reference implementation @[REF]o. */
+/* Reference: `cbd2()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4])
 {
@@ -313,7 +313,7 @@ static uint32_t mlk_load24_littleendian(const uint8_t x[3])
   return r;
 }
 
-/* Reference: `cbd3()` in the reference implementation @[REF]o. */
+/* Reference: `cbd3()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4])
 {

--- a/crypto/fipsmodule/ml_kem/mlkem/sys.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/sys.h
@@ -48,6 +48,10 @@
 #define MLK_SYS_RISCV64
 #endif
 
+#if defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 32
+#define MLK_SYS_RISCV32
+#endif
+
 #if defined(_WIN32)
 #define MLK_SYS_WINDOWS
 #endif
@@ -67,6 +71,14 @@
 
 #if defined(MLK_FORCE_PPC64LE) && !defined(MLK_SYS_PPC64LE)
 #error "MLK_FORCE_PPC64LE is set, but we don't seem to be on a PPC64LE system."
+#endif
+
+#if defined(MLK_FORCE_RISCV64) && !defined(MLK_SYS_RISCV64)
+#error "MLK_FORCE_RISCV64 is set, but we don't seem to be on a RISCV64 system."
+#endif
+
+#if defined(MLK_FORCE_RISCV32) && !defined(MLK_SYS_RISCV32)
+#error "MLK_FORCE_RISCV32 is set, but we don't seem to be on a RISCV32 system."
 #endif
 
 /*

--- a/crypto/fipsmodule/ml_kem/mlkem_native_config.h
+++ b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
@@ -11,6 +11,11 @@
 // mlkem512*, mlkem768*, mlkem1024*.
 #define MLK_CONFIG_NAMESPACE_PREFIX mlkem
 
+// Replace mlkem-native's FIPS 202 headers with glue code to
+// AWS-LC's own FIPS 202 implementation.
+#define MLK_CONFIG_FIPS202_CUSTOM_HEADER "../fips202_glue.h"
+#define MLK_CONFIG_FIPS202X4_CUSTOM_HEADER "../fips202x4_glue.h"
+
 // Everything is built in a single CU, so both internal and external
 // mlkem-native API can have internal linkage.
 #define MLK_CONFIG_INTERNAL_API_QUALIFIER static


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

---------

This PR updates mlkem-native to v1.0.0.

The main change upstream was a file restructuring which moved `mlkem/*` to `mlkem/src/*`, and moved to `mlkem/*`  the SCU files `mlkem_native.[cS]` and the header `mlkem_native.h`. This necessitates minor changes in the importer, which were captured as an [AWS-LC patch](https://github.com/pq-code-package/mlkem-native/blob/321c30f/integration/awslc/awslc.patch) so that mlkem-native CI could continue to do AWS-LC integration tests. We don't forward the upstream layering here, but keep the original file structure. Also, we don't need the assembly SCU file yet.

Other than that, a new typo-checker upstream found some stale macro names in the documentation, which are now corrected. 

This PR first applies said patch, and then re-imports mlkem-native via `GITHUB_SHA=v1.0.0 importer.sh --force`.