### PR TITLE
Intentionally redefine iovec in headers as CI

### DIFF
--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 
 #include <openssl/bio.h>
-#include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/mem.h>
 
@@ -29,23 +28,7 @@
 #include "../test/file_util.h"
 #include "../test/test_util.h"
 
-#if !defined(OPENSSL_WINDOWS)
-#include <arpa/inet.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <netinet/in.h>
-#include <poll.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <unistd.h>
-#else
-#include <io.h>
-#include <fcntl.h>
-OPENSSL_MSVC_PRAGMA(warning(push, 3))
-#include <winsock2.h>
-#include <ws2tcpip.h>
-OPENSSL_MSVC_PRAGMA(warning(pop))
-#endif
 
 #if !defined(OPENSSL_WINDOWS)
 static const int kOpenReadOnlyBinary = O_RDONLY;
@@ -590,7 +573,7 @@ TEST(BIOTest, FileMode) {
   bio.reset(BIO_new_file(temp.path().c_str(), "r"));
   ASSERT_TRUE(bio);
   // NOTE: Our behavior here aligns with OpenSSL which is to |_setmode| the file
-  // to binary. BoringSSL would |expect_text_mode| below because it respects 
+  // to binary. BoringSSL would |expect_text_mode| below because it respects
   // default mode on Windows which is text and doesn't call |_setmode| (unless
   // |BIO_FP_TEXT| is set, which is not the case here).
   expect_binary_mode(bio.get());

--- a/ssl/bio_ssl.cc
+++ b/ssl/bio_ssl.cc
@@ -11,6 +11,19 @@
 
 #include <openssl/bio.h>
 
+// We intentionally redefine |iovec| here without header guards or redefinition
+// protection to prevent "bio.h" from inadvertently including system headers
+// (like <sys/socket.h>) in consuming applications. This avoids potential
+// conflicts where system headers might define types that interfere with the
+// consumer's code. Consumers should ideally handle potential struct
+// redefinitions themselves, but unfortunately most legacy codebases do not
+// implement such checks, making this approach necessary for compatibility.
+//
+// See commit aws-lc@9db959e for more details.
+struct iovec {
+  void* iov_base;
+  size_t iov_len;
+};
 
 static SSL *get_ssl(BIO *bio) {
   return reinterpret_cast<SSL *>(bio->ptr);


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-3316`, `CryptoAlg-3292`, `CryptoAlg-3310`, `CryptoAlg-3284`, and `CryptoAlg-3346`.

### Description of changes: 
An extension off of https://github.com/aws/aws-lc/commit/9db959e270a02de5d2460f934830538711996f1b, this commit adds "CI" for the change. Instead of adding a new integration CI dimension that's likely going to be ignored, the best (and noisier) way to enforce this was introducing a similar concept in one of the files that referenced `bio.h`. The test files that include `bio.h` have too many header file references to introduce this to, so `bio_ssl.cc` seemed like the more suitable choice.

### Testing:
Rolled back https://github.com/aws/aws-lc/commit/9db959e270a02de5d2460f934830538711996f1b and ran the build, the build does fail without the necessary change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
