### PR TITLE
Fix logical bug and add test for tree-DRBG fork

### DIFF
--- a/crypto/fipsmodule/rand/entropy/internal.h
+++ b/crypto/fipsmodule/rand/entropy/internal.h
@@ -131,7 +131,7 @@ struct test_tree_drbg_t {
 // In addition, it returns the number of reseeds applied on the tread-local and
 // global tree-DRBG. These values of copied to |test_tree_drbg|.
 OPENSSL_EXPORT int get_thread_and_global_tree_drbg_calls_FOR_TESTING(
-  struct entropy_source_t *entropy_source,
+  const struct entropy_source_t *entropy_source,
   struct test_tree_drbg_t *test_tree_drbg);
 
 // set_thread_and_global_tree_drbg_reseed_counter_FOR_TESTING sets the reseed

--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
@@ -468,7 +468,6 @@ int get_thread_and_global_tree_drbg_calls_FOR_TESTING(
   struct test_tree_drbg_t *test_tree_drbg) {
 
   if (test_tree_drbg == NULL || entropy_source == NULL) {
-    fprintf(stderr, "something is NULL\n");
     return 0;
   }
 
@@ -481,7 +480,6 @@ int get_thread_and_global_tree_drbg_calls_FOR_TESTING(
     (struct tree_jitter_drbg_t *) entropy_source->state;
 
   if (global_tree_jitter_drbg == NULL || thread_tree_jitter_drbg == NULL) {
-    fprintf(stderr, "more something is NULL\n");
     goto out;
   }
 

--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
@@ -468,6 +468,7 @@ int get_thread_and_global_tree_drbg_calls_FOR_TESTING(
   struct test_tree_drbg_t *test_tree_drbg) {
 
   if (test_tree_drbg == NULL || entropy_source == NULL) {
+    fprintf(stderr, "something is NULL\n");
     return 0;
   }
 
@@ -480,6 +481,7 @@ int get_thread_and_global_tree_drbg_calls_FOR_TESTING(
     (struct tree_jitter_drbg_t *) entropy_source->state;
 
   if (global_tree_jitter_drbg == NULL || thread_tree_jitter_drbg == NULL) {
+    fprintf(stderr, "more something is NULL\n");
     goto out;
   }
 

--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
@@ -157,7 +157,7 @@ static int tree_jitter_check_drbg_must_reseed(
   struct tree_jitter_drbg_t *tree_jitter_drbg) {
 
   uint64_t current_generation_number = 0;
-  if (CRYPTO_get_ube_generation_number(&current_generation_number) != 1 &&
+  if (CRYPTO_get_ube_generation_number(&current_generation_number) == 1 &&
       current_generation_number != tree_jitter_drbg->generation_number) {
     tree_jitter_drbg->generation_number = current_generation_number;
     return 1;
@@ -464,7 +464,7 @@ void tree_jitter_zeroize_thread_drbg(struct entropy_source_t *entropy_source) {
 }
 
 int get_thread_and_global_tree_drbg_calls_FOR_TESTING(
-  struct entropy_source_t *entropy_source,
+  const struct entropy_source_t *entropy_source,
   struct test_tree_drbg_t *test_tree_drbg) {
 
   if (test_tree_drbg == NULL || entropy_source == NULL) {

--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
@@ -279,6 +279,7 @@ TEST_F(treeDrbgJitterentropyTest, BasicFork) {
       }
     );
 
+    tree_jitter_free_thread_drbg(&entropy_source);
     exit(exit_code ? 0 : 1);
   };
 
@@ -309,6 +310,7 @@ TEST_F(treeDrbgJitterentropyTest, BasicFork) {
             }, "child")
           )
 
+          tree_jitter_free_thread_drbg(&thread_entropy_source);
           *result = true;
         };
 
@@ -343,6 +345,7 @@ TEST_F(treeDrbgJitterentropyTest, BasicFork) {
       }
     );
 
+    tree_jitter_free_thread_drbg(&entropy_source);
     exit(exit_code ? 0 : 1);
   };
 

--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
@@ -235,6 +235,8 @@ static bool assertSeedOrReseed(const struct entropy_source_t *entropy_source,
     expect_reseed_thread, expect_reseed_global, error_text);
 }
 
+#if !defined(OPENSSL_WINDOWS)
+
 TEST_F(treeDrbgJitterentropyTest, BasicFork) {
 
   if (runtimeEmulationIsIntelSde() && addressSanitizerIsEnabled()) {
@@ -352,6 +354,8 @@ TEST_F(treeDrbgJitterentropyTest, BasicFork) {
   EXPECT_EXIT(testFuncSingleForkThenThread(), ::testing::ExitedWithCode(0), "");
 
 }
+
+#endif // !defined(OPENSSL_WINDOWS)
 
 TEST_F(treeDrbgJitterentropyTest, TreeDRBGThreadReseedInterval) {
 

--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
@@ -250,12 +250,12 @@ TEST_F(treeDrbgJitterentropyTest, BasicFork) {
           expect_reseed = 1;
         }
 
-        return assertReseed(&entropy_source, expect_reseed, [this, entropy_source]() {
+        return assertReseed(&entropy_source, expect_reseed, [entropy_source]() {
           uint8_t child_out[CTR_DRBG_ENTROPY_LEN];
           return tree_jitter_get_seed(&entropy_source, child_out);
         }, "child");
       },
-      [this, entropy_source]() {
+      [entropy_source]() {
         // In child. If UBE detection is supported, we expect a reseed.
         // No UBE detection is handled via prediction resistance.
         return assertReseed(&entropy_source, 0, [entropy_source]() {

--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
@@ -201,6 +201,8 @@ TEST_F(treeDrbgJitterentropyTest, BasicReseed) {
   EXPECT_EXIT(testFunc(), ::testing::ExitedWithCode(0), "");
 }
 
+#if !defined(OPENSSL_WINDOWS)
+
 static bool veryifySeedOrReseed(const struct test_tree_drbg_t *test_tree_drbg,
   const struct test_tree_drbg_t *cached_test_tree_drbg,
   size_t expect_reseed_thread, size_t expect_reseed_global,
@@ -234,8 +236,6 @@ static bool assertSeedOrReseed(const struct entropy_source_t *entropy_source,
   return veryifySeedOrReseed(&test_tree_drbg, &cached_test_tree_drbg,
     expect_reseed_thread, expect_reseed_global, error_text);
 }
-
-#if !defined(OPENSSL_WINDOWS)
 
 TEST_F(treeDrbgJitterentropyTest, BasicFork) {
 

--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc
@@ -298,7 +298,7 @@ TEST_F(treeDrbgJitterentropyTest, BasicFork) {
         // If fork detection is not enabled, we also expect a seed in each
         // thread. However, this seed should occur when calling
         // tree_jitter_initialize.
-        std::function<void(bool*)> threadFunc = [this, entropy_source](bool *result) {
+        std::function<void(bool*)> threadFunc = [](bool *result) {
 
           struct entropy_source_t thread_entropy_source = {0, 0};
           TEST_IN_FORK_ASSERT_TRUE(tree_jitter_initialize(&thread_entropy_source))

--- a/crypto/thread_pthread.c
+++ b/crypto/thread_pthread.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <openssl/target.h>
 #include <openssl/type_check.h>
 
 
@@ -66,20 +67,115 @@ void CRYPTO_MUTEX_cleanup(CRYPTO_MUTEX *lock) {
   pthread_rwlock_destroy((pthread_rwlock_t *) lock);
 }
 
+#ifdef __MINGW32__
+
+#ifndef MIN
+#define MINGW_AWSLC_MIN(X,Y) (((X) < (Y)) ? (X) : (Y))
+#else
+#define MINGW_AWSLC_MIN(X,Y) MIN(X,Y)
+#endif
+
+// MINGW implements nanosleep on X86_64 but not on other architectures.
+// Prefer using nanosleep because of its higher resolution.
+// https://gist.github.com/scivision/dbbbf33c2faf5a16f31fd6d144adc314 claims
+// that MINGW only implements nanpsleep on X86, but not Arm64. The linked
+// MINGW source code
+// https://github.com/mingw-w64/mingw-w64/blob/master/mingw-w64-libraries/winpthreads/src/nanosleep.c
+// does not seem to exclude any platforms though. But since this code is only
+// really needed for X86 in the first place, avoid creating more availability
+// risks.
+#if defined(OPENSSL_X86_64)
+#include <time.h>
+// One second in nanoseconds.
+#define MINGW_ONE_SECOND INT64_C(1000000000)
+// 250 milliseconds in nanoseconds.
+#define MINGW_MILLISECONDS_250 INT64_C(
+#define MINGW_INITIAL_BACKOFF_DELAY 1
+
+static void mingw_do_backoff(long *backoff) {
+
+  // Exponential backoff.
+  //
+  // iteration          delay
+  // ---------    -----------------
+  //    1         10          nsec
+  //    2         100         nsec
+  //    3         1,000       nsec
+  //    4         10,000      nsec
+  //    5         100,000     nsec
+  //    6         1,000,000   nsec
+  //    7         10,000,000  nsec
+  //    8         99,999,999  nsec
+  //    9         99,999,999  nsec
+  //    ...
+
+  struct timespec sleep_time = {.tv_sec = 0, .tv_nsec = 0 };
+
+  // Cap backoff at 99,999,999  nsec, which is the maximum value the nanoseconds
+  // field in |timespec| can hold.
+  *backoff = MINGW_AWSLC_MIN((*backoff) * 10, MINGW_ONE_SECOND - 1);
+  // |nanosleep| can mutate |sleep_time|. Hence, we use |backoff| for state.
+  sleep_time.tv_nsec = *backoff;
+
+  nanosleep(&sleep_time, &sleep_time);
+}
+
+#else // defined(OPENSSL_X86_64)
+
+#include <windows.h>
+// 10 milliseconds.
+#define MINGW_MILLISECONDS_10 INT64_C(10)
+#define MINGW_INITIAL_BACKOFF_DELAY 1
+
+static void mingw_do_backoff(long *backoff) {
+
+  // Additive backoff.
+  //
+  // iteration     delay
+  // ---------    -------
+  //    1         1    ms
+  //    2         2    ms
+  //    3         3    ms
+  //    4         4    ms
+  //    5         5    ms
+  //    6         6    ms
+  //    7         7    ms
+  //    8         8    ms
+  //    9         9    ms
+  //    10        10   ms
+  //    10        10   ms
+  //    ...
+
+  // Cap backoff at 10ms.
+  *backoff = MINGW_AWSLC_MIN((*backoff) + 1, MINGW_MILLISECONDS_10);
+  Sleep((int)*backoff);
+}
+#endif // defined(OPENSSL_X86_64)
+
+#endif // __MINGW32__
+
 // Some MinGW pthreads implementations might fail on first use of
 // locks initialized using PTHREAD_RWLOCK_INITIALIZER.
 // See: https://sourceforge.net/p/mingw-w64/bugs/883/
 typedef int (*pthread_rwlock_func_ptr)(pthread_rwlock_t *);
 static int rwlock_EINVAL_fallback_retry(const pthread_rwlock_func_ptr func_ptr, pthread_rwlock_t* lock) {
+
   int result = EINVAL;
 #ifdef __MINGW32__
-  const int MAX_ATTEMPTS = 10;
+  const int MAX_ATTEMPTS = 50;
   int attempt_num = 0;
+  long backoff = MINGW_INITIAL_BACKOFF_DELAY;
   do {
     sched_yield();
     attempt_num += 1;
     result = func_ptr(lock);
+    mingw_do_backoff(&backoff);
   } while(result == EINVAL && attempt_num < MAX_ATTEMPTS);
+
+  // To aid in debugging
+  if (result == EINVAL && attempt_num >= MAX_ATTEMPTS) {
+    fprintf(stderr, "ERROR: rwlock_EINVAL_fallback_retry() failed after %i attempts\n", MAX_ATTEMPTS);
+  }
 #endif
   return result;
 }

--- a/tests/ci/run_bsd_tests.sh
+++ b/tests/ci/run_bsd_tests.sh
@@ -21,10 +21,12 @@ if [ "$PLATFORM" != "amd64" ] && [ "$PLATFORM" != "x86_64" ]; then
     shard_gtest ${BUILD_ROOT}/crypto/mem_set_test
     shard_gtest ${BUILD_ROOT}/crypto/rand_isolated_test
     shard_gtest ${BUILD_ROOT}/crypto/tree_drbg_jitter_entropy_isolated_test
-    shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init
 
     shard_gtest ${BUILD_ROOT}/ssl/ssl_test
     shard_gtest ${BUILD_ROOT}/ssl/integration_test
+
+    # Does not use GoogleTest
+    ${BUILD_ROOT}/crypto/rwlock_static_init
 
     # Due to its special linkage, this does not use GoogleTest
     ${BUILD_ROOT}/crypto/dynamic_loading_test

--- a/tests/ci/run_cross_mingw_tests.sh
+++ b/tests/ci/run_cross_mingw_tests.sh
@@ -70,10 +70,12 @@ for BO in "${BUILD_OPTIONS[@]}"; do
   shard_gtest ${BUILD_ROOT}/crypto/mem_set_test.exe
   shard_gtest ${BUILD_ROOT}/crypto/rand_isolated_test.exe
   shard_gtest ${BUILD_ROOT}/crypto/tree_drbg_jitter_entropy_isolated_test.exe
-  shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init.exe
 
   shard_gtest ${BUILD_ROOT}/ssl/ssl_test.exe
   shard_gtest ${BUILD_ROOT}/ssl/integration_test.exe
+
+  # Does not use GoogleTest
+  ${BUILD_ROOT}/crypto/rwlock_static_init.exe
 
   # Due to its special linkage, this does not use GoogleTest
   ${BUILD_ROOT}/crypto/dynamic_loading_test.exe

--- a/tests/ci/run_cross_tests.sh
+++ b/tests/ci/run_cross_tests.sh
@@ -67,10 +67,12 @@ for BO in "${BUILD_OPTIONS[@]}"; do
   shard_gtest ${BUILD_ROOT}/crypto/mem_set_test
   shard_gtest ${BUILD_ROOT}/crypto/rand_isolated_test
   shard_gtest ${BUILD_ROOT}/crypto/tree_drbg_jitter_entropy_isolated_test
-  shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init
 
   shard_gtest ${BUILD_ROOT}/ssl/ssl_test
   shard_gtest ${BUILD_ROOT}/ssl/integration_test
+
+  # Does not use GoogleTest
+  ${BUILD_ROOT}/crypto/rwlock_static_init
 
   # Due to its special linkage, this does not use GoogleTest
   ${BUILD_ROOT}/crypto/dynamic_loading_test

--- a/tests/ci/run_ios_sim_tests.sh
+++ b/tests/ci/run_ios_sim_tests.sh
@@ -101,11 +101,13 @@ shard_gtest ${BUILD_ROOT}/crypto/mem_test.app/mem_test
 shard_gtest ${BUILD_ROOT}/crypto/mem_set_test.app/mem_set_test
 shard_gtest ${BUILD_ROOT}/crypto/rand_isolated_test.app/rand_isolated_test
 shard_gtest ${BUILD_ROOT}/crypto/tree_drbg_jitter_entropy_isolated_test.app/tree_drbg_jitter_entropy_isolated_test
-shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init.app/rwlock_static_init
 
 shard_gtest ${BUILD_ROOT}/ssl/ssl_test.app/ssl_test
 # TODO: This test is failing on iOS simulator
 #${BUILD_ROOT}/ssl/integration_test.app/integration_test
+
+# Does not use GoogleTest
+${BUILD_ROOT}/crypto/rwlock_static_init.app/rwlock_static_init
 
 # Due to its special linkage, this does not use GoogleTest
 ${BUILD_ROOT}/crypto/dynamic_loading_test.app/dynamic_loading_test


### PR DESCRIPTION
### Issues:

V1827078279

### Description of changes: 

Fixes a logical bug in the tree-DRBG `tree_jitter_check_drbg_must_reseed()` that would prevent a reseed under UBE.

Adds test coverage for tree-DRBG under UBE's. 

Must amend the retry logic for mingw due to the bug https://sourceforge.net/p/mingw-w64/bugs/883/. The existing mitigation for that issue wasn't sufficient anymore (for unknown reasons). I counted up to thousands of retries required.
Instead of relying on tight retries, we implement time-based backoff. This added another complication that `nanosleep()` might not be available on Arm64. To get around that on Arm64, use `Sleep`. Buuut, this function has millisecond resolution, so we don't apply exponential backoff, instead we backoff with 1 ms at a time, to avoid it exploding. x86 still use nanosleep.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
