### PR TITLE
Use max_cert_list for TLSv1.3 NewSessionTicket

### DIFF
--- a/ssl/handshake.cc
+++ b/ssl/handshake.cc
@@ -253,8 +253,9 @@ size_t ssl_max_handshake_message_len(const SSL *ssl) {
     return 1;
   }
 
-  // Clients must accept NewSessionTicket, so allow the default size.
-  return kMaxMessageLen;
+  // Clients must accept NewSessionTicket, so allow the default size or
+  // max_cert_list, whichever is greater.
+  return std::max(kMaxMessageLen, size_t{ssl->max_cert_list});
 }
 
 bool ssl_hash_message(SSL_HANDSHAKE *hs, const SSLMessage &msg) {


### PR DESCRIPTION
Certificate chains are transfered to the respective peer during the TLS handshake in the ServerHello, and sometimes the ClientHello, messages. These certificate chains can be of arbitrary size due to the number of intermediary issuers, and due to the extensions within the certificates.

To avoid resource exhaustion, BoringSSL limits the size of handshake messages, and rejects handshakes beyond a certain size. By default, the max message size is 16 KiB, but it can be increased with the SSL_CTX_set_cert_max_list setting.

This setting allows handshakes to complete with large certificate chains. However, a new problem surfaces for TLSv1.3 sessions. In TLSv1.3, session tickets (for supporting session resumption) are sent after the handshake in NewSessionTicket messages. BoringSSL currently encode the entire peer certificate chain (and some other things) in the session ticket, which means the size of the certificate chains influence the size of the corresponding NewSessionTicket.

To avoid breaking the TLS session on oversized NewSessionTicket messages, a BoringSSL server will refuse to send any NewSessionTicket that looks like it will be larger than 16 KiB. Unfortunately, this accounting is inaccurate and does not take the entire NewSessionTicket message into account. Thus, certificate chains that are a few hundred bytes smaller than 16 KiB can be accepted by a handshake when the max_cert_list setting has been increased, and by the NewSessionTicket size accounting, but then later fail on the client with an EXCESSIVE_MESSAGE_SIZE error, because ssl_max_handshake_message_len() returns the default 16 KiB, in turn because the handshake has finished and that causes it to ignore the configured max_cert_list.

This patch fixes this problem by making TLSv1.3 clients keep using the max_cert_list setting post-handshake, when it is greater than the default 16 KiB.

Change-Id: I17d689906a12079add4ad48b679508bc09a79f7c Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/78647
Reviewed-by: David Benjamin <davidben@google.com>
Reviewed-by: Adam Langley <agl@google.com>
Commit-Queue: Adam Langley <agl@google.com>
(cherry picked from commit cccf8525db8a57153d3cb3e22efed2db4b71a8ab)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
