### PR TITLE
Add SSL_CTRL defines for SSL_*_tlsext_status_type

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -6068,7 +6068,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 #define SSL_CTRL_GET_SESSION_REUSED doesnt_exist
 #define SSL_CTRL_GET_SESS_CACHE_MODE doesnt_exist
 #define SSL_CTRL_GET_SESS_CACHE_SIZE doesnt_exist
-#define SSL_CTRL_SET_TLSEXT_STATUS_REQ_CB doesnt_exist
+#define SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE doesnt_exist
 #define SSL_CTRL_GET_TLSEXT_TICKET_KEYS doesnt_exist
 #define SSL_CTRL_GET_TOTAL_RENEGOTIATIONS doesnt_exist
 #define SSL_CTRL_MODE doesnt_exist
@@ -6091,6 +6091,8 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 #define SSL_CTRL_SET_TLSEXT_HOSTNAME doesnt_exist
 #define SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG doesnt_exist
 #define SSL_CTRL_SET_TLSEXT_SERVERNAME_CB doesnt_exist
+#define SSL_CTRL_SET_TLSEXT_STATUS_REQ_CB doesnt_exist
+#define SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE doesnt_exist
 #define SSL_CTRL_SET_TLSEXT_TICKET_KEYS doesnt_exist
 #define SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB doesnt_exist
 #define SSL_CTRL_SET_TMP_DH doesnt_exist


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-3349`

### Description of changes: 
There's usage of the ssl structure in Openresty where it's trying to pull from SSL as if it's non-opaque.

Looking more closely, the failure is around this code block: https://github.com/openresty/lua-nginx-module/blob/9688812a4eba47c1f43892c998e50b988d740f5d/src/ngx_http_lua_ssl_ocsp.c#L514-L518
```
#ifdef SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE
    if (SSL_get_tlsext_status_type(ssl_conn) == -1) {
#else
    if (ssl_conn->tlsext_status_type == -1) {
#endif
```
`SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE` [is used](https://github.com/openssl/openssl/blob/b6ff5598539bf91608246ed81b4b534cbea6539d/include/openssl/tls1.h#L304-L305) by `SSL_get_tlsext_status_type` in Openssl, so it's fair to assume that the functionality exists if the definition is defined.

`SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE` isn't defined in AWS-LC, but luckily for us `SSL_get_tlsext_status_type` is. We should be able to just define `SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE` in AWS-LC as an extension of `SSL_get_tlsext_status_type` and get Openresty passing further.

### Call-outs:
N/A

### Testing:
Openresty build passes internally with the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
