### PR TITLE
Migrate Openssl-tool parameter parsing

### DIFF
--- a/tool-openssl/crl.cc
+++ b/tool-openssl/crl.cc
@@ -1,10 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-#include "internal.h"
-#include <openssl/x509.h>
 #include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <algorithm>
 #include <ctime>
+#include <iostream>
+#include <string>
+#include "internal.h"
 
 static const argument_t kArguments[] = {
         { "-help", kBooleanArgument, "Display option summary" },
@@ -15,23 +18,53 @@ static const argument_t kArguments[] = {
         { "", kOptionalArgument, "" }
 };
 
+static bool handleHash(X509_CRL *crl) {
+  fprintf(stdout, "%08x\n", X509_NAME_hash(X509_CRL_get_issuer(crl)));
+  return true;
+}
+
+static bool handleFingerprint(X509_CRL *crl) {
+  int j;
+  unsigned int n;
+  unsigned char md[EVP_MAX_MD_SIZE];
+
+  if (!X509_CRL_digest(crl, EVP_sha1(), md, &n)) {
+    fprintf(stderr, "unable to get encoding of CRL\n");
+    return false;
+  }
+  fprintf(stdout, "%s Fingerprint=", OBJ_nid2sn(EVP_MD_type(EVP_sha1())));
+
+  for (j = 0; j < (int)n; j++) {
+    fprintf(stdout, "%02X%c", md[j], (j + 1 == (int)n) ? '\n' : ':');
+  }
+  return true;
+}
+
+static bool ProcessArgument(const std::string &arg_name, X509_CRL *crl) {
+  if (arg_name == "-hash") {
+    return handleHash(crl);
+  }
+  if (arg_name == "-fingerprint") {
+    return handleFingerprint(crl);
+  }
+  return true;
+}
+
 bool CRLTool(const args_list_t &args) {
-  args_map_t parsed_args;
+  ordered_args::ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }
 
   std::string in;
-  bool help = false, hash = false, fingerprint = false, noout = false;
+  bool help = false, noout = false;
 
-  GetBoolArgument(&help, "-help", parsed_args);
-  GetString(&in, "-in", "", parsed_args);
-  GetBoolArgument(&hash, "-hash", parsed_args);
-  GetBoolArgument(&fingerprint, "-fingerprint", parsed_args);
-  GetBoolArgument(&noout, "-noout", parsed_args);
+  ordered_args::GetBoolArgument(&help, "-help", parsed_args);
+  ordered_args::GetString(&in, "-in", "", parsed_args);
+  ordered_args::GetBoolArgument(&noout, "-noout", parsed_args);
 
   // Display crl tool option summary
   if (help) {
@@ -58,23 +91,17 @@ bool CRLTool(const args_list_t &args) {
     return false;
   }
 
-  if (hash) {
-    fprintf(stdout, "%08x\n", X509_NAME_hash(X509_CRL_get_issuer(crl.get())));
-  }
+  // Process arguments in the order they were provided
+  for (const auto &arg_pair : parsed_args) {
+    const std::string &arg_name = arg_pair.first;
 
-  if (fingerprint) {
-    int j;
-    unsigned int n;
-    unsigned char md[EVP_MAX_MD_SIZE];
-
-    if (!X509_CRL_digest(crl.get(), EVP_sha1(), md, &n)) {
-      fprintf(stderr, "unable to get encoding of CRL\n");
-      return false;
+    // Skip non-output arguments
+    if (arg_name == "-in" || arg_name == "-noout" || arg_name == "-help") {
+      continue;
     }
-    fprintf(stdout, "%s Fingerprint=", OBJ_nid2sn(EVP_MD_type(EVP_sha1())));
 
-    for (j = 0; j < (int)n; j++) {
-      fprintf(stdout, "%02X%c", md[j], (j + 1 == (int)n) ? '\n' : ':');
+    if (!ProcessArgument(arg_name, crl.get())) {
+      return false;
     }
   }
 

--- a/tool-openssl/crl.cc
+++ b/tool-openssl/crl.cc
@@ -51,9 +51,10 @@ static bool ProcessArgument(const std::string &arg_name, X509_CRL *crl) {
 }
 
 bool CRLTool(const args_list_t &args) {
-  ordered_args::ordered_args_map_t parsed_args;
+  using namespace ordered_args;
+  ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+  if (!ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
@@ -62,9 +63,9 @@ bool CRLTool(const args_list_t &args) {
   std::string in;
   bool help = false, noout = false;
 
-  ordered_args::GetBoolArgument(&help, "-help", parsed_args);
-  ordered_args::GetString(&in, "-in", "", parsed_args);
-  ordered_args::GetBoolArgument(&noout, "-noout", parsed_args);
+  GetBoolArgument(&help, "-help", parsed_args);
+  GetString(&in, "-in", "", parsed_args);
+  GetBoolArgument(&noout, "-noout", parsed_args);
 
   // Display crl tool option summary
   if (help) {

--- a/tool-openssl/crl_test.cc
+++ b/tool-openssl/crl_test.cc
@@ -182,3 +182,27 @@ TEST_F(CRLComparisonTest, CRLToolCompareHashFingerprintNoOutOpenSSL) {
 
   RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
 }
+
+// Test against OpenSSL output "openssl crl -in file -fingerprint -hash"
+TEST_F(CRLComparisonTest, CRLToolCompareReorderedHashFingerprintOpenSSL) {
+  std::string tool_command = std::string(tool_executable_path) + " crl -in " + in_path + " -fingerprint -hash > " + out_path_tool;
+  std::string openssl_command = std::string(openssl_executable_path) + " crl -in " + in_path + " -fingerprint -hash > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+}
+
+// Test against OpenSSL output "openssl crl -in file -fingerprint -hash -noout"
+TEST_F(CRLComparisonTest, CRLToolCompareReorderedHashFingerprintNoOutOpenSSL) {
+  std::string tool_command = std::string(tool_executable_path) + " crl -in " + in_path + " -fingerprint -hash -noout > " + out_path_tool;
+  std::string openssl_command = std::string(openssl_executable_path) + " crl -in " + in_path + " -fingerprint -hash -noout > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+}
+
+// Test against OpenSSL output "openssl crl -in file -noout -fingerprint -hash"
+TEST_F(CRLComparisonTest, CRLToolCompareReorderedNoOutHashFingerprintOpenSSL) {
+  std::string tool_command = std::string(tool_executable_path) + " crl -in " + in_path + " -noout -fingerprint -hash > " + out_path_tool;
+  std::string openssl_command = std::string(openssl_executable_path) + " crl -in " + in_path + " -noout -fingerprint -hash > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+}

--- a/tool-openssl/rehash.cc
+++ b/tool-openssl/rehash.cc
@@ -336,9 +336,10 @@ static const argument_t kArguments[] = {
 };
 
 bool RehashTool(const args_list_t &args) {
-  ordered_args::ordered_args_map_t parsed_args;
+  using namespace ordered_args;
+  ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args,
+  if (!ParseOrderedKeyValueArguments(parsed_args, extra_args, args,
     kArguments) || extra_args.size() > 1) {
     PrintUsage(kArguments);
     return false;
@@ -347,7 +348,7 @@ bool RehashTool(const args_list_t &args) {
   std::string directory_path;
   bool help = false;
 
-  ordered_args::GetBoolArgument(&help, "-help", parsed_args);
+  GetBoolArgument(&help, "-help", parsed_args);
 
   if (help) {
     fprintf(stderr, "Usage: openssl rehash [cert-directory]\n" \

--- a/tool-openssl/rehash.cc
+++ b/tool-openssl/rehash.cc
@@ -336,9 +336,9 @@ static const argument_t kArguments[] = {
 };
 
 bool RehashTool(const args_list_t &args) {
-  args_map_t parsed_args;
+  ordered_args::ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ParseKeyValueArguments(parsed_args, extra_args, args,
+  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args,
     kArguments) || extra_args.size() > 1) {
     PrintUsage(kArguments);
     return false;
@@ -347,7 +347,7 @@ bool RehashTool(const args_list_t &args) {
   std::string directory_path;
   bool help = false;
 
-  GetBoolArgument(&help, "-help", parsed_args);
+  ordered_args::GetBoolArgument(&help, "-help", parsed_args);
 
   if (help) {
     fprintf(stderr, "Usage: openssl rehash [cert-directory]\n" \

--- a/tool-openssl/req.cc
+++ b/tool-openssl/req.cc
@@ -457,9 +457,10 @@ static bool generate_serial(X509 *cert) {
 }
 
 bool reqTool(const args_list_t &args) {
-  ordered_args::ordered_args_map_t parsed_args;
+  using namespace ordered_args;
+  ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+  if (!ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
@@ -469,16 +470,16 @@ bool reqTool(const args_list_t &args) {
   unsigned int days;
   bool help = false, new_flag = false, x509_flag = false, nodes = false;
 
-  ordered_args::GetBoolArgument(&help, "-help", parsed_args);
-  ordered_args::GetBoolArgument(&new_flag, "-new", parsed_args);
-  ordered_args::GetBoolArgument(&x509_flag, "-x509", parsed_args);
-  ordered_args::GetBoolArgument(&nodes, "-nodes", parsed_args);
+  GetBoolArgument(&help, "-help", parsed_args);
+  GetBoolArgument(&new_flag, "-new", parsed_args);
+  GetBoolArgument(&x509_flag, "-x509", parsed_args);
+  GetBoolArgument(&nodes, "-nodes", parsed_args);
 
-  ordered_args::GetString(&newkey, "-newkey", "", parsed_args);
-  ordered_args::GetUnsigned(&days, "-days", 30u, parsed_args);
-  ordered_args::GetString(&subj, "-subj", "", parsed_args);
-  ordered_args::GetString(&keyout, "-keyout", "", parsed_args);
-  ordered_args::GetString(&out, "-out", "", parsed_args);
+  GetString(&newkey, "-newkey", "", parsed_args);
+  GetUnsigned(&days, "-days", 30u, parsed_args);
+  GetString(&subj, "-subj", "", parsed_args);
+  GetString(&keyout, "-keyout", "", parsed_args);
+  GetString(&out, "-out", "", parsed_args);
 
   if (help) {
     PrintUsage(kArguments);

--- a/tool-openssl/req.cc
+++ b/tool-openssl/req.cc
@@ -7,6 +7,8 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/rsa.h>
+#include <algorithm>
+#include <iostream>
 #include <stdio.h>
 #include <string.h>
 #include "../tool/internal.h"
@@ -455,9 +457,9 @@ static bool generate_serial(X509 *cert) {
 }
 
 bool reqTool(const args_list_t &args) {
-  args_map_t parsed_args;
+  ordered_args::ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
@@ -467,16 +469,16 @@ bool reqTool(const args_list_t &args) {
   unsigned int days;
   bool help = false, new_flag = false, x509_flag = false, nodes = false;
 
-  GetBoolArgument(&help, "-help", parsed_args);
-  GetBoolArgument(&new_flag, "-new", parsed_args);
-  GetBoolArgument(&x509_flag, "-x509", parsed_args);
-  GetBoolArgument(&nodes, "-nodes", parsed_args);
+  ordered_args::GetBoolArgument(&help, "-help", parsed_args);
+  ordered_args::GetBoolArgument(&new_flag, "-new", parsed_args);
+  ordered_args::GetBoolArgument(&x509_flag, "-x509", parsed_args);
+  ordered_args::GetBoolArgument(&nodes, "-nodes", parsed_args);
 
-  GetString(&newkey, "-newkey", "", parsed_args);
-  GetUnsigned(&days, "-days", 30u, parsed_args);
-  GetString(&subj, "-subj", "", parsed_args);
-  GetString(&keyout, "-keyout", "", parsed_args);
-  GetString(&out, "-out", "", parsed_args);
+  ordered_args::GetString(&newkey, "-newkey", "", parsed_args);
+  ordered_args::GetUnsigned(&days, "-days", 30u, parsed_args);
+  ordered_args::GetString(&subj, "-subj", "", parsed_args);
+  ordered_args::GetString(&keyout, "-keyout", "", parsed_args);
+  ordered_args::GetString(&out, "-out", "", parsed_args);
 
   if (help) {
     PrintUsage(kArguments);

--- a/tool-openssl/rsa.cc
+++ b/tool-openssl/rsa.cc
@@ -42,9 +42,10 @@ static bool handleModulus(RSA *rsa, ScopedFILE &out_file) {
 
 // Map arguments using tool/args.cc
 bool rsaTool(const args_list_t &args) {
-  ordered_args::ordered_args_map_t parsed_args;
+  using namespace ordered_args;
+  ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+  if (!ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
@@ -53,10 +54,10 @@ bool rsaTool(const args_list_t &args) {
   std::string in_path, out_path;
   bool noout = false, help = false;
 
-  ordered_args::GetBoolArgument(&help, "-help", parsed_args);
-  ordered_args::GetString(&in_path, "-in", "", parsed_args);
-  ordered_args::GetString(&out_path, "-out", "", parsed_args);
-  ordered_args::GetBoolArgument(&noout, "-noout", parsed_args);
+  GetBoolArgument(&help, "-help", parsed_args);
+  GetString(&in_path, "-in", "", parsed_args);
+  GetString(&out_path, "-out", "", parsed_args);
+  GetBoolArgument(&noout, "-noout", parsed_args);
 
   // Display rsa tool option summary
   if (help) {
@@ -92,7 +93,7 @@ bool rsaTool(const args_list_t &args) {
   }
 
   // The "rsa" command does not order output based on parameters:
-  if (ordered_args::HasArgument(parsed_args, "-modulus")) {
+  if (HasArgument(parsed_args, "-modulus")) {
     if (!handleModulus(rsa.get(), out_file)) {
       return false;
     }

--- a/tool-openssl/rsa.cc
+++ b/tool-openssl/rsa.cc
@@ -40,13 +40,6 @@ static bool handleModulus(RSA *rsa, ScopedFILE &out_file) {
   return true;
 }
 
-static bool ProcessArgument(const std::string &arg_name, RSA *rsa, ScopedFILE &out_file) {
-  if (arg_name == "-modulus") {
-    return handleModulus(rsa, out_file);
-  }
-  return true;
-}
-
 // Map arguments using tool/args.cc
 bool rsaTool(const args_list_t &args) {
   ordered_args::ordered_args_map_t parsed_args;
@@ -98,16 +91,9 @@ bool rsaTool(const args_list_t &args) {
     }
   }
 
-  // Process arguments in the order they were provided
-  for (const auto &arg_pair : parsed_args) {
-    const std::string &arg_name = arg_pair.first;
-
-    // Skip non-output arguments
-    if (arg_name == "-in" || arg_name == "-out" || arg_name == "-noout" || arg_name == "-help") {
-      continue;
-    }
-
-    if (!ProcessArgument(arg_name, rsa.get(), out_file)) {
+  // The "rsa" command does not order output based on parameters:
+  if (ordered_args::HasArgument(parsed_args, "-modulus")) {
+    if (!handleModulus(rsa.get(), out_file)) {
       return false;
     }
   }

--- a/tool-openssl/rsa_test.cc
+++ b/tool-openssl/rsa_test.cc
@@ -227,3 +227,34 @@ TEST_F(RSAComparisonTest, RSAToolCompareModulusOutNooutOpenSSL) {
   trim(openssl_output_str);
   ASSERT_EQ(tool_output_str, openssl_output_str);
 }
+
+// Test against OpenSSL output "openssl rsa -in file -noout -modulus"
+// Only modulus is printed to stdin (reordered parameters)
+TEST_F(RSAComparisonTest, RSAToolCompareReorderedModulusNooutOpenSSL) {
+  std::string tool_command = std::string(tool_executable_path) + " rsa -in " + in_path + " -noout -modulus > " + out_path_tool;
+  std::string openssl_command = std::string(openssl_executable_path) + " rsa -in " + in_path + " -noout -modulus > " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+
+  ASSERT_EQ(tool_output_str, openssl_output_str);
+}
+
+// Test against OpenSSL output "openssl rsa -in file -noout -modulus -out out_file"
+// Only modulus is printed to output file (reordered parameters)
+TEST_F(RSAComparisonTest, RSAToolCompareReorderedModulusOutNooutOpenSSL) {
+  std::string tool_command = std::string(tool_executable_path) + " rsa -in " + in_path + " -noout -modulus -out " + out_path_tool;
+  std::string openssl_command = std::string(openssl_executable_path) + " rsa -in " + in_path + " -noout -modulus -out " + out_path_openssl;
+
+  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_tool, out_path_openssl, tool_output_str, openssl_output_str);
+
+  ScopedFILE tool_out_file(fopen(out_path_tool, "rb"));
+  ASSERT_TRUE(tool_out_file);
+  ScopedFILE openssl_out_file(fopen(out_path_openssl, "rb"));
+  ASSERT_TRUE(openssl_out_file);
+
+  tool_output_str = ReadFileToString(out_path_tool);
+  openssl_output_str = ReadFileToString(out_path_openssl);
+  trim(tool_output_str);
+  trim(openssl_output_str);
+  ASSERT_EQ(tool_output_str, openssl_output_str);
+}

--- a/tool-openssl/s_client.cc
+++ b/tool-openssl/s_client.cc
@@ -29,19 +29,25 @@ static const argument_t kArguments[] = {
 };
 
 bool SClientTool(const args_list_t &args) {
-  std::map<std::string, std::string> args_map;
+  ordered_args::ordered_args_map_t parsed_args;
   args_list_t extra_args;
 
-  if (!ParseKeyValueArguments(args_map, extra_args, args, kArguments) ||
+  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }
 
-  if(args_map.count("help")) {
+  if(ordered_args::HasArgument(parsed_args, "-help")) {
     fprintf(stderr, "Usage: s_client [options] [host:port]\n");
     PrintUsage(kArguments);
     return true;
+  }
+
+  // Convert to std::map for DoClient compatibility
+  std::map<std::string, std::string> args_map;
+  for (const auto &arg_pair : parsed_args) {
+    args_map[arg_pair.first] = arg_pair.second;
   }
 
   return DoClient(args_map, true);

--- a/tool-openssl/s_client.cc
+++ b/tool-openssl/s_client.cc
@@ -29,16 +29,17 @@ static const argument_t kArguments[] = {
 };
 
 bool SClientTool(const args_list_t &args) {
-  ordered_args::ordered_args_map_t parsed_args;
+  using namespace ordered_args;
+  ordered_args_map_t parsed_args;
   args_list_t extra_args;
 
-  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+  if (!ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;
   }
 
-  if(ordered_args::HasArgument(parsed_args, "-help")) {
+  if(HasArgument(parsed_args, "-help")) {
     fprintf(stderr, "Usage: s_client [options] [host:port]\n");
     PrintUsage(kArguments);
     return true;

--- a/tool-openssl/verify.cc
+++ b/tool-openssl/verify.cc
@@ -4,6 +4,9 @@
 #include <openssl/base.h>
 #include <openssl/x509.h>
 #include <openssl/pem.h>
+#include <algorithm>
+#include <iostream>
+#include <string>
 #include "internal.h"
 
 // TO-DO: We do not support using a default trust store, therefore -CAfile must
@@ -171,14 +174,14 @@ static int check(X509_STORE *ctx, const char* chainfile, const char *certfile) {
 }
 
 bool VerifyTool(const args_list_t &args) {
-  args_map_t parsed_args;
+  ordered_args::ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments)) {
+  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments)) {
     PrintUsage(kArguments);
     return false;
   }
 
-  if (parsed_args.count("-help") || parsed_args.size() == 0) {
+  if (ordered_args::HasArgument(parsed_args, "-help") || parsed_args.size() == 0) {
     fprintf(stderr,
             "Usage: verify [options] [cert.pem...]\n"
             "Certificates must be in PEM format. They can be specified in one or more files.\n"
@@ -188,7 +191,8 @@ bool VerifyTool(const args_list_t &args) {
     return true;
   }
 
-  std::string cafile = parsed_args["-CAfile"];
+  std::string cafile;
+  ordered_args::GetString(&cafile, "-CAfile", "", parsed_args);
 
   bssl::UniquePtr<X509_STORE> store(setup_verification_store(cafile));
   // Initialize certificate verification store
@@ -202,7 +206,9 @@ bool VerifyTool(const args_list_t &args) {
 
   int ret = 1;
 
-  const char *chain = parsed_args.count("-untrusted") ? parsed_args["-untrusted"].c_str() : NULL;
+  std::string chain_file;
+  ordered_args::GetString(&chain_file, "-untrusted", "", parsed_args);
+  const char *chain = chain_file.empty() ? NULL : chain_file.c_str();
 
   // No additional file or certs provided, read from stdin
   if (extra_args.size() == 0) {

--- a/tool-openssl/verify.cc
+++ b/tool-openssl/verify.cc
@@ -174,14 +174,15 @@ static int check(X509_STORE *ctx, const char* chainfile, const char *certfile) {
 }
 
 bool VerifyTool(const args_list_t &args) {
-  ordered_args::ordered_args_map_t parsed_args;
+  using namespace ordered_args;
+  ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments)) {
+  if (!ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments)) {
     PrintUsage(kArguments);
     return false;
   }
 
-  if (ordered_args::HasArgument(parsed_args, "-help") || parsed_args.size() == 0) {
+  if (HasArgument(parsed_args, "-help") || parsed_args.size() == 0) {
     fprintf(stderr,
             "Usage: verify [options] [cert.pem...]\n"
             "Certificates must be in PEM format. They can be specified in one or more files.\n"
@@ -192,7 +193,7 @@ bool VerifyTool(const args_list_t &args) {
   }
 
   std::string cafile;
-  ordered_args::GetString(&cafile, "-CAfile", "", parsed_args);
+  GetString(&cafile, "-CAfile", "", parsed_args);
 
   bssl::UniquePtr<X509_STORE> store(setup_verification_store(cafile));
   // Initialize certificate verification store
@@ -207,7 +208,7 @@ bool VerifyTool(const args_list_t &args) {
   int ret = 1;
 
   std::string chain_file;
-  ordered_args::GetString(&chain_file, "-untrusted", "", parsed_args);
+  GetString(&chain_file, "-untrusted", "", parsed_args);
   const char *chain = chain_file.empty() ? NULL : chain_file.c_str();
 
   // No additional file or certs provided, read from stdin

--- a/tool-openssl/version.cc
+++ b/tool-openssl/version.cc
@@ -9,9 +9,9 @@ static const argument_t kArguments[] = {
 };
 
 bool VersionTool(const args_list_t &args) {
-  args_map_t parsed_args;
+  ordered_args::ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ParseKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;

--- a/tool-openssl/version.cc
+++ b/tool-openssl/version.cc
@@ -9,9 +9,10 @@ static const argument_t kArguments[] = {
 };
 
 bool VersionTool(const args_list_t &args) {
-  ordered_args::ordered_args_map_t parsed_args;
+  using namespace ordered_args;
+  ordered_args_map_t parsed_args;
   args_list_t extra_args;
-  if (!ordered_args::ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
+  if (!ParseOrderedKeyValueArguments(parsed_args, extra_args, args, kArguments) ||
       extra_args.size() > 0) {
     PrintUsage(kArguments);
     return false;


### PR DESCRIPTION
### Description of changes: 
Follow-up from previous PR: https://github.com/aws/aws-lc/pull/2454
* Migrates the remainder of the subcommands to using `ordered_args` for parameter processing.
* Updates tests for rsa and crl to use reordered arguments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
