### PR TITLE
Add missing x509 CI to list of tests

### DIFF
--- a/tests/ci/cdk/pipeline/ci_util.py
+++ b/tests/ci/cdk/pipeline/ci_util.py
@@ -7,6 +7,7 @@ from cdk.aws_lc_analytics_stack import AwsLcGitHubAnalyticsStack
 from cdk.aws_lc_android_ci_stack import AwsLcAndroidCIStack
 from cdk.aws_lc_ec2_test_framework_ci_stack import AwsLcEC2TestingCIStack
 from cdk.aws_lc_github_ci_stack import AwsLcGitHubCIStack
+from cdk.aws_lc_github_ci_x509_stack import AwsLcGitHubX509CIStack
 from cdk.aws_lc_github_fuzz_ci_stack import AwsLcGitHubFuzzCIStack
 
 
@@ -96,4 +97,12 @@ def add_ci_stacks(
         env=env,
         ignore_failure=False,
         stack_name="aws-lc-ci-windows-x86",
+    )
+
+    AwsLcGitHubX509CIStack(
+        scope,
+        "aws-lc-ci-x509",
+        env=env,
+        ignore_failure=True,
+        stack_name="aws-lc-ci-x509",
     )


### PR DESCRIPTION
### Description of changes: 
Add missing x509 CI back to list of tests in our CDK. This affected CDK deployment, which failed to update x509 tests after we resolved the CodeBuild security issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
