### PR TITLE
Improve OpenSSL compatibility

### DIFF
--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -110,6 +110,9 @@ extern "C" {
 #define PEM_TYPE_MIC_CLEAR 30
 #define PEM_TYPE_CLEAR 40
 
+// For compatibility with OpenSSL. First argument ignored.
+#define PEMerr(f, r) OPENSSL_PUT_ERROR(PEM, (r))
+
 // These macros make the PEM_read/PEM_write functions easier to maintain and
 // write. Now they are all implemented with either:
 // IMPLEMENT_PEM_rw(...) or IMPLEMENT_PEM_rw_cb(...)

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5922,6 +5922,11 @@ struct ssl_comp_st {
 
 DEFINE_STACK_OF(SSL_COMP)
 
+// PHA No-ops [Deprecated].
+
+// SSL_verify_client_post_handshake is a no-op function for compatibility with
+// OpenSSL. It always returns 0.
+OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_verify_client_post_handshake(SSL *ssl);
 
 // FFDH Ciphersuite No-ops [Deprecated].
 //

--- a/include/openssl/ui.h
+++ b/include/openssl/ui.h
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#ifndef UI_H
+#define UI_H
+
+#endif //UI_H
+
+// Intentionally empty.
+
+// Prevent compiler fall-through picking up "ui.h" from the system path.

--- a/include/openssl/ui.h
+++ b/include/openssl/ui.h
@@ -8,4 +8,4 @@
 
 // Intentionally empty.
 
-// Prevent compiler fall-through picking up "ui.h" from the system path.
+// Prevent compiler fall-through picking up "openssl/ui.h" from the system path.

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -3601,7 +3601,6 @@ OPENSSL_EXPORT int SSL_get_write_traffic_secret(
 
 // No-op function for compatibility with OpenSSL.
 int SSL_verify_client_post_handshake(SSL *ssl) {
-  (void)ssl;
   return 0;
 }
 

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -3599,3 +3599,9 @@ OPENSSL_EXPORT int SSL_get_write_traffic_secret(
   return 1;
 }
 
+// No-op function for compatibility with OpenSSL.
+int SSL_verify_client_post_handshake(SSL *ssl) {
+  (void)ssl;
+  return 0;
+}
+


### PR DESCRIPTION
### Description of changes: 
A few small changes to improve OpenSSL compatibility:
* Provide an (empty) "openssl/ui.h" file to prevent compiler from loading OpenSSL's "openssl/ui.h" from system headers.
* Define `PEMerr` as alias for `OPENSSL_PUT_ERROR`
```
// For compatibility with OpenSSL. First argument ignored.
#define PEMerr(f, r) OPENSSL_PUT_ERROR(PEM, (r))
```
* Define `SSL_verify_client_post_handshake` as a no-op function:
```
int SSL_verify_client_post_handshake(SSL *ssl) {
  return 0;
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
