### PR TITLE
Remove obsolete python main patch

### DIFF
--- a/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
@@ -31,19 +31,3 @@ index 029bf52..3fada48 100755
        EVP_PBE_scrypt(NULL, 0, NULL, 0, 2, 8, 1, 0, NULL, 0);
 
    ;
-diff --git a/Lib/test/test_hashlib.py b/Lib/test/test_hashlib.py
-index b83ae181718b7a..ff52e73100e373 100644
---- a/Lib/test/test_hashlib.py
-+++ b/Lib/test/test_hashlib.py
-@@ -274,7 +274,10 @@ def test_clinic_signature(self):
-                 with self.assertWarnsRegex(DeprecationWarning,
-                                            DEPRECATED_STRING_PARAMETER):
-                     hashlib.new(digest_name, string=b'')
--                if self._hashlib:
-+                # when using a combination of libcrypto and interned hash
-+                # implementations, we need to make sure that _hashlib contains
-+                # the constructor we're testing
-+                if self._hashlib and digest_name in self._hashlib._constructors:
-                     self._hashlib.new(digest_name, b'')
-                     self._hashlib.new(digest_name, data=b'')
-                     with self.assertWarnsRegex(DeprecationWarning,


### PR DESCRIPTION
### Issues:

n/a

### Description of changes: 

This PR updates our CPython `main` patch to account for CPython PR [135572](https://github.com/python/cpython/pull/135572). We'll need to update the patch file one more time to remove the the `configure` script change if/when [CPython PR 135402](https://github.com/python/cpython/pull/135402) is merged.

### Call-outs:

n/a

### Testing:
- CI

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
