### PR TITLE
Add a couple more no-ops for legacy builds

### DIFF
--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -149,6 +149,10 @@ int OPENSSL_malloc_init(void) { return 1; }
 
 void ENGINE_load_builtin_engines(void) {}
 
+void ENGINE_register_all_ciphers(void) {}
+
+void ENGINE_register_all_digests(void) {}
+
 int ENGINE_register_all_complete(void) { return 1; }
 
 void OPENSSL_load_builtin_modules(void) {}

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -182,10 +182,16 @@ OPENSSL_EXPORT int CRYPTO_malloc_init(void);
 OPENSSL_EXPORT int OPENSSL_malloc_init(void);
 
 // ENGINE_load_builtin_engines does nothing.
-OPENSSL_EXPORT void ENGINE_load_builtin_engines(void);
+OPENSSL_DEPRECATED OPENSSL_EXPORT void ENGINE_load_builtin_engines(void);
+
+// ENGINE_register_all_ciphers does nothing.
+OPENSSL_DEPRECATED OPENSSL_EXPORT void ENGINE_register_all_ciphers(void);
+
+// ENGINE_register_all_digests does nothing.
+OPENSSL_DEPRECATED OPENSSL_EXPORT void ENGINE_register_all_digests(void);
 
 // ENGINE_register_all_complete returns one.
-OPENSSL_EXPORT int ENGINE_register_all_complete(void);
+OPENSSL_DEPRECATED OPENSSL_EXPORT int ENGINE_register_all_complete(void);
 
 // OPENSSL_load_builtin_modules does nothing.
 OPENSSL_EXPORT void OPENSSL_load_builtin_modules(void);
@@ -222,6 +228,8 @@ OPENSSL_EXPORT int FIPS_mode_set(int on);
 // These are related to memory debugging functionalities provided by OpenSSL,
 // but are not supported in AWS-LC.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int CRYPTO_mem_ctrl(int mode);
+
+#define CRYPTO_MEM_CHECK_ON 0
 
 #if defined(BORINGSSL_FIPS_140_3)
 


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-3350`

### Description of changes: 
Some more internal legacy builds have a dependency on some old OpenSSL symbols. All relevant symbols are already no-ops within AWS-LC, this is just expanding upon them a bit more. I've also marked these as deprecated to indicate such.

### Call-outs:
N/A

### Testing:
Internal build works once defined with `-Wno-deprecated-declarations`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
