### PR TITLE
Return NULL when a NULL or empty string is passed to NETSCAPE_SPKI_b64_decode.

### DIFF
--- a/crypto/x509/x509spki.c
+++ b/crypto/x509/x509spki.c
@@ -83,6 +83,10 @@ NETSCAPE_SPKI *NETSCAPE_SPKI_b64_decode(const char *str, ossl_ssize_t len) {
   const unsigned char *p;
   size_t spki_len;
   NETSCAPE_SPKI *spki;
+
+  if (!str || (str[0] == 0)) {
+    return NULL;
+  }
   if (len <= 0) {
     len = strlen(str);
   }


### PR DESCRIPTION
### Issues:
Addresses [aws-lc issue 2578](https://github.com/aws/aws-lc/issues/2578)

### Description of changes: 
Return NULL when a NULL or empty string is passed to NETSCAPE_SPKI_b64_decode.
Was causing a segmentation fault in Deno, see https://github.com/denoland/deno/issues/30180. 
Was fixed there as well in https://github.com/denoland/deno/pull/30207.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
