### PR TITLE
ABI monitoring GitHub workflow improvements

### DIFF
--- a/.github/actions/latest-semver-tag/README.md
+++ b/.github/actions/latest-semver-tag/README.md
@@ -50,12 +50,12 @@ This action:
 1. Validates the provided `release` input parameter (must be one of: `main`, `fips1`, `fips2`, `fips3`)
 2. Validates that the specified path exists and is a git repository if provided
 3. Fetches all tags from the repository
-3. Based on the release type:
+4. Based on the release type:
    - For `main`: Filters tags to only include those that follow the format `vX.Y.Z`
    - For `fipsN`: Filters tags to only include those that follow the format `AWS-LC-FIPS-N.Y.Z` where N matches the FIPS version
-4. Sorts the tags according to semantic versioning rules
-5. Determines the latest tag (fails if no matching tag is found)
-6. Outputs the latest tag and version (without the prefix)
+5. Sorts the tags according to semantic versioning rules
+6. Determines the latest tag (fails if no matching tag is found)
+7. Outputs the latest tag and version (without the prefix)
 
 ## Requirements
 

--- a/.github/actions/latest-semver-tag/README.md
+++ b/.github/actions/latest-semver-tag/README.md
@@ -1,0 +1,65 @@
+# Latest Semantic Version Tag Action
+
+A GitHub Action that determines the latest tagged git release following semantic versioning and outputs that value for subsequent steps to use.
+
+## Inputs
+
+| Input | Description | Required | Default | Allowed Values |
+|-------|-------------|----------|---------|----------------|
+| `release` | The release type to filter tags by | Yes | `main` | `main`, `fips1`, `fips2`, `fips3` |
+| `path` | The path containing the git repository to check | No | `.` | Any valid directory path |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `latest-tag` | The latest semantic version tag (format depends on release type) |
+| `latest-version` | The latest semantic version without the prefix (format depends on release type) |
+
+### Tag Formats by Release Type
+
+- For `main` release: Tags in `vX.Y.Z` format (e.g., `v1.2.3`)
+- For `fipsN` releases: Tags in `AWS-LC-FIPS-N.Y.Z` format (e.g., `AWS-LC-FIPS-1.2.3` for `fips1`)
+
+## Usage
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Get Latest Tag
+        id: latest-tag
+        uses: ./.github/actions/latest-semver-tag
+        with:
+          release: 'main'  # Optional: Allowed values: main, fips1, fips2, fips3
+          path: '.'   # Optional: Directory containing the git repository
+      
+      - name: Use Latest Tag
+        run: |
+          echo "Latest tag is ${{ steps.latest-tag.outputs.latest-tag }}"
+          echo "Latest version is ${{ steps.latest-tag.outputs.latest-version }}"
+```
+
+## How It Works
+
+This action:
+
+1. Validates the provided `release` input parameter (must be one of: `main`, `fips1`, `fips2`, `fips3`)
+2. Validates that the specified path exists and is a git repository if provided
+3. Fetches all tags from the repository
+3. Based on the release type:
+   - For `main`: Filters tags to only include those that follow the format `vX.Y.Z`
+   - For `fipsN`: Filters tags to only include those that follow the format `AWS-LC-FIPS-N.Y.Z` where N matches the FIPS version
+4. Sorts the tags according to semantic versioning rules
+5. Determines the latest tag (fails if no matching tag is found)
+6. Outputs the latest tag and version (without the prefix)
+
+## Requirements
+
+- The repository must use semantic versioning tags in the appropriate format:
+  - For `main` release: Tags in `vX.Y.Z` format
+  - For `fipsN` releases: Tags in `AWS-LC-FIPS-N.Y.Z` format
+- The checkout action must be configured with `fetch-depth: 0` to fetch all tags

--- a/.github/actions/latest-semver-tag/action.yml
+++ b/.github/actions/latest-semver-tag/action.yml
@@ -1,0 +1,28 @@
+name: 'Latest Semantic Version Tag'
+description: 'Determines the latest tagged git release following semantic versioning'
+inputs:
+  release:
+    description: 'The release type to filter tags by'
+    required: true
+    default: 'main'
+    # Allowed values: main, fips1, fips2, fips3
+  path:
+    description: 'The path containing the git repository to check'
+    required: false
+    default: '.'
+outputs:
+  latest-tag:
+    description: 'The latest semantic version tag (vX.Y.Z format)'
+    value: ${{ steps.get-tag.outputs.latest-tag }}
+  latest-version:
+    description: 'The latest semantic version without the "v" prefix (X.Y.Z format)'
+    value: ${{ steps.get-tag.outputs.latest-version }}
+runs:
+  using: 'composite'
+  steps:
+    - id: get-tag
+      shell: bash
+      env:
+        INPUT_RELEASE: ${{ inputs.release }}
+        INPUT_PATH: ${{ inputs.path }}
+      run: ${{ github.action_path }}/get-latest-tag.sh

--- a/.github/actions/latest-semver-tag/get-latest-tag.sh
+++ b/.github/actions/latest-semver-tag/get-latest-tag.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -e
+
+# Read and validate the release input parameter
+RELEASE="${INPUT_RELEASE:-main}"
+REPO_PATH="${INPUT_PATH:-.}"
+
+# Validate that the release parameter is one of the allowed values
+if [[ ! "$RELEASE" =~ ^(main|fips1|fips2|fips3)$ ]]; then
+  echo "Error: Invalid release parameter. Allowed values are: main, fips1, fips2, fips3"
+  exit 1
+fi
+
+echo "Using release type: $RELEASE"
+
+# Validate that the directory exists
+if [ ! -d "$REPO_PATH" ]; then
+  echo "Error: Directory '$REPO_PATH' does not exist"
+  exit 1
+fi
+
+# Validate that the directory is a git repository
+if [ ! -d "$REPO_PATH/.git" ] && ! git -C "$REPO_PATH" rev-parse --git-dir > /dev/null 2>&1; then
+  echo "Error: Directory '$REPO_PATH' is not a git repository"
+  exit 1
+fi
+
+echo "Using git repository in directory: $REPO_PATH"
+
+# Ensure we have all tags
+git -C "$REPO_PATH" fetch --tags
+
+# Different tag format based on release type
+if [[ "$RELEASE" == "main" ]]; then
+  # For main release, use vX.Y.Z format
+  echo "Looking for tags in vX.Y.Z format..."
+  LATEST_TAG=$(git -C "$REPO_PATH" tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)
+  
+  # Extract version without the 'v' prefix
+  LATEST_VERSION=${LATEST_TAG#v}
+else
+  # Extract the FIPS version number from the release parameter (e.g., fips1 -> 1)
+  FIPS_VERSION=${RELEASE#fips}
+  
+  # For FIPS releases, use AWS-LC-FIPS-N.Y.Z format where N is the FIPS version
+  echo "Looking for tags in AWS-LC-FIPS-${FIPS_VERSION}.Y.Z format..."
+  LATEST_TAG=$(git -C "$REPO_PATH" tag -l "AWS-LC-FIPS-${FIPS_VERSION}.[0-9]*.[0-9]*" | sort -V | tail -n 1)
+  
+  # Extract version without the AWS-LC-FIPS- prefix
+  LATEST_VERSION=${LATEST_TAG#AWS-LC-FIPS-}
+fi
+
+# Handle case where no matching tag was found
+if [[ -z "$LATEST_TAG" ]]; then
+  echo "error: No matching tags found for release type: $RELEASE"
+  exit 1
+fi
+
+# Set outputs for GitHub Actions
+echo "latest-tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+echo "latest-version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+
+# Print for logging
+echo "Latest tag: ${LATEST_TAG}"
+echo "Latest version: ${LATEST_VERSION}"

--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -1,4 +1,4 @@
-name: ABI Diff
+name: ABI Monitoring
 on:
   push:
     branches: [ '*' ]
@@ -11,9 +11,9 @@ env:
   DOCKER_BUILDKIT: 1
   GOPROXY: https://proxy.golang.org,direct
 jobs:
-  libs:
+  libcrypto-incremental:
     if: github.repository_owner == 'aws'
-    name: libcrypto and libssl
+    name: libcrypto incremental ABI check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -33,7 +33,82 @@ jobs:
       - name: Perform libcrypto ABI Diff
         run: |
           docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff crypto
+
+  libssl-incremental:
+    if: github.repository_owner == 'aws'
+    name: libssl incremental ABI check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ github.event_name == 'push' && github.event.ref || github.event.pull_request.head.sha }}
+          path: ${{ github.workspace }}/next
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          path: ${{ github.workspace }}/previous
+      - name: Build Docker Image
+        working-directory: ${{ github.workspace }}/next/.github/docker_images/abidiff
+        run: |
+          docker build -t abidiff .
       - name: Perform libssl ABI Diff
-        if: ${{ success() || failure() }}
+        run: |
+          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff ssl
+
+  libcrypto-release:
+    if: github.repository_owner == 'aws'
+    name: libcrypto release ABI check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ github.event_name == 'push' && github.event.ref || github.event.pull_request.head.sha }}
+          path: ${{ github.workspace }}/next
+      - name: Get latest release tag
+        id: get-latest-tag
+        uses: ./next/.github/actions/latest-semver-tag
+        with:
+          path: ${{ github.workspace }}/next
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ steps.get-latest-tag.outputs.latest-tag }}
+          path: ${{ github.workspace }}/previous
+      - name: Build Docker Image
+        working-directory: ${{ github.workspace }}/next/.github/docker_images/abidiff
+        run: |
+          docker build -t abidiff .
+      - name: Perform libcrypto ABI Diff against release
+        run: |
+          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff crypto
+
+  libssl-release:
+    if: github.repository_owner == 'aws'
+    name: libssl release ABI check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ github.event_name == 'push' && github.event.ref || github.event.pull_request.head.sha }}
+          path: ${{ github.workspace }}/next
+      - name: Get latest release tag
+        id: get-latest-tag
+        uses: ./next/.github/actions/latest-semver-tag
+        with:
+          path: ${{ github.workspace }}/next
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/aws-lc
+          ref: ${{ steps.get-latest-tag.outputs.latest-tag }}
+          path: ${{ github.workspace }}/previous
+      - name: Build Docker Image
+        working-directory: ${{ github.workspace }}/next/.github/docker_images/abidiff
+        run: |
+          docker build -t abidiff .
+      - name: Perform libssl ABI Diff against release
         run: |
           docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff ssl


### PR DESCRIPTION
### Description of changes: 
Improve the ABI diff monitoring workflow to also compute whether the current pull request or push event to a branch breaks (or has broken) ABI compatibility when compared to the latest tagged release.

Previously the workflow jobs (now called incremental diffs) compared the current pull request or push event to the target branch / previous commit. This is problematic in the push event scenario when trying to track whether the current main branch has broken ABI comparability with the previous tagged release. For example:

`A -> B -> C -> C_1 -> C_2` where each is a commit on the main branch.

Assume `B` is the latest tagged release commit. Commit C does not break ABI compatibility, `C_1` is then merged from a pull request commit that breaks ABI compatibility (shows on the branch checks). If `C_2` makes changes that do not break ABI compatibility from the changes in `C_1` then the checks on the branch would pass.  The additions to this workflow will also ensure that all commits following release tag `B` will also diff themselves to `B` and report what that result is in addition the current incremental diffs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
