### PR TITLE
Fix python main diff after upstream PR 135402 merge

### DIFF
--- a/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/main/aws-lc-cpython.patch
@@ -19,15 +19,3 @@ index a066982..3d7fbc3 100644
  
  # The _tkinter module.
  #
-diff --git a/configure b/configure
-index 029bf52..3fada48 100755
---- a/configure
-+++ b/configure
-@@ -30873,7 +30873,6 @@ main (void)
-       OBJ_nid2sn(NID_md5);
-       OBJ_nid2sn(NID_sha1);
-       OBJ_nid2sn(NID_sha3_512);
--      OBJ_nid2sn(NID_blake2b512);
-       EVP_PBE_scrypt(NULL, 0, NULL, 0, 2, 8, 1, 0, NULL, 0);
-
-   ;


### PR DESCRIPTION
### Issues:
n/a

### Description of changes: 

Updating our python main CI patch now that [upstream PR 135402](https://github.com/python/cpython/pull/135402) has been merged.

### Call-outs:

n/a

### Testing:

- CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
