### PR TITLE
Add standalone MLKEM supported groups

### DIFF
--- a/ssl/ssl_ciphers_test.cc
+++ b/ssl/ssl_ciphers_test.cc
@@ -505,6 +505,22 @@ static const CurveTest kCurveTests[] = {
             SSL_GROUP_SECP256R1_MLKEM768,
         },
     },
+    {
+      "MLKEM512:MLKEM768:MLKEM1024",
+      {
+        SSL_GROUP_MLKEM512,
+        SSL_GROUP_MLKEM768,
+        SSL_GROUP_MLKEM1024,
+      },
+    },
+    {
+      "ML-KEM-512:ML-KEM-768:ML-KEM-1024",
+      {
+        SSL_GROUP_MLKEM512,
+        SSL_GROUP_MLKEM768,
+        SSL_GROUP_MLKEM1024,
+      },
+    },
 };
 
 

--- a/ssl/ssl_hybrid_handshake_test.cc
+++ b/ssl/ssl_hybrid_handshake_test.cc
@@ -370,6 +370,32 @@ static const HybridHandshakeTest kHybridHandshakeTests[] = {
         false,
     },
 
+    // Pure MLKEM at all key sizes
+    {
+      "MLKEM512",
+      TLS1_3_VERSION,
+      "MLKEM512",
+      TLS1_3_VERSION,
+      SSL_GROUP_MLKEM512,
+      false,
+    },
+    {
+      "MLKEM768",
+      TLS1_3_VERSION,
+      "MLKEM768",
+      TLS1_3_VERSION,
+      SSL_GROUP_MLKEM768,
+      false,
+    },
+    {
+      "MLKEM1024",
+      TLS1_3_VERSION,
+      "MLKEM1024",
+      TLS1_3_VERSION,
+      SSL_GROUP_MLKEM1024,
+      false,
+    },
+
     // The client's preferred hybrid group should be negotiated when also
     // supported by the server, even if the server "prefers"/supports other
     // groups.

--- a/ssl/ssl_key_share.cc
+++ b/ssl/ssl_key_share.cc
@@ -699,6 +699,9 @@ CONSTEXPR_ARRAY NamedGroup kNamedGroups[] = {
     {NID_SecP256r1MLKEM768, SSL_GROUP_SECP256R1_MLKEM768, "SecP256r1MLKEM768", ""},
     {NID_X25519MLKEM768, SSL_GROUP_X25519_MLKEM768, "X25519MLKEM768", ""},
     {NID_SecP384r1MLKEM1024, SSL_GROUP_SECP384R1_MLKEM1024, "SecP384r1MLKEM1024", ""},
+    {NID_MLKEM512, SSL_GROUP_MLKEM512, "MLKEM512", "ML-KEM-512"},
+    {NID_MLKEM768, SSL_GROUP_MLKEM768, "MLKEM768", "ML-KEM-768"},
+    {NID_MLKEM1024, SSL_GROUP_MLKEM1024, "MLKEM1024", "ML-KEM-1024"},
 };
 
 CONSTEXPR_ARRAY uint16_t kPQGroups[] = {
@@ -789,13 +792,11 @@ UniquePtr<SSLKeyShare> SSLKeyShare::Create(uint16_t group_id) {
       return MakeUnique<HybridKeyShare>(SSL_GROUP_SECP256R1_KYBER768_DRAFT00);
     case SSL_GROUP_X25519_KYBER768_DRAFT00:
       return MakeUnique<HybridKeyShare>(SSL_GROUP_X25519_KYBER768_DRAFT00);
+    case SSL_GROUP_MLKEM512:
+      return MakeUnique<KEMKeyShare>(NID_MLKEM512, SSL_GROUP_MLKEM512);
     case SSL_GROUP_MLKEM768:
-      // MLKEM768, as a standalone group, is not a NamedGroup; however, we
-      // need to create MLKEM768 key shares as part of hybrid groups.
       return MakeUnique<KEMKeyShare>(NID_MLKEM768, SSL_GROUP_MLKEM768);
     case SSL_GROUP_MLKEM1024:
-      // MLKEM1024, as a standalone group, is not a NamedGroup; however, we
-      // need to create MLKEM1024 key shares as part of hybrid groups.
       return MakeUnique<KEMKeyShare>(NID_MLKEM1024, SSL_GROUP_MLKEM1024);
     case SSL_GROUP_SECP256R1_MLKEM768:
       return MakeUnique<HybridKeyShare>(SSL_GROUP_SECP256R1_MLKEM768);


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Adds opt-in support for standalone MLKEM SupportedGroup for all key sizes. 

### Call-outs:
None

### Testing:
Unit tests. I also confirmed interoperability with Openssl v3.5. 

```
# AWS-LC Server
$ ./build/tool/bssl s_server -curves MLKEM768:MLKEM1024:MLKEM512 -accept 44330 -debug

# Openssl 3.5 Client
$ openssl3 s_client -curves MLKEM512 -connect 127.0.0.1:44330 -debug
$ openssl3 s_client -curves MLKEM768 -connect 127.0.0.1:44330 -debug
$ openssl3 s_client -curves MLKEM1024 -connect 127.0.0.1:44330 -debug
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
