### PR TITLE
Add back RC4_options from decrepit

### DIFF
--- a/crypto/rc4/rc4.c
+++ b/crypto/rc4/rc4.c
@@ -56,6 +56,9 @@
 
 #include <openssl/rc4.h>
 
+const char *RC4_options(void) {
+  return "rc4(ptr,int)";
+}
 
 void RC4(RC4_KEY *key, size_t len, const uint8_t *in, uint8_t *out) {
   uint32_t x = key->x;

--- a/include/openssl/rc4.h
+++ b/include/openssl/rc4.h
@@ -83,6 +83,12 @@ OPENSSL_EXPORT void RC4(RC4_KEY *key, size_t len, const uint8_t *in,
                         uint8_t *out);
 
 
+// Deprecated functions.
+
+// RC4_options returns the string "rc4(ptr,int)".
+OPENSSL_EXPORT OPENSSL_DEPRECATED const char *RC4_options(void);
+
+
 #if defined(__cplusplus)
 }  // extern C
 #endif


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-3312`

### Description of changes: 
Some older builds were found to depend on this symbol. We initially removed this from AWS-LC along with some decrepit functions that we didn't think were necessary: https://github.com/aws/aws-lc/commit/abbbd0045c9dc3a6f7de0fa29efaf298f44b7852.
Things have changed though, this adds the same implementation back.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
