### PR TITLE
Silence GCC 15 warning for uninitialized variable

### DIFF
--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -160,7 +160,7 @@ static int do_buf(const unsigned char *buf, int buflen, int encoding,
     // for invalid codepoints. Before doing that, enforce it in the parser,
     // https://crbug.com/boringssl/427, so these error cases are not
     // reachable from parsed objects.
-    uint32_t c;
+    uint32_t c = 0;
     switch (encoding) {
       case MBSTRING_UNIV:
         c = ((uint32_t)*p++) << 24;


### PR DESCRIPTION
### Issues:

https://github.com/aws/aws-lc/issues/2516

### Description of changes: 

GCC 15 started warning about uninitialized variable. Correct/silence that by just initializing it to 0.

Code execution won't/shouldn't reach `utflen = UTF8_putc(utfbuf, sizeof utfbuf, c);` if `c` has not been initialized by prior operations. So, this is a false-positive. However, it probably ain't trivial static analysis given the `UTF8_getc` function call is one code-path that must be inspected for assurance that `c` has been initialized. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
