### PR TITLE
Fix some theoretical missing earlyclobber markers in inline assembly

### DIFF
--- a/crypto/fipsmodule/bn/asm/x86_64-gcc.c
+++ b/crypto/fipsmodule/bn/asm/x86_64-gcc.c
@@ -63,19 +63,17 @@
 #undef mul_add
 
 // "m"(a), "+m"(r)	is the way to favor DirectPath µ-code;
-// "g"(0)		let the compiler to decide where does it
-//			want to keep the value of zero;
 #define mul_add(r, a, word, carry)                                         \
   do {                                                                     \
     register BN_ULONG high, low;                                           \
     __asm__("mulq %3" : "=a"(low), "=d"(high) : "a"(word), "m"(a) : "cc"); \
-    __asm__("addq %2,%0; adcq %3,%1"                                       \
+    __asm__("addq %2,%0; adcq $0,%1"                                       \
             : "+r"(carry), "+d"(high)                                      \
-            : "a"(low), "g"(0)                                             \
+            : "a"(low)                                                     \
             : "cc");                                                       \
-    __asm__("addq %2,%0; adcq %3,%1"                                       \
+    __asm__("addq %2,%0; adcq $0,%1"                                       \
             : "+m"(r), "+d"(high)                                          \
-            : "r"(carry), "g"(0)                                           \
+            : "r"(carry)                                                   \
             : "cc");                                                       \
     (carry) = high;                                                        \
   } while (0)
@@ -84,9 +82,9 @@
   do {                                                                     \
     register BN_ULONG high, low;                                           \
     __asm__("mulq %3" : "=a"(low), "=d"(high) : "a"(word), "g"(a) : "cc"); \
-    __asm__("addq %2,%0; adcq %3,%1"                                       \
+    __asm__("addq %2,%0; adcq $0,%1"                                       \
             : "+r"(carry), "+d"(high)                                      \
-            : "a"(low), "g"(0)                                             \
+            : "a"(low)                                                     \
             : "cc");                                                       \
     (r) = (carry);                                                         \
     (carry) = high;                                                        \
@@ -206,7 +204,7 @@ BN_ULONG bn_add_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
       "	dec	%1		\n"
       "	jnz	1b		\n"
       "	sbbq	%0,%0		\n"
-      : "=&r"(ret), "+c"(n), "+r"(i)
+      : "=&r"(ret), "+&c"(n), "+&r"(i)
       : "r"(rp), "r"(ap), "r"(bp)
       : "cc", "memory");
 
@@ -234,7 +232,7 @@ BN_ULONG bn_sub_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
       "	dec	%1		\n"
       "	jnz	1b		\n"
       "	sbbq	%0,%0		\n"
-      : "=&r"(ret), "+c"(n), "+r"(i)
+      : "=&r"(ret), "+&c"(n), "+&r"(i)
       : "r"(rp), "r"(ap), "r"(bp)
       : "cc", "memory");
 
@@ -252,9 +250,9 @@ BN_ULONG bn_sub_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
   do {                                                               \
     BN_ULONG t1, t2;                                                 \
     __asm__("mulq %3" : "=a"(t1), "=d"(t2) : "a"(a), "m"(b) : "cc"); \
-    __asm__("addq %3,%0; adcq %4,%1; adcq %5,%2"                     \
-            : "+r"(c0), "+r"(c1), "+r"(c2)                           \
-            : "r"(t1), "r"(t2), "g"(0)                               \
+    __asm__("addq %3,%0; adcq %4,%1; adcq $0,%2"                     \
+            : "+&r"(c0), "+r"(c1), "+r"(c2)                          \
+            : "r"(t1), "r"(t2)                                       \
             : "cc");                                                 \
   } while (0)
 
@@ -262,9 +260,9 @@ BN_ULONG bn_sub_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
   do {                                                            \
     BN_ULONG t1, t2;                                              \
     __asm__("mulq %2" : "=a"(t1), "=d"(t2) : "a"((a)[i]) : "cc"); \
-    __asm__("addq %3,%0; adcq %4,%1; adcq %5,%2"                  \
-            : "+r"(c0), "+r"(c1), "+r"(c2)                        \
-            : "r"(t1), "r"(t2), "g"(0)                            \
+    __asm__("addq %3,%0; adcq %4,%1; adcq $0,%2"                  \
+            : "+&r"(c0), "+r"(c1), "+r"(c2)                       \
+            : "r"(t1), "r"(t2)                                    \
             : "cc");                                              \
   } while (0)
 
@@ -272,13 +270,13 @@ BN_ULONG bn_sub_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
   do {                                                               \
     BN_ULONG t1, t2;                                                 \
     __asm__("mulq %3" : "=a"(t1), "=d"(t2) : "a"(a), "m"(b) : "cc"); \
-    __asm__("addq %3,%0; adcq %4,%1; adcq %5,%2"                     \
-            : "+r"(c0), "+r"(c1), "+r"(c2)                           \
-            : "r"(t1), "r"(t2), "g"(0)                               \
+    __asm__("addq %3,%0; adcq %4,%1; adcq $0,%2"                     \
+            : "+&r"(c0), "+r"(c1), "+r"(c2)                          \
+            : "r"(t1), "r"(t2)                                       \
             : "cc");                                                 \
-    __asm__("addq %3,%0; adcq %4,%1; adcq %5,%2"                     \
-            : "+r"(c0), "+r"(c1), "+r"(c2)                           \
-            : "r"(t1), "r"(t2), "g"(0)                               \
+    __asm__("addq %3,%0; adcq %4,%1; adcq $0,%2"                     \
+            : "+&r"(c0), "+r"(c1), "+r"(c2)                          \
+            : "r"(t1), "r"(t2)                                       \
             : "cc");                                                 \
   } while (0)
 


### PR DESCRIPTION
Searched for other cases using `grep -rl "_asm_" ./`. My analysis:

./crypto/internal.h: Not multi-instruction inline asm
./crypto/mem.c: Not multi-instruction inline asm
./crypto/fipsmodule/ml_kem/mlkem/verify.h: Not multi-instruction inline asm
./crypto/fipsmodule/bn/asm/x86_64-gcc.c: This commit
./crypto/fipsmodule/bn/div.c: Not multi-instruction inline asm
./crypto/fipsmodule/cpucap/cpu_aarch64_linux.c: Not multi-instruction inline asm
./crypto/fipsmodule/cpucap/cpu_intel.c: Explicitly registers
./crypto/fipsmodule/cpucap/cpu_aarch64_sysreg.c: Not multi-instruction inline asm
./crypto/fipsmodule/cpucap/cpu_aarch64.c: Not multi-instruction inline asm
./third_party/jitterentropy/jitterentropy-base-user.h: Not multi-instruction inline asm
./third_party/jitterentropy/README.md: Text file
./third_party/jitterentropy/arch/jitterentropy-base-x86.h: Not multi-instruction inline asm
./third_party/fiat/curve25519_64.h: Not multi-instruction inline asm
./third_party/fiat/p256_64.h: Not multi-instruction inline asm
./third_party/fiat/p256_32.h: Not multi-instruction inline asm
./third_party/fiat/curve25519_32.h: Not multi-instruction inline asm

### Original commit message

GCC inline assembly, by default, assumes that, like most single instructions, the assembly block reads all inputs before writing any outputs. This way it can use the same register for some input and some output operand.

When the assembly block contains multiple instructions, this may not be the case. Then registers must be marked '&' for earlyclobber. OpenSSL did, from what I can tell, correctly mark all "=" output constraints as earlyclobber, but not "+".

See https://gcc.gnu.org/onlinedocs/gcc/Modifiers.html

Naively, it would seem earlyclobber is redundant for "+" because input/output constraints cannot alias with other inputs. *However*, if the compiler can prove that, on input to inline asm, some "+r" input/output constraint and some "r" input constraint have the same value, it might merge the registers. If the "+r" constraint is clobbered before the "r" is read, the code will then break.

GCC seems to do exactly this: https://godbolt.org/z/7hEGoE66a

I've not been able to come up with any other scenario where the compiler is allowed to do this. If the values are not proven equal at the point the inline assembly block is lowered, the compiler is obligated to present different registers to carry the different values.

There were a few inline assembly blocks that were missing an "&" based on this requirement. These instances seem to all be theoretical:

- In mul_add's second block, %0 (carry) might alias %3 (0) if carry is known to be zero. But presumably any compiler would just bind %3 to a $0 literal. To be sure it does that, I've just removed it in favor of $0 in the assembly string because that seems absurd.

  Once that's removed, I do not believe & is needed because now we only need to worry about clobbering %1 (high). That is an output operand and I don't believe there's any scenario where the compiler is allowed to alias two outputs. The GCC documentation also specifically says "input operands" and %1 is an output operand that happens to have an in/out constraint on it.

- In mul_add's third block, %0 (r) might alias %3 (0) if r is known to be zero. Ditto.

- In mul's second block, %0 (carry) might alias %3 (0) if carry is known to be zero. Ditto.

- In bn_add_words, %1 (n) and %2 (i) might alias any of %3 (rp), %4 (ap), or %5 (r). The in/out params are numbers, while the inputs are pointers, so they can only be proven equal by the compiler if the numbers are zero and the pointers are null. (It is conceivably possible for a buffer size and buffer address to overlap, but it will never be statically true that this happened except in intentionally contrived calling code.) The pointers can only be null if n is zero, but the functions already check this.

- In bn_sub_words, we have the same situation as bn_add_words.

- In mul_add_c's second block, %0 (c0) and %1 (c1) might alias with %4 (t2) and %5 (0). See the above discussion for 0. t2 is the output of another inline asm block, so it is impossible for the compiler to prove anything about its value. Once the 0 is resolved, only %0 needs an earlyclobber marker because %1 is only in danger of clobbering another in/out output operand.

- In sqr_add_c's second block, ditto.

- In mul_add_c2's second and third blocks, ditto.

Note +m does not seem to need &. Clang complains when I even put one on, and m cannot alias r.

Change-Id: I3edbc7e6347f0271b87c7fc4da5b2971c6861f5a
Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/79387
Commit-Queue: David Benjamin <davidben@google.com>
Reviewed-by: Adam Langley <agl@google.com>
Auto-Submit: David Benjamin <davidben@google.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
