### PR TITLE
fix: Update Clang version from 18 to 19 in Windows workflow

### DIFF
--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -56,7 +56,7 @@ jobs:
         uses: KyleMayes/install-llvm-action@v2
         id: clang
         with:
-          version: 18
+          version: 19
           env: true
       - name: Setup CMake
         uses: threeal/cmake-action@v1.3.0


### PR DESCRIPTION
### Issues:
Addresses AWS-LC-861

### Description of changes: 
This PR updates the Clang version used in the Windows CI workflow from 18 to 19 to match the version expected by the MSVC headers. The current workflow uses Clang 18, but the MSVC headers are expecting Clang 19.0.0 or newer, causing the following error:

```
error STL1000: Unexpected compiler version, expected Clang 19.0.0 or newer.
```

This change ensures compatibility between the Clang compiler and MSVC headers in the Windows CI environment.

### Call-outs:
This is a simple version update in the GitHub Actions workflow file. The change is minimal but necessary to fix CI failures on Windows builds.

### Testing:
This change will be tested by the CI system itself when the PR is submitted. The Windows workflow should now build successfully without the compiler version mismatch error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.