### PR TITLE
Simply kdf ctr hmac

### DIFF
--- a/crypto/fipsmodule/kdf/kbkdf.c
+++ b/crypto/fipsmodule/kdf/kbkdf.c
@@ -80,6 +80,7 @@ int KBKDF_ctr_hmac(uint8_t *out_key, size_t out_len, const EVP_MD *digest,
     // NIST.SP.800-108r1-upd1: Step 4b, Step 5
     // result := result || K(i)
     if (written > out_len - done) {
+      // Last block of output might not be a full block
       written = out_len - done;
     }
     OPENSSL_memcpy(out_key + done, out_key_i, written);


### PR DESCRIPTION
### Description of changes: 

Move `out_key_i` out of loop to allow one zeroising call site. Also eliminate one variable (`todo`).

### Testing:

Existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
