### PR TITLE
s2n-bignum: Add prefix header to _s2n_bignum_internal.h

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -293,14 +293,6 @@ if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) OR
     )
   endif()
 
-  if(BORINGSSL_PREFIX)
-    # s2n-bignum is third-party code and therefore doesn't have an explicit
-    # definition of symbol prefixes under the prefix build. Inject prefix
-    # definitions instead. One could set this property for just the s2n-bignum
-    # source. But for simplicity, do it for all. The pre-processor will remove
-    # any duplicate header files.
-    set_source_files_properties(${BCM_ASM_SOURCES} PROPERTIES COMPILE_FLAGS "--include=\"${AWSLC_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols_asm.h\"")
-  endif()
 endif()
 
 if(FIPS_DELOCATE)

--- a/third_party/s2n-bignum/import.sh
+++ b/third_party/s2n-bignum/import.sh
@@ -73,6 +73,22 @@ ls -la ${SRC}
 echo "Remove temporary artifacts ..."
 rm -rf ${TMP}
 
+echo "Adding ASM prefix header include to _internal_s2n_bignum.h ..."
+INTERNAL_HEADER="${SRC}/include/_internal_s2n_bignum.h"
+if [ ! -f "${INTERNAL_HEADER}" ]; then
+  echo "Error: ${INTERNAL_HEADER} not found"
+  exit 1
+fi
+
+# Create a temporary file with the prefix include at the top
+TEMP_FILE=$(mktemp)
+echo '// Auto-added during import for AWS-LC symbol prefixing support' > "${TEMP_FILE}"
+echo '#include <openssl/boringssl_prefix_symbols_asm.h>' >> "${TEMP_FILE}"
+echo '' >> "${TEMP_FILE}"
+cat "${INTERNAL_HEADER}" >> "${TEMP_FILE}"
+mv "${TEMP_FILE}" "${INTERNAL_HEADER}"
+echo "Added ASM prefix header include to ${INTERNAL_HEADER}"
+
 echo "Generating META.yml file ..."
 cat <<EOF > META.yml
 name: ${SRC}

--- a/third_party/s2n-bignum/s2n-bignum-imported/include/_internal_s2n_bignum.h
+++ b/third_party/s2n-bignum/s2n-bignum-imported/include/_internal_s2n_bignum.h
@@ -1,3 +1,5 @@
+// Auto-added during import for AWS-LC symbol prefixing support
+#include <openssl/boringssl_prefix_symbols_asm.h>
 
 #ifdef __APPLE__
 #   define S2N_BN_SYMBOL(NAME) _##NAME


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

------------

AWS-LC's prefix build works by providing a 'prefix header' which prefixes global symbols through a series of `#define ...` directives. This header needs to be included ahead of the source files it applies to.

1. For C files, the prefix header is pulled in through openssl/base.h.
2. For perl-generated ASM files, it comes from openssl/asm_base.h which is `#include`d through `xxx-xlate.pl`.
3. In contrast to 1. and 2., for s2n-bignum assembly, the prefix header is indirectly included through an `--include` directive in the CMakeLists.txt. Similarly, the cc_builder in aws-lc-rs is patched to use such `--include` clause when building s2n-bignum files.

This commit simplifies and improves the transparency of prefix handling for s2n-bignum files (case 3): Instead of using an `--include` directive in the build files, it explicitly adds the prefix header in the header _s2n_bignum_internal.h. This header is included by all s2n-bignum assembly. This is functionally equivalent to the previous --include directive, but avoids having to patch CMakeLists.txt or cc_builder.

The cc_builder patch can be removed from aws-lc-rs when convenient -- this commit renders the `--include` directive redundant, but not harmful.
