### PR TITLE
ci: Add GitHub user ID 159580656 to CI allowlist

### DIFF
--- a/tests/ci/cdk/cdk/aws_lc_base_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_base_ci_stack.py
@@ -51,7 +51,7 @@ class AwsLcBaseCiStack(Stack):
                     codebuild.EventAction.PULL_REQUEST_REOPENED,
                 # Temporarily allowlist the webhook to members of the Github team:
                 # https://github.com/orgs/aws/teams/aws-lc-dev.
-                ).and_actor_account_is('(549813|3589880|11924508|25055813|38119460|41167468|50673096|66388554|69484052|103147162|107728331)'),
+                ).and_actor_account_is('(549813|3589880|11924508|25055813|38119460|41167468|50673096|66388554|69484052|103147162|107728331|159580656)'),
                 codebuild.FilterGroup.in_event_of(
                     codebuild.EventAction.PUSH
                 ).and_branch_is(GITHUB_PUSH_CI_BRANCH_TARGETS),


### PR DESCRIPTION
### Issues:
No specific issue number, but this PR addresses a CI configuration issue.

### Description of changes:
Add kingstjo GitHub user ID (159580656) to the CI allowlist to enable CI checks for pull requests. I am a member of the aws-lc-dev team but my GitHub user ID was not in the allowlist, which prevented CI checks from running on my pull requests.

### Call-outs:
This is a simple change to the CI configuration to add my GitHub user ID to the allowlist of users who can trigger CI checks.

### Testing:
This change doesn't require specific testing as it only affects the CI configuration. Once merged, CI checks should run properly on my future pull requests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.