### PR TITLE
Order tool output by options provided - x509

### DIFF
--- a/tool-openssl/CMakeLists.txt
+++ b/tool-openssl/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
     dgst.cc
     rehash.cc
     req.cc
+    ordered_args.cc
     rsa.cc
     s_client.cc
     tool.cc
@@ -92,6 +93,7 @@ if(BUILD_TESTING)
         rsa.cc
         rsa_test.cc
         s_client.cc
+        ordered_args.cc
         verify.cc
         verify_test.cc
         x509.cc
@@ -114,5 +116,6 @@ if(BUILD_TESTING)
     target_link_libraries(tool_openssl_test boringssl_gtest_main ssl crypto)
     target_include_directories(tool_openssl_test BEFORE PRIVATE ${AWSLC_BINARY_DIR}/symbol_prefix_include)
     add_dependencies(all_tests tool_openssl_test)
+    add_dependencies(tool_openssl_test openssl)
     set_test_location(tool_openssl_test)
 endif()

--- a/tool-openssl/internal.h
+++ b/tool-openssl/internal.h
@@ -1,13 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-#ifndef INTERNAL_H
-#define INTERNAL_H
+#ifndef TOOL_OPENSSL_INTERNAL_H
+#define TOOL_OPENSSL_INTERNAL_H
 
-#include "../tool/internal.h"
 #include <openssl/digest.h>
+#include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
+#include "../tool/internal.h"
 
 #if !defined(O_BINARY)
 #define O_BINARY 0
@@ -20,12 +22,13 @@ struct Tool {
   tool_func_t func;
 };
 
-bool IsNumeric(const std::string& str);
+bool IsNumeric(const std::string &str);
 
-X509* CreateAndSignX509Certificate();
-X509_CRL* createTestCRL();
+X509 *CreateAndSignX509Certificate();
+X509_CRL *createTestCRL();
 
-bool LoadPrivateKeyAndSignCertificate(X509 *x509, const std::string &signkey_path);
+bool LoadPrivateKeyAndSignCertificate(X509 *x509,
+                                      const std::string &signkey_path);
 
 tool_func_t FindTool(const std::string &name);
 tool_func_t FindTool(int argc, char **argv, int &starting_arg);
@@ -46,27 +49,76 @@ bssl::UniquePtr<X509_NAME> parse_subject_name(std::string &subject_string);
 
 
 // Rehash tool Utils
