### PR TITLE
Fix Console Test Suite Execution Locally

### DIFF
--- a/crypto/console/console.c
+++ b/crypto/console/console.c
@@ -146,7 +146,6 @@ int openssl_console_open(void) {
     }
 
 #if !defined(OPENSSL_WINDOWS)
-    // Unix/Linux path
     if ((tty_in = fopen(DEV_TTY, "r")) == NULL) {
         tty_in = stdin;
     }
@@ -163,7 +162,6 @@ int openssl_console_open(void) {
           }
     }
 #else
-    // Windows path
     DWORD console_mode;
     HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
 

--- a/crypto/console/console.c
+++ b/crypto/console/console.c
@@ -137,7 +137,7 @@ int openssl_console_open(void) {
     assert(CRYPTO_STATIC_MUTEX_is_write_locked(&console_global_mutex));
 
     // Check for test environment variable first (platform-independent)
-    const char* test_mode = getenv("OPENSSL_CONSOLE_TEST_MODE");
+    const char* test_mode = getenv("AWSLC_CONSOLE_NO_TTY_DETECT");
     if (test_mode != NULL) {
         tty_in = stdin;
         tty_out = stderr;

--- a/crypto/console/console.c
+++ b/crypto/console/console.c
@@ -136,7 +136,17 @@ int openssl_console_open(void) {
     is_a_tty = 1;
     assert(CRYPTO_STATIC_MUTEX_is_write_locked(&console_global_mutex));
 
+    // Check for test environment variable first (platform-independent)
+    const char* test_mode = getenv("OPENSSL_CONSOLE_TEST_MODE");
+    if (test_mode != NULL) {
+        tty_in = stdin;
+        tty_out = stderr;
+        is_a_tty = 0;
+        return 1;
+    }
+
 #if !defined(OPENSSL_WINDOWS)
+    // Unix/Linux path
     if ((tty_in = fopen(DEV_TTY, "r")) == NULL) {
         tty_in = stdin;
     }
@@ -153,6 +163,7 @@ int openssl_console_open(void) {
           }
     }
 #else
+    // Windows path
     DWORD console_mode;
     HANDLE hStdIn = GetStdHandle(STD_INPUT_HANDLE);
 

--- a/crypto/console/console_test.cc
+++ b/crypto/console/console_test.cc
@@ -23,7 +23,7 @@
 class PemPasswdTest : public testing::Test {
  protected:
   void SetUp() override {
-    setenv("OPENSSL_CONSOLE_TEST_MODE", "1", 1);
+    setenv("AWSLC_CONSOLE_NO_TTY_DETECT", "1", 1);
 
     // Save original file descriptors
     original_stdin = dup(fileno(stdin));
@@ -45,7 +45,7 @@ class PemPasswdTest : public testing::Test {
   }
 
   void TearDown() override {
-    unsetenv("OPENSSL_CONSOLE_TEST_MODE");
+    unsetenv("AWSLC_CONSOLE_NO_TTY_DETECT");
 
     // Close console for each test
     ASSERT_TRUE(openssl_console_close());

--- a/crypto/console/console_test.cc
+++ b/crypto/console/console_test.cc
@@ -23,7 +23,11 @@
 class PemPasswdTest : public testing::Test {
  protected:
   void SetUp() override {
+#if defined(OPENSSL_WINDOWS)
+    _putenv_s("AWSLC_CONSOLE_NO_TTY_DETECT", "1");
+#else
     setenv("AWSLC_CONSOLE_NO_TTY_DETECT", "1", 1);
+#endif
 
     // Save original file descriptors
     original_stdin = dup(fileno(stdin));
@@ -45,7 +49,11 @@ class PemPasswdTest : public testing::Test {
   }
 
   void TearDown() override {
+#if defined(OPENSSL_WINDOWS)
+    _putenv_s("AWSLC_CONSOLE_NO_TTY_DETECT", ""); 
+#else
     unsetenv("AWSLC_CONSOLE_NO_TTY_DETECT");
+#endif
 
     // Close console for each test
     ASSERT_TRUE(openssl_console_close());

--- a/crypto/console/console_test.cc
+++ b/crypto/console/console_test.cc
@@ -23,6 +23,8 @@
 class PemPasswdTest : public testing::Test {
  protected:
   void SetUp() override {
+    setenv("OPENSSL_CONSOLE_TEST_MODE", "1", 1);
+
     // Save original file descriptors
     original_stdin = dup(fileno(stdin));
     original_stderr = dup(fileno(stderr));
@@ -43,6 +45,8 @@ class PemPasswdTest : public testing::Test {
   }
 
   void TearDown() override {
+    unsetenv("OPENSSL_CONSOLE_TEST_MODE");
+
     // Close console for each test
     ASSERT_TRUE(openssl_console_close());
     openssl_console_release_mutex();


### PR DESCRIPTION
### Description of changes: 
PemPasswdTest suite of tests hang when running them locally on a terminal. Currently the code directly tries to connect to /dev/tty and if not available falls back to stdin and stdout. In the CI env, there is no /dev/tty so the redirection in the test suite works. But when running locally, the code bypasses this since a /dev/tty is available. 

This PR introduces an env var to force using stdin/stdout when running the test suite. This ensures in both CI and local environments, the stdin/stdout redirection works as intended with PemPasswdTest. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
