### PR TITLE
Add RNG isolated test executables to shard_gtest sections in some test runner scripts

### DIFF
--- a/tests/ci/run_bsd_tests.sh
+++ b/tests/ci/run_bsd_tests.sh
@@ -20,6 +20,7 @@ if [ "$PLATFORM" != "amd64" ] && [ "$PLATFORM" != "x86_64" ]; then
     shard_gtest ${BUILD_ROOT}/crypto/mem_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_set_test
     shard_gtest ${BUILD_ROOT}/crypto/rand_isolated_test
+    shard_gtest ${BUILD_ROOT}/crypto/tree_drbg_jitter_entropy_isolated_test
     shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init
 
     shard_gtest ${BUILD_ROOT}/ssl/ssl_test

--- a/tests/ci/run_cross_mingw_tests.sh
+++ b/tests/ci/run_cross_mingw_tests.sh
@@ -69,6 +69,7 @@ for BO in "${BUILD_OPTIONS[@]}"; do
   shard_gtest ${BUILD_ROOT}/crypto/mem_test.exe
   shard_gtest ${BUILD_ROOT}/crypto/mem_set_test.exe
   shard_gtest ${BUILD_ROOT}/crypto/rand_isolated_test.exe
+  shard_gtest ${BUILD_ROOT}/crypto/tree_drbg_jitter_entropy_isolated_test.exe
   shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init.exe
 
   shard_gtest ${BUILD_ROOT}/ssl/ssl_test.exe

--- a/tests/ci/run_cross_tests.sh
+++ b/tests/ci/run_cross_tests.sh
@@ -66,6 +66,7 @@ for BO in "${BUILD_OPTIONS[@]}"; do
   shard_gtest ${BUILD_ROOT}/crypto/mem_test
   shard_gtest ${BUILD_ROOT}/crypto/mem_set_test
   shard_gtest ${BUILD_ROOT}/crypto/rand_isolated_test
+  shard_gtest ${BUILD_ROOT}/crypto/tree_drbg_jitter_entropy_isolated_test
   shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init
 
   shard_gtest ${BUILD_ROOT}/ssl/ssl_test

--- a/tests/ci/run_ios_sim_tests.sh
+++ b/tests/ci/run_ios_sim_tests.sh
@@ -99,6 +99,8 @@ shard_gtest "${BUILD_ROOT}/crypto/crypto_test.app/crypto_test --gtest_also_run_d
 shard_gtest ${BUILD_ROOT}/crypto/urandom_test.app/urandom_test
 shard_gtest ${BUILD_ROOT}/crypto/mem_test.app/mem_test
 shard_gtest ${BUILD_ROOT}/crypto/mem_set_test.app/mem_set_test
+shard_gtest ${BUILD_ROOT}/crypto/rand_isolated_test.app/rand_isolated_test
+shard_gtest ${BUILD_ROOT}/crypto/tree_drbg_jitter_entropy_isolated_test.app/tree_drbg_jitter_entropy_isolated_test
 shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init.app/rwlock_static_init
 
 shard_gtest ${BUILD_ROOT}/ssl/ssl_test.app/ssl_test


### PR DESCRIPTION
### Description of changes: 

I forgot to add `tree_drbg_jitter_entropy_isolated_test` to the `shard_gtest` tests in some of the test runner scripts. While I'm here, add the new RNG text executables to the iOS test case using shard_gtest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
