### PR TITLE
Revert "Implement SSL_set_verify_result (#2526)"

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -3138,9 +3138,6 @@ OPENSSL_EXPORT int SSL_CTX_load_verify_locations(SSL_CTX *ctx,
 // either |X509_V_OK| or a |X509_V_ERR_*| value.
 OPENSSL_EXPORT long SSL_get_verify_result(const SSL *ssl);
 
-// SSL_set_verify_result sets the result of certificate verification.
-OPENSSL_EXPORT void SSL_set_verify_result(SSL *ssl, long arg);
-
 // SSL_alert_from_verify_result returns the SSL alert code, such as
 // |SSL_AD_CERTIFICATE_EXPIRED|, that corresponds to an |X509_V_ERR_*| value.
 // The return value is always an alert, even when |result| is |X509_V_OK|.

--- a/ssl/handshake.cc
+++ b/ssl/handshake.cc
@@ -361,7 +361,6 @@ enum ssl_verify_result_t ssl_verify_peer_cert(SSL_HANDSHAKE *hs) {
     hs->new_session->signed_cert_timestamp_list =
         UpRef(prev_session->signed_cert_timestamp_list);
     hs->new_session->verify_result = prev_session->verify_result;
-    ssl->verify_result = hs->new_session->verify_result;
     return ssl_verify_ok;
   }
 
@@ -411,8 +410,6 @@ enum ssl_verify_result_t ssl_verify_peer_cert(SSL_HANDSHAKE *hs) {
       ret = ssl_verify_invalid;
     }
   }
-
-  ssl->verify_result = hs->new_session->verify_result;
 
   return ret;
 }

--- a/ssl/handshake_server.cc
+++ b/ssl/handshake_server.cc
@@ -947,7 +947,6 @@ static enum ssl_hs_wait_t do_select_parameters(SSL_HANDSHAKE *hs) {
     ssl->session = std::move(session);
     ssl->s3->session_reused = true;
     hs->can_release_private_key = true;
-    ssl->verify_result = ssl->session->verify_result;
   } else {
     hs->ticket_expected = tickets_supported;
     ssl_set_session(ssl, nullptr);

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -4206,10 +4206,6 @@ struct ssl_st {
   // extra application data
   CRYPTO_EX_DATA ex_data;
 
-  // verify_result is the result of certificate verification in the case of
-  // non-fatal certificate errors.
-  long verify_result = X509_V_ERR_INVALID_CALL;
-
   uint32_t options = 0;  // protocol behaviour
   uint32_t mode = 0;     // API behaviour
   uint32_t max_cert_list = 0;

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -155,7 +155,6 @@
 #include <openssl/rand.h>
 
 #include "../crypto/internal.h"
-#include "../crypto/x509/internal.h"
 #include "internal.h"
 
 #if defined(OPENSSL_WINDOWS)
@@ -688,7 +687,6 @@ SSL *SSL_new(SSL_CTX *ctx) {
   ssl->config->permute_extensions = ctx->permute_extensions;
   ssl->config->aes_hw_override = ctx->aes_hw_override;
   ssl->config->aes_hw_override_value = ctx->aes_hw_override_value;
-  ssl->verify_result = X509_V_OK;
 
   if (!ssl->config->supported_group_list.CopyFrom(ctx->supported_group_list) ||
       !ssl->config->alpn_client_proto_list.CopyFrom(

--- a/ssl/ssl_session.cc
+++ b/ssl/ssl_session.cc
@@ -800,10 +800,6 @@ void ssl_set_session(SSL *ssl, SSL_SESSION *session) {
   }
 
   ssl->session = UpRef(session);
-
-  if (ssl->session) {
-    ssl->verify_result = session->verify_result;
-  }
 }
 
 // locked by SSL_CTX in the calling function

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -809,29 +809,7 @@ TEST(SSLTest, SetVersion) {
   EXPECT_EQ(0, SSL_CTX_get_min_proto_version(ctx.get()));
 }
 
-TEST(SSLTest, SetVerifyResult) {
-  bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
-  bssl::UniquePtr<SSL_CTX> server_ctx =
-      CreateContextWithTestCertificate(TLS_method());
-  ASSERT_TRUE(client_ctx);
-  ASSERT_TRUE(server_ctx);
 
-  bssl::UniquePtr<SSL> client, server;
-  ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx.get(),
-                                     server_ctx.get()));
-
-  SSL_SESSION *client_session = SSL_get_session(client.get());
-  SSL_SESSION *server_session = SSL_get_session(server.get());
-
-  // SSL and SSL_SESSION should share the same verify_result after a handshake
-  EXPECT_EQ(SSL_get_verify_result(client.get()), client_session->verify_result);
-  EXPECT_EQ(SSL_get_verify_result(server.get()), server_session->verify_result);
-
-  // Use custom verification result
-  SSL_set_verify_result(client.get(), X509_V_ERR_CERT_REVOKED);
-  EXPECT_EQ(X509_V_ERR_CERT_REVOKED, SSL_get_verify_result(client.get()));
-  EXPECT_NE(SSL_get_verify_result(client.get()), client_session->verify_result);
-}
 
 TEST(SSLTest, BuildCertChain) {
   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -744,17 +744,13 @@ int SSL_CTX_load_verify_locations(SSL_CTX *ctx, const char *ca_file,
   return X509_STORE_load_locations(ctx->cert_store, ca_file, ca_dir);
 }
 
-void SSL_set_verify_result(SSL *ssl, long arg) {
-  check_ssl_x509_method(ssl);
-  ssl->verify_result = arg;
-}
-
 long SSL_get_verify_result(const SSL *ssl) {
   check_ssl_x509_method(ssl);
-  if (SSL_get_session(ssl) == nullptr) {
+  SSL_SESSION *session = SSL_get_session(ssl);
+  if (session == NULL) {
     return X509_V_ERR_INVALID_CALL;
   }
-  return ssl->verify_result;
+  return session->verify_result;
 }
 
 X509_STORE *SSL_CTX_get_cert_store(const SSL_CTX *ctx) {


### PR DESCRIPTION
This reverts commit 127633fc77e752b12e12d8e05304e52b3230b65f.

### Description of changes: 
This PR was accidentally merged in by auto-merge

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
