### PR TITLE
Allow disabling symbol prefixing in the headers for certain use-cases

### DIFF
--- a/util/make_prefix_headers.go
+++ b/util/make_prefix_headers.go
@@ -97,9 +97,9 @@ func writeCHeader(symbols []string, path string) error {
 
 #define BORINGSSL_PREFIX_SYMBOLS_H	
 
-#ifndef BORINGSSL_PREFIX
+#if !(defined(BORINGSSL_PREFIX) || defined(BORINGSSL_DISABLE_PREFIX))
 #define BORINGSSL_PREFIX %s
-#endif // BORINGSSL_PREFIX
+#endif // !(defined(BORINGSSL_PREFIX) || defined(BORINGSSL_DISABLE_PREFIX))
 
 `, *prefix); err != nil {
 		return err
@@ -160,9 +160,9 @@ func writeASMHeader(symbols []string, path string) error {
 
 #define BORINGSSL_PREFIX_SYMBOLS_ASM_H
 
-#ifndef BORINGSSL_PREFIX
+#if !(defined(BORINGSSL_PREFIX) || defined(BORINGSSL_DISABLE_PREFIX))
 #define BORINGSSL_PREFIX %s
-#endif // BORINGSSL_PREFIX
+#endif // !(defined(BORINGSSL_PREFIX) || defined(BORINGSSL_DISABLE_PREFIX))
 
 // On iOS and macOS, we need to treat assembly symbols differently from other
 // symbols. The linker expects symbols to be prefixed with an underscore.
@@ -221,9 +221,9 @@ func writeNASMHeader(symbols []string, path string) error {
 
 %%define BORINGSSL_PREFIX_SYMBOLS_NASM_INC
 
-%%ifndef BORINGSSL_PREFIX
+%%if !(defined(BORINGSSL_PREFIX) || defined(BORINGSSL_DISABLE_PREFIX))
 %%define BORINGSSL_PREFIX %s
-%%endif ; BORINGSSL_PREFIX
+%%endif ; !(defined(BORINGSSL_PREFIX) || defined(BORINGSSL_DISABLE_PREFIX))
 `, *prefix); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description of changes:
The use-case here is to be able to support a specific use case for users using the bindgen-cli in Rust to produce AWS-LC bindings against an existing AWS-LC(-FIPS) installation that is already prefixed. The bindge-cli needs to be able to parse the AWS-LC headers (using libclang) with the prefixes not visible/defined so that the bindings have the correct Rust symbol names. The CLI can then be told what the prefix is when producing the actual link name for the C FFI.

This is not a problem when using the actual `bindgen` dependency itself as that library provides a programmatic hook that allows for the symbol names to be stripped, but the CLI only provides an interface to define a prefix to be added. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
