### PR TITLE
Centralize password handling tool-openssl

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -238,6 +238,10 @@ mechanism is ignored.
 Snapshots taken on active hosts can potentially be unsafe to use.
 See "Snapshot Safety Prerequisites" here: https://lkml.org/lkml/2021/3/8/677
 
+# FIPS Mode
+
+For more details on building AWS-LC in FIPS mode, see the [crypto/fipsmodule/FIPS.md](crypto/fipsmodule/FIPS.md).
+
 # Data Independent Timing on AArch64
 
 The functions described in this section are still experimental.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ that improve the experience for consumers on these platforms.
 | OpenBSD   | x86-64      |
 | FreeBSD   | x86-64      |
 
+### FIPS Compliance
+
+For information about FIPS compliance, building AWS-LC in FIPS mode, and platform limitations, see [crypto/fipsmodule/FIPS.md](crypto/fipsmodule/FIPS.md).
+
 ### Post-Quantum Cryptography
 
 Details on the post-quantum algorithms supported by AWS-LC can be found at [PQREADME](https://github.com/aws/aws-lc/tree/main/crypto/fipsmodule/PQREADME.md).
@@ -188,5 +192,3 @@ Security via our
 Please do **not** create a public GitHub issue.
 
 If you package or distribute AWS-LC, or use AWS-LC as part of a large multi-user service, you may be eligible for pre-notification of future AWS-LC releases. Please contact aws-lc-pre-notifications@amazon.com.
-
-

--- a/crypto/fipsmodule/FIPS.md
+++ b/crypto/fipsmodule/FIPS.md
@@ -14,6 +14,14 @@ NIST has also awarded SP 800-90B validation certificate for our CPU Jitter Entro
 
 1. 2023-09-14: entropy certificate [#E77](https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/77), [public use document](https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/entropy/E77_PublicUse.pdf)
 
+## Platform Limitations
+
+When building AWS-LC in FIPS mode, please be aware of the following platform limitations:
+
+- Static FIPS builds are only supported on Linux platforms
+- Shared library FIPS builds are supported on both Linux and Windows
+- Windows Debug builds are not supported with FIPS
+
 ### Modules in Process
 
 The modules below have been tested by an accredited lab and have been submitted to NIST for FIPS 140-3 validation.
@@ -180,4 +188,3 @@ Initially the known-good value will be incorrect. Another script (`inject_hash.g
 The utility in `util/fipstools/break-hash.go` can be used to corrupt the FIPS module inside a binary and thus trigger a failure of the integrity test. Note that the binary must not be stripped, otherwise the utility will not be able to find the FIPS module.
 
 ![build process](./intcheck2.png)
-

--- a/tool-openssl/CMakeLists.txt
+++ b/tool-openssl/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(
 
     crl.cc
     dgst.cc
+    password.cc
     pkcs8.cc
     pkey.cc
     rehash.cc
@@ -88,6 +89,7 @@ if(BUILD_TESTING)
         crl_test.cc
         dgst.cc
         dgst_test.cc
+        password.cc
         pkcs8.cc
         pkcs8_test.cc
         pkey.cc

--- a/tool-openssl/CMakeLists.txt
+++ b/tool-openssl/CMakeLists.txt
@@ -90,6 +90,7 @@ if(BUILD_TESTING)
         dgst.cc
         dgst_test.cc
         password.cc
+        password_test.cc
         pkcs8.cc
         pkcs8_test.cc
         pkey.cc

--- a/tool-openssl/password.cc
+++ b/tool-openssl/password.cc
@@ -1,0 +1,142 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <openssl/base.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <string>
+#include <cstring>
+#include "internal.h"
+
+// Maximum length limit for sensitive strings like passwords (4KB)
+static constexpr size_t DEFAULT_MAX_SENSITIVE_STRING_LENGTH = 4096;
+
+namespace password {
+
+void SensitiveStringDeleter(std::string* str) {
+    if (str && !str->empty()) {
+        OPENSSL_cleanse(&(*str)[0], str->size());
+    }
+    delete str;
+}
+
+bool HandlePassOptions(bssl::UniquePtr<std::string> *passin_arg,
+                      bssl::UniquePtr<std::string> *passout_arg) {
+  // Handle passin if provided
+  if (passin_arg && *passin_arg) {
+    bssl::UniquePtr<std::string> extracted_passin = ExtractPassword(*passin_arg);
+    if (!extracted_passin) {
+      return false;
+    }
+    *passin_arg = std::move(extracted_passin);
+  }
+  
+  // Handle passout if provided
+  if (passout_arg && *passout_arg) {
+    // Check if both arguments point to the same source and passin was already processed
+    bool same_source = (passin_arg && *passin_arg && passout_arg && *passout_arg && 
+                       **passin_arg == **passout_arg);
+    
+    if (same_source) {
+      // Create a new string to avoid sharing the same memory
+      bssl::UniquePtr<std::string> extracted_passout(
+          new std::string(**passin_arg));
+      *passout_arg = std::move(extracted_passout);
+    } else {
+      // Extract output password separately
+      bssl::UniquePtr<std::string> extracted_passout = ExtractPassword(*passout_arg);
+      if (!extracted_passout) {
+        return false;
+      }
+      *passout_arg = std::move(extracted_passout);
+    }
+  }
+  
+  return true;
+}
+
+bssl::UniquePtr<std::string> ExtractPassword(const bssl::UniquePtr<std::string>& source) {
+    // Create a new string and wrap it in a UniquePtr
+    std::string* str = new std::string();
+    bssl::UniquePtr<std::string> result(str);
+    
+    // Empty source means empty password
+    if (!source || source->empty()) {
+        return result;
+    }
+
+    const std::string& source_str = *source;
+
+    // Direct password: pass:password
+    if (source_str.compare(0, 5, "pass:") == 0) {
+        std::string password = source_str.substr(5); 
+        if (password.length() > DEFAULT_MAX_SENSITIVE_STRING_LENGTH) {
+            fprintf(stderr, "Password exceeds maximum allowed length\n");
+            return bssl::UniquePtr<std::string>();
+        }
+        *str = std::move(password);
+        return result;
+    }
+
+    // Password from file: file:/path/to/file
+    if (source_str.compare(0, 5, "file:") == 0) {
+        std::string path = source_str.substr(5);
+        bssl::UniquePtr<BIO> bio(BIO_new_file(path.c_str(), "r"));
+        if (!bio) {
+            fprintf(stderr, "Cannot open password file\n");
+            return bssl::UniquePtr<std::string>();
+        }
+        char buf[DEFAULT_MAX_SENSITIVE_STRING_LENGTH] = {};
+        int len = BIO_gets(bio.get(), buf, sizeof(buf));
+        if (len <= 0) {
+            OPENSSL_cleanse(buf, sizeof(buf));
+            fprintf(stderr, "Cannot read password file\n");
+            return bssl::UniquePtr<std::string>();
+        }
+        const bool possible_truncation = (static_cast<size_t>(len) == DEFAULT_MAX_SENSITIVE_STRING_LENGTH - 1 && 
+                                        buf[len - 1] != '\n' && buf[len - 1] != '\r');
+        if (possible_truncation) {
+            OPENSSL_cleanse(buf, sizeof(buf));
+            fprintf(stderr, "Password file content too long\n");
+            return bssl::UniquePtr<std::string>();
+        }
+        size_t buf_len = len;
+        while (buf_len > 0 && (buf[buf_len-1] == '\n' || buf[buf_len-1] == '\r')) {
+            buf[--buf_len] = '\0';
+        }
+        *str = std::string(buf);
+        OPENSSL_cleanse(buf, sizeof(buf));
+        return result;
+    }
+
+    // Password from environment variable: env:VAR_NAME
+    if (source_str.compare(0, 4, "env:") == 0) {
+        std::string env_var = source_str.substr(4);
+        if (env_var.empty()) {
+            fprintf(stderr, "Empty environment variable name\n");
+            return bssl::UniquePtr<std::string>();
+        }
+        const char* env_val = getenv(env_var.c_str());
+        if (!env_val) {
+            fprintf(stderr, "Environment variable '%s' not set\n", env_var.c_str());
+            return bssl::UniquePtr<std::string>();
+        }
+        size_t env_val_len = strlen(env_val);
+        if (env_val_len == 0) {
+            fprintf(stderr, "Environment variable '%s' is empty\n", env_var.c_str());
+            return bssl::UniquePtr<std::string>();
+        }
+        if (env_val_len > DEFAULT_MAX_SENSITIVE_STRING_LENGTH) {
+            fprintf(stderr, "Environment variable value too long\n");
+            return bssl::UniquePtr<std::string>();
+        }
+        *str = std::string(env_val);
+        return result;
+    }
+
+    // Invalid format
+    fprintf(stderr, "Invalid password format (use pass:, file:, or env:)\n");
+    return bssl::UniquePtr<std::string>();
+}
+
+} // namespace password

--- a/tool-openssl/password_test.cc
+++ b/tool-openssl/password_test.cc
@@ -1,0 +1,241 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <gtest/gtest.h>
+#include <openssl/base.h>
+#include <openssl/mem.h>
+#include <openssl/bio.h>
+#include <string>
+#include "internal.h"
+#include "test_util.h"
+
+class PasswordTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Create temporary files for testing
+    ASSERT_GT(createTempFILEpath(pass_path), 0u);
+    ASSERT_GT(createTempFILEpath(pass_path2), 0u);
+    
+    // Write test passwords to files
+    bssl::UniquePtr<BIO> pass_bio(BIO_new_file(pass_path, "wb"));
+    ASSERT_TRUE(pass_bio);
+    ASSERT_TRUE(BIO_printf(pass_bio.get(), "testpassword") > 0);
+    BIO_flush(pass_bio.get());
+    
+    bssl::UniquePtr<BIO> pass_bio2(BIO_new_file(pass_path2, "wb"));
+    ASSERT_TRUE(pass_bio2);
+    ASSERT_TRUE(BIO_printf(pass_bio2.get(), "anotherpassword") > 0);
+    BIO_flush(pass_bio2.get());
+    
+    // Set up environment variable for testing
+    setenv("TEST_PASSWORD_ENV", "envpassword", 1);
+  }
+  
+  void TearDown() override {
+    RemoveFile(pass_path);
+    RemoveFile(pass_path2);
+    unsetenv("TEST_PASSWORD_ENV");
+  }
+  
+  char pass_path[PATH_MAX] = {};
+  char pass_path2[PATH_MAX] = {};
+};
+
+// Test ExtractPassword with direct password
+TEST_F(PasswordTest, ExtractPasswordDirect) {
+  bssl::UniquePtr<std::string> source(new std::string("pass:directpassword"));
+  bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
+  
+  ASSERT_TRUE(result);
+  EXPECT_EQ(*result, "directpassword");
+}
+
+// Test ExtractPassword with file
+TEST_F(PasswordTest, ExtractPasswordFile) {
+  std::string file_path = std::string("file:") + pass_path;
+  bssl::UniquePtr<std::string> source(new std::string(file_path));
+  bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
+  
+  ASSERT_TRUE(result);
+  EXPECT_EQ(*result, "testpassword");
+}
+
+// Test ExtractPassword with environment variable
+TEST_F(PasswordTest, ExtractPasswordEnv) {
+  bssl::UniquePtr<std::string> source(new std::string("env:TEST_PASSWORD_ENV"));
+  bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
+  
+  ASSERT_TRUE(result);
+  EXPECT_EQ(*result, "envpassword");
+}
+
+// Test ExtractPassword with empty source
+TEST_F(PasswordTest, ExtractPasswordEmpty) {
+  bssl::UniquePtr<std::string> source(new std::string(""));
+  bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
+  
+  ASSERT_TRUE(result);
+  EXPECT_TRUE(result->empty());
+}
+
+// Test ExtractPassword with nullptr source
+TEST_F(PasswordTest, ExtractPasswordNull) {
+  bssl::UniquePtr<std::string> source;
+  bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
+  
+  ASSERT_TRUE(result);
+  EXPECT_TRUE(result->empty());
+}
+
+// Test ExtractPassword with invalid format
+TEST_F(PasswordTest, ExtractPasswordInvalidFormat) {
+  bssl::UniquePtr<std::string> source(new std::string("invalid:format"));
+  bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
+  
+  EXPECT_FALSE(result);
+}
+
+// Test ExtractPassword with non-existent file
+TEST_F(PasswordTest, ExtractPasswordNonExistentFile) {
+  bssl::UniquePtr<std::string> source(new std::string("file:/non/existent/file"));
+  bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
+  
+  EXPECT_FALSE(result);
+}
+
+// Test ExtractPassword with non-existent environment variable
+TEST_F(PasswordTest, ExtractPasswordNonExistentEnv) {
+  bssl::UniquePtr<std::string> source(new std::string("env:NON_EXISTENT_ENV_VAR"));
+  bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
+  
+  EXPECT_FALSE(result);
+}
+
+// Test HandlePassOptions with both passin and passout
+TEST_F(PasswordTest, HandlePassOptionsBoth) {
+  bssl::UniquePtr<std::string> passin(new std::string("pass:inputpass"));
+  bssl::UniquePtr<std::string> passout(new std::string("pass:outputpass"));
+  
+  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
+  
+  EXPECT_EQ(*passin, "inputpass");
+  EXPECT_EQ(*passout, "outputpass");
+}
+
+// Test HandlePassOptions with only passin
+TEST_F(PasswordTest, HandlePassOptionsPassinOnly) {
+  bssl::UniquePtr<std::string> passin(new std::string("pass:inputpass"));
+  bssl::UniquePtr<std::string> passout;
+  
+  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
+  
+  EXPECT_EQ(*passin, "inputpass");
+  EXPECT_FALSE(passout);
+}
+
+// Test HandlePassOptions with only passout
+TEST_F(PasswordTest, HandlePassOptionsPassoutOnly) {
+  bssl::UniquePtr<std::string> passin;
+  bssl::UniquePtr<std::string> passout(new std::string("pass:outputpass"));
+  
+  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
+  
+  EXPECT_FALSE(passin);
+  EXPECT_EQ(*passout, "outputpass");
+}
+
+// Test HandlePassOptions with nullptr for both
+TEST_F(PasswordTest, HandlePassOptionsNullBoth) {
+  ASSERT_TRUE(password::HandlePassOptions(nullptr, nullptr));
+}
+
+// Test HandlePassOptions with same source for both
+TEST_F(PasswordTest, HandlePassOptionsSameSource) {
+  std::string file_path = std::string("file:") + pass_path;
+  bssl::UniquePtr<std::string> passin(new std::string(file_path));
+  bssl::UniquePtr<std::string> passout(new std::string(file_path));
+  
+  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
+  
+  EXPECT_EQ(*passin, "testpassword");
+  EXPECT_EQ(*passout, "testpassword");
+  
+  // Verify they are different objects in memory
+  EXPECT_NE(passin.get(), passout.get());
+}
+
+// Test HandlePassOptions with different sources
+TEST_F(PasswordTest, HandlePassOptionsDifferentSources) {
+  std::string file_path1 = std::string("file:") + pass_path;
+  std::string file_path2 = std::string("file:") + pass_path2;
+  bssl::UniquePtr<std::string> passin(new std::string(file_path1));
+  bssl::UniquePtr<std::string> passout(new std::string(file_path2));
+  
+  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
+  
+  EXPECT_EQ(*passin, "testpassword");
+  EXPECT_EQ(*passout, "anotherpassword");
+}
+
+// Test HandlePassOptions with invalid passin
+TEST_F(PasswordTest, HandlePassOptionsInvalidPassin) {
+  bssl::UniquePtr<std::string> passin(new std::string("invalid:format"));
+  bssl::UniquePtr<std::string> passout(new std::string("pass:outputpass"));
+  
+  EXPECT_FALSE(password::HandlePassOptions(&passin, &passout));
+}
+
+// Test HandlePassOptions with invalid passout
+TEST_F(PasswordTest, HandlePassOptionsInvalidPassout) {
+  bssl::UniquePtr<std::string> passin(new std::string("pass:inputpass"));
+  bssl::UniquePtr<std::string> passout(new std::string("invalid:format"));
+  
+  EXPECT_FALSE(password::HandlePassOptions(&passin, &passout));
+}
+
+// Test SensitiveStringDeleter properly clears memory
+TEST_F(PasswordTest, SensitiveStringDeleter) {
+  const char* test_password = "sensitive_data_to_be_cleared";
+  std::string* str = new std::string(test_password);
+  
+  // Get the memory address and make a copy of the content
+  const char* memory_ptr = str->c_str();
+  char memory_copy[64] = {};
+  memcpy(memory_copy, memory_ptr, str->length());
+  
+  // Verify the copy contains the password
+  EXPECT_STREQ(memory_copy, test_password);
+  
+  // Call the deleter
+  password::SensitiveStringDeleter(str);
+  
+  // The memory should now be cleared (all zeros or at least not the original password)
+  // Note: This test is somewhat implementation-dependent and may not always work
+  // as expected due to compiler optimizations or memory management
+  bool memory_cleared = (memcmp(memory_copy, memory_ptr, strlen(test_password)) != 0);
+  EXPECT_TRUE(memory_cleared);
+}
+
+// Test memory safety with HandlePassOptions
+TEST_F(PasswordTest, HandlePassOptionsMemorySafety) {
+  // Create a password with a known pattern
+  const char* test_pattern = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  bssl::UniquePtr<std::string> passin(new std::string("pass:"));
+  passin->append(test_pattern);
+  
+  // Create a copy to verify it's properly cleaned up
+  std::string original_passin = *passin;
+  
+  {
+    // Create a scope to test cleanup
+    bssl::UniquePtr<std::string> passout;
+    ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
+    
+    // Verify the password was extracted correctly
+    EXPECT_EQ(*passin, test_pattern);
+  }
+  
+  // After the scope, the original string should still be intact
+  // but the extracted password should be gone
+  EXPECT_EQ(original_passin, "pass:ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+}

--- a/tool-openssl/password_test.cc
+++ b/tool-openssl/password_test.cc
@@ -46,8 +46,10 @@ TEST_F(PasswordTest, ExtractPasswordDirect) {
   bssl::UniquePtr<std::string> source(new std::string("pass:directpassword"));
   bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
   
-  ASSERT_TRUE(result);
-  EXPECT_EQ(*result, "directpassword");
+  EXPECT_TRUE(result);
+  if (result) {
+    EXPECT_EQ(*result, "directpassword");
+  }
 }
 
 // Test ExtractPassword with file
@@ -56,8 +58,10 @@ TEST_F(PasswordTest, ExtractPasswordFile) {
   bssl::UniquePtr<std::string> source(new std::string(file_path));
   bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
   
-  ASSERT_TRUE(result);
-  EXPECT_EQ(*result, "testpassword");
+  EXPECT_TRUE(result);
+  if (result) {
+    EXPECT_EQ(*result, "testpassword");
+  }
 }
 
 // Test ExtractPassword with environment variable
@@ -65,8 +69,10 @@ TEST_F(PasswordTest, ExtractPasswordEnv) {
   bssl::UniquePtr<std::string> source(new std::string("env:TEST_PASSWORD_ENV"));
   bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
   
-  ASSERT_TRUE(result);
-  EXPECT_EQ(*result, "envpassword");
+  EXPECT_TRUE(result);
+  if (result) {
+    EXPECT_EQ(*result, "envpassword");
+  }
 }
 
 // Test ExtractPassword with empty source
@@ -74,8 +80,10 @@ TEST_F(PasswordTest, ExtractPasswordEmpty) {
   bssl::UniquePtr<std::string> source(new std::string(""));
   bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
   
-  ASSERT_TRUE(result);
-  EXPECT_TRUE(result->empty());
+  EXPECT_TRUE(result);
+  if (result) {
+    EXPECT_TRUE(result->empty());
+  }
 }
 
 // Test ExtractPassword with nullptr source
@@ -83,8 +91,10 @@ TEST_F(PasswordTest, ExtractPasswordNull) {
   bssl::UniquePtr<std::string> source;
   bssl::UniquePtr<std::string> result = password::ExtractPassword(source);
   
-  ASSERT_TRUE(result);
-  EXPECT_TRUE(result->empty());
+  EXPECT_TRUE(result);
+  if (result) {
+    EXPECT_TRUE(result->empty());
+  }
 }
 
 // Test ExtractPassword with invalid format
@@ -116,10 +126,13 @@ TEST_F(PasswordTest, HandlePassOptionsBoth) {
   bssl::UniquePtr<std::string> passin(new std::string("pass:inputpass"));
   bssl::UniquePtr<std::string> passout(new std::string("pass:outputpass"));
   
-  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
-  
-  EXPECT_EQ(*passin, "inputpass");
-  EXPECT_EQ(*passout, "outputpass");
+  EXPECT_TRUE(password::HandlePassOptions(&passin, &passout));
+  if (passin) {
+    EXPECT_EQ(*passin, "inputpass");
+  }
+  if (passout) {
+    EXPECT_EQ(*passout, "outputpass");
+  }
 }
 
 // Test HandlePassOptions with only passin
@@ -127,9 +140,10 @@ TEST_F(PasswordTest, HandlePassOptionsPassinOnly) {
   bssl::UniquePtr<std::string> passin(new std::string("pass:inputpass"));
   bssl::UniquePtr<std::string> passout;
   
-  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
-  
-  EXPECT_EQ(*passin, "inputpass");
+  EXPECT_TRUE(password::HandlePassOptions(&passin, &passout));
+  if (passin) {
+    EXPECT_EQ(*passin, "inputpass");
+  }
   EXPECT_FALSE(passout);
 }
 
@@ -138,15 +152,16 @@ TEST_F(PasswordTest, HandlePassOptionsPassoutOnly) {
   bssl::UniquePtr<std::string> passin;
   bssl::UniquePtr<std::string> passout(new std::string("pass:outputpass"));
   
-  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
-  
+  EXPECT_TRUE(password::HandlePassOptions(&passin, &passout));
   EXPECT_FALSE(passin);
-  EXPECT_EQ(*passout, "outputpass");
+  if (passout) {
+    EXPECT_EQ(*passout, "outputpass");
+  }
 }
 
 // Test HandlePassOptions with nullptr for both
 TEST_F(PasswordTest, HandlePassOptionsNullBoth) {
-  ASSERT_TRUE(password::HandlePassOptions(nullptr, nullptr));
+  EXPECT_TRUE(password::HandlePassOptions(nullptr, nullptr));
 }
 
 // Test HandlePassOptions with same source for both
@@ -155,13 +170,14 @@ TEST_F(PasswordTest, HandlePassOptionsSameSource) {
   bssl::UniquePtr<std::string> passin(new std::string(file_path));
   bssl::UniquePtr<std::string> passout(new std::string(file_path));
   
-  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
-  
-  EXPECT_EQ(*passin, "testpassword");
-  EXPECT_EQ(*passout, "testpassword");
-  
-  // Verify they are different objects in memory
-  EXPECT_NE(passin.get(), passout.get());
+  EXPECT_TRUE(password::HandlePassOptions(&passin, &passout));
+  if (passin && passout) {
+    EXPECT_EQ(*passin, "testpassword");
+    EXPECT_EQ(*passout, "testpassword");
+    
+    // Verify they are different objects in memory
+    EXPECT_NE(passin.get(), passout.get());
+  }
 }
 
 // Test HandlePassOptions with different sources
@@ -171,10 +187,11 @@ TEST_F(PasswordTest, HandlePassOptionsDifferentSources) {
   bssl::UniquePtr<std::string> passin(new std::string(file_path1));
   bssl::UniquePtr<std::string> passout(new std::string(file_path2));
   
-  ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
-  
-  EXPECT_EQ(*passin, "testpassword");
-  EXPECT_EQ(*passout, "anotherpassword");
+  EXPECT_TRUE(password::HandlePassOptions(&passin, &passout));
+  if (passin && passout) {
+    EXPECT_EQ(*passin, "testpassword");
+    EXPECT_EQ(*passout, "anotherpassword");
+  }
 }
 
 // Test HandlePassOptions with invalid passin
@@ -229,10 +246,12 @@ TEST_F(PasswordTest, HandlePassOptionsMemorySafety) {
   {
     // Create a scope to test cleanup
     bssl::UniquePtr<std::string> passout;
-    ASSERT_TRUE(password::HandlePassOptions(&passin, &passout));
+    EXPECT_TRUE(password::HandlePassOptions(&passin, &passout));
     
     // Verify the password was extracted correctly
-    EXPECT_EQ(*passin, test_pattern);
+    if (passin) {
+      EXPECT_EQ(*passin, test_pattern);
+    }
   }
   
   // After the scope, the original string should still be intact


### PR DESCRIPTION
### Issues:
Addresses CryptoAlg-3387
Addresses CryptoAlg-3383

### Description of changes:
This PR introduces a centralized password handling approach:

1. New Password Handling Implementation:
   - Created password.cc for centralized password functionality
   - Implemented HandlePassOptions for unified passin/passout processing
   - Added optimization for same password source usage
   - Implemented SensitiveStringDeleter for secure memory cleanup
   - Updated pkcs8.cc to use the new centralized functions

### Call-outs:
- The implementation follows OpenSSL's app_passwd approach
- Memory safety is prioritized with proper cleanup and null checks
- No changes to existing password handling behavior in pkcs8.cc

### Testing:
- Created password_test.cc with test coverage for:
  - ExtractPassword with various sources (direct, file, env)
  - HandlePassOptions with both passin and passout
  - HandlePassOptions with only passin or passout
  - Same source optimization validation
  - Memory safety and cleanup verification
  - SensitiveStringDeleter validation
- Test design follows Google Test best practices:
  - Uses EXPECT_TRUE with proper null checks
  - Enables full test execution to show all failures
  - Includes comprehensive error case coverage
- Cross-validation with existing pkcs8.cc functionality
- All tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.