### PR TITLE
Support other field for PKCS7

### DIFF
--- a/crypto/pkcs7/pkcs7_asn1.c
+++ b/crypto/pkcs7/pkcs7_asn1.c
@@ -10,7 +10,7 @@
 #include "../internal.h"
 #include "internal.h"
 
-ASN1_ADB_TEMPLATE(p7default) = ASN1_EXP_OPT(PKCS7, d.data, ASN1_ANY, 0);
+ASN1_ADB_TEMPLATE(p7default) = ASN1_EXP_OPT(PKCS7, d.other, ASN1_ANY, 0);
 
 ASN1_ADB(PKCS7) = {
     ADB_ENTRY(NID_pkcs7_data,

--- a/include/openssl/pkcs7.h
+++ b/include/openssl/pkcs7.h
@@ -158,6 +158,8 @@ struct pkcs7_st {
     PKCS7_SIGN_ENVELOPE *signed_and_enveloped;
     PKCS7_DIGEST *digest;
     PKCS7_ENCRYPT *encrypted;
+    // Other things provided by the user. Not specified in the RFC.
+    ASN1_TYPE *other;
   } d;
 };
 


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-3279`

### Description of changes: 
OpenSSL's `PKCS7` structure has historically been non-opaque. This causes issues like projects depending on the `PKCS7` internals to be of a certain format. OpenSSL's `PKCS7` struct has a field called `other`, which various projects internally have found to have a dependence on. The usage spans multiple projects and seeing that OpenSSL 3.x still supports the field, this isn't going away anytime soon.

examples:
* https://github.com/tianocore/edk2/blob/686f1e3ea8373db48ea3a8457cc758c986455de0/CryptoPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyBase.c#L69-L71
* https://github.com/krb5/krb5/blob/820a7277ed1c553d33b2a7f3efb48655fb993b77/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c#L1615-L1636

### Call-outs:
N/A

### Testing:
New tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
