### PR TITLE
Synchronise access to global test variables

### DIFF
--- a/crypto/fipsmodule/rand/entropy/entropy_sources.c
+++ b/crypto/fipsmodule/rand/entropy/entropy_sources.c
@@ -14,6 +14,7 @@
 
 DEFINE_BSS_GET(const struct entropy_source_methods *, entropy_source_methods_override)
 DEFINE_BSS_GET(int, allow_entropy_source_methods_override)
+DEFINE_STATIC_MUTEX(global_entropy_source_lock)
 
 static int entropy_get_prediction_resistance(
   const struct entropy_source_t *entropy_source,
@@ -132,6 +133,8 @@ int have_hw_rng_x86_64_for_testing(void) {
 void override_entropy_source_method_FOR_TESTING(
   const struct entropy_source_methods *override_entropy_source_methods) {
 
+  CRYPTO_STATIC_MUTEX_lock_write(global_entropy_source_lock_bss_get());
   *allow_entropy_source_methods_override_bss_get() = 1;
   *entropy_source_methods_override_bss_get() = override_entropy_source_methods;
+  CRYPTO_STATIC_MUTEX_unlock_write(global_entropy_source_lock_bss_get());
 }

--- a/crypto/fipsmodule/rand/entropy/internal.h
+++ b/crypto/fipsmodule/rand/entropy/internal.h
@@ -40,6 +40,11 @@ struct entropy_source_methods {
 // get_entropy_source will return an entropy source configured for the platform.
 struct entropy_source_t * get_entropy_source(void);
 
+// override_entropy_source_method_FOR_TESTING will override the global
+// entropy source that is assigned when calling |get_entropy_source|.
+// |override_entropy_source_method_FOR_TESTING| can be called multiple times but
+// it's designed to allow overriding the entropy source for testing purposes at
+// the start of a process.
 OPENSSL_EXPORT void override_entropy_source_method_FOR_TESTING(
   const struct entropy_source_methods *override_entropy_source_methods);
 

--- a/crypto/ube/fork_detect.c
+++ b/crypto/ube/fork_detect.c
@@ -14,8 +14,6 @@
 
 #include <openssl/target.h>
 
-#include "../internal.h"
-
 // Methods to detect fork events aren't generally portable over our supported
 // platforms. Fork detection is therefore an opt-in. Capture the opt-in logic
 // below that categorizes a platform targets as either having
@@ -43,6 +41,7 @@
 #endif
 
 #include "fork_detect.h"
+#include "../internal.h"
 
 static struct CRYPTO_STATIC_MUTEX ignore_testing_lock = CRYPTO_STATIC_MUTEX_INIT;
 static int ignore_wipeonfork = 0;


### PR DESCRIPTION
### Issues:

V1827263140, V1827262677, V1827258013

### Description of changes: 

For test purposes, there are global variables which could be read and/or mutated concurrently. No attention was paid to synchronising these because they are only relevant for the test code. But given these functions are exported, without any declaration in header files though, implement synchronisation anyway.

One special case is the global variables in  `CRYPTO_get_ube_generation_number`. This could be a hot path and I don't want to shower it with multiple read locks. So, here we assume that variables being typed `uint8_t` have atomic read/write, which should be true for any memory model we care about. Ordering is also not strictly necessary. So, we can basically have a lock free workflow in this case.

### Testing:

Existing testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
