### PR TITLE
Fix Bind9 CI test

### DIFF
--- a/tests/ci/integration/run_bind9_integration.sh
+++ b/tests/ci/integration/run_bind9_integration.sh
@@ -28,6 +28,8 @@ AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
 
 function bind9_build() {
+  BIND9_VERSION=$(meson introspect meson.build --projectinfo | jq -r '.version')
+
   #dnsrps was removed since bind9 9.21.2
   meson setup "$BIND9_BUILD_FOLDER" \
     --pkg-config-path="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig" \
@@ -69,8 +71,8 @@ bind9_run_tests
 
 # Iterate through all of bind's vended artifacts.
 for libname in dns ns isc isccc isccfg; do
-  ${AWS_LC_BUILD_FOLDER}/check-linkage.sh "${BIND9_BUILD_FOLDER}/lib${libname}.so" crypto || exit 1
-  ${AWS_LC_BUILD_FOLDER}/check-linkage.sh "${BIND9_BUILD_FOLDER}/lib${libname}.so" ssl || exit 1
+  ${AWS_LC_BUILD_FOLDER}/check-linkage.sh "${BIND9_BUILD_FOLDER}/lib${libname}-${BIND9_VERSION}.so" crypto || exit 1
+  ${AWS_LC_BUILD_FOLDER}/check-linkage.sh "${BIND9_BUILD_FOLDER}/lib${libname}-${BIND9_VERSION}.so" ssl || exit 1
 done
 
 popd


### PR DESCRIPTION
### Issues:
Resolves #P289577271

### Description of changes: 
Bind9 made an upstream change to append project version to the library name, leading to failure in our CI. This PR fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
