### PR TITLE
target.h: more clearly check for ppc64 endianness

### DIFF
--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -41,7 +41,7 @@
 #define OPENSSL_64_BIT
 #define OPENSSL_PPC64BE
 #define OPENSSL_BIG_ENDIAN
-#elif (defined(__PPC__) || defined(__powerpc__)) && defined(_BIG_ENDIAN)
+#elif (defined(__PPC__) || defined(__powerpc__)) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define OPENSSL_32_BIT
 #define OPENSSL_PPC32BE
 #define OPENSSL_BIG_ENDIAN
@@ -49,7 +49,7 @@
 #define OPENSSL_64_BIT
 #define OPENSSL_S390X
 #define OPENSSL_BIG_ENDIAN
-#elif defined(__sparc__) && defined(_BIG_ENDIAN)
+#elif defined(__sparc__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define OPENSSL_64_BIT
 #define OPENSSL_SPARCV9
 #define OPENSSL_BIG_ENDIAN

--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -34,10 +34,10 @@
 #elif defined(__ARMEL__) || defined(_M_ARM)
 #define OPENSSL_32_BIT
 #define OPENSSL_ARM
-#elif (defined(__PPC64__) || defined(__powerpc64__)) && defined(_LITTLE_ENDIAN)
+#elif (defined(__PPC64__) || defined(__powerpc64__)) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define OPENSSL_64_BIT
 #define OPENSSL_PPC64LE
-#elif (defined(__PPC64__) || defined(__powerpc64__)) && defined(_BIG_ENDIAN)
+#elif (defined(__PPC64__) || defined(__powerpc64__)) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define OPENSSL_64_BIT
 #define OPENSSL_PPC64BE
 #define OPENSSL_BIG_ENDIAN


### PR DESCRIPTION
Currently clang builds on ppc64 (big-endian) fail because little-endian code path is attempted. This patch uses the canonical way of checking endianness.

### Description of changes: 
Fixes build on ppc64 (big-endian)

### Testing:
Build testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
