### PR TITLE
Fix PKCS12 Error Code

### DIFF
--- a/crypto/pkcs8/pkcs8_x509.c
+++ b/crypto/pkcs8/pkcs8_x509.c
@@ -706,7 +706,7 @@ int PKCS12_get_key_and_certs(EVP_PKEY **out_key, STACK_OF(X509) *out_certs,
       }
     }
     if (!mac_ok) {
-      OPENSSL_PUT_ERROR(PKCS8, PKCS8_R_INCORRECT_PASSWORD);
+      OPENSSL_PUT_ERROR(PKCS12, PKCS12_R_MAC_VERIFY_FAILURE);
       goto err;
     }
   }

--- a/include/openssl/pkcs8.h
+++ b/include/openssl/pkcs8.h
@@ -307,8 +307,9 @@ BSSL_NAMESPACE_END
 #define PKCS8_R_UNSUPPORTED_OPTIONS 132
 #define PKCS8_R_AMBIGUOUS_FRIENDLY_NAME 133
 
-
-// PKCS#12 Error code defined for compatibility
-#define PKCS12_R_MAC_VERIFY_FAILURE 113
+// PKCS12_R_MAC_VERIFY_FAILURE is an error code defined for
+// compatability. It points to our equivalent for this OpenSSL error,
+// |PKCS8_R_INCORRECT_PASSWORD|
+#define PKCS12_R_MAC_VERIFY_FAILURE PKCS8_R_INCORRECT_PASSWORD
 
 #endif  // OPENSSL_HEADER_PKCS8_H

--- a/include/openssl/pkcs8.h
+++ b/include/openssl/pkcs8.h
@@ -307,9 +307,8 @@ BSSL_NAMESPACE_END
 #define PKCS8_R_UNSUPPORTED_OPTIONS 132
 #define PKCS8_R_AMBIGUOUS_FRIENDLY_NAME 133
 
-// PKCS12_R_MAC_VERIFY_FAILURE is an error code defined for
-// compatability. It points to our equivalent for this OpenSSL error,
-// |PKCS8_R_INCORRECT_PASSWORD|
-#define PKCS12_R_MAC_VERIFY_FAILURE PKCS8_R_INCORRECT_PASSWORD
+
+// PKCS#12 Error code defined for compatibility
+#define PKCS12_R_MAC_VERIFY_FAILURE 113
 
 #endif  // OPENSSL_HEADER_PKCS8_H


### PR DESCRIPTION
### Issues:
`CryptoAlg-3347`

### Description of changes: 
Serf forces a failure and checks for the PKCS12 error library and  PKCS12_R_MAC_VERIFY_FAILURE  error code in a specific test. This change aligns our PKCS12_Parse implementation to align with OpenSSL for this test case. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
