### PR TITLE
Use SP 800-56Arev3 Section 5.6.2.1.4.b instead of ECDSA PCT method

### DIFF
--- a/crypto/fips_callback_test.cc
+++ b/crypto/fips_callback_test.cc
@@ -23,7 +23,7 @@ void AWS_LC_fips_failure_callback(const char* message) {
   SCOPED_TRACE(message);
   const std::map<std::string, std::vector<std::string>> kat_failure_messages = {
     {"RSA_PWCT", {"RSA keygen checks failed"}},
-    {"ECDSA_PWCT", {"EC keygen checks failed"}},
+    {"EC_PWCT", {"EC keygen checks failed"}},
     {"EDDSA_PWCT", {"Ed25519 keygen PCT failed"}},
     {"MLKEM_PWCT", {"ML-KEM keygen PCT failed", "ML-KEM self tests failed", "ML-KEM keygen PCT failed"}},
     {"MLDSA_PWCT", {"ML-DSA keygen PCT failed", "ML-DSA self tests failed", "ML-DSA keygen PCT failed"}},
@@ -138,7 +138,7 @@ TEST(FIPSCallback, PWCT) {
   }
 
   bssl::UniquePtr<EC_KEY> key(EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
-  if (broken_runtime_test != nullptr && strcmp(broken_runtime_test, "ECDSA_PWCT" ) == 0) {
+  if (broken_runtime_test != nullptr && strcmp(broken_runtime_test, "EC_PWCT" ) == 0) {
     EXPECT_FALSE(EC_KEY_generate_key_fips(key.get()));
   } else {
     EXPECT_TRUE(EC_KEY_generate_key_fips(key.get()));

--- a/crypto/fipsmodule/FIPS.md
+++ b/crypto/fipsmodule/FIPS.md
@@ -44,7 +44,7 @@ Each known-answer test (KAT) uses a unique, random input value. `util/fipstools/
 Some FIPS tests cannot be broken by replacing a known string in the binary. For those, when `BORINGSSL_FIPS_BREAK_TESTS` is defined, the environment variable `BORINGSSL_FIPS_BREAK_TEST` can be set to one of a number of values in order to break the corresponding test:
 
 1. `RSA_PWCT`
-2. `ECDSA_PWCT`
+2. `EC_PWCT`
 3. `EDDSA_PWCT`
 4. `MLKEM_PWCT`
 5. `MLDSA_PWCT`

--- a/crypto/fipsmodule/ec/ec_key.c
+++ b/crypto/fipsmodule/ec/ec_key.c
@@ -80,6 +80,7 @@
 
 #include "internal.h"
 #include "../delocate.h"
+#include "../service_indicator/internal.h"
 #include "../../internal.h"
 
 
@@ -292,18 +293,19 @@ void EC_KEY_set_conv_form(EC_KEY *key, point_conversion_form_t cform) {
   }
 }
 
+// ec_key_gen_pct computes the PCT: SP 800-56Arev3 Section 5.6.2.1.4 option ‘b’.
+// Should only be used for NIST P-curves.
 static int ec_key_gen_pct(const EC_KEY *key) {
 
-  // SP 800-56Arev3 Section 5.6.2.1.4 option ‘b’
-  //
-  // Technically, not needed for ECDH in non-FIPS. However, other APIs use this
-  // function for validations e.g. the EVP private key parsing. This part is
-  // also open for optimization later.
   if (key->priv_key != NULL) {
 
     EC_SCALAR *priv_key_scalar = &key->priv_key->scalar;
 
-    EC_SCALAR priv_key_scalar_bit_flipped = {0};
+    // In theory, we could just flip a bit in the existing private key. The
+    // test below is supposed to hard abort and the code-path is only active
+    // during testing the break KAT framework. But prefer to keep it local to
+    // the PCT to isolate errors.
+    EC_SCALAR priv_key_scalar_bit_flipped = {{0}};
     if (boringssl_fips_break_test("EC_PWCT")) {
       OPENSSL_memcpy(&priv_key_scalar_bit_flipped, priv_key_scalar,
         sizeof(priv_key_scalar->words));
@@ -321,10 +323,10 @@ static int ec_key_gen_pct(const EC_KEY *key) {
     // Leaking this comparison only leaks whether |key|'s public key was
     // correct.
     //
-    // |ec_GFp_simple_points_equal| is quite expensive (relatively). If we were
-    // sure that points aren't in jacobian, but in affine representation, then
-    // the comparison reduces to simple byte array equality. The current
-    // comparison function does a non-negligible amount of field arithmetic.
+    // |ec_GFp_simple_points_equal| is quite expensive (relatively); The current
+    // comparison function does a non-negligible amount of field arithmetic If
+    // we were sure that points aren't in jacobian, but in affine
+    // representation, then the comparison reduces to fast byte array equality.
     if (!constant_time_declassify_int(ec_GFp_simple_points_equal(
           key->group, &point, &key->pub_key->raw))) {
       OPENSSL_PUT_ERROR(EC, EC_R_INVALID_PRIVATE_KEY);
@@ -352,6 +354,12 @@ int EC_KEY_check_key(const EC_KEY *eckey) {
     return 0;
   }
 
+  // Many code-paths end up in |EC_KEY_check_key|. For example, ECDH operations.
+  // Technically, the PCT is not needed for ECDH in non-FIPS. However, other
+  // APIs use this function for validations e.g. the EVP private key parsing (to
+  // validate that public key is indeed generate from the private key) and there
+  // is currently no way to distinguish the code-paths at this level. This could
+  // be optimized.
   if (!ec_key_gen_pct(eckey)) {
     return 0;
   }
@@ -360,8 +368,12 @@ int EC_KEY_check_key(const EC_KEY *eckey) {
 }
 
 int EC_KEY_check_fips(const EC_KEY *key) {
-  FIPS_service_indicator_lock_state();
+
   int ret = 0;
+
+  // Nothing obvious will falsely increment the service indicator. But lock to
+  // be safe.
+  FIPS_service_indicator_lock_state();
 
   if (EC_KEY_is_opaque(key)) {
     // Opaque keys can't be checked.
@@ -408,7 +420,7 @@ int EC_KEY_check_fips(const EC_KEY *key) {
 end:
   FIPS_service_indicator_unlock_state();
   if(ret){
-    EC_KEY_keygen_verify_service_indicator((EC_KEY*)key);
+    EC_KEY_keygen_verify_service_indicator(key);
   }
   return ret;
 }
@@ -508,8 +520,8 @@ int EC_KEY_generate_key(EC_KEY *key) {
 int EC_KEY_generate_key_fips(EC_KEY *eckey) {
   int ret = 0;
 
-  // We have to verify both |EC_KEY_generate_key| and |EC_KEY_check_fips| both
-  // succeed before updating the indicator state, so we lock the state here.
+  // At least |EC_KEY_check_fips| will certainly update the service indicator.
+  // Hence, must lock here.
   FIPS_service_indicator_lock_state();
 
   boringssl_ensure_ecc_self_test();

--- a/tests/ci/run_fips_callback_tests.sh
+++ b/tests/ci/run_fips_callback_tests.sh
@@ -59,7 +59,7 @@ function run_all_break_tests() {
     unset FIPS_CALLBACK_TEST_EXPECTED_FAILURE
   done
 
-  for TEST in RSA_PWCT ECDSA_PWCT EDDSA_PWCT MLKEM_PWCT MLDSA_PWCT; do
+  for TEST in RSA_PWCT EC_PWCT EDDSA_PWCT MLKEM_PWCT MLDSA_PWCT; do
       export FIPS_CALLBACK_TEST_EXPECTED_FAILURE="${TEST}"
       export BORINGSSL_FIPS_BREAK_TEST="${TEST}"
       $original_test --gtest_filter=FIPSCallback.PWCT

--- a/util/fipstools/break-tests.sh
+++ b/util/fipstools/break-tests.sh
@@ -182,7 +182,7 @@ done
 
 if [ "$MODE" = "local" ]; then
   # TODO(prb): add support for Android devices.
-  for runtime_test in ECDSA_PWCT RSA_PWCT; do
+  for runtime_test in EC_PWCT RSA_PWCT; do
     echo
     echo -e "\033[1m${runtime_test} failure\033[0m"
     $RUNTIME_BREAK_TEST ${runtime_test}

--- a/util/fipstools/test-runtime-pwct.sh
+++ b/util/fipstools/test-runtime-pwct.sh
@@ -20,7 +20,7 @@ check_test_output() {
   local test_name="$1"
   local output="$2"
   case "$test_name" in
-    "ECDSA_PWCT")  expected="EC keygen checks failed" ;;
+    "EC_PWCT")  expected="EC keygen checks failed" ;;
     "RSA_PWCT")    expected="RSA keygen checks failed" ;;
     "MLKEM_PWCT")  expected="ML-KEM keygen PCT failed" ;;
     "MLDSA_PWCT")  expected="ML-DSA keygen PCT failed" ;;
@@ -36,7 +36,7 @@ check_test_output() {
   return 0
 }
 
-for runtime_test in ECDSA_PWCT RSA_PWCT EDDSA_PWCT MLKEM_PWCT MLDSA_PWCT; do
+for runtime_test in EC_PWCT RSA_PWCT EDDSA_PWCT MLKEM_PWCT MLDSA_PWCT; do
   output=$(2>&1 BORINGSSL_FIPS_BREAK_TEST=$runtime_test $TEST_FIPS_BIN 2>&1 >/dev/null || true)
   echo $output
   if ! check_test_output "$runtime_test" "$output"; then


### PR DESCRIPTION
### Description of changes: 

The FIPS build type is currently employing an "ECDSA PCT" on the EC key generation code-path and EC key check code-path. This has explosive performance impact.

Our key generation is agnostic (and totally unaware) to which algorithm type a key is being generated for. Hence switch method to "SP 800-56Arev3 Section 5.6.2.1.4.b PCT" (the "New PCT"). For key generation primitives, this will increase performance by up 4-5x. For an ECDH workflow, performance could increase by 2-3x.

Funnily, the current implementation performs the ECDSA PCT but also does the New PCT in `EC_KEY_check_key()` irrespective of FIPS build type or not. Basic impl is to just delete the ECDSA PCT.

Hence, if things were easy, the only thing we must do is to remove the existing ECDSA PCT. But, the `ECDSA_PWCT` test is embedded in the ECDSA PCT in the function `EVP_EC_KEY_check_fips()`. So, we must find a new place for that. Do this by flipping a bit in the private key instead. Also change the name to `EC_PWCT` which seems a tad more precise.

### Call outs

While I was here:
* `EC_KEY_keygen_verify_service_indicator((EC_KEY*)key);` does not need to be cast to non-const.
* Fix-up the service indicator comments and explicitly include the service indicator function declarations.
* Document various optimizations that might be possible by doing more bookkeeping.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
