### PR TITLE
Release v1.54.0

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -5321,7 +5321,7 @@ TEST(ServiceIndicatorTest, ED25519SigGenVerify) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.53.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.54.0");
 }
 
 #else
@@ -5364,6 +5364,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.53.1");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.54.0");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.53.1"
+#define AWSLC_VERSION_NUMBER_STRING "1.54.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Rename SSL test files to match Scrutinice filter by @nhatnghiho in https://github.com/aws/aws-lc/pull/2491
* Order tool output by options provided - x509 by @justsmth in https://github.com/aws/aws-lc/pull/2454
* Fix Console Test Suite Execution Locally by @smittals2 in https://github.com/aws/aws-lc/pull/2493
* Re-remove afunix.h by @justsmth in https://github.com/aws/aws-lc/pull/2495
* Note a couple of typoed struct names that we'll leave alone. by @justsmth in https://github.com/aws/aws-lc/pull/2499
* Document that EVP_PKEY_CTX_set_rsa_keygen_pubexp takes ownership by @justsmth in https://github.com/aws/aws-lc/pull/2503
* Remove sys headers from bio.h by @samuel40791765 in https://github.com/aws/aws-lc/pull/2508
* rwlock race tests is not a GoogleTest executable by @torben-hansen in https://github.com/aws/aws-lc/pull/2509
* Add two new APIs to expose TLS 1.3 traffic secrets for kTLS by @skmcgrail in https://github.com/aws/aws-lc/pull/2506

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
