### PR TITLE
Export BF_cfb64_encrypt

### DIFF
--- a/crypto/decrepit/blowfish/blowfish.c
+++ b/crypto/decrepit/blowfish/blowfish.c
@@ -504,9 +504,9 @@ void BF_set_key(BF_KEY *key, size_t len, const uint8_t *data) {
   }
 }
 
-static void BF_cfb64_encrypt(const uint8_t *in, uint8_t *out, size_t length,
-                             const BF_KEY *schedule, uint8_t *ivec, int *num,
-                             int encrypt) {
+void BF_cfb64_encrypt(const uint8_t *in, uint8_t *out, size_t length,
+                      const BF_KEY *schedule, uint8_t *ivec, int *num,
+                      int encrypt) {
   uint32_t v0, v1, t;
   int n = *num;
   size_t l = length;

--- a/crypto/decrepit/blowfish/blowfish.c
+++ b/crypto/decrepit/blowfish/blowfish.c
@@ -138,6 +138,8 @@ void BF_decrypt(uint32_t *data, const BF_KEY *key) {
   data[0] = r & 0xffffffffL;
 }
 
+OPENSSL_BEGIN_ALLOW_DEPRECATED
+
 void BF_ecb_encrypt(const uint8_t *in, uint8_t *out,
                     const BF_KEY *key, int encrypt) {
   uint32_t d[2];
@@ -597,6 +599,8 @@ static int bf_cfb_cipher(EVP_CIPHER_CTX *ctx, uint8_t *out, const uint8_t *in,
   ctx->num = num;
   return 1;
 }
+
+OPENSSL_END_ALLOW_DEPRECATED
 
 static const EVP_CIPHER bf_ecb = {
     .nid = NID_bf_ecb,

--- a/include/openssl/blowfish.h
+++ b/include/openssl/blowfish.h
@@ -85,6 +85,9 @@ OPENSSL_EXPORT void BF_cbc_encrypt(const uint8_t *in, uint8_t *out,
                                    size_t length, const BF_KEY *schedule,
                                    uint8_t *ivec, int enc);
 
+OPENSSL_EXPORT void BF_cfb64_encrypt(const uint8_t *in, uint8_t *out, size_t length,
+                                     const BF_KEY *schedule, uint8_t *ivec, int *num,
+                                     int encrypt);
 
 #ifdef  __cplusplus
 }

--- a/include/openssl/blowfish.h
+++ b/include/openssl/blowfish.h
@@ -59,7 +59,7 @@
 
 #include <openssl/base.h>
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -75,21 +75,28 @@ typedef struct bf_key_st {
   uint32_t S[4 * 256];
 } BF_KEY;
 
-OPENSSL_EXPORT void BF_set_key(BF_KEY *key, size_t len, const uint8_t *data);
-OPENSSL_EXPORT void BF_encrypt(uint32_t *data, const BF_KEY *key);
-OPENSSL_EXPORT void BF_decrypt(uint32_t *data, const BF_KEY *key);
+OPENSSL_DEPRECATED OPENSSL_EXPORT void BF_set_key(BF_KEY *key, size_t len,
+                                                  const uint8_t *data);
+OPENSSL_DEPRECATED OPENSSL_EXPORT void BF_encrypt(uint32_t *data,
+                                                  const BF_KEY *key);
+OPENSSL_DEPRECATED OPENSSL_EXPORT void BF_decrypt(uint32_t *data,
+                                                  const BF_KEY *key);
 
-OPENSSL_EXPORT void BF_ecb_encrypt(const uint8_t *in, uint8_t *out,
-                                   const BF_KEY *key, int enc);
-OPENSSL_EXPORT void BF_cbc_encrypt(const uint8_t *in, uint8_t *out,
-                                   size_t length, const BF_KEY *schedule,
-                                   uint8_t *ivec, int enc);
+OPENSSL_DEPRECATED OPENSSL_EXPORT void BF_ecb_encrypt(const uint8_t *in,
+                                                      uint8_t *out,
+                                                      const BF_KEY *key,
+                                                      int enc);
+OPENSSL_DEPRECATED OPENSSL_EXPORT void BF_cbc_encrypt(const uint8_t *in,
+                                                      uint8_t *out,
+                                                      size_t length,
+                                                      const BF_KEY *schedule,
+                                                      uint8_t *ivec, int enc);
 
-OPENSSL_EXPORT void BF_cfb64_encrypt(const uint8_t *in, uint8_t *out, size_t length,
-                                     const BF_KEY *schedule, uint8_t *ivec, int *num,
-                                     int encrypt);
+OPENSSL_DEPRECATED OPENSSL_EXPORT void BF_cfb64_encrypt(
+    const uint8_t *in, uint8_t *out, size_t length, const BF_KEY *schedule,
+    uint8_t *ivec, int *num, int encrypt);
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-3304`

### Description of changes: 
`BF_cfb64_encrypt` was historically a public symbol in OpenSSL until BoringSSL made it internal. This exports the symbol for applications still dependent on it from OpenSSL.

### Call-outs:
N/A

### Testing:
Only exports the symbol, our existing test coverage should already have this covered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
