### PR TITLE
Add test for snapsafe ensuring read permission failure is not silent

### DIFF
--- a/crypto/fipsmodule/rand/snapsafe_detect_test.cc
+++ b/crypto/fipsmodule/rand/snapsafe_detect_test.cc
@@ -94,20 +94,17 @@ TEST(SnapsafeGenerationTest, DISABLED_SysGenIDretrievalTesting) {
 // This test verifies that AWS-LC properly handles the case where /dev/sysgenid
 // exists but cannot be opened due to permission restrictions.
 TEST(SnapsafePermissionTest, DISABLED_PermissionDeniedTest) {
-  ASSERT_TRUE(HAZMAT_init_sysgenid_file());
-
   // Verify the file was created and initially accessible
+  ASSERT_TRUE(HAZMAT_init_sysgenid_file());
   const char* sysgenid_path = CRYPTO_get_sysgenid_path();
   struct stat file_stat;
   ASSERT_EQ(0, stat(sysgenid_path, &file_stat));
 
-  // Change permissions to make the file unreadable
+  // Make file unreadable by anyone
   ASSERT_EQ(0, chmod(sysgenid_path, 0000));
 
-  // Should return 1 because the file exists (stat() succeeds)
+  // There is support, but it's not active due to read failure
   EXPECT_EQ(1, CRYPTO_get_snapsafe_supported());
-
-  // Should return 0 because initialization failed (open() failed)
   EXPECT_EQ(0, CRYPTO_get_snapsafe_active());
 
   // Should return 0 (failure) and set generation number to 0

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -58,6 +58,12 @@
     "shard": false
   },
   {
+    "comment": "Run snapsafe permissions test suite",
+    "cmd": ["crypto/crypto_test",  "--gtest_also_run_disabled_tests", "--gtest_filter=SnapsafePermissionTest.*"],
+    "skip_valgrind": true,
+    "shard": false
+  },
+  {
     "comment": "Potentially with RDRAND, but not Intel",
     "cmd": ["crypto/urandom_test"],
     "env": ["OPENSSL_ia32cap=~0x0000000040000000"],


### PR DESCRIPTION
### Issues:
`P255829478`

### Description of changes: 
Adds a new test to ensure read permission failure on /dev/sysgenid is appropriately tracked and not silently failing.

This was added as a separate test suite as snapsafe detection is meant to run once per process. So we need to ensure this test suite can be executed in its own process.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
