### PR TITLE
Fix service indicator in HKDF, more paranoid zeroization, and simplify logic

### DIFF
--- a/crypto/fipsmodule/hkdf/hkdf.c
+++ b/crypto/fipsmodule/hkdf/hkdf.c
@@ -12,22 +12,18 @@
  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
 
-#include <openssl/hkdf.h>
-
 #include <assert.h>
 #include <string.h>
 
 #include <openssl/err.h>
+#include <openssl/hkdf.h>
 #include <openssl/hmac.h>
+#include <openssl/mem.h>
 
 #include "../../internal.h"
-#include "../service_indicator/internal.h"
 #include "../cpucap/internal.h"
+#include "../service_indicator/internal.h"
 
-// TODO(CryptoAlg-1281): We need to get our FIPS testing partner's opinion on
-// which API level(s) we need to check at. HKDF_extract() originally had checks
-// similar to HKDF_expand(), but we were unsure whether it was required at that
-// level.
 
 int HKDF(uint8_t *out_key, size_t out_len, const EVP_MD *digest,
          const uint8_t *secret, size_t secret_len, const uint8_t *salt,
@@ -35,7 +31,7 @@ int HKDF(uint8_t *out_key, size_t out_len, const EVP_MD *digest,
   // https://tools.ietf.org/html/rfc5869#section-2
   uint8_t prk[EVP_MAX_MD_SIZE];
   size_t prk_len;
-  int ret = 1;
+  int ret = 0;
 
   // We have to avoid the underlying HKDF services updating the indicator
   // state, so we lock the state here.
@@ -44,14 +40,18 @@ int HKDF(uint8_t *out_key, size_t out_len, const EVP_MD *digest,
   if (!HKDF_extract(prk, &prk_len, digest, secret, secret_len, salt,
                     salt_len) ||
       !HKDF_expand(out_key, out_len, digest, prk, prk_len, info, info_len)) {
-    ret = 0;
+    // HKDF_expand zeroizes |out_key| on failure.
     goto out;
   }
 
-out:
-  FIPS_service_indicator_unlock_state();
-  HKDF_verify_service_indicator(digest, salt, salt_len, info_len);
+  ret = 1;
 
+out:
+  OPENSSL_cleanse(prk, prk_len);
+  FIPS_service_indicator_unlock_state();
+  if (ret == 1) {
+    HKDF_verify_service_indicator(digest, salt, salt_len, info_len);
+  }
   return ret;
 }
 
@@ -73,6 +73,7 @@ int HKDF_extract(uint8_t *out_key, size_t *out_len, const EVP_MD *digest,
     OPENSSL_PUT_ERROR(HKDF, ERR_R_HMAC_LIB);
     goto out;
   }
+
   *out_len = len;
   assert(*out_len == EVP_MD_size(digest));
   ret = 1;
@@ -89,59 +90,66 @@ int HKDF_expand(uint8_t *out_key, size_t out_len, const EVP_MD *digest,
   SET_DIT_AUTO_RESET;
   const size_t digest_len = EVP_MD_size(digest);
   uint8_t previous[EVP_MAX_MD_SIZE];
-  size_t n, done = 0;
-  unsigned i;
   int ret = 0;
   HMAC_CTX hmac;
 
   // Expand key material to desired length.
-  n = (out_len + digest_len - 1) / digest_len;
+  size_t n = (out_len + digest_len - 1) / digest_len;
   if (out_len + digest_len < out_len || n > 255) {
     OPENSSL_PUT_ERROR(HKDF, HKDF_R_OUTPUT_TOO_LARGE);
     return 0;
   }
 
-  HMAC_CTX_init(&hmac);
-
   // We have to avoid the underlying HMAC services updating the indicator
   // state, so we lock the state here.
   FIPS_service_indicator_lock_state();
 
+  HMAC_CTX_init(&hmac);
   if (!HMAC_Init_ex(&hmac, prk, prk_len, digest, NULL)) {
     goto out;
   }
 
-  for (i = 0; i < n; i++) {
+  size_t done = 0;
+  uint32_t written = 0;
+
+  for (size_t i = 0; i < n; i++) {
+    // n is verified above to be <= 255. Hence 8-bit type is sufficient.
     uint8_t ctr = i + 1;
-    size_t todo;
 
     if (i != 0 && (!HMAC_Init_ex(&hmac, NULL, 0, NULL, NULL) ||
                    !HMAC_Update(&hmac, previous, digest_len))) {
       goto out;
     }
+
+    written = 0;
     if (!HMAC_Update(&hmac, info, info_len) ||
         !HMAC_Update(&hmac, &ctr, 1) ||
-        !HMAC_Final(&hmac, previous, NULL)) {
+        !HMAC_Final(&hmac, previous, &written) ||
+        written != digest_len) {
       goto out;
     }
 
-    todo = digest_len;
-    if (todo > out_len - done) {
-      todo = out_len - done;
+    if (written > out_len - done) {
+      written = out_len - done;
     }
-    OPENSSL_memcpy(out_key + done, previous, todo);
-    done += todo;
+    OPENSSL_memcpy(out_key + done, previous, written);
+    done += written;
   }
 
   ret = 1;
 
 out:
-  FIPS_service_indicator_unlock_state();
-  HKDFExpand_verify_service_indicator(digest);
-
+  OPENSSL_cleanse(previous, EVP_MAX_MD_SIZE);
   HMAC_CTX_cleanup(&hmac);
   if (ret != 1) {
     OPENSSL_PUT_ERROR(HKDF, ERR_R_HMAC_LIB);
+    OPENSSL_cleanse(out_key, out_len);
   }
+
+  FIPS_service_indicator_unlock_state();
+  if (ret == 1) {
+    HKDFExpand_verify_service_indicator(digest);
+  }
+
   return ret;
 }

--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -2040,7 +2040,7 @@ TEST_P(HKDF_ServiceIndicatorTest, HKDFTest) {
 }
 
 TEST(HKDF_ServiceIndicatorTest, NegativeTests) {
-  FIPSStatus status = AWSLC_NOT_APPROVED;
+  FIPSStatus status = AWSLC_APPROVED;
 
   // Setting |out_len| to (256 * 254 + 1) implies n = 255 in |HKDF_expand|.
   // This should cause a failure and no service indicator set to approved.
@@ -2052,6 +2052,7 @@ TEST(HKDF_ServiceIndicatorTest, NegativeTests) {
                                kHKDF_info_tc1, sizeof(kHKDF_info_tc1))));
   EXPECT_EQ(status, AWSLC_NOT_APPROVED);
 
+  status = AWSLC_APPROVED;
   CALL_SERVICE_AND_CHECK_APPROVED(
     status, ASSERT_FALSE(HKDF_expand(output, (256 * 254 + 1), EVP_sha256(),
                                kHKDF_ikm_tc1, sizeof(kHKDF_ikm_tc1),

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -307,6 +307,11 @@ void *OPENSSL_realloc(void *orig_ptr, size_t new_size) {
 }
 
 void OPENSSL_cleanse(void *ptr, size_t len) {
+
+  if (ptr == NULL || len == 0) {
+    return;
+  }
+
 #if defined(OPENSSL_WINDOWS)
   SecureZeroMemory(ptr, len);
 #else


### PR DESCRIPTION
### Description of changes: 

Fixup HKDF a bit:
* Service indicator is not guarded by a failure in HKDF implementation.
* Can be more paranoid with zeroization. 
* Tidy up the logic.

### Testing:

Existing testing. But added negative tests for service indicator to the extend it's possible to trigger error sin the HKDF logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
