### PR TITLE
Remove sys headers from bio.h

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -7,19 +7,6 @@
 
 #include <openssl/mem.h>
 
-#include <stddef.h>
-#if defined(OPENSSL_WINDOWS)
-#if !defined(_SSIZE_T_DEFINED)
-typedef SSIZE_T ssize_t;
-#endif
-#else
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/un.h>
-#include <unistd.h>
-#endif
-
 #include "../internal.h"
 #include "./internal.h"
 

--- a/crypto/bio/dgram.c
+++ b/crypto/bio/dgram.c
@@ -7,19 +7,6 @@
 
 #include <openssl/mem.h>
 
-#include <stddef.h>
-#if defined(OPENSSL_WINDOWS)
-#if !defined(_SSIZE_T_DEFINED)
-typedef SSIZE_T ssize_t;
-#endif
-#else
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/un.h>
-#include <unistd.h>
-#endif
-
 #include "../internal.h"
 #include "./internal.h"
 

--- a/crypto/bio/internal.h
+++ b/crypto/bio/internal.h
@@ -69,11 +69,16 @@ typedef unsigned short u_short;
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <sys/un.h>
+#include <unistd.h>
 #else
 OPENSSL_MSVC_PRAGMA(warning(push, 3))
 #include <winsock2.h>
+#include <ws2ipdef.h>
 OPENSSL_MSVC_PRAGMA(warning(pop))
 typedef int socklen_t;
+#if !defined(_SSIZE_T_DEFINED)
+typedef SSIZE_T ssize_t;
+#endif
 #endif
 #endif  // !OPENSSL_NO_SOCK
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -67,19 +67,6 @@
 #include <openssl/stack.h>
 #include <openssl/thread.h>
 
-#if defined(OPENSSL_WINDOWS)
-// Due to name conflicts, we must prevent "wincrypt.h" from being included
-#define NOCRYPT
-#include <winsock2.h>
-#include <ws2ipdef.h>
-#undef NOCRYPT
-#else
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
-#endif
-
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -779,11 +766,6 @@ OPENSSL_EXPORT int BIO_dgram_get_peer(BIO* bp, BIO_ADDR *peer) OPENSSL_WARN_UNUS
 // BIO_dgram_set_peer sets the peer address for the datagram BIO to |peer|.
 // It returns 1 on success and a non-positive value on error.
 OPENSSL_EXPORT int BIO_dgram_set_peer(BIO* bp, const BIO_ADDR *peer) OPENSSL_WARN_UNUSED_RESULT;
-
-// BIO_dgram_get_mtu_overhead returns the number of bytes of overhead when sending
-// a datagram of the maximum size through |bp| to the specified |peer| address.
-// This is used for PMTU discovery in DTLS.
-OPENSSL_EXPORT unsigned int BIO_dgram_get_mtu_overhead(BIO* bp, struct sockaddr *peer) OPENSSL_WARN_UNUSED_RESULT;
 
 // BIO_ADDR_new allocates and initializes a new BIO_ADDR structure.
 // Returns the new BIO_ADDR structure on success, NULL on error.


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-3316`, `CryptoAlg-3292`, `CryptoAlg-3310`, `CryptoAlg-3284`, and `CryptoAlg-3346`.

### Description of changes: 
Some internal builds are failing due to the duplicate header file references that `bio.h` has.
```
/usr/include/bits/types/struct_iovec.h:26:8: error: redefinition of 'struct iovec'
struct iovec
        ^~~~~
In file included from src/core/tsi/alts/crypt/aes_gcm.cc:23:0:
./src/core/tsi/alts/crypt/gsec.h:30:8: note: previous definition of 'struct iovec'
struct iovec {
```

The `sockaddr` references requires the `<sys/socket.h>` header to exist, but it turns out we never actually implemented `BIO_dgram_get_mtu_overhead`. Removing `BIO_dgram_get_mtu_overhead` for now allows us to get around the "redefinition failure".

OpenSSL gets around the `sockaddr` by containing `BIO_dgram_get_mtu_overhead` in [a macro pointing to `BIO_ctrl`](https://github.com/openssl/openssl/blob/2e1b046d9af20f9d1b981e5aa4a8b498155f5c0e/include/openssl/bio.h.in#L652-L653C38). We'll likely have to do the same here when we eventually implement `BIO_dgram_get_mtu_overhead`.

### Callouts
I'll introduce CI for the issue in another PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
