### PR TITLE
Document that EVP_PKEY_CTX_set_rsa_keygen_pubexp takes ownership

### DIFF
--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -917,7 +917,9 @@ OPENSSL_EXPORT int EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX *ctx,
                                                     int bits);
 
 // EVP_PKEY_CTX_set_rsa_keygen_pubexp sets |e| as the public exponent for key
-// generation. Returns one on success or zero on error.
+// generation. Returns one on success or zero on error. On success, |ctx| takes
+// ownership of |e|. The library will then call |BN_free| on |e| when |ctx| is
+// destroyed.
 OPENSSL_EXPORT int EVP_PKEY_CTX_set_rsa_keygen_pubexp(EVP_PKEY_CTX *ctx,
                                                       BIGNUM *e);
 


### PR DESCRIPTION
See upstream commit: https://github.com/google/boringssl/commit/860c27038fcd9c2c27242e9874c18408dec1f84c

------
Change-Id: I66fa0b3ebc0cc79c29dafa74509ff6f06ad94ecf
Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/79747
Reviewed-by: Adam Langley <agl@google.com>
Auto-Submit: David Benjamin <davidben@google.com>
Commit-Queue: Adam Langley <agl@google.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
