### PR TITLE
Pull in SSL_get_negotiated_group and TLSEXT_nid_unknown from upstream

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2689,6 +2689,10 @@ OPENSSL_EXPORT int SSL_CTX_set1_groups_list(SSL_CTX *ctx, const char *groups);
 // failure.
 OPENSSL_EXPORT int SSL_set1_groups_list(SSL *ssl, const char *groups);
 
+// SSL_get_negotiated_group returns the NID of the group used by |ssl|'s most
+// recently completed handshake, or |NID_undef| if not applicable.
+OPENSSL_EXPORT int SSL_get_negotiated_group(const SSL *ssl);
+
 // SSL_GROUP_* define TLS group IDs.
 #define SSL_GROUP_SECP224R1 21
 #define SSL_GROUP_SECP256R1 23
@@ -6098,6 +6102,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 #define SSL_CTRL_GET_CLIENT_CERT_TYPES doesnt_exist
 #define SSL_CTRL_GET_EXTRA_CHAIN_CERTS doesnt_exist
 #define SSL_CTRL_GET_MAX_CERT_LIST doesnt_exist
+#define SSL_CTRL_GET_NEGOTIATED_GROUP doesnt_exist
 #define SSL_CTRL_GET_NUM_RENEGOTIATIONS doesnt_exist
 #define SSL_CTRL_GET_READ_AHEAD doesnt_exist
 #define SSL_CTRL_GET_RI_SUPPORT doesnt_exist
@@ -6196,6 +6201,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 #define SSL_get0_chain_certs SSL_get0_chain_certs
 #define SSL_get_max_cert_list SSL_get_max_cert_list
 #define SSL_get_mode SSL_get_mode
+#define SSL_get_negotiated_group SSL_get_negotiated_group
 #define SSL_get_options SSL_get_options
 #define SSL_get_secure_renegotiation_support \
   SSL_get_secure_renegotiation_support

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5718,6 +5718,11 @@ OPENSSL_EXPORT int SSL_CTX_set_tlsext_status_arg(SSL_CTX *ctx, void *arg);
   SSL_GROUP_SECP256R1_KYBER768_DRAFT00
 #define SSL_CURVE_X25519_KYBER768_DRAFT00 SSL_GROUP_X25519_KYBER768_DRAFT00
 
+// TLSEXT_nid_unknown is a constant used in OpenSSL for
+// |SSL_get_negotiated_group| to return an unrecognized group. AWS-LC never
+// returns this value, but we define this constant for compatibility.
+#define TLSEXT_nid_unknown 0x1000000
+
 // SSL_get_curve_id calls |SSL_get_group_id|.
 OPENSSL_EXPORT uint16_t SSL_get_curve_id(const SSL *ssl);
 

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -1308,6 +1308,10 @@ bool ssl_group_id_to_nid(uint16_t *out_nid, int group_id);
 // true. Otherwise, it returns false.
 bool ssl_name_to_group_id(uint16_t *out_group_id, const char *name, size_t len);
 
+// ssl_group_id_to_nid returns the NID corresponding to |group_id| or
+// |NID_undef| if unknown.
+int ssl_group_id_to_nid(uint16_t group_id);
+
 
 // Handshake messages.
 

--- a/ssl/ssl_handshake_test.cc
+++ b/ssl/ssl_handshake_test.cc
@@ -696,6 +696,7 @@ TEST(SSLTest, ConnectionPropertiesDuringRenegotiate) {
     EXPECT_EQ(SSL_CIPHER_get_id(cipher),
               uint32_t{TLS1_CK_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256});
     EXPECT_EQ(SSL_get_group_id(client.get()), SSL_GROUP_X25519);
+    EXPECT_EQ(SSL_get_negotiated_group(client.get()), NID_X25519);
     EXPECT_EQ(SSL_get_peer_signature_algorithm(client.get()),
               SSL_SIGN_RSA_PKCS1_SHA256);
 

--- a/ssl/ssl_key_share.cc
+++ b/ssl/ssl_key_share.cc
@@ -852,6 +852,15 @@ bool ssl_name_to_group_id(uint16_t *out_group_id, const char *name, size_t len) 
   return false;
 }
 
+int ssl_group_id_to_nid(uint16_t group_id) {
+  for (const auto &group : kNamedGroups) {
+    if (group.group_id == group_id) {
+      return group.nid;
+    }
+  }
+  return NID_undef;
+}
+
 BSSL_NAMESPACE_END
 
 using namespace bssl;

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2148,6 +2148,14 @@ uint16_t SSL_get_group_id(const SSL *ssl) {
   return session->group_id;
 }
 
+int SSL_get_negotiated_group(const SSL *ssl) {
+  uint16_t group_id = SSL_get_group_id(ssl);
+  if (group_id == 0) {
+    return NID_undef;
+  }
+  return ssl_group_id_to_nid(group_id);
+}
+
 int SSL_CTX_set_tmp_dh(SSL_CTX *ctx, const DH *dh) { return 1; }
 
 int SSL_set_tmp_dh(SSL *ssl, const DH *dh) { return 1; }


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1969`

### Description of changes: 
We're preparing to see if nginx is willing to accept our changes. I found these email threads regarding past attempts to integrate AWS-LC:
* https://mailman.nginx.org/pipermail/nginx-devel/2024-March/2JRAR2JEHWUTVQIAQJZEHHILR6JNXQ6S.html
* https://mailman.nginx.org/pipermail/nginx-devel/2024-March/RAS6R7UE3ZK6K6EQQVA4AHVV4WYNYX3P.html

The second change requested us to pull in the two commits from BoringSSL to support `SSL_get_negotiated_group` and `TLSEXT_nid_unknown `.
* https://github.com/google/boringssl/commit/6cf98208371e5c2c8b9d34ce3b8c452ea90e2963
* https://github.com/google/boringssl/commit/28c24092e39bfd70852afa2923a3d12d2e9be2f5

The first commit has additional complexities with new BoringSSL specific APIs that we probably aren't going to support (`SSL(_CTX)_set1_group_ids`). I've only pulled in the OpenSSL compatibility layer that grants us better support for nginx and other future integrations. 

### Call-outs:
N/A

### Testing:
Upstream commit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
