### PR TITLE
Explicitly don't allow buffers aliasing in ctr-drbg implementation

### DIFF
--- a/crypto/fipsmodule/rand/ctrdrbg.c
+++ b/crypto/fipsmodule/rand/ctrdrbg.c
@@ -50,6 +50,12 @@ int CTR_DRBG_init(CTR_DRBG_STATE *drbg,
                   const uint8_t entropy[CTR_DRBG_ENTROPY_LEN],
                   const uint8_t *personalization, size_t personalization_len) {
   SET_DIT_AUTO_RESET;
+
+  if (buffers_alias(entropy, CTR_DRBG_ENTROPY_LEN,
+                    personalization, personalization_len)) {
+    return 0;
+  }
+
   // Section 10.2.1.3.1
   if (personalization_len > CTR_DRBG_ENTROPY_LEN) {
     return 0;
@@ -124,6 +130,12 @@ int CTR_DRBG_reseed(CTR_DRBG_STATE *drbg,
                     const uint8_t *additional_data,
                     size_t additional_data_len) {
   SET_DIT_AUTO_RESET;
+
+  if (buffers_alias(entropy, CTR_DRBG_ENTROPY_LEN,
+                    additional_data, additional_data_len)) {
+    return 0;
+  }
+
   // Section 10.2.1.4
   uint8_t entropy_copy[CTR_DRBG_ENTROPY_LEN];
 

--- a/crypto/fipsmodule/rand/ctrdrbg_test.cc
+++ b/crypto/fipsmodule/rand/ctrdrbg_test.cc
@@ -127,3 +127,21 @@ TEST(CTRDRBGTest, TestVectors) {
     EXPECT_EQ(Bytes(expected), Bytes(out));
   });
 }
+
+TEST(CTRDRBGTest, NoAlias) {
+  const uint8_t kSeed[CTR_DRBG_ENTROPY_LEN] = {0};
+  const uint8_t *kAliasEqual = kSeed;
+  const uint8_t kSeedOversized[CTR_DRBG_ENTROPY_LEN+10] = {0};
+  const uint8_t *kAliasOverlapping = &kSeedOversized[10];
+
+  CTR_DRBG_STATE drbg;
+  ASSERT_FALSE(CTR_DRBG_init(&drbg, kSeed, kAliasEqual, CTR_DRBG_ENTROPY_LEN));
+  ASSERT_FALSE(CTR_DRBG_init(&drbg, kSeedOversized, kAliasOverlapping, CTR_DRBG_ENTROPY_LEN));
+
+  ASSERT_TRUE(CTR_DRBG_init(&drbg, kSeed, nullptr, 0));
+
+  ASSERT_FALSE(CTR_DRBG_reseed(&drbg, kSeed, kAliasEqual, CTR_DRBG_ENTROPY_LEN));
+  ASSERT_FALSE(CTR_DRBG_reseed(&drbg, kSeedOversized, kAliasOverlapping, CTR_DRBG_ENTROPY_LEN));
+
+  CTR_DRBG_clear(&drbg);
+}

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -87,7 +87,7 @@ struct ctr_drbg_state_st {
 // CTR_DRBG_init initialises |*drbg| given |CTR_DRBG_ENTROPY_LEN| bytes of
 // entropy in |entropy| and, optionally, a personalization string up to
 // |CTR_DRBG_ENTROPY_LEN| bytes in length. It returns one on success and zero
-// on error.
+// on error. |entropy| and |personalization| must not alias.
 OPENSSL_EXPORT int CTR_DRBG_init(CTR_DRBG_STATE *drbg,
                                  const uint8_t entropy[CTR_DRBG_ENTROPY_LEN],
                                  const uint8_t *personalization,

--- a/include/openssl/ctrdrbg.h
+++ b/include/openssl/ctrdrbg.h
@@ -50,7 +50,8 @@ OPENSSL_EXPORT void CTR_DRBG_free(CTR_DRBG_STATE* state);
 
 // CTR_DRBG_reseed reseeds |drbg| given |CTR_DRBG_ENTROPY_LEN| bytes of entropy
 // in |entropy| and, optionally, up to |CTR_DRBG_ENTROPY_LEN| bytes of
-// additional data. It returns one on success or zero on error.
+// additional data. It returns one on success or zero on error. |entropy| and
+// |additional_data| must not alias.
 OPENSSL_EXPORT int CTR_DRBG_reseed(CTR_DRBG_STATE *drbg,
                                    const uint8_t entropy[CTR_DRBG_ENTROPY_LEN],
                                    const uint8_t *additional_data,


### PR DESCRIPTION
### Description of changes: 

In e.g. `CTR_DRBG_init` arguments `entropy` and `personalization` are effectively xor'd `entropy XOR personalization`. If the two arguments were to ever alias, the resulting XOR would be `0` and therefore predictable (if the aliasing would turn out to be predictable, of course).

This is theoretical, but prevent it explicitly anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
