### PR TITLE
Add HMAC SHA3 benchmarks

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -114,7 +114,7 @@ extern "C" {
 // A consumer may use this symbol in the preprocessor to temporarily build
 // against multiple revisions of BoringSSL at the same time. It is not
 // recommended to do so for longer than is necessary.
-#define AWSLC_API_VERSION 34
+#define AWSLC_API_VERSION 35
 
 // This string tracks the most current production release version on Github
 // https://github.com/aws/aws-lc/releases.

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -2919,11 +2919,23 @@ bool Speed(const std::vector<std::string> &args) {
        !SpeedHmac(EVP_sha256(), "HMAC-SHA256", selected) ||
        !SpeedHmac(EVP_sha384(), "HMAC-SHA384", selected) ||
        !SpeedHmac(EVP_sha512(), "HMAC-SHA512", selected) ||
+#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >= 35
+       !SpeedHmac(EVP_sha3_224(), "HMAC-SHA3-224", selected) ||
+       !SpeedHmac(EVP_sha3_256(), "HMAC-SHA3-256", selected) ||
+       !SpeedHmac(EVP_sha3_384(), "HMAC-SHA3-384", selected) ||
+       !SpeedHmac(EVP_sha3_512(), "HMAC-SHA3-512", selected) ||
+#endif
        !SpeedHmacOneShot(EVP_md5(), "HMAC-MD5-OneShot", selected) ||
        !SpeedHmacOneShot(EVP_sha1(), "HMAC-SHA1-OneShot", selected) ||
        !SpeedHmacOneShot(EVP_sha256(), "HMAC-SHA256-OneShot", selected) ||
        !SpeedHmacOneShot(EVP_sha384(), "HMAC-SHA384-OneShot", selected) ||
        !SpeedHmacOneShot(EVP_sha512(), "HMAC-SHA512-OneShot", selected) ||
+#if (!defined(OPENSSL_1_0_BENCHMARK) && !defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >=35
+       !SpeedHmacOneShot(EVP_sha3_224(), "HMAC-SHA3-224-OneShot", selected) ||
+       !SpeedHmacOneShot(EVP_sha3_256(), "HMAC-SHA3-256-OneShot", selected) ||
+       !SpeedHmacOneShot(EVP_sha3_384(), "HMAC-SHA3-384-OneShot", selected) ||
+       !SpeedHmacOneShot(EVP_sha3_512(), "HMAC-SHA3-512-OneShot", selected) ||
+#endif
 #if !defined(OPENSSL_1_0_BENCHMARK)
        !SpeedCmac(EVP_aes_128_cbc(), "CMAC-AES-128-CBC", selected) ||
        !SpeedCmac(EVP_aes_256_cbc(), "CMAC-AES-256-CBC", selected) ||


### PR DESCRIPTION
### Description of changes: 
Follow up to https://github.com/aws/aws-lc/commit/80f986b9430c520462973dcc3aa1b31da1f74b5e. 

### Testing:
On an M1 mac:
```
./tool/bssl speed -filter HMAC -chunks 16,16384
Did 5260000 HMAC-MD5 init operations in 1000094us (5259505.6 ops/sec)
Did 5034750 HMAC-MD5 (16 bytes) operations in 1000048us (5034508.3 ops/sec): 80.6 MB/s
Did 41000 HMAC-MD5 (16384 bytes) operations in 1009616us (40609.5 ops/sec): 665.3 MB/s
Did 13546000 HMAC-SHA1 init operations in 1000004us (13545945.8 ops/sec)
Did 10967750 HMAC-SHA1 (16 bytes) operations in 1000016us (10967574.5 ops/sec): 175.5 MB/s
Did 145000 HMAC-SHA1 (16384 bytes) operations in 1002971us (144570.5 ops/sec): 2368.6 MB/s
Did 14913750 HMAC-SHA256 init operations in 1000013us (14913556.1 ops/sec)
Did 12340000 HMAC-SHA256 (16 bytes) operations in 1000018us (12339777.9 ops/sec): 197.4 MB/s
Did 147000 HMAC-SHA256 (16384 bytes) operations in 1003065us (146550.8 ops/sec): 2401.1 MB/s
Did 5589000 HMAC-SHA384 init operations in 1000043us (5588759.7 ops/sec)
Did 4864000 HMAC-SHA384 (16 bytes) operations in 1000172us (4863163.5 ops/sec): 77.8 MB/s
Did 86000 HMAC-SHA384 (16384 bytes) operations in 1008178us (85302.4 ops/sec): 1397.6 MB/s
Did 5692250 HMAC-SHA512 init operations in 1000010us (5692193.1 ops/sec)
Did 4793500 HMAC-SHA512 (16 bytes) operations in 1000024us (4793385.0 ops/sec): 76.7 MB/s
Did 86000 HMAC-SHA512 (16384 bytes) operations in 1007811us (85333.5 ops/sec): 1398.1 MB/s
Did 2257000 HMAC-SHA3-224 init operations in 1000036us (2256918.8 ops/sec)
Did 2243000 HMAC-SHA3-224 (16 bytes) operations in 1000077us (2242827.3 ops/sec): 35.9 MB/s
Did 43000 HMAC-SHA3-224 (16384 bytes) operations in 1022913us (42036.8 ops/sec): 688.7 MB/s
Did 2293000 HMAC-SHA3-256 init operations in 1000266us (2292390.2 ops/sec)
Did 2183000 HMAC-SHA3-256 (16 bytes) operations in 1000165us (2182639.9 ops/sec): 34.9 MB/s
Did 40000 HMAC-SHA3-256 (16384 bytes) operations in 1008098us (39678.7 ops/sec): 650.1 MB/s
Did 2282000 HMAC-SHA3-384 init operations in 1000119us (2281728.5 ops/sec)
Did 2211750 HMAC-SHA3-384 (16 bytes) operations in 1000112us (2211502.3 ops/sec): 35.4 MB/s
Did 31000 HMAC-SHA3-384 (16384 bytes) operations in 1027743us (30163.2 ops/sec): 494.2 MB/s
Did 2271750 HMAC-SHA3-512 init operations in 1000046us (2271645.5 ops/sec)
Did 2231500 HMAC-SHA3-512 (16 bytes) operations in 1000017us (2231462.1 ops/sec): 35.7 MB/s
Did 21000 HMAC-SHA3-512 (16384 bytes) operations in 1004539us (20905.1 ops/sec): 342.5 MB/s
```
```
Did 2392000 HMAC-MD5-OneShot (16 bytes) operations in 1000376us (2391100.9 ops/sec): 38.3 MB/s
Did 42000 HMAC-MD5-OneShot (16384 bytes) operations in 1008653us (41639.7 ops/sec): 682.2 MB/s
Did 5317000 HMAC-SHA1-OneShot (16 bytes) operations in 1000154us (5316181.3 ops/sec): 85.1 MB/s
Did 143000 HMAC-SHA1-OneShot (16384 bytes) operations in 1000247us (142964.7 ops/sec): 2342.3 MB/s
Did 5672000 HMAC-SHA256-OneShot (16 bytes) operations in 1000081us (5671540.6 ops/sec): 90.7 MB/s
Did 143000 HMAC-SHA256-OneShot (16384 bytes) operations in 1004266us (142392.6 ops/sec): 2333.0 MB/s
Did 2367000 HMAC-SHA384-OneShot (16 bytes) operations in 1000109us (2366742.0 ops/sec): 37.9 MB/s
Did 83000 HMAC-SHA384-OneShot (16384 bytes) operations in 1000407us (82966.2 ops/sec): 1359.3 MB/s
Did 2432500 HMAC-SHA512-OneShot (16 bytes) operations in 1000098us (2432261.6 ops/sec): 38.9 MB/s
Did 84000 HMAC-SHA512-OneShot (16384 bytes) operations in 1011683us (83030.0 ops/sec): 1360.4 MB/s
Did 1078000 HMAC-SHA3-224-OneShot (16 bytes) operations in 1000751us (1077191.0 ops/sec): 17.2 MB/s
Did 41000 HMAC-SHA3-224-OneShot (16384 bytes) operations in 1011168us (40547.2 ops/sec): 664.3 MB/s
Did 1061000 HMAC-SHA3-256-OneShot (16 bytes) operations in 1000382us (1060594.9 ops/sec): 17.0 MB/s
Did 39000 HMAC-SHA3-256-OneShot (16384 bytes) operations in 1024957us (38050.4 ops/sec): 623.4 MB/s
Did 1093000 HMAC-SHA3-384-OneShot (16 bytes) operations in 1000670us (1092268.2 ops/sec): 17.5 MB/s
Did 30000 HMAC-SHA3-384-OneShot (16384 bytes) operations in 1010453us (29689.7 ops/sec): 486.4 MB/s
Did 1086000 HMAC-SHA3-512-OneShot (16 bytes) operations in 1000957us (1084961.7 ops/sec): 17.4 MB/s
Did 21000 HMAC-SHA3-512-OneShot (16384 bytes) operations in 1011928us (20752.5 ops/sec): 340.0 MB/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
