### PR TITLE
Fix Ruby mainline and nginx CI

### DIFF
--- a/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x_integration/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-22.04_gcc-12x_integration/Dockerfile
@@ -5,6 +5,9 @@ FROM ubuntu-22.04:gcc-12x
 
 SHELL ["/bin/bash", "-c"]
 
+# Define Ruby version (used to build Ruby).
+ARG RUBY_VERSION=3.4.3
+
 RUN set -ex && \
     apt-get update && \
     apt-get -y --no-install-recommends upgrade && \
@@ -72,6 +75,15 @@ RUN set -ex && \
     uthash-dev \
     uuid-dev \
     vim-common && \
+    # Download and install Ruby using the version from ARG
+    cd /tmp && \
+    wget https://cache.ruby-lang.org/pub/ruby/$(echo ${RUBY_VERSION} | cut -d. -f1-2)/ruby-${RUBY_VERSION}.tar.gz && \
+    tar -xzf ruby-${RUBY_VERSION}.tar.gz && \
+    cd ruby-${RUBY_VERSION} && \
+    ./configure --disable-install-doc && \
+    make -j "$(nproc)" && \
+    make install && \
+    ruby -v && \
     pip3 install gcovr && \
     apt-get autoremove --purge -y && \
     apt-get clean && \

--- a/tests/ci/integration/nginx_patch/aws-lc-nginx.patch
+++ b/tests/ci/integration/nginx_patch/aws-lc-nginx.patch
@@ -1,7 +1,8 @@
-diff --color -Naur a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
---- a/src/event/ngx_event_openssl.h	2025-04-23 15:48:54.000000000 +0400
-+++ b/src/event/ngx_event_openssl.h	2025-04-26 21:53:15.697269418 +0400
-@@ -25,7 +25,7 @@
+diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
+index 9e68deb..f63d238 100644
+--- a/src/event/ngx_event_openssl.h
++++ b/src/event/ngx_event_openssl.h
+@@ -27,7 +27,7 @@
  #endif
  #include <openssl/evp.h>
  #if (NGX_QUIC)
@@ -10,22 +11,24 @@ diff --color -Naur a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl
  #include <openssl/hkdf.h>
  #include <openssl/chacha.h>
  #else
-diff --color -Naur a/src/event/quic/ngx_event_quic.c b/src/event/quic/ngx_event_quic.c
---- a/src/event/quic/ngx_event_quic.c	2025-04-23 15:48:54.000000000 +0400
-+++ b/src/event/quic/ngx_event_quic.c	2025-04-26 21:38:24.905884275 +0400
-@@ -970,7 +970,7 @@
-         return NGX_DECLINED;
-     }
+diff --git a/src/event/quic/ngx_event_quic.h b/src/event/quic/ngx_event_quic.h
+index d95d3d8..ef7cb0c 100644
+--- a/src/event/quic/ngx_event_quic.h
++++ b/src/event/quic/ngx_event_quic.h
+@@ -18,7 +18,7 @@
+ #elif (defined SSL_R_MISSING_QUIC_TRANSPORT_PARAMETERS_EXTENSION)
+ #define NGX_QUIC_QUICTLS_API                 1
  
--#if !defined (OPENSSL_IS_BORINGSSL)
-+#if !defined (OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
-     /* OpenSSL provides read keys for an application level before it's ready */
+-#elif (defined OPENSSL_IS_BORINGSSL || defined LIBRESSL_VERSION_NUMBER)
++#elif (defined OPENSSL_IS_BORINGSSL || defined LIBRESSL_VERSION_NUMBER || defined OPENSSL_IS_AWSLC)
+ #define NGX_QUIC_BORINGSSL_API               1
  
