### PR TITLE
Openssl tool output ordered by options provided

### DIFF
--- a/tool-openssl/x509_test.cc
+++ b/tool-openssl/x509_test.cc
@@ -459,15 +459,15 @@ TEST_F(X509ComparisonTest, X509ToolCompareSubjectOpenSSL) {
 
 // Test against OpenSSL output "openssl x509 -in file -fingerprint -subject_hash -subject_hash_old"
 TEST_F(X509ComparisonTest, X509ToolCompareFingerprintOpenSSL) {
-  std::string tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -fingerprint -subject_hash -subject_hash_old > " + out_path_tool;
-  std::string openssl_command = std::string(openssl_executable_path) + " x509 -in " + in_path + " -fingerprint -subject_hash -subject_hash_old > " + out_path_openssl;
+  std::string tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -subject_hash -subject_hash_old -fingerprint > " + out_path_tool;
+  std::string openssl_command = std::string(openssl_executable_path) + " x509 -in " + in_path + " -subject_hash -subject_hash_old -fingerprint > " + out_path_openssl;
 
   RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
 
   ASSERT_EQ(tool_output_str, openssl_output_str);
 
-  tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -fingerprint -subject_hash -subject_hash_old -out " + out_path_tool;
-  openssl_command = std::string(openssl_executable_path) + " x509 -in " + in_path + " -fingerprint -subject_hash -subject_hash_old -out " + out_path_openssl;
+  tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -subject_hash -subject_hash_old -fingerprint -out " + out_path_tool;
+  openssl_command = std::string(openssl_executable_path) + " x509 -in " + in_path + " -subject_hash -subject_hash_old -fingerprint -out " + out_path_openssl;
 
   RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
 


### PR DESCRIPTION
### Description of changes: 
Quick fix for failing Openssl tool output comparison test.

### Call-outs:
* The Openssl cli tool orders its output by the order that the parameters were specified.

### Testing:
Verified locally on macos.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
