### PR TITLE
Revert "Rework memory BIOs and implement BIO_seek (2nd try) (#2433)"

### DIFF
--- a/crypto/bio/bio_mem.c
+++ b/crypto/bio/bio_mem.c
@@ -65,16 +65,10 @@
 
 #include "../internal.h"
 
-typedef struct bio_buf_mem_st {
-  struct buf_mem_st *buf;   /* allocated buffer */
-  size_t read_off;          /* read pointer offset from current buffer position */
-} BIO_BUF_MEM;
-
 
 BIO *BIO_new_mem_buf(const void *buf, ossl_ssize_t len) {
   BIO *ret;
   BUF_MEM *b;
-  BIO_BUF_MEM *bbm;
 
   if (!buf && len != 0) {
     OPENSSL_PUT_ERROR(BIO, BIO_R_NULL_PARAMETER);
@@ -88,8 +82,7 @@ BIO *BIO_new_mem_buf(const void *buf, ossl_ssize_t len) {
     return NULL;
   }
 
-  bbm = (BIO_BUF_MEM *)ret->ptr;
-  b = bbm->buf;
+  b = (BUF_MEM *)ret->ptr;
   // BIO_FLAGS_MEM_RDONLY ensures |b->data| is not written to.
   b->data = (void *)buf;
   b->length = size;
@@ -106,25 +99,19 @@ BIO *BIO_new_mem_buf(const void *buf, ossl_ssize_t len) {
 }
 
 static int mem_new(BIO *bio) {
-  BIO_BUF_MEM *bbm = OPENSSL_zalloc(sizeof(*bbm));
+  BUF_MEM *b;
 
-  if (bbm == NULL) {
-    return 0;
-  }
-
-  bbm->buf = BUF_MEM_new();
-  if (bbm->buf == NULL) {
-    OPENSSL_free(bbm);
+  b = BUF_MEM_new();
+  if (b == NULL) {
     return 0;
   }
 
   // |shutdown| is used to store the close flag: whether the BIO has ownership
   // of the BUF_MEM.
-  bbm->read_off = 0;
   bio->shutdown = 1;
   bio->init = 1;
   bio->num = -1;
-  bio->ptr = (char *)bbm;
+  bio->ptr = (char *)b;
 
   return 1;
 }
@@ -134,33 +121,13 @@ static int mem_free(BIO *bio) {
     return 1;
   }
 
-  BIO_BUF_MEM *bbm = (BIO_BUF_MEM *)bio->ptr;
-  BUF_MEM *b = bbm->buf;
-
+  BUF_MEM *b = (BUF_MEM *)bio->ptr;
   if (bio->flags & BIO_FLAGS_MEM_RDONLY) {
     b->data = NULL;
   }
   BUF_MEM_free(b);
   bio->ptr = NULL;
-
-  OPENSSL_free(bbm);
   return 1;
-}
-
-static void mem_buf_sync(BIO *bio) {
-  if (bio->init != 0 && bio->ptr != NULL) {
-    BIO_BUF_MEM *bbm = (BIO_BUF_MEM *) bio->ptr;
-    BUF_MEM *b = bbm->buf;
-
-    if (b->data != NULL) {
-      if (bio->flags & BIO_FLAGS_MEM_RDONLY) {
-        b->data += bbm->read_off;
-      } else {
-        OPENSSL_memmove(b->data, &b->data[bbm->read_off], b->length);
-      }
-      bbm->read_off = 0;
-    }
-  }
 }
 
 static int mem_read(BIO *bio, char *out, int outl) {
@@ -169,18 +136,20 @@ static int mem_read(BIO *bio, char *out, int outl) {
     return 0;
   }
 
-  BIO_BUF_MEM *bbm = (BIO_BUF_MEM *) bio->ptr;
-  BUF_MEM *b = bbm->buf;
-
+  BUF_MEM *b = bio->ptr;
   int ret = outl;
   if ((size_t)ret > b->length) {
     ret = (int)b->length;
   }
 
   if (ret > 0) {
-    OPENSSL_memcpy(out, &b->data[bbm->read_off], ret);
+    OPENSSL_memcpy(out, b->data, ret);
     b->length -= ret;
-    bbm->read_off += ret;
+    if (bio->flags & BIO_FLAGS_MEM_RDONLY) {
+      b->data += ret;
+    } else {
+      OPENSSL_memmove(b->data, &b->data[ret], b->length);
+    }
   } else if (b->length == 0) {
     ret = bio->num;
     if (ret != 0) {
@@ -201,11 +170,7 @@ static int mem_write(BIO *bio, const char *in, int inl) {
     return -1;
   }
 
-  BIO_BUF_MEM *bbm = (BIO_BUF_MEM *) bio->ptr;
-  BUF_MEM *b = bbm->buf;
-
-  mem_buf_sync(bio);
-
+  BUF_MEM *b = bio->ptr;
   if (!BUF_MEM_append(b, in, inl)) {
     return -1;
   }
@@ -221,21 +186,16 @@ static int mem_gets(BIO *bio, char *buf, int size) {
 
   // The buffer size includes space for the trailing NUL, so we can read at most
   // one fewer byte.
-  BIO_BUF_MEM *bbm = (BIO_BUF_MEM *) bio->ptr;
-  BUF_MEM *b = bbm->buf;
+  BUF_MEM *b = bio->ptr;
   int ret = size - 1;
   if ((size_t)ret > b->length) {
     ret = (int)b->length;
   }
 
   // Stop at the first newline.
-  if (b->data != NULL) {
-    char *readp = &b->data[bbm->read_off];
-
-    const char *newline = OPENSSL_memchr(readp, '\n', ret);
-    if (newline != NULL) {
-      ret = (int)(newline - readp + 1);
-    }
+  const char *newline = OPENSSL_memchr(b->data, '\n', ret);
+  if (newline != NULL) {
+    ret = (int)(newline - b->data + 1);
   }
 
   ret = mem_read(bio, buf, ret);
@@ -248,45 +208,20 @@ static int mem_gets(BIO *bio, char *buf, int size) {
 static long mem_ctrl(BIO *bio, int cmd, long num, void *ptr) {
   long ret = 1;
 
-  BIO_BUF_MEM *bbm = (BIO_BUF_MEM *) bio->ptr;
-  BUF_MEM *b = bbm->buf;
+  BUF_MEM *b = (BUF_MEM *)bio->ptr;
 
   switch (cmd) {
     case BIO_CTRL_RESET:
       if (b->data != NULL) {
         // For read only case reset to the start again
         if (bio->flags & BIO_FLAGS_MEM_RDONLY) {
-          b->data -= b->max - b->length - bbm->read_off;
+          b->data -= b->max - b->length;
           b->length = b->max;
         } else {
           OPENSSL_cleanse(b->data, b->max);
           b->length = 0;
         }
-        bbm->read_off = 0;
-      } else {
-        ret = -1;
       }
-      break;
-    case BIO_C_FILE_SEEK:
-      if (b->data == NULL || num < 0 || (size_t)num > b->max) {
-        ret = -1;
-        break;
-      }
-
-      if (bio->flags & BIO_FLAGS_MEM_RDONLY) {
-        b->data -= b->max - b->length - bbm->read_off;
-        b->length = b->max - num;
-      } else {
-        if ((size_t)num > bbm->read_off + b->length) {
-          ret = -1;
-          break;
-        }
-
-        b->length = (b->length + bbm->read_off) - num;
-      }
-
-      bbm->read_off = num;
-      ret = num;
       break;
     case BIO_CTRL_EOF:
       ret = (long)(b->length == 0);
@@ -298,7 +233,7 @@ static long mem_ctrl(BIO *bio, int cmd, long num, void *ptr) {
       ret = (long)b->length;
       if (ptr != NULL) {
         char **pptr = ptr;
-        *pptr = (b->data != NULL) ? &b->data[bbm->read_off] : NULL;
+        *pptr = b->data;
       }
       break;
     case BIO_C_SET_BUF_MEM:
@@ -308,7 +243,6 @@ static long mem_ctrl(BIO *bio, int cmd, long num, void *ptr) {
       break;
     case BIO_C_GET_BUF_MEM_PTR:
       if (ptr != NULL) {
-        mem_buf_sync(bio);
         BUF_MEM **pptr = ptr;
         *pptr = b;
       }
@@ -348,15 +282,12 @@ const BIO_METHOD *BIO_s_mem(void) { return &mem_method; }
 
 int BIO_mem_contents(const BIO *bio, const uint8_t **out_contents,
                      size_t *out_len) {
+  const BUF_MEM *b;
   if (!bio || bio->method != &mem_method) {
     return 0;
   }
 
-  BIO_BUF_MEM *bbm = (BIO_BUF_MEM *) bio->ptr;
-  const BUF_MEM *b = bbm->buf;
-
-  mem_buf_sync((BIO *)bio);
-
+  b = (BUF_MEM *)bio->ptr;
   if (out_contents != NULL) {
     *out_contents = (uint8_t *)b->data;
   }

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -247,30 +247,17 @@ TEST(BIOTest, ReadASN1) {
 
 TEST(BIOTest, MemReadOnly) {
   // A memory BIO created from |BIO_new_mem_buf| is a read-only buffer.
-  static const char kData[] = "abcdefghijklmno\npqrs";
+  static const char kData[] = "abcdefghijklmno";
   bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(kData, strlen(kData)));
   ASSERT_TRUE(bio);
-
-  auto check_bio_contents = [&](Bytes b) {
-    char *contents = nullptr;
-    long len_l = BIO_get_mem_data(bio.get(), &contents);
-    ASSERT_GE(len_l, 0);
-    EXPECT_EQ(Bytes(contents, len_l), b);
-
-    const uint8_t *contents_c = nullptr;
-    size_t len = 0;
-    ASSERT_TRUE(BIO_mem_contents(bio.get(), &contents_c, &len));
-    EXPECT_EQ(Bytes(contents_c, len), b);
-
-    BUF_MEM *buf = nullptr;
-    ASSERT_EQ(BIO_get_mem_ptr(bio.get(), &buf), 1);
-    EXPECT_EQ(Bytes(buf->data, buf->length), b);
-  };
 
   // Writing to read-only buffers should fail.
   EXPECT_EQ(BIO_write(bio.get(), kData, strlen(kData)), -1);
 
-  check_bio_contents(Bytes(kData));
+  const uint8_t *contents;
+  size_t len;
+  ASSERT_TRUE(BIO_mem_contents(bio.get(), &contents, &len));
+  EXPECT_EQ(Bytes(contents, len), Bytes(kData));
   EXPECT_EQ(BIO_eof(bio.get()), 0);
 
   // Read less than the whole buffer.
@@ -278,28 +265,26 @@ TEST(BIOTest, MemReadOnly) {
   int ret = BIO_read(bio.get(), buf, sizeof(buf));
   ASSERT_GT(ret, 0);
   EXPECT_EQ(Bytes(buf, ret), Bytes("abcdef"));
-  check_bio_contents(Bytes("ghijklmno\npqrs"));
+
+  ASSERT_TRUE(BIO_mem_contents(bio.get(), &contents, &len));
+  EXPECT_EQ(Bytes(contents, len), Bytes("ghijklmno"));
   EXPECT_EQ(BIO_eof(bio.get()), 0);
 
   ret = BIO_read(bio.get(), buf, sizeof(buf));
   ASSERT_GT(ret, 0);
   EXPECT_EQ(Bytes(buf, ret), Bytes("ghijkl"));
-  check_bio_contents(Bytes("mno\npqrs"));
-  EXPECT_EQ(BIO_eof(bio.get()), 0);
 
-  // Read stops at newline
-  ret = BIO_gets(bio.get(), buf, sizeof(buf));
-  ASSERT_GT(ret, 0);
-  EXPECT_EQ(Bytes(buf, ret), Bytes("mno\n"));
-  check_bio_contents(Bytes("pqrs"));
+  ASSERT_TRUE(BIO_mem_contents(bio.get(), &contents, &len));
+  EXPECT_EQ(Bytes(contents, len), Bytes("mno"));
   EXPECT_EQ(BIO_eof(bio.get()), 0);
 
   // Read the remainder of the buffer.
   ret = BIO_read(bio.get(), buf, sizeof(buf));
   ASSERT_GT(ret, 0);
-  EXPECT_EQ(Bytes(buf, ret), Bytes("pqrs"));
-  EXPECT_EQ(BIO_eof(bio.get()), 1);
-  check_bio_contents(Bytes(""));
+  EXPECT_EQ(Bytes(buf, ret), Bytes("mno"));
+
+  ASSERT_TRUE(BIO_mem_contents(bio.get(), &contents, &len));
+  EXPECT_EQ(Bytes(contents, len), Bytes(""));
   EXPECT_EQ(BIO_eof(bio.get()), 1);
 
   // By default, reading from a consumed read-only buffer returns EOF.
@@ -312,32 +297,6 @@ TEST(BIOTest, MemReadOnly) {
   EXPECT_EQ(BIO_set_mem_eof_return(bio.get(), -1), 1);
   EXPECT_EQ(BIO_read(bio.get(), buf, sizeof(buf)), -1);
   EXPECT_TRUE(BIO_should_read(bio.get()));
-
-  // Rewind buffer when buffer pointer aligns with read pointer
-  ret = BIO_seek(bio.get(), 3);
-  ASSERT_EQ(ret, 3);
-  check_bio_contents(Bytes("defghijklmno\npqrs"));
-  EXPECT_EQ(BIO_eof(bio.get()), 0);
-
-  // Rewind buffer when buffer pointer does not align with read pointer
-  EXPECT_GT(BIO_read(bio.get(), buf, sizeof(buf)), 0);
-  ret = BIO_seek(bio.get(), 4);
-  ASSERT_EQ(ret, 4);
-  check_bio_contents(Bytes("efghijklmno\npqrs"));
-  EXPECT_EQ(BIO_eof(bio.get()), 0);
-
-  // Reset buffer when buffer pointer aligns with read pointer
-  ret = BIO_reset(bio.get());
-  ASSERT_EQ(ret, 1);
-  check_bio_contents(Bytes(kData));
-  EXPECT_EQ(BIO_eof(bio.get()), 0);
-
-  // Reset buffer when buffer pointer does not align with read pointer
-  EXPECT_GT(BIO_read(bio.get(), buf, sizeof(buf)), 0);
-  ret = BIO_reset(bio.get());
-  ASSERT_EQ(ret, 1);
-  check_bio_contents(Bytes(kData));
-  EXPECT_EQ(BIO_eof(bio.get()), 0);
 
   // Read exactly the right number of bytes, to test the boundary condition is
   // correct.
@@ -355,17 +314,17 @@ TEST(BIOTest, MemWritable) {
   ASSERT_TRUE(bio);
 
   auto check_bio_contents = [&](Bytes b) {
-    char *contents = nullptr;
-    long len_l = BIO_get_mem_data(bio.get(), &contents);
+    const uint8_t *contents;
+    size_t len;
+    ASSERT_TRUE(BIO_mem_contents(bio.get(), &contents, &len));
+    EXPECT_EQ(Bytes(contents, len), b);
+
+    char *contents_c;
+    long len_l = BIO_get_mem_data(bio.get(), &contents_c);
     ASSERT_GE(len_l, 0);
-    EXPECT_EQ(Bytes(contents, len_l), b);
+    EXPECT_EQ(Bytes(contents_c, len_l), b);
 
-    const uint8_t *contents_c = nullptr;
-    size_t len = 0;
-    ASSERT_TRUE(BIO_mem_contents(bio.get(), &contents_c, &len));
-    EXPECT_EQ(Bytes(contents_c, len), b);
-
-    BUF_MEM *buf = nullptr;
+    BUF_MEM *buf;
     ASSERT_EQ(BIO_get_mem_ptr(bio.get(), &buf), 1);
     EXPECT_EQ(Bytes(buf->data, buf->length), b);
   };
@@ -393,57 +352,34 @@ TEST(BIOTest, MemWritable) {
   check_bio_contents(Bytes("abcdef"));
   EXPECT_EQ(BIO_eof(bio.get()), 0);
 
-  // Reset clears the buffer
-  int ret = BIO_reset(bio.get());
-  ASSERT_EQ(ret, 1);
-  EXPECT_EQ(BIO_eof(bio.get()), 1);
-  EXPECT_EQ(BIO_read(bio.get(), buf, sizeof(buf)), -1);
-  EXPECT_TRUE(BIO_should_read(bio.get()));
-
   // Writes can include embedded NULs.
-  ASSERT_EQ(BIO_write(bio.get(), "abcdef\0ghijk", 12), 12);
+  ASSERT_EQ(BIO_write(bio.get(), "\0ghijk", 6), 6);
   check_bio_contents(Bytes("abcdef\0ghijk", 12));
   EXPECT_EQ(BIO_eof(bio.get()), 0);
 
   // Do a partial read.
-  ret = BIO_read(bio.get(), buf, 4);
+  int ret = BIO_read(bio.get(), buf, 4);
   ASSERT_GT(ret, 0);
   EXPECT_EQ(Bytes(buf, ret), Bytes("abcd"));
   check_bio_contents(Bytes("ef\0ghijk", 8));
   EXPECT_EQ(BIO_eof(bio.get()), 0);
 
   // Reads and writes may alternate.
-  ASSERT_EQ(BIO_write(bio.get(), "\nlmnopq", 7), 7);
-  check_bio_contents(Bytes("ef\0ghijk\nlmnopq", 15));
+  ASSERT_EQ(BIO_write(bio.get(), "lmnopq", 6), 6);
+  check_bio_contents(Bytes("ef\0ghijklmnopq", 14));
   EXPECT_EQ(BIO_eof(bio.get()), 0);
 
   // Reads may consume embedded NULs.
   ret = BIO_read(bio.get(), buf, 4);
   ASSERT_GT(ret, 0);
   EXPECT_EQ(Bytes(buf, ret), Bytes("ef\0g", 4));
-  check_bio_contents(Bytes("hijk\nlmnopq"));
-  EXPECT_EQ(BIO_eof(bio.get()), 0);
-
-  // Read then rewind.
-  ret = BIO_read(bio.get(), buf, 4);
-  ASSERT_GT(ret, 0);
-  EXPECT_EQ(Bytes(buf, ret), Bytes("hijk", 4));
-  ret = BIO_seek(bio.get(), 0);
-  ASSERT_EQ(ret, 0);
-  check_bio_contents(Bytes("hijk\nlmnopq"));
-  EXPECT_EQ(BIO_eof(bio.get()), 0);
-
-  // Gets stop at newline
-  ret = BIO_gets(bio.get(), buf, sizeof(buf));
-  ASSERT_GT(ret, 0);
-  EXPECT_EQ(Bytes(buf, ret), Bytes("hijk\n", 5));
-  check_bio_contents(Bytes("lmnopq"));
+  check_bio_contents(Bytes("hijklmnopq"));
   EXPECT_EQ(BIO_eof(bio.get()), 0);
 
   // The read buffer exceeds the |BIO|, so we consume everything.
   ret = BIO_read(bio.get(), buf, sizeof(buf));
   ASSERT_GT(ret, 0);
-  EXPECT_EQ(Bytes(buf, ret), Bytes("lmnopq"));
+  EXPECT_EQ(Bytes(buf, ret), Bytes("hijklmnopq"));
   check_bio_contents(Bytes(""));
   EXPECT_EQ(BIO_eof(bio.get()), 1);
 
@@ -1277,8 +1213,8 @@ TEST_P(BIOPairTest, TestCtrlCallback) {
 
   char buf[TEST_BUF_LEN];
   // Test BIO_ctrl. This is not normally called directly so we can use one of
-  // the macros such as BIO_reset to test it. Buffer is null so BIO_reset returns -1
-  ASSERT_EQ(BIO_reset(bio.get()), -1);
+  // the macros such as BIO_reset to test it
+  ASSERT_EQ(BIO_reset(bio.get()), 1);
 
   ASSERT_EQ(param_oper_ex[0], BIO_CB_CTRL);
   ASSERT_EQ(param_oper_ex[1], BIO_CB_CTRL | BIO_CB_RETURN);
@@ -1287,9 +1223,9 @@ TEST_P(BIOPairTest, TestCtrlCallback) {
   ASSERT_EQ(param_argi_ex[0], BIO_CTRL_RESET);
   ASSERT_EQ(param_argi_ex[1], BIO_CTRL_RESET);
 
-  // BIO_ctrl of a memory bio sets ret to -1 when it calls the reset method
+  // BIO_ctrl of a memory bio sets ret to 1 when it calls the reset method
   ASSERT_EQ(param_ret_ex[0], 1);
-  ASSERT_EQ(param_ret_ex[1], -1);
+  ASSERT_EQ(param_ret_ex[1], 1);
 
   // processed is unused in ctrl
   ASSERT_EQ(param_processed_ex[0], 0u);


### PR DESCRIPTION
This reverts commit d93dde30f13f15e0aea34e6519a244b0eab688ae.

### Description of changes: 
It's not clear why yet, but reverting [this PR](https://github.com/aws/aws-lc/pull/2433) seems to [fix HAProxy](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoicEtxdUl5RTdsWW95MmtnM0pSWjJmQU92T2RhQUJPN2VzRFdXZTdHOG1FWU1NQ2VwcGtucE92ZlA1Q3pSRHFCWW1VRTFLa3VTN1RWVC96dmsraFl5WXZwSmFha2tOTFZBOEdiWittVlRGKzlBVkRqVk5Gaz0iLCJpdlBhcmFtZXRlclNwZWMiOiJxS01SNWtSdUR0d2NvSUMvIiwibWF0ZXJpYWxTZXRTZXJpYWwiOjF9/build/a0318c48-a852-4f79-8ddb-85f17ce12755).  🤷‍♂️

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