-     if (pkt->level == ssl_encryption_application && !c->ssl->handshaked) {
-diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic/ngx_event_quic_protection.c
---- a/src/event/quic/ngx_event_quic_protection.c	2025-04-23 15:48:54.000000000 +0400
-+++ b/src/event/quic/ngx_event_quic_protection.c	2025-04-26 22:30:58.506191433 +0400
-@@ -33,7 +33,7 @@
+ #else
+diff --git a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic/ngx_event_quic_protection.c
+index 885843d..90a1d98 100644
+--- a/src/event/quic/ngx_event_quic_protection.c
++++ b/src/event/quic/ngx_event_quic_protection.c
+@@ -33,7 +33,7 @@ static uint64_t ngx_quic_parse_pn(u_char **pos, ngx_int_t len, u_char *mask,
  
  static ngx_int_t ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out,
      const u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
@@ -34,7 +37,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
  static ngx_int_t ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out,
      const u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
  #endif
-@@ -58,7 +58,7 @@
+@@ -58,7 +58,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
      switch (id) {
  
      case TLS1_3_CK_AES_128_GCM_SHA256:
@@ -43,7 +46,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
          ciphers->c = EVP_aead_aes_128_gcm();
  #else
          ciphers->c = EVP_aes_128_gcm();
-@@ -69,7 +69,7 @@
+@@ -69,7 +69,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
          break;
  
      case TLS1_3_CK_AES_256_GCM_SHA384:
@@ -52,7 +55,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
          ciphers->c = EVP_aead_aes_256_gcm();
  #else
          ciphers->c = EVP_aes_256_gcm();
-@@ -80,12 +80,12 @@
+@@ -80,12 +80,12 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
          break;
  
      case TLS1_3_CK_CHACHA20_POLY1305_SHA256:
@@ -67,7 +70,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
          ciphers->hp = (const EVP_CIPHER *) EVP_aead_chacha20_poly1305();
  #else
          ciphers->hp = EVP_chacha20();
-@@ -94,7 +94,7 @@
+@@ -94,7 +94,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
          len = 32;
          break;
  
@@ -76,7 +79,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
      case TLS1_3_CK_AES_128_CCM_SHA256:
          ciphers->c = EVP_aes_128_ccm();
          ciphers->hp = EVP_aes_128_ctr();
-@@ -263,7 +263,7 @@
+@@ -263,7 +263,7 @@ static ngx_int_t
  ngx_hkdf_expand(u_char *out_key, size_t out_len, const EVP_MD *digest,
      const uint8_t *prk, size_t prk_len, const u_char *info, size_t info_len)
  {
@@ -85,7 +88,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
  
      if (HKDF_expand(out_key, out_len, digest, prk, prk_len, info, info_len)
          == 0)
-@@ -325,7 +325,7 @@
+@@ -325,7 +325,7 @@ ngx_hkdf_extract(u_char *out_key, size_t *out_len, const EVP_MD *digest,
      const u_char *secret, size_t secret_len, const u_char *salt,
      size_t salt_len)
  {
@@ -94,7 +97,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
  
      if (HKDF_extract(out_key, out_len, digest, secret, secret_len, salt,
                       salt_len)
-@@ -388,7 +388,7 @@
+@@ -388,7 +388,7 @@ ngx_quic_crypto_init(const ngx_quic_cipher_t *cipher, ngx_quic_secret_t *s,
      ngx_quic_md_t *key, ngx_int_t enc, ngx_log_t *log)
  {
  
@@ -103,7 +106,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
      EVP_AEAD_CTX  *ctx;
  
      ctx = EVP_AEAD_CTX_new(cipher, key->data, key->len,
-@@ -448,7 +448,7 @@
+@@ -448,7 +448,7 @@ static ngx_int_t
  ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
      ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log)
  {
@@ -112,7 +115,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
      if (EVP_AEAD_CTX_open(s->ctx, out->data, &out->len, out->len, nonce,
                            s->iv.len, in->data, in->len, ad->data, ad->len)
          != 1)
-@@ -468,7 +468,7 @@
+@@ -468,7 +468,7 @@ ngx_int_t
  ngx_quic_crypto_seal(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
      ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log)
  {
@@ -121,7 +124,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
      if (EVP_AEAD_CTX_seal(s->ctx, out->data, &out->len, out->len, nonce,
                            s->iv.len, in->data, in->len, ad->data, ad->len)
          != 1)
-@@ -484,7 +484,7 @@
+@@ -484,7 +484,7 @@ ngx_quic_crypto_seal(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
  }
  
  
@@ -130,7 +133,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
  
  static ngx_int_t
  ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out,
-@@ -563,7 +563,7 @@
+@@ -563,7 +563,7 @@ void
  ngx_quic_crypto_cleanup(ngx_quic_secret_t *s)
  {
      if (s->ctx) {
@@ -139,7 +142,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
          EVP_AEAD_CTX_free(s->ctx);
  #else
          EVP_CIPHER_CTX_free(s->ctx);
-@@ -579,7 +579,7 @@
+@@ -579,7 +579,7 @@ ngx_quic_crypto_hp_init(const EVP_CIPHER *cipher, ngx_quic_secret_t *s,
  {
      EVP_CIPHER_CTX  *ctx;
  
@@ -148,7 +151,7 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
      if (cipher == (EVP_CIPHER *) EVP_aead_chacha20_poly1305()) {
          /* no EVP interface */
          s->hp_ctx = NULL;
-@@ -615,7 +615,7 @@
+@@ -615,7 +615,7 @@ ngx_quic_crypto_hp(ngx_quic_secret_t *s, u_char *out, u_char *in,
  
      ctx = s->hp_ctx;
  
@@ -157,10 +160,11 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.c b/src/event/quic
      uint32_t         cnt;
  
      if (ctx == NULL) {
-diff --color -Naur a/src/event/quic/ngx_event_quic_protection.h b/src/event/quic/ngx_event_quic_protection.h
---- a/src/event/quic/ngx_event_quic_protection.h	2025-04-23 15:48:54.000000000 +0400
-+++ b/src/event/quic/ngx_event_quic_protection.h	2025-04-26 21:55:34.479043252 +0400
-@@ -24,7 +24,7 @@
+diff --git a/src/event/quic/ngx_event_quic_protection.h b/src/event/quic/ngx_event_quic_protection.h
+index fddc608..85cc7f0 100644
+--- a/src/event/quic/ngx_event_quic_protection.h
++++ b/src/event/quic/ngx_event_quic_protection.h
+@@ -22,7 +22,7 @@
  #define NGX_QUIC_MAX_MD_SIZE          48
  
  
@@ -169,42 +173,37 @@ diff --color -Naur a/src/event/quic/ngx_event_quic_protection.h b/src/event/quic
  #define ngx_quic_cipher_t             EVP_AEAD
  #define ngx_quic_crypto_ctx_t         EVP_AEAD_CTX
  #else
-diff --color -Naur a/src/event/quic/ngx_event_quic_ssl.c b/src/event/quic/ngx_event_quic_ssl.c
---- a/src/event/quic/ngx_event_quic_ssl.c	2025-04-23 15:48:54.000000000 +0400
-+++ b/src/event/quic/ngx_event_quic_ssl.c	2025-04-26 22:38:34.152015187 +0400
-@@ -11,6 +11,7 @@
- 
- 
- #if defined OPENSSL_IS_BORINGSSL                                              \
-+    || defined OPENSSL_IS_AWSLC                                               \
-     || defined LIBRESSL_VERSION_NUMBER                                        \
-     || NGX_QUIC_OPENSSL_COMPAT
- #define NGX_QUIC_BORINGSSL_API   1
-@@ -583,7 +584,7 @@
-         return NGX_ERROR;
+diff --git a/src/event/quic/ngx_event_quic_ssl.c b/src/event/quic/ngx_event_quic_ssl.c
+index e961c80..0ffdcff 100644
+--- a/src/event/quic/ngx_event_quic_ssl.c
++++ b/src/event/quic/ngx_event_quic_ssl.c
+@@ -968,7 +968,7 @@ ngx_quic_init_connection(ngx_connection_t *c)
      }
+ #endif
  
 -#ifdef OPENSSL_IS_BORINGSSL
 +#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
      if (SSL_set_quic_early_data_context(ssl_conn, p, clen) == 0) {
-         ngx_log_error(NGX_LOG_INFO, c->log, 0,
+         ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
                        "quic SSL_set_quic_early_data_context() failed");
-diff --color -Naur a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
---- a/src/http/ngx_http_request.c	2025-04-23 15:48:54.000000000 +0400
-+++ b/src/http/ngx_http_request.c	2025-04-26 21:38:47.476172719 +0400
-@@ -935,7 +935,7 @@
+diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
+index ceac8d3..e00f523 100644
+--- a/src/http/ngx_http_request.c
++++ b/src/http/ngx_http_request.c
+@@ -935,7 +935,7 @@ ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
      sscf = ngx_http_get_module_srv_conf(cscf->ctx, ngx_http_ssl_module);
  
  #if (defined TLS1_3_VERSION                                                   \
 -     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL)
-+     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL && !defined OPENSSL_IS_AWSLC) 
++     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL && !defined OPENSSL_IS_AWSLC)
  
      /*
       * SSL_SESSION_get0_hostname() is only available in OpenSSL 1.1.1+,
-diff --color -Naur a/src/stream/ngx_stream_ssl_module.c b/src/stream/ngx_stream_ssl_module.c
---- a/src/stream/ngx_stream_ssl_module.c	2025-04-23 15:48:54.000000000 +0400
-+++ b/src/stream/ngx_stream_ssl_module.c	2025-04-26 21:55:53.449285719 +0400
-@@ -592,7 +592,7 @@
+diff --git a/src/stream/ngx_stream_ssl_module.c b/src/stream/ngx_stream_ssl_module.c
+index 2f1b996..538cdca 100644
+--- a/src/stream/ngx_stream_ssl_module.c
++++ b/src/stream/ngx_stream_ssl_module.c
+@@ -592,7 +592,7 @@ ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
      sscf = ngx_stream_get_module_srv_conf(cscf->ctx, ngx_stream_ssl_module);
  
  #if (defined TLS1_3_VERSION                                                   \


### PR DESCRIPTION
### Issues:
Resolves `V1795618378` & `V1795619787`

### Description of changes: 
1. Ruby's mainline CI was broken due to the required Ruby version to build Ruby was upgraded to be at least 3.1. This updates the docker image to reflect the necessary change.
2. nginx patch was broken due to this commit changing the quic API layer: https://github.com/nginx/nginx/commit/e561f7dbcfc27f5f648e5151de0796e691cbc1b0

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
