### PR TITLE
Only configure check-linkage.sh if BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1342,4 +1342,7 @@ endforeach()
 
 configure_file(include/openssl/base.h.in ${AWSLC_SOURCE_DIR}/include/openssl/base.h @ONLY)
 configure_file(include/openssl/opensslv.h.in ${AWSLC_SOURCE_DIR}/include/openssl/opensslv.h @ONLY)
-configure_file(tests/ci/check-linkage.sh.in check-linkage.sh @ONLY)
+
+if(BUILD_TESTING)
+  configure_file(tests/ci/check-linkage.sh.in check-linkage.sh @ONLY)
+endif()


### PR DESCRIPTION

### Description of changes: 
Avoid referencing files under "tests" when BUILD_TESTING is off.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
