### PR TITLE
Add CMake Configure pre-push checker

### DIFF
--- a/tests/check_cmake_configure.sh
+++ b/tests/check_cmake_configure.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -exo pipefail
+
+source tests/ci/common_posix_setup.sh
+
+TMP_BUILD_DIR=$(mktemp -d)
+
+echo "Running CMake configure step"
+${CMAKE_COMMAND} -B "${TMP_BUILD_DIR}" -S . -GNinja
+
+rm -rf "${TMP_BUILD_DIR:?}"
+
+echo "Adding all changed files to the git tree"
+git add -A
+
+echo "Checking for any changes"
+git diff --exit-code HEAD

--- a/tests/ci/codebuild/linux-x86/pre-push.yml
+++ b/tests/ci/codebuild/linux-x86/pre-push.yml
@@ -11,6 +11,7 @@ phases:
   build:
     commands:
       - ./tests/check_objects_and_errors.sh
+      - ./tests/check_cmake_configure.sh
       - go run ./tests/check_licenses.go
       - ./tests/check_generated_src.sh
       - ./tests/coding_guidelines/style.sh


### PR DESCRIPTION
### Description of changes: 
Validates that there is no CMake configure template file changes that haven't been committed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
