### PR TITLE
Prepare v1.53.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5321,7 +5321,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.52.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.53.0");
 }
 
 #else
@@ -5364,6 +5364,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.52.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.53.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.52.1"
+#define AWSLC_VERSION_NUMBER_STRING "1.53.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Add build with hardened flag by @m271828 in https://github.com/aws/aws-lc/pull/2396
* Openssl tool output ordered by options provided by @justsmth in https://github.com/aws/aws-lc/pull/2452
* [SCRUTINICE] Remove redundant condition check by @nhatnghiho in https://github.com/aws/aws-lc/pull/2450
* Support relro in delocator by @torben-hansen in https://github.com/aws/aws-lc/pull/2455
* Explicitly don't allow buffers aliasing in ctr-drbg implementation by @torben-hansen in https://github.com/aws/aws-lc/pull/2458
* Remove unused Windows afunix.h by @justsmth in https://github.com/aws/aws-lc/pull/2461
* Revert "Rework memory BIOs and implement BIO_seek (2nd try) (#2433)" by @justsmth in https://github.com/aws/aws-lc/pull/2466
* Use max_cert_list for TLSv1.3 NewSessionTicket by @skmcgrail in https://github.com/aws/aws-lc/pull/2453
* ML-KEM memory safety by @m271828 in https://github.com/aws/aws-lc/pull/2263
* Simplify Compiler CI jobs by @justsmth in https://github.com/aws/aws-lc/pull/2430
* Improve support for multilib-style distros in our test scripts by @justsmth in https://github.com/aws/aws-lc/pull/2467
* Fix Ruby mainline and nginx CI by @samuel40791765 in https://github.com/aws/aws-lc/pull/2460
* Add hardened build back in by @m271828 in https://github.com/aws/aws-lc/pull/2474
* Fix OCSP integration test failures by @samuel40791765 in https://github.com/aws/aws-lc/pull/2480
* Fix some theoretical missing earlyclobber markers in inline assembly by @torben-hansen in https://github.com/aws/aws-lc/pull/2477
* Simplify sshkdf and kbkdf by @torben-hansen in https://github.com/aws/aws-lc/pull/2478
* Run 3p module tests on python 3.13, add patch for 3.14 by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2476
* [UPSTREAM] Fix BIO_eof for BIO pairs by @justsmth in https://github.com/aws/aws-lc/pull/2440
* Fix service indicator in HKDF, more paranoid zeroization, and simplify logic by @torben-hansen in https://github.com/aws/aws-lc/pull/2482


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
