### PR TITLE
No-op impls for PHA functions

### DIFF
--- a/docs/porting/functionality-differences.md
+++ b/docs/porting/functionality-differences.md
@@ -240,6 +240,38 @@ libssl is the portion of OpenSSL which supports TLS. AWS-LC does not have suppor
   <p><span>Returns zero.</span></p>
   </td>
  </tr>
+ <tr>
+  <td rowspan=3>
+    <p><span>Post-handshake authentication</span></p>
+  </td>
+  <td rowspan=3>
+    <p><span>
+<a href="https://github.com/aws/aws-lc/blob/b6063413c8cfa2302f750a8cf90de550a598671d/include/openssl/ssl.h#L5981-L5995">Post-handshake authentication</a>
+</span></p>
+  </td>
+  <td>
+    <p><span>SSL_verify_client_post_handshake</span></p>
+  </td>
+  <td>
+    <p><span>Returns zero.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td>
+    <p><span>SSL_CTX_set_post_handshake_auth</span></p>
+  </td>
+  <td>
+    <p><span>Does nothing.</span></p>
+  </td>
+ </tr>
+ <tr>
+  <td>
+    <p><span>SSL_set_post_handshake_auth</span></p>
+  </td>
+  <td>
+    <p><span>Does nothing.</span></p>
+  </td>
+ </tr>
 </table>
 
 ### libssl TLS supported ciphersuites

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5984,6 +5984,16 @@ DEFINE_STACK_OF(SSL_COMP)
 // OpenSSL. It always returns 0.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_verify_client_post_handshake(SSL *ssl);
 
+// SSL_CTX_set_post_handshake_auth is a no-op function for compatibility with
+// OpenSSL. PHA is not supported in AWS-LC. Calls with val == 1 have no effect;
+// the "post_handshake_auth" extension is never sent.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_CTX_set_post_handshake_auth(SSL_CTX *ctx, int val);
+
+// SSL_set_post_handshake_auth is a no-op function for compatibility with
+// OpenSSL. PHA is not supported in AWS-LC. Calls with val == 1 have no effect;
+// the "post_handshake_auth" extension is never sent.
+OPENSSL_EXPORT OPENSSL_DEPRECATED void SSL_set_post_handshake_auth(SSL *ssl, int val);
+
 // FFDH Ciphersuite No-ops [Deprecated].
 //
 // AWS-LC does not support the use of FFDH cipher suites in libssl. The

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -3642,3 +3642,13 @@ int SSL_verify_client_post_handshake(SSL *ssl) {
   return 0;
 }
 
+// No-op function for compatibility with OpenSSL.
+void SSL_CTX_set_post_handshake_auth(SSL_CTX *ctx, int val) {
+  // No internal flag is set, as there is no PHA handling in AWS-LC.
+}
+
+// No-op function for compatibility with OpenSSL.
+void SSL_set_post_handshake_auth(SSL *ssl, int val) {
+  // No internal flag is set, as there is no PHA handling in AWS-LC.
+}
+


### PR DESCRIPTION
### Description of changes: 
* Provide no-op implementations for functions related to post-handshake authentication (PHA):
  * SSL_CTX_set_post_handshake_auth
  * SSL_set_post_handshake_auth
* Update `docs/porting/functionality-differences.md` to document behavior of PHA functions.

### Call-outs:
* When a project attempts to enable PHA (but AWS-LC ignores it), the connection proceeds securely without PHA (using standard TLS 1.3 authentication during the initial handshake). There is no downgrade or exposure to weaker security, as PHA is an optional enhancement for deferred client authentication. If the project strictly requires PHA, it will fail functionally (e.g., the server won't request post-handshake auth), but not in a way that compromises the core TLS session.
* I considered alternatives like aborting or failing the handshake if val == 1. I chose a no-op implementation as this doesn't introduce crashes or errors in unrelated code paths. It keeps the library usable for projects that call the function but don't critically depend on PHA working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
