### PR TITLE
Align -help return codes in tool-openssl CLI to match Openssl

### DIFF
--- a/tool-openssl/crl.cc
+++ b/tool-openssl/crl.cc
@@ -36,7 +36,7 @@ bool CRLTool(const args_list_t &args) {
   // Display crl tool option summary
   if (help) {
     PrintUsage(kArguments);
-    return false;
+    return true;
   }
 
   // Read from stdin if no -in path provided

--- a/tool-openssl/dgst.cc
+++ b/tool-openssl/dgst.cc
@@ -153,7 +153,7 @@ static bool dgst_tool_op(const args_list_t &args, const EVP_MD *digest) {
       const std::string option = arg.substr(1);
       if (option == "help") {
         PrintUsage(kArguments);
-        return false;
+        return true;
       } else if (option == "hmac") {
         // Read next argument as key string.
         it++;

--- a/tool-openssl/pkey.cc
+++ b/tool-openssl/pkey.cc
@@ -93,7 +93,7 @@ bool pkeyTool(const args_list_t &args) {
   // Display pkey tool option summary
   if (HasArgument(parsed_args, "-help")) {
     PrintUsage(kArguments);
-    return false;
+    return true;
   }
 
   // Check input format

--- a/tool-openssl/rehash.cc
+++ b/tool-openssl/rehash.cc
@@ -359,7 +359,7 @@ bool RehashTool(const args_list_t &args) {
       "removes any existing symbolic links that match the regex \n" \
       "[0-9a-f]{8}.([r])?[0-9]+ in that directory. \n");
     PrintUsage(kArguments);
-    return false;
+    return true;
   }
 
   if (extra_args.empty()) { // No directory path provided on command line

--- a/tool-openssl/req.cc
+++ b/tool-openssl/req.cc
@@ -480,7 +480,7 @@ bool reqTool(const args_list_t &args) {
 
   if (help) {
     PrintUsage(kArguments);
-    return false;
+    return true;
   }
 
   if (!new_flag && !x509_flag && newkey.empty()) {

--- a/tool-openssl/rsa.cc
+++ b/tool-openssl/rsa.cc
@@ -37,7 +37,7 @@ bool rsaTool(const args_list_t &args) {
   // Display rsa tool option summary
   if (help) {
     PrintUsage(kArguments);
-    return false;
+    return true;
   }
 
   // Check for required option -in

--- a/tool-openssl/s_client.cc
+++ b/tool-openssl/s_client.cc
@@ -41,7 +41,7 @@ bool SClientTool(const args_list_t &args) {
   if(args_map.count("help")) {
     fprintf(stderr, "Usage: s_client [options] [host:port]\n");
     PrintUsage(kArguments);
-    return false;
+    return true;
   }
 
   return DoClient(args_map, true);

--- a/tool-openssl/verify.cc
+++ b/tool-openssl/verify.cc
@@ -185,7 +185,7 @@ bool VerifyTool(const args_list_t &args) {
             "If no files are specified, the tool will read from stdin.\n\n"
             "Valid options are:\n");
     PrintUsage(kArguments);
-    return false;
+    return true;
   }
 
   std::string cafile = parsed_args["-CAfile"];

--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -252,7 +252,7 @@ bool X509Tool(const args_list_t &args) {
   // Display x509 tool option summary
   if (help) {
     PrintUsage(kArguments);
-    return false;
+    return true;
   }
   bssl::UniquePtr<BIO> output_bio;
   if (out_path.empty()) {


### PR DESCRIPTION
### Description of changes: 
AWS-LC's openssl CLI tool incorrectly returned false for openssl <tool> -help commands, while OpenSSL returns true for the same queries. This change aligns AWS-LC's CLI behavior with OpenSSL's expected return codes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
