### PR TITLE
rwlock race tests is not a GoogleTest executable

### DIFF
--- a/tests/ci/run_bsd_tests.sh
+++ b/tests/ci/run_bsd_tests.sh
@@ -19,10 +19,12 @@ if [ "$PLATFORM" != "amd64" ] && [ "$PLATFORM" != "x86_64" ]; then
     shard_gtest ${BUILD_ROOT}/crypto/urandom_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_set_test
-    shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init
 
     shard_gtest ${BUILD_ROOT}/ssl/ssl_test
     shard_gtest ${BUILD_ROOT}/ssl/integration_test
+
+    # Does not use GoogleTest
+    ${BUILD_ROOT}/crypto/rwlock_static_init
 
     # Due to its special linkage, this does not use GoogleTest
     ${BUILD_ROOT}/crypto/dynamic_loading_test

--- a/tests/ci/run_cross_mingw_tests.sh
+++ b/tests/ci/run_cross_mingw_tests.sh
@@ -68,10 +68,12 @@ for BO in "${BUILD_OPTIONS[@]}"; do
   shard_gtest ${BUILD_ROOT}/crypto/urandom_test.exe
   shard_gtest ${BUILD_ROOT}/crypto/mem_test.exe
   shard_gtest ${BUILD_ROOT}/crypto/mem_set_test.exe
-  shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init.exe
 
   shard_gtest ${BUILD_ROOT}/ssl/ssl_test.exe
   shard_gtest ${BUILD_ROOT}/ssl/integration_test.exe
+
+  # Does not use GoogleTest
+  ${BUILD_ROOT}/crypto/rwlock_static_init.exe
 
   # Due to its special linkage, this does not use GoogleTest
   ${BUILD_ROOT}/crypto/dynamic_loading_test.exe

--- a/tests/ci/run_cross_tests.sh
+++ b/tests/ci/run_cross_tests.sh
@@ -65,10 +65,12 @@ for BO in "${BUILD_OPTIONS[@]}"; do
   shard_gtest ${BUILD_ROOT}/crypto/urandom_test
   shard_gtest ${BUILD_ROOT}/crypto/mem_test
   shard_gtest ${BUILD_ROOT}/crypto/mem_set_test
-  shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init
 
   shard_gtest ${BUILD_ROOT}/ssl/ssl_test
   shard_gtest ${BUILD_ROOT}/ssl/integration_test
+
+  # Does not use GoogleTest
+  ${BUILD_ROOT}/crypto/rwlock_static_init
 
   # Due to its special linkage, this does not use GoogleTest
   ${BUILD_ROOT}/crypto/dynamic_loading_test

--- a/tests/ci/run_ios_sim_tests.sh
+++ b/tests/ci/run_ios_sim_tests.sh
@@ -99,11 +99,13 @@ shard_gtest "${BUILD_ROOT}/crypto/crypto_test.app/crypto_test --gtest_also_run_d
 shard_gtest ${BUILD_ROOT}/crypto/urandom_test.app/urandom_test
 shard_gtest ${BUILD_ROOT}/crypto/mem_test.app/mem_test
 shard_gtest ${BUILD_ROOT}/crypto/mem_set_test.app/mem_set_test
-shard_gtest ${BUILD_ROOT}/crypto/rwlock_static_init.app/rwlock_static_init
 
 shard_gtest ${BUILD_ROOT}/ssl/ssl_test.app/ssl_test
 # TODO: This test is failing on iOS simulator
 #${BUILD_ROOT}/ssl/integration_test.app/integration_test
+
+# Does not use GoogleTest
+${BUILD_ROOT}/crypto/rwlock_static_init.app/rwlock_static_init
 
 # Due to its special linkage, this does not use GoogleTest
 ${BUILD_ROOT}/crypto/dynamic_loading_test.app/dynamic_loading_test


### PR DESCRIPTION
### Description of changes: 

`shard_gtest()` spaws multiple child processes to shard test GoogleTest fixtures. But `rwlock_static_init` is not a GoogleTest executable. So, this is redundant.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
