### PR TITLE
Complete integrity check for Linux and MacOS shared builds

### DIFF
--- a/tests/ci/run_inject_hash_cpp.sh
+++ b/tests/ci/run_inject_hash_cpp.sh
@@ -102,8 +102,14 @@ END_OFFSET=$((16#$END_OFFSET))
 RANDOM_OFFSET=$((START_OFFSET + RANDOM % (END_OFFSET - START_OFFSET)))
 echo "Corrupting FIPS module at offset $RANDOM_OFFSET"
 
-# Corrupt one byte
-printf '\x00' | dd of=./test_corrupted/libcrypto.${LIB_EXT} bs=1 seek=$RANDOM_OFFSET count=1 conv=notrunc
+# Read current byte
+CURRENT_BYTE=$(dd if=./test_corrupted/libcrypto.${LIB_EXT} bs=1 skip=$RANDOM_OFFSET count=1 2>/dev/null | xxd -p)
+
+# Flip the bit (XOR with 1)
+FLIPPED_BYTE=$(printf "%02x" "$((0x$CURRENT_BYTE ^ 1))")
+
+# Write back the flipped byte
+echo $FLIPPED_BYTE | xxd -r -p | dd of=./test_corrupted/libcrypto.${LIB_EXT} bs=1 seek=$RANDOM_OFFSET count=1 conv=notrunc
 
 # Change to test directory and set library path
 cd ./test_corrupted

--- a/util/fipstools/inject_hash_cpp/inject_hash.cpp
+++ b/util/fipstools/inject_hash_cpp/inject_hash.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 // currently only supports shared builds for Linux and MacOS
-#include <getopt.h>
 #include <inttypes.h>
 #include <openssl/base.h>
 #include <openssl/hmac.h>
@@ -341,7 +340,6 @@ static bool calculate_hash(const std::vector<uint8_t> &text_module,
 
 static bool process(const std::string &input_path,
                     const std::string &output_path, bool is_apple) {
-  // Read the input binary file
   std::ifstream input_file(
       input_path, std::ios::binary |
                       std::ios::ate);  // Open the file in binary mode and move
@@ -356,6 +354,7 @@ static bool process(const std::string &input_path,
   input_file.seekg(0, std::ios::beg);  // Move back to the beginning of the file
                                        // to read its content
 
+   // Read the input binary file
   std::vector<uint8_t> binary_data(file_size);
   if (!input_file.read(reinterpret_cast<char *>(binary_data.data()),
                        file_size)) {


### PR DESCRIPTION
Description
This pull request implements a C++ version of inject_hash for AWS-LC's FIPS module integrity verification. The implementation focuses on using LIEF for binary parsing for Linux and MacOS shared builds and the calculating hashes of non-relocatable module sections. It also maintains compatibility with existing FIPS integrity verification workflow

Key Implementation Changes
Added comprehensive platform-specific binary parsing
Implemented HMAC-SHA256 calculation for static module sections
Added proper error handling and validation

Files Modified
tests/ci/run_inject_hash_cpp.sh: Updated test script with new test cases
util/fipstools/inject_hash_cpp/inject_hash.cpp: Main implementation file with hash injection functionality implemented

Testing
Basic argument validation
Platform-specific behavior
Invalid file handling
Successful hash injection
Hash verification using crypto_test