### PR TITLE
Add support for EVP_PKEY_param_check

### DIFF
--- a/crypto/evp_extra/evp_asn1.c
+++ b/crypto/evp_extra/evp_asn1.c
@@ -59,16 +59,18 @@
 #include <string.h>
 
 #include <openssl/bytestring.h>
+#include <openssl/dh.h>
 #include <openssl/dsa.h>
 #include <openssl/ec_key.h>
 #include <openssl/err.h>
 #include <openssl/rsa.h>
 
-#include "../fipsmodule/evp/internal.h"
 #include "../bytestring/internal.h"
+#include "../fipsmodule/dh/internal.h"
+#include "../fipsmodule/evp/internal.h"
+#include "../fipsmodule/pqdsa/internal.h"
 #include "../internal.h"
 #include "internal.h"
-#include "../fipsmodule/pqdsa/internal.h"
 
 // parse_key_type takes the algorithm cbs sequence |cbs| and extracts the OID.
 // The extracted OID will be set on |out_oid| so that it may be used later in
@@ -344,12 +346,33 @@ int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx) {
     OPENSSL_PUT_ERROR(EVP, EVP_R_NO_KEY_SET);
     return 0;
   }
-
   switch (pkey->type) {
     case EVP_PKEY_EC:
       return EC_KEY_check_key(pkey->pkey.ec);
     case EVP_PKEY_RSA:
       return RSA_check_key(pkey->pkey.rsa);
+    default:
+      OPENSSL_PUT_ERROR(EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+    return 0;
+  }
+}
+
+int EVP_PKEY_param_check(EVP_PKEY_CTX *ctx) {
+  if (ctx == NULL) {
+    OPENSSL_PUT_ERROR(EVP, ERR_R_PASSED_NULL_PARAMETER);
+    return 0;
+  }
+
+  EVP_PKEY *pkey = ctx->pkey;
+  if (pkey == NULL) {
+    OPENSSL_PUT_ERROR(EVP, EVP_R_NO_KEY_SET);
+    return 0;
+  }
+
+  int err_flags = 0;
+  switch (pkey->type) {
+    case EVP_PKEY_DH:
+      return DH_check(pkey->pkey.dh, &err_flags) && err_flags == 0;
     default:
       OPENSSL_PUT_ERROR(EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
     return 0;

--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -1737,6 +1737,8 @@ TEST(EVPExtraTest, ECKeygen) {
     ASSERT_TRUE(maybe_copy(&ctx));
     EVP_PKEY *raw = nullptr;
     ASSERT_TRUE(EVP_PKEY_paramgen(ctx.get(), &raw));
+    // |EVP_PKEY_param_check| does not support EC keys yet.
+    ASSERT_FALSE(EVP_PKEY_param_check(ctx.get()));
     bssl::UniquePtr<EVP_PKEY> pkey(raw);
     raw = nullptr;
     ExpectECGroupOnly(pkey.get(), NID_X9_62_prime256v1);
@@ -1801,6 +1803,7 @@ TEST(EVPExtraTest, DHKeygen) {
     ASSERT_TRUE(ctx);
     ASSERT_TRUE(maybe_copy(&ctx));
     ASSERT_TRUE(EVP_PKEY_keygen_init(ctx.get()));
+    ASSERT_TRUE(EVP_PKEY_param_check(ctx.get()));
     ASSERT_TRUE(maybe_copy(&ctx));
     EVP_PKEY *raw = nullptr;
     ASSERT_TRUE(EVP_PKEY_keygen(ctx.get(), &raw));
@@ -1853,6 +1856,8 @@ TEST(EVPExtraTest, DHParamgen) {
     EVP_PKEY *raw_pkey = NULL;
     // Generate the parameters
     ASSERT_TRUE(EVP_PKEY_paramgen(ctx.get(), &raw_pkey));
+    // Only parameters have been generated, but no key has actually been set.
+    EXPECT_FALSE(EVP_PKEY_param_check(ctx.get()));
     bssl::UniquePtr<EVP_PKEY> pkey(raw_pkey);
     ASSERT_TRUE(raw_pkey);
 
@@ -1876,6 +1881,7 @@ TEST(EVPExtraTest, DHParamgen) {
   ASSERT_NE(EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx.get(), prime_len), 1);
   // Set the generator
   ASSERT_NE(EVP_PKEY_CTX_set_dh_paramgen_generator(ctx.get(), generator), 1);
+  ASSERT_FALSE(EVP_PKEY_param_check(ctx.get()));
 }
 
 // Test that |EVP_PKEY_keygen| works for Ed25519.

--- a/crypto/fipsmodule/evp/evp_ctx_test.cc
+++ b/crypto/fipsmodule/evp/evp_ctx_test.cc
@@ -263,6 +263,8 @@ TEST_F(EvpPkeyCtxCtrlStrTest, DhParamGen) {
 
   EVP_PKEY* raw = nullptr;
   ASSERT_EQ(EVP_PKEY_paramgen(ctx.get(), &raw), 1);
+  // Only parameters have been generated, but no key has actually been set.
+  EXPECT_FALSE(EVP_PKEY_param_check(ctx.get()));
   bssl::UniquePtr<EVP_PKEY> pkey(raw);
   ASSERT_TRUE(raw);
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -774,6 +774,15 @@ OPENSSL_EXPORT int EVP_PKEY_check(EVP_PKEY_CTX *ctx);
 // It returns one on success and zero on error.
 OPENSSL_EXPORT int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx);
 
+// EVP_PKEY_param_check validates the parameters component of the key given by
+// |ctx|. OpenSSL only supports by DH and EC keys via this API.
+// For DH keys, this calls |DH_check| to validate the parameters. EC key
+// parameter validations are not supported as of now.
+// TODO: Support EC group validations.
+//
+// It returns one on success and zero on error.
+OPENSSL_EXPORT int EVP_PKEY_param_check(EVP_PKEY_CTX *ctx);
+
 // EVP_PKEY_keygen_init initialises an |EVP_PKEY_CTX| for a key generation
 // operation. It should be called before |EVP_PKEY_keygen|.
 //


### PR DESCRIPTION
### Issues:
Resolves https://github.com/ruby/openssl/issues/933

### Description of changes: 
Ironically, this was a discrepancy introduced due to our recent endeavors for more OpenSSL compatibility. We introduced support for `EVP_PKEY_check` and `EVP_PKEY_public_check` with https://github.com/aws/aws-lc/commit/bbf9ff6176b056bfbeab9d46f719fc724fc5edb8 and this was pulled into the latest release.

Unfortunately, ruby/openssl uses `EVP_PKEY_check` as a function support check for `EVP_PKEY_param_check` and we happened to only implement `EVP_PKEY_check` without `EVP_PKEY_param_check`. This PR implements support for such to resolve the OpenSSL discrepency.

### Call-outs:
N/A

### Testing:
Tests inserted within code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
