### PR TITLE
Reimplement SSL_clear_num_renegotiations

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -5312,6 +5312,10 @@ OPENSSL_EXPORT int SSL_cutthrough_complete(const SSL *ssl);
 // SSL_num_renegotiations calls |SSL_total_renegotiations|.
 OPENSSL_EXPORT int SSL_num_renegotiations(const SSL *ssl);
 
+// SSL_clear_num_renegotiations calls |SSL_total_renegotiations| and resets the
+// total number of renegotiation handshakes performed by |ssl| to 0.
+OPENSSL_EXPORT int SSL_clear_num_renegotiations(const SSL *ssl);
+
 // SSL_CTX_get_read_ahead returns 1 if |ctx| is not null and read ahead is
 // enabled, otherwise it returns 0.
 OPENSSL_EXPORT int SSL_CTX_get_read_ahead(const SSL_CTX *ctx);
@@ -6156,6 +6160,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 #define SSL_CTRL_CHANNEL_ID doesnt_exist
 #define SSL_CTRL_CLEAR_EXTRA_CHAIN_CERTS doesnt_exist
 #define SSL_CTRL_CLEAR_MODE doesnt_exist
+#define SSL_CTRL_CLEAR_NUM_RENEGOTIATIONS doesnt_exist
 #define SSL_CTRL_CLEAR_OPTIONS doesnt_exist
 #define SSL_CTRL_EXTRA_CHAIN_CERT doesnt_exist
 #define SSL_CTRL_GET_CHAIN_CERTS doesnt_exist
@@ -6256,6 +6261,7 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED int SSL_set_tmp_rsa(SSL *ssl, const RSA *rsa);
 #define SSL_add1_chain_cert SSL_add1_chain_cert
 #define SSL_build_cert_chain SSL_build_cert_chain
 #define SSL_clear_chain_certs SSL_clear_chain_certs
+#define SSL_clear_num_renegotiations SSL_clear_num_renegotiations
 #define SSL_clear_mode SSL_clear_mode
 #define SSL_clear_options SSL_clear_options
 #define SSL_get0_certificate_types SSL_get0_certificate_types

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -3432,6 +3432,12 @@ int SSL_num_renegotiations(const SSL *ssl) {
   return SSL_total_renegotiations(ssl);
 }
 
+int SSL_clear_num_renegotiations(const SSL *ssl) {
+  int ret = SSL_total_renegotiations(ssl);
+  ssl->s3->total_renegotiations = 0;
+  return ret;
+}
+
 int SSL_CTX_need_tmp_RSA(const SSL_CTX *ctx) { return 0; }
 int SSL_need_tmp_RSA(const SSL *ssl) { return 0; }
 int SSL_CTX_set_tmp_rsa(SSL_CTX *ctx, const RSA *rsa) { return 1; }

--- a/ssl/test/bssl_shim.cc
+++ b/ssl/test/bssl_shim.cc
@@ -1415,6 +1415,14 @@ static bool DoExchange(bssl::UniquePtr<SSL_SESSION> *out_session,
     return false;
   }
 
+  if (SSL_clear_num_renegotiations(ssl) !=
+          config->expect_total_renegotiations ||
+      SSL_total_renegotiations(ssl) != 0) {
+    fprintf(stderr, "Expected renegotiation count to be reset to 0, got %d\n",
+            SSL_total_renegotiations(ssl));
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-3252` & `CryptoAlg-3341`

### Description of changes: 
Some older internal software happens to depend on `SSL_clear_num_renegotiations`. This was taken out in https://github.com/aws/aws-lc/commit/7cde0dee7cfc508835bf47200004960a58353631, but too much has changed since then and it's not directly revertable.

### Call-outs:
N/A

### Testing:
SSL runner tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
