### PR TITLE
Explicitly test that input length is as expected for ed25519ph

### DIFF
--- a/crypto/fipsmodule/curve25519/curve25519.c
+++ b/crypto/fipsmodule/curve25519/curve25519.c
@@ -253,6 +253,12 @@ int ed25519_sign_internal(
   // implementation, we want to reserve the ability to allocate in this
   // implementation in the future.
 
+  if (alg == ED25519PH_ALG &&
+      message_len != SHA512_DIGEST_LENGTH) {
+    OPENSSL_PUT_ERROR(CRYPTO, ERR_R_CRYPTO_LIB);
+    return 0;
+  }
+
   // Ed25519 sign: rfc8032 5.1.6
   //
   // Step: rfc8032 5.1.6.1
@@ -484,6 +490,12 @@ int ed25519_verify_internal(
     const uint8_t public_key[ED25519_PUBLIC_KEY_LEN],
     const uint8_t *ctx, size_t ctx_len) {
   // Ed25519 verify: rfc8032 5.1.7
+
+  if (alg == ED25519PH_ALG &&
+      message_len != SHA512_DIGEST_LENGTH) {
+    OPENSSL_PUT_ERROR(CRYPTO, ERR_R_CRYPTO_LIB);
+    return 0;
+  }
 
   // Step: rfc8032 5.1.7.1 (up to decoding the public key)
   // Decode signature as:


### PR DESCRIPTION
### Description of changes: 

the ed25519 Algorithm, as a subroutine, computes `SHA-512(... || PH(M))`, where `PH = SHA-512` (for ed25519ph). In turn, a pre-condition is that the length is the output length of SHA-512. Check this explicitly, which was previously an implicitly assumption. Improves proof ability.

From Xin Zhang.

### Testing:

Existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
