### PR TITLE
Remove unused Windows afunix.h

### DIFF
--- a/crypto/bio/bio_socket_test.cc
+++ b/crypto/bio/bio_socket_test.cc
@@ -574,7 +574,7 @@ TEST_P(BIODgramTest, SocketDatagramSetPeer) {
     GTEST_SKIP() << "IPv6 not supported";
     return;
   }
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && defined(AWS_LC_HAS_AF_UNIX)
   if (addr_family == AF_UNIX) {
     // Wine (is not an emulator) doesn't properly support Unix domain sockets
     GTEST_SKIP() << "Unix domain sockets not supported";

--- a/crypto/bio/dgram.c
+++ b/crypto/bio/dgram.c
@@ -10,9 +10,6 @@
 #include <stddef.h>
 #if defined(OPENSSL_WINDOWS)
 typedef SSIZE_T ssize_t;
-#if !defined(__MINGW32__)
-#include <afunix.h>
-#endif
 #else
 #include <netinet/in.h>
 #include <sys/socket.h>


### PR DESCRIPTION
### Issues:
Addresses P247622553

### Description of changes: 
On Windows `AF_UNIX` is not used, so `#include <afunix.h>` is not needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