-typedef struct hash_entry_st {        // Represents a single certificate/CRL file
-  struct hash_entry_st *next;         // Links to next entry in same bucket
-  char *filename;                     // Actual filename
-  uint8_t digest[EVP_MAX_MD_SIZE];    // File's cryptographic digest
+typedef struct hash_entry_st {      // Represents a single certificate/CRL file
+  struct hash_entry_st *next;       // Links to next entry in same bucket
+  char *filename;                   // Actual filename
+  uint8_t digest[EVP_MAX_MD_SIZE];  // File's cryptographic digest
 } HASH_ENTRY;
 
-typedef struct bucket_st {    // Groups entries with same hash
-  struct bucket_st *next;     // Links to next bucket in hash table slot
-  HASH_ENTRY *first_entry;    // Start of entry list
-  HASH_ENTRY *last_entry;     // End of entry list
-  uint32_t hash;              // Hash value of the certificates/CRLs
-  uint16_t type;              // CERT or CRL Bucket
-  uint16_t num_entries;       // Count of entries
+typedef struct bucket_st {  // Groups entries with same hash
+  struct bucket_st *next;   // Links to next bucket in hash table slot
+  HASH_ENTRY *first_entry;  // Start of entry list
+  HASH_ENTRY *last_entry;   // End of entry list
+  uint32_t hash;            // Hash value of the certificates/CRLs
+  uint16_t type;            // CERT or CRL Bucket
+  uint16_t num_entries;     // Count of entries
 } BUCKET;
 
-enum Type {
-  TYPE_CERT=0, TYPE_CRL=1
-};
+enum Type { TYPE_CERT = 0, TYPE_CRL = 1 };
 void add_entry(enum Type type, uint32_t hash, const char *filename,
-                     const uint8_t *digest);
-BUCKET** get_table();
+               const uint8_t *digest);
+BUCKET **get_table();
 void cleanup_hash_table();
 
-#endif //INTERNAL_H
+// Ordered argument processing (specific to tool-openssl)
+namespace ordered_args {
+typedef std::vector<std::pair<std::string, std::string>> ordered_args_map_t;
+
+// Helper function to find an argument in the ordered args vector
+static inline bool HasArgument(const ordered_args_map_t &args,
+                               const std::string &arg_name) {
+  return std::find_if(
+             args.begin(), args.end(),
+             [&arg_name](const std::pair<std::string, std::string> &pair) {
+               return pair.first == arg_name;
+             }) != args.end();
+}
+
+// Helper function to count occurrences of an argument
+static inline size_t CountArgument(const ordered_args_map_t &args,
+                                   const std::string &arg_name) {
+  size_t count = 0;
+  for (const auto &pair : args) {
+    if (pair.first == arg_name) {
+      count++;
+    }
+  }
+  return count;
+}
+
+// Helper function to find an argument in the ordered args vector
+static inline ordered_args_map_t::const_iterator FindArg(
+    const ordered_args_map_t &args, const std::string &arg_name) {
+  return std::find_if(
+      args.begin(), args.end(),
+      [&arg_name](const std::pair<std::string, std::string> &pair) {
+        return pair.first == arg_name;
+      });
+}
+
+// Parse arguments in order of appearance
+bool ParseOrderedKeyValueArguments(ordered_args_map_t &out_args,
+                                   args_list_t &extra_args,
+                                   const args_list_t &args,
+                                   const argument_t *templates);
+
+// Get helpers for ordered arguments
+bool GetUnsigned(unsigned *out, const std::string &arg_name,
+                 unsigned default_value, const ordered_args_map_t &args);
+bool GetString(std::string *out, const std::string &arg_name,
+               std::string default_value, const ordered_args_map_t &args);
+bool GetBoolArgument(bool *out, const std::string &arg_name,
+                     const ordered_args_map_t &args);
+}  // namespace ordered_args
+
+#endif  // TOOL_OPENSSL_INTERNAL_H

--- a/tool-openssl/ordered_args.cc
+++ b/tool-openssl/ordered_args.cc
@@ -1,0 +1,134 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "internal.h"
+
+namespace ordered_args {
+
+bool ParseOrderedKeyValueArguments(ordered_args_map_t &out_args,
+                                   args_list_t &extra_args,
+                                   const args_list_t &args,
+                                   const argument_t *templates) {
+  out_args.clear();
+  extra_args.clear();
+
+  for (size_t i = 0; i < args.size(); i++) {
+    const std::string &arg = args[i];
+    const argument_t *templ = nullptr;
+    for (size_t j = 0; templates[j].name[0] != 0; j++) {
+      if (strcmp(arg.c_str(), templates[j].name) == 0) {
+        templ = &templates[j];
+        break;
+      }
+    }
+
+    if (templ == nullptr) {
+      if (::IsFlag(arg)) {
+        fprintf(stderr, "Unknown flag: %s\n", arg.c_str());
+        return false;
+      }
+      extra_args.push_back(arg);
+      continue;
+    }
+
+    // Check for duplicate arguments - allowed for order preservation
+    // but warn about it when debugging
+#ifndef NDEBUG
+    if (HasArgument(out_args, arg)) {
+      fprintf(stderr, "Warning: Duplicate argument: %s\n", arg.c_str());
+    }
+#endif
+
+    if (templ->type == kBooleanArgument) {
+      out_args.push_back(std::pair<std::string, std::string>(arg, ""));
+    } else {
+      if (i + 1 >= args.size()) {
+        fprintf(stderr, "Missing argument for option: %s\n", arg.c_str());
+        return false;
+      }
+      out_args.push_back(std::pair<std::string, std::string>(arg, args[++i]));
+    }
+  }
+
+  for (size_t j = 0; templates[j].name[0] != 0; j++) {
+    const argument_t *templ = &templates[j];
+    if (templ->type == kRequiredArgument &&
+        !HasArgument(out_args, templ->name)) {
+      fprintf(stderr, "Missing value for required argument: %s\n", templ->name);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool GetUnsigned(unsigned *out, const std::string &arg_name,
+                 unsigned default_value, const ordered_args_map_t &args) {
+  auto it = FindArg(args, arg_name);
+  if (it == args.end()) {
+    *out = default_value;
+    return true;
+  }
+
+  const std::string &value = it->second;
+  if (value.empty()) {
+    return false;
+  }
+
+  errno = 0;
+  char *endptr = nullptr;
+  unsigned long int num = strtoul(value.c_str(), &endptr, 10);
+  if (num == ULONG_MAX && errno == ERANGE) {
+    return false;
+  }
+  if (endptr == nullptr || endptr == value.c_str()) {
+    return false;
+  }
+  if (*endptr != 0 || num > UINT_MAX) {
+    return false;
+  }
+  *out = static_cast<unsigned>(num);
+
+  return true;
+}
+
+bool GetString(std::string *out, const std::string &arg_name,
+               std::string default_value, const ordered_args_map_t &args) {
+  auto it = FindArg(args, arg_name);
+  if (it == args.end()) {
+    *out = default_value;
+    return true;
+  }
+
+  const std::string &value = it->second;
+  *out = value;
+
+  return true;
+}
+
+bool GetBoolArgument(bool *out, const std::string &arg_name,
+                     const ordered_args_map_t &args) {
+  auto it = FindArg(args, arg_name);
+  if (it == args.end()) {
+    // Boolean argument not found
+    *out = false;
+  } else {
+    *out = true;
+  }
+
+  // amazonq-ignore-next-line
+  return true;
+}
+
+}  // namespace ordered_args

--- a/tool-openssl/ordered_args.cc
+++ b/tool-openssl/ordered_args.cc
@@ -127,7 +127,6 @@ bool GetBoolArgument(bool *out, const std::string &arg_name,
     *out = true;
   }
 
-  // amazonq-ignore-next-line
   return true;
 }
 

--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -132,7 +132,7 @@ static bool handleSubject(X509 *x509, BIO *output_bio) {
 }
 
 static bool handleFingerprint(X509 *x509, BIO *output_bio) {
-  unsigned int out_len;
+  unsigned int out_len = 0;
   unsigned char md[EVP_MAX_MD_SIZE];
   const EVP_MD *digest = EVP_sha1();
 
@@ -171,7 +171,7 @@ static bool handleCheckend(X509 *x509, BIO *output_bio,
   bssl::UniquePtr<ASN1_TIME> current_time(
       ASN1_TIME_set(nullptr, std::time(nullptr)));
   ASN1_TIME *end_time = X509_getm_notAfter(x509);
-  int days_left, seconds_left;
+  int days_left = 0, seconds_left = 0;
 
   if (!ASN1_TIME_diff(&days_left, &seconds_left, current_time.get(),
                       end_time)) {

--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-#include <openssl/x509.h>
 #include <openssl/pem.h>
 #include <openssl/rsa.h>
-#include "internal.h"
+#include <openssl/x509.h>
+#include <algorithm>
 #include <ctime>
+#include <iostream>
 #include <string>
+#include "internal.h"
 
 static const argument_t kArguments[] = {
   { "-help", kBooleanArgument, "Display option summary" },
@@ -42,12 +44,16 @@ static bool WriteSignedCertificate(X509 *x509, bssl::UniquePtr<BIO> &output_bio,
   return true;
 }
 
-static bool isCharUpperCaseEqual(char a, char b) {
-  return ::toupper(a) ==  ::toupper(b);
-}
-
 static bool isStringUpperCaseEqual(const std::string &a, const std::string &b) {
-  return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(), isCharUpperCaseEqual);
+  if (a.size() != b.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (::toupper(a[i]) != ::toupper(b[i])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 bool LoadPrivateKeyAndSignCertificate(X509 *x509, const std::string &signkey_path) {
@@ -75,37 +81,177 @@ bool IsNumeric(const std::string& str) {
   return !str.empty() && std::all_of(str.begin(), str.end(), ::isdigit);
 }
 
+static bool handleModulus(X509 *x509, BIO *output_bio) {
+  bssl::UniquePtr<EVP_PKEY> pkey(X509_get_pubkey(x509));
+  if (!pkey) {
+    fprintf(stderr, "Error: unable to load public key from certificate\n");
+    return false;
+  }
+
+  if (EVP_PKEY_base_id(pkey.get()) != EVP_PKEY_RSA) {
+    fprintf(stderr, "Error: public key is not an RSA key\n");
+    return false;
+  }
+
+  const RSA *rsa = EVP_PKEY_get0_RSA(pkey.get());
+  if (!rsa) {
+    fprintf(stderr, "Error: unable to load RSA key\n");
+    return false;
+  }
+
+  const BIGNUM *n = RSA_get0_n(rsa);
+  if (!n) {
+    fprintf(stderr, "Error: unable to load modulus\n");
+    return false;
+  }
+
+  char *hex_modulus = BN_bn2hex(n);
+  if (!hex_modulus) {
+    fprintf(stderr, "Error: unable to convert modulus to hex\n");
+    return false;
+  }
+
+  for (char *p = hex_modulus; *p; ++p) {
+    *p = toupper(*p);
+  }
+  BIO_printf(output_bio, "Modulus=%s\n", hex_modulus);
+  OPENSSL_free(hex_modulus);
+  return true;
+}
+
+static bool handleSubject(X509 *x509, BIO *output_bio) {
+  X509_NAME *subject_name = X509_get_subject_name(x509);
+  if (!subject_name) {
+    fprintf(stderr, "Error: unable to obtain subject from certificate\n");
+    return false;
+  }
+  BIO_printf(output_bio, "subject=");
+  X509_NAME_print_ex(output_bio, subject_name, 0, XN_FLAG_ONELINE);
+  BIO_printf(output_bio, "\n");
+  return true;
+}
+
+static bool handleFingerprint(X509 *x509, BIO *output_bio) {
+  unsigned int out_len;
+  unsigned char md[EVP_MAX_MD_SIZE];
+  const EVP_MD *digest = EVP_sha1();
+
+  if (!X509_digest(x509, digest, md, &out_len)) {
+    fprintf(stderr, "Error: unable to obtain digest\n");
+    return false;
+  }
+
+  BIO_printf(output_bio, "%s Fingerprint=", OBJ_nid2sn(EVP_MD_type(digest)));
+  for (int j = 0; j < (int)out_len; j++) {
+    BIO_printf(output_bio, "%02X%c", md[j],
+               (j + 1 == (int)out_len) ? '\n' : ':');
+  }
+  return true;
+}
+
+static bool handleDates(X509 *x509, BIO *output_bio) {
+  BIO_printf(output_bio, "notBefore=");
+  ASN1_TIME_print(output_bio, X509_get_notBefore(x509));
+  BIO_printf(output_bio, "\n");
+  BIO_printf(output_bio, "notAfter=");
+  ASN1_TIME_print(output_bio, X509_get_notAfter(x509));
+  BIO_printf(output_bio, "\n");
+  return true;
+}
+
+static bool handleCheckend(X509 *x509, BIO *output_bio,
+                           const std::string &arg_value) {
+  if (!IsNumeric(arg_value)) {
+    fprintf(stderr,
+            "Error: '-checkend' option must include a non-negative integer\n");
+    return false;
+  }
+
+  unsigned checkend_val = std::stoul(arg_value);
+  bssl::UniquePtr<ASN1_TIME> current_time(
+      ASN1_TIME_set(nullptr, std::time(nullptr)));
+  ASN1_TIME *end_time = X509_getm_notAfter(x509);
+  int days_left, seconds_left;
+
+  if (!ASN1_TIME_diff(&days_left, &seconds_left, current_time.get(),
+                      end_time)) {
+    fprintf(stderr, "Error: failed to calculate time difference\n");
+    return false;
+  }
+
+  BIO_printf(output_bio, "%s\n",
+             (days_left * 86400 + seconds_left) < static_cast<int>(checkend_val)
+                 ? "Certificate will expire"
+                 : "Certificate will not expire");
+  return true;
+}
+
+static bool ProcessArgument(const std::string &arg_name,
+                            const std::string &arg_value, X509 *x509,
+                            bssl::UniquePtr<BIO> &output_bio,
+                            bool *dates_processed) {
+  if (arg_name == "-modulus") {
+    return handleModulus(x509, output_bio.get());
+  }
+  if (arg_name == "-text") {
+    X509_print(output_bio.get(), x509);
+    return true;
+  }
+  if (arg_name == "-subject") {
+    return handleSubject(x509, output_bio.get());
+  }
+  if (arg_name == "-subject_hash") {
+    const uint32_t hash_value = X509_subject_name_hash(x509);
+    BIO_printf(output_bio.get(), "%08x\n", hash_value);
+    return true;
+  }
+  if (arg_name == "-subject_hash_old") {
+    const uint32_t hash_value = X509_subject_name_hash_old(x509);
+    BIO_printf(output_bio.get(), "%08x\n", hash_value);
+    return true;
+  }
+  if (arg_name == "-fingerprint") {
+    return handleFingerprint(x509, output_bio.get());
+  }
+  if (arg_name == "-dates") {
+    *dates_processed = true;
+    return handleDates(x509, output_bio.get());
+  }
+  if (arg_name == "-enddate" && !*dates_processed) {
+    BIO_printf(output_bio.get(), "notAfter=");
+    ASN1_TIME_print(output_bio.get(), X509_get_notAfter(x509));
+    BIO_printf(output_bio.get(), "\n");
+    return true;
+  }
+  if (arg_name == "-checkend") {
+    return handleCheckend(x509, output_bio.get(), arg_value);
+  }
+  return true;
+}
+
 // Map arguments using tool/args.cc
 bool X509Tool(const args_list_t &args) {
-  args_map_t parsed_args;
+  // Use the ordered argument list instead of the standard map
+  ordered_args::ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }
 
-  std::string in_path, out_path, signkey_path, checkend_str, days_str, inform;
-  bool noout = false, modulus = false, dates = false, req = false, help = false,
-  text = false, subject = false, fingerprint = false, enddate = false,
-  subject_hash = false, subject_hash_old = false;
-  std::unique_ptr<unsigned> checkend, days;
+  std::string in_path, out_path, signkey_path, days_str, inform;
+  bool noout = false, dates = false, req = false, help = false;
+  std::unique_ptr<unsigned> days;
 
-  GetBoolArgument(&help, "-help", parsed_args);
-  GetString(&in_path, "-in", "", parsed_args);
-  GetBoolArgument(&req, "-req", parsed_args);
-  GetString(&signkey_path, "-signkey", "", parsed_args);
-  GetString(&out_path, "-out", "", parsed_args);
-  GetBoolArgument(&noout, "-noout", parsed_args);
-  GetBoolArgument(&dates, "-dates", parsed_args);
-  GetBoolArgument(&modulus, "-modulus", parsed_args);
-  GetBoolArgument(&subject, "-subject", parsed_args);
-  GetBoolArgument(&subject_hash, "-subject_hash", parsed_args);
-  GetBoolArgument(&subject_hash_old, "-subject_hash_old", parsed_args);
-  GetBoolArgument(&fingerprint, "-fingerprint", parsed_args);
-  GetBoolArgument(&text, "-text", parsed_args);
-  GetString(&inform, "-inform", "", parsed_args);
-  GetBoolArgument(&enddate, "-enddate", parsed_args);
+  ordered_args::GetBoolArgument(&help, "-help", parsed_args);
+  ordered_args::GetString(&in_path, "-in", "", parsed_args);
+  ordered_args::GetBoolArgument(&req, "-req", parsed_args);
+  ordered_args::GetString(&signkey_path, "-signkey", "", parsed_args);
+  ordered_args::GetString(&out_path, "-out", "", parsed_args);
+  ordered_args::GetBoolArgument(&noout, "-noout", parsed_args);
+  ordered_args::GetBoolArgument(&dates, "-dates", parsed_args);
+  ordered_args::GetString(&inform, "-inform", "", parsed_args);
 
   // Display x509 tool option summary
   if (help) {
@@ -117,7 +263,10 @@ bool X509Tool(const args_list_t &args) {
     output_bio.reset(BIO_new_fp(stdout, BIO_NOCLOSE));
   } else {
     output_bio.reset(BIO_new(BIO_s_file()));
-    BIO_write_filename(output_bio.get(), out_path.c_str());
+    if (1 != BIO_write_filename(output_bio.get(), out_path.c_str())) {
+      fprintf(stderr, "Error: unable to write to '%s'\n", out_path.c_str());
+      return false;
+    }
   }
 
   // -req must include -signkey
@@ -127,32 +276,22 @@ bool X509Tool(const args_list_t &args) {
   }
 
   // Check for mutually exclusive options
-  if (req && (dates || parsed_args.count("-checkend"))){
+  if (req && (dates || ordered_args::HasArgument(parsed_args, "-checkend"))) {
     fprintf(stderr, "Error: '-req' option cannot be used with '-dates' and '-checkend' options\n");
     return false;
   }
-  if (!signkey_path.empty() && (dates || parsed_args.count("-checkend"))){
+  if (!signkey_path.empty() && (dates || ordered_args::HasArgument(parsed_args, "-checkend"))) {
     fprintf(stderr, "Error: '-signkey' option cannot be used with '-dates' and '-checkend' options\n");
     return false;
   }
-  if (parsed_args.count("-days") && (dates || parsed_args.count("-checkend"))){
+  if (ordered_args::HasArgument(parsed_args, "-days") && (dates || ordered_args::HasArgument(parsed_args, "-checkend"))) {
     fprintf(stderr, "Error: '-days' option cannot be used with '-dates' and '-checkend' options\n");
     return false;
   }
 
-  // Check that -checkend argument is valid, int >=0
-  if (parsed_args.count("-checkend")) {
-    checkend_str = parsed_args["-checkend"];
-    if (!IsNumeric(checkend_str)) {
-      fprintf(stderr, "Error: '-checkend' option must include a non-negative integer\n");
-      return false;
-    }
-    checkend.reset(new unsigned(std::stoul(checkend_str)));
-  }
-
   // Check that -days argument is valid, int > 0
-  if (parsed_args.count("-days")) {
-    days_str = parsed_args["-days"];
+  if (ordered_args::HasArgument(parsed_args, "-days")) {
+    ordered_args::GetString(&days_str, "-days", "", parsed_args);
     if (!IsNumeric(days_str) || std::stoul(days_str) == 0) {
       fprintf(stderr, "Error: '-days' option must include a positive integer\n");
       return false;
@@ -253,111 +392,21 @@ bool X509Tool(const args_list_t &args) {
       return false;
     }
 
-    if (modulus) {
-      bssl::UniquePtr<EVP_PKEY> pkey(X509_get_pubkey(x509.get()));
-      if (!pkey) {
-        fprintf(stderr, "Error: unable to load public key from certificate\n");
+    // Process arguments in the order they were provided
+    bool dates_processed = false;
+    for (const auto &arg_pair : parsed_args) {
+      const std::string &arg_name = arg_pair.first;
+      const std::string &arg_value = arg_pair.second;
+
+      // Skip non-output arguments
+      if (arg_name == "-in" || arg_name == "-out" || arg_name == "-inform" || 
+          arg_name == "-signkey" || arg_name == "-days" || arg_name == "-req" ||
+          arg_name == "-noout" || arg_name == "-help") {
+        continue;
+      }
+
+      if (!ProcessArgument(arg_name, arg_value, x509.get(), output_bio, &dates_processed)) {
         return false;
-      }
-
-      if (EVP_PKEY_base_id(pkey.get()) == EVP_PKEY_RSA) {
-        const RSA *rsa = EVP_PKEY_get0_RSA(pkey.get());
-        if (!rsa) {
-          fprintf(stderr, "Error: unable to load RSA key\n");
-          return false;
-        }
-        const BIGNUM *n = RSA_get0_n(rsa);
-        if (!n) {
-          fprintf(stderr, "Error: unable to load modulus\n");
-          return false;
-        }
-        char *hex_modulus = BN_bn2hex(n);
-        if (!hex_modulus) {
-          fprintf(stderr, "Error: unable to convert modulus to hex\n");
-          return false;
-        }
-        for (char *p = hex_modulus; *p; ++p) {
-          *p = toupper(*p);
-        }
-        BIO_printf(output_bio.get(), "Modulus=%s\n", hex_modulus);
-
-        OPENSSL_free(hex_modulus);
-      } else {
-        fprintf(stderr, "Error: public key is not an RSA key\n");
-        return false;
-      }
-    }
-
-    if(text) {
-      X509_print(output_bio.get(), x509.get());
-    }
-
-    if (subject) {
-      X509_NAME *subject_name = X509_get_subject_name(x509.get());
-      if (!subject_name) {
-        fprintf(stderr, "Error: unable to obtain subject from certificate\n");
-        return false;
-      }
-
-      BIO_printf(output_bio.get(), "subject=");
-      X509_NAME_print_ex(output_bio.get(), subject_name, 0, XN_FLAG_ONELINE);
-      BIO_printf(output_bio.get(), "\n");
-    }
-
-    if (subject_hash) {
-      BIO_printf(output_bio.get(), "%08x\n", X509_subject_name_hash(x509.get()));
-    }
-
-    if(subject_hash_old) {
-      BIO_printf(output_bio.get(), "%08x\n", X509_subject_name_hash_old(x509.get()));
-    }
-
-    if (fingerprint) {
-      unsigned int out_len;
-      unsigned char md[EVP_MAX_MD_SIZE];
-      const EVP_MD *digest = EVP_sha1();
-
-      if (!X509_digest(x509.get(), digest, md, &out_len)) {
-        fprintf(stderr, "Error: unable to obtain digest\n");
-        return false;
-      }
-      BIO_printf(output_bio.get(), "%s Fingerprint=",
-                 OBJ_nid2sn(EVP_MD_type(digest)));
-      for (int j = 0; j < (int)out_len; j++) {
-        BIO_printf(output_bio.get(), "%02X%c", md[j], (j + 1 == (int)out_len)
-                                                      ? '\n' : ':');
-      }
-    }
-
-    if (dates) {
-      BIO_printf(output_bio.get(), "notBefore=");
-      ASN1_TIME_print(output_bio.get(), X509_get_notBefore(x509.get()));
-      BIO_printf(output_bio.get(), "\n");
-
-      BIO_printf(output_bio.get(), "notAfter=");
-      ASN1_TIME_print(output_bio.get(), X509_get_notAfter(x509.get()));
-      BIO_printf(output_bio.get(), "\n");
-    }
-
-    if (!dates && enddate) {
-      BIO_printf(output_bio.get(), "notAfter=");
-      ASN1_TIME_print(output_bio.get(), X509_get_notAfter(x509.get()));
-      BIO_printf(output_bio.get(), "\n");
-    }
-
-    if (checkend) {
-      bssl::UniquePtr<ASN1_TIME> current_time(ASN1_TIME_set(nullptr, std::time(nullptr)));
-      ASN1_TIME *end_time = X509_getm_notAfter(x509.get());
-      int days_left, seconds_left;
-      if (!ASN1_TIME_diff(&days_left, &seconds_left, current_time.get(), end_time)) {
-        fprintf(stderr, "Error: failed to calculate time difference\n");
-        return false;
-      }
-
-      if ((days_left * 86400 + seconds_left) < static_cast<int>(*checkend)) {
-        BIO_printf(output_bio.get(), "Certificate will expire\n");
-      } else {
-        BIO_printf(output_bio.get(), "Certificate will not expire\n");
       }
     }
 
@@ -367,7 +416,7 @@ bool X509Tool(const args_list_t &args) {
       }
     }
 
-    if (!noout && !checkend) {
+    if (!noout && !ordered_args::HasArgument(parsed_args, "-checkend")) {
       if (!WriteSignedCertificate(x509.get(), output_bio, out_path)) {
         return false;
       }

--- a/tool-openssl/x509_test.cc
+++ b/tool-openssl/x509_test.cc
@@ -475,6 +475,23 @@ TEST_F(X509ComparisonTest, X509ToolCompareFingerprintOpenSSL) {
 }
 
 // Test against OpenSSL output "openssl x509 -in file -fingerprint -subject_hash -subject_hash_old"
+TEST_F(X509ComparisonTest, X509ToolCompareReorderedFingerprintOpenSSL) {
+  std::string tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -subject_hash -fingerprint -subject_hash_old > " + out_path_tool;
+  std::string openssl_command = std::string(openssl_executable_path) + " x509 -in " + in_path + " -subject_hash -fingerprint -subject_hash_old > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+
+  ASSERT_EQ(tool_output_str, openssl_output_str);
+
+  tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -fingerprint -subject_hash_old -subject_hash -out " + out_path_tool;
+  openssl_command = std::string(openssl_executable_path) + " x509 -in " + in_path + " -fingerprint -subject_hash_old -subject_hash -out " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+
+  ASSERT_EQ(tool_output_str, openssl_output_str);
+}
+
+// Test against OpenSSL output "openssl x509 -in file -fingerprint -subject_hash -subject_hash_old"
 TEST_F(X509ComparisonTest, X509ToolCompareHashFingerprintOpenSSL) {
   std::string tool_command = std::string(tool_executable_path)       + " x509 -subject_hash -fingerprint -noout -in " + in_path + " > " + out_path_tool;
   std::string openssl_command = std::string(openssl_executable_path) + " x509 -subject_hash -fingerprint -noout -in " + in_path + " > " + out_path_openssl;
@@ -499,6 +516,31 @@ TEST_F(X509ComparisonTest, X509ToolCompareSubjectFingerprintOpenSSL) {
 
   tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -noout -subject -fingerprint -out " + out_path_tool;
   openssl_command = std::string(openssl_executable_path) + " x509 -in " + in_path + " -noout -subject -fingerprint -out " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+
+  // OpenSSL master and versions <= 3.2 have differences in spacing for the subject field
+  tool_output_str = normalize_subject(tool_output_str);
+  openssl_output_str = normalize_subject(openssl_output_str);
+
+  ASSERT_EQ(tool_output_str, openssl_output_str);
+}
+
+// Test against OpenSSL output "openssl x509 -in file -noout -subject -fingerprint"
+TEST_F(X509ComparisonTest, X509ToolCompareReorderedSubjectFingerprintOpenSSL) {
+  std::string tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -noout -fingerprint -subject > " + out_path_tool;
+  std::string openssl_command = std::string(openssl_executable_path) + " x509 -in " + in_path + " -noout -fingerprint -subject > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+
+  // OpenSSL master and versions <= 3.2 have differences in spacing for the subject field
+  tool_output_str = normalize_subject(tool_output_str);
+  openssl_output_str = normalize_subject(openssl_output_str);
+
+  ASSERT_EQ(tool_output_str, openssl_output_str);
+
+  tool_command = std::string(tool_executable_path) + " x509 -in " + in_path + " -noout -fingerprint -subject -out " + out_path_tool;
+  openssl_command = std::string(openssl_executable_path) + " x509 -in " + in_path + " -noout -fingerprint -subject -out " + out_path_openssl;
 
   RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
 


### PR DESCRIPTION
### Context
* The OpenSSL CLI tool orders its output based on the order of the options passed to it.
* Our tool was using a static order that was unaffected by the order of the options.

### Description of changes: 
* This change adds an alternative suite of functions to parse options in a way that preserves their order.
* The new argument parser was integrated into the "X509" subcommand logic for the tool.

### Call-outs:
* The new parser still needs to be integrated with the other subcommands as well.

### Testing:
Added new tests that vary the order of the parameters provided.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
