### PR TITLE
Rewrite 4-fold batched SHAKE to be amenable to batched Keccak-F1600 assembly

### DIFF
--- a/crypto/fipsmodule/sha/internal.h
+++ b/crypto/fipsmodule/sha/internal.h
@@ -111,7 +111,11 @@ OPENSSL_STATIC_ASSERT(sizeof(KECCAK1600_CTX) <= sizeof(union md_ctx_union),
                       hmac_md_ctx_union_sha3_size_needs_update)
 
 // KECCAK1600 x4 batched context structure
-typedef KECCAK1600_CTX KECCAK1600_CTX_x4[4];
+typedef struct keccak_ctx_st_x4 KECCAK1600_CTX_x4;
+
+struct keccak_ctx_st_x4 {
+  uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS];
+};
 
 // Define SHA{n}[_{variant}]_ASM if sha{n}_block_data_order[_{variant}] is
 // defined in assembly.
@@ -600,6 +604,20 @@ OPENSSL_EXPORT int SHAKE256_x4(const uint8_t *data0, const uint8_t *data1,
 // |len| bytes and returns the remaining number of bytes.
 size_t Keccak1600_Absorb(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS],
                                   const uint8_t *data, size_t len, size_t r);
+
+// Keccak1600_Absorb_once_x4 absorbs exactly |len| bytes from four inputs into four
+// Keccak states, applying padding character |p|. Unlike Keccak1600_Absorb, this
+// processes a single block and takes the padding character as an additional argument.
+void Keccak1600_Absorb_once_x4(uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS],
+                               const uint8_t *inp0, const uint8_t *inp1,
+                               const uint8_t *inp2, const uint8_t *inp3,
+                               size_t len, size_t r, uint8_t p);
+
+// Keccak1600_Squeezeblocks_x4 squeezes |num_blocks| blocks from four Keccak states
+// into four output buffers, with each block being |r| bytes.
+void Keccak1600_Squeezeblocks_x4(uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS],
+                                 uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3,
+                                 size_t num_blocks, size_t r);
 
 // Keccak1600_Squeeze generates |out| value of |len| bytes (per call). It can be called
 // multiple times when used as eXtendable Output Function. |padded| indicates

--- a/crypto/fipsmodule/sha/keccak1600.c
+++ b/crypto/fipsmodule/sha/keccak1600.c
@@ -72,8 +72,7 @@ static const uint8_t rhotates[KECCAK1600_ROWS][KECCAK1600_ROWS] = {
 
 #define ROL32(a, offset) (((a) << (offset)) | ((a) >> ((32 - (offset)) & 31)))
 
-static uint64_t ROL64(uint64_t val, int offset)
-{
+static uint64_t ROL64(uint64_t val, int offset) {
     if (offset == 0) {
         return val;
     } else if (!BIT_INTERLEAVE) {
@@ -103,11 +102,10 @@ static uint64_t ROL64(uint64_t val, int offset)
  // This implementation is a variant of KECCAK_1X (see OpenSSL)
  // This implementation allows to take temporary storage
  // out of round procedure and simplify references to it by alternating
- // it with actual data (see round loop below). 
- // It ensures best compiler interpretation to assembly and provides best 
+ // it with actual data (see round loop below).
+ // It ensures best compiler interpretation to assembly and provides best
  // instruction per processed byte ratio at minimal round unroll factor.
-static void Round(uint64_t R[KECCAK1600_ROWS][KECCAK1600_ROWS], uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS], size_t i)
-{
+static void Round(uint64_t R[KECCAK1600_ROWS][KECCAK1600_ROWS], uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS], size_t i) {
     uint64_t C[KECCAK1600_ROWS], D[KECCAK1600_ROWS];
 
     assert(i < (sizeof(iotas) / sizeof(iotas[0])));
@@ -225,8 +223,7 @@ static void Round(uint64_t R[KECCAK1600_ROWS][KECCAK1600_ROWS], uint64_t A[KECCA
 #endif
 }
 
-static void KeccakF1600_c(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS])
-{
+static void KeccakF1600_c(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS]) {
     uint64_t T[KECCAK1600_ROWS][KECCAK1600_ROWS];
     size_t i;
 
@@ -255,8 +252,7 @@ static void KeccakF1600_c(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS])
 }
 #endif // !KECCAK1600_ASM
 
-static uint64_t BitInterleave(uint64_t Ai)
-{
+static uint64_t BitInterleave(uint64_t Ai) {
     if (BIT_INTERLEAVE) {
         uint32_t hi = (uint32_t)(Ai >> 32), lo = (uint32_t)Ai;
         uint32_t t0, t1;
@@ -291,8 +287,7 @@ static uint64_t BitInterleave(uint64_t Ai)
     return Ai;
 }
 
-static uint64_t BitDeinterleave(uint64_t Ai)
-{
+static uint64_t BitDeinterleave(uint64_t Ai) {
     if (BIT_INTERLEAVE) {
         uint32_t hi = (uint32_t)(Ai >> 32), lo = (uint32_t)Ai;
         uint32_t t0, t1;
@@ -338,66 +333,86 @@ void KeccakF1600(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS]);
  // 72, but can also be (1600 - 448)/8 = 144. All this means that message
  // padding and intermediate sub-block buffering, byte- or bitwise, is
  // caller's responsibility.
-size_t Keccak1600_Absorb(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS], const uint8_t *inp, size_t len,
-                   size_t r)
-{
-    uint64_t *A_flat = (uint64_t *)A;
-    size_t i, w = r / 8;
 
+// KeccakF1600_XORBytes XORs |len| bytes from |inp| into the Keccak state |A|.
+// |len| must be a multiple of 8.
+static void KeccakF1600_XORBytes(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS], const uint8_t *inp, size_t len) {
+    assert(len <= SHA3_MAX_BLOCKSIZE);
+    assert((len % 8) == 0);
+
+    uint64_t *A_flat = (uint64_t *)A;
+    size_t w = len / 8;
+
+    for (size_t i = 0; i < w; i++) {
+        uint64_t Ai = (uint64_t)inp[0]       | (uint64_t)inp[1] << 8  |
+                      (uint64_t)inp[2] << 16 | (uint64_t)inp[3] << 24 |
+                      (uint64_t)inp[4] << 32 | (uint64_t)inp[5] << 40 |
+                      (uint64_t)inp[6] << 48 | (uint64_t)inp[7] << 56;
+        inp += 8;
+        A_flat[i] ^= BitInterleave(Ai);
+    }
+}
+
+size_t Keccak1600_Absorb(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS], const uint8_t *inp, size_t len,
+                         size_t r) {
     assert(r < (25 * sizeof(A[0][0])) && (r % 8) == 0);
 
     while (len >= r) {
-        for (i = 0; i < w; i++) {
-            uint64_t Ai = (uint64_t)inp[0]       | (uint64_t)inp[1] << 8  |
-                          (uint64_t)inp[2] << 16 | (uint64_t)inp[3] << 24 |
-                          (uint64_t)inp[4] << 32 | (uint64_t)inp[5] << 40 |
-                          (uint64_t)inp[6] << 48 | (uint64_t)inp[7] << 56;
-            inp += 8;
-
-            A_flat[i] ^= BitInterleave(Ai);
-        }
+        KeccakF1600_XORBytes(A, inp, r);
         KeccakF1600(A);
+        inp += r;
         len -= r;
     }
 
     return len;
 }
 
-void Keccak1600_Squeeze(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS], uint8_t *out, size_t len, size_t r, int padded)
-// Keccak1600_Squeeze can be called multiple times to incrementally 
-{
+// KeccakF1600_ExtractBytes extracts |len| bytes from the Keccak state |A| into |out|.
+// This function operates on up to block_size bytes (a single block). For extracting
+// more data, the state must be processed again through KeccakF1600 (see Keccak1600_Squeeze).
+static void KeccakF1600_ExtractBytes(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS], uint8_t *out, size_t len) {
     uint64_t *A_flat = (uint64_t *)A;
-    size_t i, w = r / 8;
+    assert(len <= SHA3_MAX_BLOCKSIZE);
+    size_t i = 0;
 
+    while (len != 0) {
+        uint64_t Ai = BitDeinterleave(A_flat[i]);
+
+        if (len < 8) {
+            for (size_t j = 0; j < len; j++) {
+                *out++ = (uint8_t)Ai;
+                Ai >>= 8;
+            }
+            return;
+        }
+
+        out[0] = (uint8_t)(Ai);
+        out[1] = (uint8_t)(Ai >> 8);
+        out[2] = (uint8_t)(Ai >> 16);
+        out[3] = (uint8_t)(Ai >> 24);
+        out[4] = (uint8_t)(Ai >> 32);
+        out[5] = (uint8_t)(Ai >> 40);
+        out[6] = (uint8_t)(Ai >> 48);
+        out[7] = (uint8_t)(Ai >> 56);
+        out += 8;
+        len -= 8;
+        i++;
+    }
+}
+
+void Keccak1600_Squeeze(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS], uint8_t *out, size_t len, size_t r, int padded) {
     assert(r < (25 * sizeof(A[0][0])) && (r % 8) == 0);
 
     while (len != 0) {
         if (padded) {
-            KeccakF1600(A); 
+            KeccakF1600(A);
         }
         padded = 1;
-        for (i = 0; i < w && len != 0; i++) {
-            uint64_t Ai = BitDeinterleave(A_flat[i]);
 
-            if (len < 8) {
-                for (i = 0; i < len; i++) {
-                    *out++ = (uint8_t)Ai;
-                    Ai >>= 8;
-                }
-                return;
-            }
-
-            out[0] = (uint8_t)(Ai);
-            out[1] = (uint8_t)(Ai >> 8);
-            out[2] = (uint8_t)(Ai >> 16);
-            out[3] = (uint8_t)(Ai >> 24);
-            out[4] = (uint8_t)(Ai >> 32);
-            out[5] = (uint8_t)(Ai >> 40);
-            out[6] = (uint8_t)(Ai >> 48);
-            out[7] = (uint8_t)(Ai >> 56);
-            out += 8;
-            len -= 8;
-        }
+        size_t extract_len = len < r ? len : r;
+        KeccakF1600_ExtractBytes(A, out, extract_len);
+        out += extract_len;
+        len -= extract_len;
     }
 }
 
@@ -442,14 +457,14 @@ void KeccakF1600(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS]) {
 
 #if defined(KECCAK1600_S2N_BIGNUM_ASM)
     if (CRYPTO_is_Neoverse_N1() || CRYPTO_is_Neoverse_V1() || CRYPTO_is_Neoverse_V2()) {
-	keccak_log_dispatch(10); // kFlag_sha3_keccak_f1600
-	sha3_keccak_f1600((uint64_t *)A, iotas);
-	return;
+        keccak_log_dispatch(10); // kFlag_sha3_keccak_f1600
+        sha3_keccak_f1600((uint64_t *)A, iotas);
+        return;
     }
 
 #if defined(MY_ASSEMBLER_SUPPORTS_NEON_SHA3_EXTENSION)
     if (CRYPTO_is_ARMv8_SHA3_capable()) {
-	keccak_log_dispatch(11); // kFlag_sha3_keccak_f1600_alt
+        keccak_log_dispatch(11); // kFlag_sha3_keccak_f1600_alt
         sha3_keccak_f1600_alt((uint64_t *)A, iotas);
         return;
     }
@@ -468,3 +483,98 @@ void KeccakF1600(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS])
 }
 
 #endif // !KECCAK1600_ASM
+
+// KeccakF1600_XORBytes_x4 XORs |len| bytes from |inp0|, |inp1|, |inp2|, |inp3|
+// into the four Keccak states in |A|. |len| must be a multiple of 8.
+static void KeccakF1600_XORBytes_x4(uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS],
+                                    const uint8_t *inp0, const uint8_t *inp1,
+                                    const uint8_t *inp2, const uint8_t *inp3,
+                                    size_t len) {
+    KeccakF1600_XORBytes(A[0], inp0, len);
+    KeccakF1600_XORBytes(A[1], inp1, len);
+    KeccakF1600_XORBytes(A[2], inp2, len);
+    KeccakF1600_XORBytes(A[3], inp3, len);
+}
+
+// KeccakF1600_ExtractBytes_x4 extracts |len| bytes from the four Keccak states in |A|
+// into |out0|, |out1|, |out2|, |out3|.
+static void KeccakF1600_ExtractBytes_x4(uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS],
+                                        uint8_t *out0, uint8_t *out1,
+                                        uint8_t *out2, uint8_t *out3,
+                                        size_t len) {
+    KeccakF1600_ExtractBytes(A[0], out0, len);
+    KeccakF1600_ExtractBytes(A[1], out1, len);
+    KeccakF1600_ExtractBytes(A[2], out2, len);
+    KeccakF1600_ExtractBytes(A[3], out3, len);
+}
+
+static void Keccak1600_x4(uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS]) {
+    KeccakF1600(A[0]);
+    KeccakF1600(A[1]);
+    KeccakF1600(A[2]);
+    KeccakF1600(A[3]);
+}
+
+// One-shot absorb + finalize. Note that in contract to non-batched Keccak,
+// this does _not_ run a Keccak permutation at the end, allowing for a uniform
+// implementation of Keccak1600_Squeezeblocks_x4() without `padded` parameter
+// as in the non-batched implementation.
+void Keccak1600_Absorb_once_x4(uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS],
+                               const uint8_t *inp0, const uint8_t *inp1,
+                               const uint8_t *inp2, const uint8_t *inp3,
+                               size_t len, size_t r, uint8_t p) {
+    assert(r <= SHA3_MAX_BLOCKSIZE);
+
+    while (len >= r) {
+        KeccakF1600_XORBytes_x4(A, inp0, inp1, inp2, inp3, r);
+        Keccak1600_x4(A);
+        inp0 += r;
+        inp1 += r;
+        inp2 += r;
+        inp3 += r;
+        len -= r;
+    }
+
+    // Build 16-byte aligned final blocks for each input
+    alignas(16) uint8_t final[4][SHA3_MAX_BLOCKSIZE] = {{0}};
+
+    // Copy the remainder bytes to final blocks
+    OPENSSL_memcpy(final[0], inp0, len);
+    OPENSSL_memcpy(final[1], inp1, len);
+    OPENSSL_memcpy(final[2], inp2, len);
+    OPENSSL_memcpy(final[3], inp3, len);
+
+    if (len == r - 1) {
+        p |= 128;
+    } else {
+        final[0][r - 1] |= 128;
+        final[1][r - 1] |= 128;
+        final[2][r - 1] |= 128;
+        final[3][r - 1] |= 128;
+    }
+
+    final[0][len] |= p;
+    final[1][len] |= p;
+    final[2][len] |= p;
+    final[3][len] |= p;
+
+    KeccakF1600_XORBytes_x4(A, final[0], final[1], final[2], final[3], r);
+
+    // Clean up final blocks to avoid stack leakage
+    OPENSSL_cleanse(final, sizeof(final));
+}
+
+void Keccak1600_Squeezeblocks_x4(uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS], uint8_t *out0, uint8_t *out1,
+                                 uint8_t *out2, uint8_t *out3,
+                                 size_t num_blocks, size_t r) {
+    while (num_blocks != 0) {
+        Keccak1600_x4(A);
+        KeccakF1600_ExtractBytes_x4(A, out0, out1, out2, out3, r);
+
+        out0 += r;
+        out1 += r;
+        out2 += r;
+        out3 += r;
+        num_blocks--;
+    }
+}

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -91,6 +91,10 @@ static inline void *align_pointer(void *ptr, size_t alignment) {
 #include "../crypto/fipsmodule/rand/internal.h"
 #endif
 
+#if defined(OPENSSL_IS_AWSLC) && (AWSLC_API_VERSION >= 35)
+#include "../crypto/fipsmodule/sha/internal.h"
+#endif
+
 
 #if defined(OPENSSL_IS_AWSLC) && defined(AARCH64_DIT_SUPPORTED) && (AWSLC_API_VERSION > 30)
 #include "../crypto/fipsmodule/cpucap/internal.h"
@@ -1160,6 +1164,78 @@ static bool SpeedHash(const EVP_MD *md, const std::string &name,
 
   return true;
 }
+
+#if defined(OPENSSL_IS_AWSLC) && (AWSLC_API_VERSION >= 35)
+static bool SpeedSHAKE256_x4_Chunks(std::string name, size_t len) {
+  size_t input_len = 0, output_len = 0;
+
+  if (name.find("Absorb") != std::string::npos) {
+    input_len = len;
+    output_len = 32;
+  } else {
+    input_len = 32;
+    output_len = len;
+  }
+
+  std::unique_ptr<uint8_t[]> input0(new uint8_t[input_len]);
+  std::unique_ptr<uint8_t[]> input1(new uint8_t[input_len]);
+  std::unique_ptr<uint8_t[]> input2(new uint8_t[input_len]);
+  std::unique_ptr<uint8_t[]> input3(new uint8_t[input_len]);
+
+  BM_memset(input0.get(), 0, input_len);
+  BM_memset(input1.get(), 0, input_len);
+  BM_memset(input2.get(), 0, input_len);
+  BM_memset(input3.get(), 0, input_len);
+
+  std::unique_ptr<uint8_t[]> output0(new uint8_t[output_len]);
+  std::unique_ptr<uint8_t[]> output1(new uint8_t[output_len]);
+  std::unique_ptr<uint8_t[]> output2(new uint8_t[output_len]);
+  std::unique_ptr<uint8_t[]> output3(new uint8_t[output_len]);
+
+  TimeResults results;
+  if (!TimeFunction(&results, [&]() -> bool {
+        return SHAKE256_x4(input0.get(), input1.get(), input2.get(), input3.get(), input_len,
+                          output0.get(), output1.get(), output2.get(), output3.get(), output_len);
+      })) {
+    fprintf(stderr, "SHAKE256_x4 failed.\n");
+    ERR_print_errors_fp(stderr);
+    return false;
+  }
+
+  results.PrintWithBytes(name, len);
+  return true;
+}
+
+static bool SpeedSHAKE256_x4_Absorb(const std::string &selected) {
+  if (!selected.empty() && selected.find("SHAKE256-x4") == std::string::npos &&
+      selected.find("Absorb") == std::string::npos) {
+    return true;
+  }
+
+  for (size_t input_len : g_chunk_lengths) {
+    if (!SpeedSHAKE256_x4_Chunks("SHAKE256-x4 (Absorb)", input_len)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool SpeedSHAKE256_x4_Squeeze(const std::string &selected) {
+  if (!selected.empty() && selected.find("SHAKE256-x4") == std::string::npos &&
+      selected.find("Squeeze") == std::string::npos) {
+    return true;
+  }
+
+  for (size_t output_len : g_chunk_lengths) {
+    if (!SpeedSHAKE256_x4_Chunks("SHAKE256-x4 (Squeeze)", output_len)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+#endif // OPENSSL_IS_AWSLC && (AWSLC_API_VERSION >= 35)
 
 static bool SpeedHmacChunk(const EVP_MD *md, std::string name,
                            size_t chunk_len) {
@@ -2906,6 +2982,10 @@ bool Speed(const std::vector<std::string> &args) {
        // OpenSSL 1.0 and BoringSSL don't support SHAKE
        !SpeedHash(EVP_shake128(), "SHAKE-128", selected) ||
        !SpeedHash(EVP_shake256(), "SHAKE-256", selected) ||
+#if defined(OPENSSL_IS_AWSLC) && (AWSLC_API_VERSION >= 35)
+       !SpeedSHAKE256_x4_Absorb(selected) ||
+       !SpeedSHAKE256_x4_Squeeze(selected) ||
+#endif
 #endif
 #if (!defined(BORINGSSL_BENCHMARK) && !defined(OPENSSL_IS_AWSLC)) || AWSLC_API_VERSION >= 20
        // BoringSSL doesn't support ripemd160


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

-----------

Previously, the 4-fold batched SHAKE APIs

- SHAKE256_Init_x4
- SHAKE256_Squeezeblocks_x4
- SHAKE256_Absorb_once_x4
- SHAKE256_x4

were implemented as four sequential calls to the toplevel 1-fold SHAKE_Init, SHAKE_Squeeze, SHAKE_Absorb, and SHAKE256, respectively.

As such, the implementations can not readily make use of the optimized and verified 4-fold Keccak-F1600 implementations that s2n-bignum provides.

To pave the way for this, this commit rewrites the implementations of the above functions by effectively inlining the definitions of the underlying SHAKE_xxx functions and interleaving them at the function level, exposing KeccakF1600_x4 as the core of the new implementation.

In more detail, we hoist out of the existing 1-fold SHA3/SHAKE implementations two core helper functions:
- Keccak1600_XORBytes, for absorbing a chunk of data into the Keccak state (during absorb phase)
- Keccak1600_ExtractBytes, for extracting a chunk of data from the Keccak state (during squeeze phase).

The 1-fold implementation is rewritten to build on those helper functions, and the 4-fold implementations are rewritten to build on new helper functions

- KeccakF1600_XORBytes_x4
- KeccakF1600_ExtractBytes_x4
- KeccakF1600_x4,

all of which are currently implemented as sequential invocations of the corresponding unbatched functionality.

Importantly, though, with KeccakF1600_x4() isolated as the core component of the new implementation of the SHAKE_xxx_x4() API, this commit enables the drop-in of optimized assembly for KeccakF1600_x4, which will be done in a subsequent commit.

## Performance

As expected, performance is largely unaffected. 

### 1. c6i

#### C-Only Build Performance (Absorb)
|    Size     |    New (Absorb)      |      Old (Absorb)        | Improvement |
|:-----------:|:--------------------:|:------------------------:|:-----------:|
|  16 bytes   |      42.0 MB/s       |       42.4 MB/s          |    -1.2%    |
|  256 bytes  |     350.8 MB/s       |      351.2 MB/s          |    -0.0%    |
| 1350 bytes  |     385.2 MB/s       |      382.8 MB/s          |    +0.7%    |
| 8192 bytes  |     386.8 MB/s       |      383.2 MB/s          |    +0.9%    |
| 16384 bytes |     390.0 MB/s       |      386.4 MB/s          |    +0.9%    |

#### Assembly Build Performance (Absorb)
|    Size     |    New (Absorb)      |      Old (Absorb)         | Improvement |
|:-----------:|:--------------------:|:------------------------:|:-----------:|
|  16 bytes   |      41.6 MB/s       |       42.4 MB/s          |    -1.4%    |
|  256 bytes  |     349.6 MB/s       |      351.2 MB/s          |    -0.5%    |
| 1350 bytes  |     385.2 MB/s       |      382.0 MB/s          |    +0.7%    |
| 8192 bytes  |     386.4 MB/s       |      382.8 MB/s          |    +0.9%    |
| 16384 bytes |     390.0 MB/s       |      386.4 MB/s          |    +1.0%    |

### 2. c6g

#### C-Only Build Performance
|    Size     |    New (Squeeze)     |      Old (Squeeze)       | Improvement |
|:-----------:|:--------------------:|:------------------------:|:-----------:|
|  16 bytes   |       26.0 MB/s      |        25.2 MB/s         |    +3.4%    |
|  256 bytes  |      213.2 MB/s      |       203.2 MB/s         |    +4.9%    |
| 1350 bytes  |      229.6 MB/s      |       220.0 MB/s         |    +4.6%    |
| 8192 bytes  |      229.6 MB/s      |       220.0 MB/s         |    +4.4%    |
| 16384 bytes |      231.6 MB/s      |       222.0 MB/s         |    +4.4%    |

#### Assembly Build Performance
|    Size     |    New (Squeeze)     |      Old (Squeeze)       | Improvement |
|:-----------:|:--------------------:|:------------------------:|:-----------:|
|  16 bytes   |       38.8 MB/s      |        37.6 MB/s         |    +2.6%    |
|  256 bytes  |      319.6 MB/s      |       310.8 MB/s         |    +2.9%    |
| 1350 bytes  |      348.8 MB/s      |       340.4 MB/s         |    +2.5%    |
| 8192 bytes  |      350.0 MB/s      |       342.8 MB/s         |    +2.1%    |
| 16384 bytes |      352.8 MB/s      |       346.0 MB/s         |    +2.1%    |

### 3. c7g

#### C-Only Build Performance
|    Size     |    New (Absorb)      |      Old (Absorb)        | Improvement |
|:-----------:|:--------------------:|:------------------------:|:-----------:|
|  16 bytes   |      38.0 MB/s       |       36.8 MB/s          |    +3.5%    |
|  256 bytes  |     312.0 MB/s       |      300.4 MB/s          |    +3.9%    |
| 1350 bytes  |     336.8 MB/s       |      321.2 MB/s          |    +4.8%    |
| 8192 bytes  |     336.8 MB/s       |      321.2 MB/s          |    +5.0%    |
| 16384 bytes |     339.6 MB/s       |      323.2 MB/s          |    +5.0%    |

#### Assembly Build Performance
|    Size     |    New (Absorb)      |      Old (Absorb)        | Improvement |
|:-----------:|:--------------------:|:------------------------:|:-----------:|
|  16 bytes   |      52.0 MB/s       |       50.8 MB/s          |    +2.8%    |
|  256 bytes  |     432.0 MB/s       |      425.6 MB/s          |    +1.5%    |
| 1350 bytes  |     470.4 MB/s       |      466.8 MB/s          |    +0.8%    |
| 8192 bytes  |     471.6 MB/s       |      469.6 MB/s          |    +0.5%    |
| 16384 bytes |     475.2 MB/s       |      473.6 MB/s          |    +0.3%    |

### 4. c8g

#### C-Only Build Performance (Absorb)
|    Size     |    New (Absorb)      |      Old (Absorb)        | Improvement |
|:-----------:|:--------------------:|:------------------------:|:-----------:|
|  16 bytes   |      43.6 MB/s       |       43.6 MB/s          |    +0.4%    |
|  256 bytes  |     359.2 MB/s       |      363.2 MB/s          |    -1.0%    |
| 1350 bytes  |     391.2 MB/s       |      393.2 MB/s          |    -0.4%    |
| 8192 bytes  |     391.6 MB/s       |      393.6 MB/s          |    -0.5%    |
| 16384 bytes |     394.4 MB/s       |      396.8 MB/s          |    -0.6%    |

#### Assembly Build Performance (Absorb)
|    Size     |    New (Absorb)      |      Old (Absorb)        | Improvement |
|:-----------:|:--------------------:|:------------------------:|:-----------:|
|  16 bytes   |      60.8 MB/s       |       58.8 MB/s          |    +3.5%    |
|  256 bytes  |     503.6 MB/s       |      496.0 MB/s          |    +1.6%    |
| 1350 bytes  |     546.8 MB/s       |      545.2 MB/s          |    +0.2%    |
| 8192 bytes  |     547.6 MB/s       |      549.2 MB/s          |    -0.3%    |
| 16384 bytes |     552.0 MB/s       |      554.0 MB/s          |    -0.3%    |

