### PR TITLE
ML-KEM: Re-import mlkem-native

### DIFF
--- a/crypto/fipsmodule/ml_kem/META.yml
+++ b/crypto/fipsmodule/ml_kem/META.yml
@@ -1,5 +1,5 @@
 name: mlkem-native
 source: pq-code-package/mlkem-native.git
 branch: main
-commit: a67a02ee3fa05713ae01572efce741caa63285e6
-imported-at: 2025-06-25T12:11:38+0100
+commit: ed62d31297bca103cbbf02e125646af098253872
+imported-at: 2025-08-20T09:29:34+0100

--- a/crypto/fipsmodule/ml_kem/mlkem/cbmc.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/cbmc.h
@@ -125,6 +125,28 @@
 #define array_bound(array_var, qvar_lb, qvar_ub, value_lb, value_ub) \
   array_bound_core(CBMC_CONCAT(_cbmc_idx, __LINE__), (qvar_lb),      \
       (qvar_ub), (array_var), (value_lb), (value_ub))
+
+#define array_unchanged_core(qvar, qvar_lb, qvar_ub, array_var)        \
+  __CPROVER_forall                                                     \
+  {                                                                    \
+    unsigned qvar;                                                     \
+    ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==>                    \
+    ((array_var)[(qvar)]) == (old(* (int16_t (*)[(qvar_ub)])(array_var)))[(qvar)] \
+  }
+
+#define array_unchanged(array_var, N) \
+    array_unchanged_core(CBMC_CONCAT(_cbmc_idx, __LINE__), 0, (N), (array_var))
+
+#define array_unchanged_u64_core(qvar, qvar_lb, qvar_ub, array_var)        \
+  __CPROVER_forall                                                     \
+  {                                                                    \
+    unsigned qvar;                                                     \
+    ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==>                    \
+    ((array_var)[(qvar)]) == (old(* (uint64_t (*)[(qvar_ub)])(array_var)))[(qvar)] \
+  }
+
+#define array_unchanged_u64(array_var, N) \
+    array_unchanged_u64_core(CBMC_CONCAT(_cbmc_idx, __LINE__), 0, (N), (array_var))
 /* clang-format on */
 
 /* Wrapper around array_bound operating on absolute values.

--- a/crypto/fipsmodule/ml_kem/mlkem/common.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/common.h
@@ -135,6 +135,19 @@
 #define MLK_FIPS202X4_HEADER_FILE MLK_CONFIG_FIPS202X4_CUSTOM_HEADER
 #endif
 
+/* Standard library function replacements */
+#if !defined(__ASSEMBLER__)
+#if !defined(MLK_CONFIG_CUSTOM_MEMCPY)
+#include <string.h>
+#define mlk_memcpy memcpy
+#endif
+
+#if !defined(MLK_CONFIG_CUSTOM_MEMSET)
+#include <string.h>
+#define mlk_memset memset
+#endif
+#endif /* !__ASSEMBLER__ */
+
 /* Just in case we want to include mlkem_native.h, set the configuration
  * for that header in accordance with the configuration used here. */
 

--- a/crypto/fipsmodule/ml_kem/mlkem/compress.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/compress.c
@@ -28,7 +28,6 @@
 #include "verify.h"
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || (MLKEM_K == 2 || MLKEM_K == 3)
-#if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D4)
 /* Reference: `poly_compress()` in the reference implementation @[REF],
  *            for ML-KEM-{512,768}.
  *            - In contrast to the reference implementation, we assume
@@ -40,6 +39,15 @@ void mlk_poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
                           const mlk_poly *a)
 {
   unsigned i;
+#if defined(MLK_USE_NATIVE_POLY_COMPRESS_D4)
+  int ret;
+  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  ret = mlk_poly_compress_d4_native(r, a->coeffs);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_COMPRESS_D4 */
   mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
 
   for (i = 0; i < MLKEM_N / 8; i++)
@@ -61,17 +69,7 @@ void mlk_poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
     r[i * 4 + 3] = t[6] | (t[7] << 4);
   }
 }
-#else  /* !MLK_USE_NATIVE_POLY_COMPRESS_D4 */
-MLK_INTERNAL_API
-void mlk_poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
-                          const mlk_poly *a)
-{
-  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
-  mlk_poly_compress_d4_native(r, a->coeffs);
-}
-#endif /* MLK_USE_NATIVE_POLY_COMPRESS_D4 */
 
-#if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D10)
 /* Reference: Embedded into `polyvec_compress()` in the
  *            reference implementation, for ML-KEM-{512,768}.
  *            - In contrast to the reference implementation, we assume
@@ -83,6 +81,15 @@ void mlk_poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
                            const mlk_poly *a)
 {
   unsigned j;
+#if defined(MLK_USE_NATIVE_POLY_COMPRESS_D10)
+  int ret;
+  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  ret = mlk_poly_compress_d10_native(r, a->coeffs);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_COMPRESS_D10 */
   mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
   for (j = 0; j < MLKEM_N / 4; j++)
   __loop__(invariant(j <= MLKEM_N / 4))
@@ -108,17 +115,7 @@ void mlk_poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
     r[5 * j + 4] = (t[3] >> 2);
   }
 }
-#else  /* !MLK_USE_NATIVE_POLY_COMPRESS_D10 */
-MLK_INTERNAL_API
-void mlk_poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
-                           const mlk_poly *a)
-{
-  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
-  mlk_poly_compress_d10_native(r, a->coeffs);
-}
-#endif /* MLK_USE_NATIVE_POLY_COMPRESS_D10 */
 
-#if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D4)
 /* Reference: `poly_decompress()` in the reference implementation @[REF],
  *            for ML-KEM-{512,768}. */
 MLK_INTERNAL_API
@@ -126,6 +123,15 @@ void mlk_poly_decompress_d4(mlk_poly *r,
                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
 {
   unsigned i;
+#if defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D4)
+  int ret;
+  ret = mlk_poly_decompress_d4_native(r->coeffs, a);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D4 */
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(
     invariant(i <= MLKEM_N / 2)
@@ -137,17 +143,7 @@ void mlk_poly_decompress_d4(mlk_poly *r,
 
   mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
-#else  /* !MLK_USE_NATIVE_POLY_DECOMPRESS_D4 */
-MLK_INTERNAL_API
-void mlk_poly_decompress_d4(mlk_poly *r,
-                            const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
-{
-  mlk_poly_decompress_d4_native(r->coeffs, a);
-  mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
-}
-#endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D4 */
 
-#if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D10)
 /* Reference: Embedded into `polyvec_decompress()` in the
  *            reference implementation, for ML-KEM-{512,768}. */
 MLK_INTERNAL_API
@@ -155,6 +151,15 @@ void mlk_poly_decompress_d10(mlk_poly *r,
                              const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10])
 {
   unsigned j;
+#if defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D10)
+  int ret;
+  ret = mlk_poly_decompress_d10_native(r->coeffs, a);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D10 */
   for (j = 0; j < MLKEM_N / 4; j++)
   __loop__(
     invariant(j <= MLKEM_N / 4)
@@ -180,19 +185,9 @@ void mlk_poly_decompress_d10(mlk_poly *r,
 
   mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
-#else  /* !MLK_USE_NATIVE_POLY_DECOMPRESS_D10 */
-MLK_INTERNAL_API
-void mlk_poly_decompress_d10(mlk_poly *r,
-                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10])
-{
-  mlk_poly_decompress_d10_native(r->coeffs, a);
-  mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
-}
-#endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D10 */
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 2 || MLKEM_K == 3 */
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || MLKEM_K == 4
-#if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D5)
 /* Reference: `poly_compress()` in the reference implementation @[REF],
  *            for ML-KEM-1024.
  *            - In contrast to the reference implementation, we assume
@@ -204,6 +199,15 @@ void mlk_poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
                           const mlk_poly *a)
 {
   unsigned i;
+#if defined(MLK_USE_NATIVE_POLY_COMPRESS_D5)
+  int ret;
+  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  ret = mlk_poly_compress_d5_native(r, a->coeffs);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_COMPRESS_D5 */
   mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
 
   for (i = 0; i < MLKEM_N / 8; i++)
@@ -231,17 +235,7 @@ void mlk_poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
     r[i * 5 + 4] = 0xFF & ((t[6] >> 2) | (t[7] << 3));
   }
 }
-#else  /* !MLK_USE_NATIVE_POLY_COMPRESS_D5 */
-MLK_INTERNAL_API
-void mlk_poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
-                          const mlk_poly *a)
-{
-  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
-  mlk_poly_compress_d5_native(r, a->coeffs);
-}
-#endif /* MLK_USE_NATIVE_POLY_COMPRESS_D5 */
 
-#if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D11)
 /* Reference: Embedded into `polyvec_compress()` in the
  *            reference implementation, for ML-KEM-1024.
  *            - In contrast to the reference implementation, we assume
@@ -253,6 +247,15 @@ void mlk_poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
                            const mlk_poly *a)
 {
   unsigned j;
+#if defined(MLK_USE_NATIVE_POLY_COMPRESS_D11)
+  int ret;
+  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  ret = mlk_poly_compress_d11_native(r, a->coeffs);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_COMPRESS_D11 */
   mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
 
   for (j = 0; j < MLKEM_N / 8; j++)
@@ -285,17 +288,7 @@ void mlk_poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
     r[11 * j + 10] = (t[7] >> 3);
   }
 }
-#else  /* !MLK_USE_NATIVE_POLY_COMPRESS_D11 */
-MLK_INTERNAL_API
-void mlk_poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
-                           const mlk_poly *a)
-{
-  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
-  mlk_poly_compress_d11_native(r, a->coeffs);
-}
-#endif /* MLK_USE_NATIVE_POLY_COMPRESS_D11 */
 
-#if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D5)
 /* Reference: `poly_decompress()` in the reference implementation @[REF],
  *            for ML-KEM-1024. */
 MLK_INTERNAL_API
@@ -303,6 +296,15 @@ void mlk_poly_decompress_d5(mlk_poly *r,
                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5])
 {
   unsigned i;
+#if defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D5)
+  int ret;
+  ret = mlk_poly_decompress_d5_native(r->coeffs, a);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D5 */
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
     invariant(i <= MLKEM_N / 8)
@@ -342,17 +344,7 @@ void mlk_poly_decompress_d5(mlk_poly *r,
 
   mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
-#else  /* !MLK_USE_NATIVE_POLY_DECOMPRESS_D5 */
-MLK_INTERNAL_API
-void mlk_poly_decompress_d5(mlk_poly *r,
-                            const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5])
-{
-  mlk_poly_decompress_d5_native(r->coeffs, a);
-  mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
-}
-#endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D5 */
 
-#if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D11)
 /* Reference: Embedded into `polyvec_decompress()` in the
  *            reference implementation, for ML-KEM-1024. */
 MLK_INTERNAL_API
@@ -360,6 +352,15 @@ void mlk_poly_decompress_d11(mlk_poly *r,
                              const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D11])
 {
   unsigned j;
+#if defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D11)
+  int ret;
+  ret = mlk_poly_decompress_d11_native(r->coeffs, a);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D11 */
   for (j = 0; j < MLKEM_N / 8; j++)
   __loop__(
     invariant(j <= MLKEM_N / 8)
@@ -390,19 +391,9 @@ void mlk_poly_decompress_d11(mlk_poly *r,
 
   mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
-#else  /* !MLK_USE_NATIVE_POLY_DECOMPRESS_D11 */
-MLK_INTERNAL_API
-void mlk_poly_decompress_d11(mlk_poly *r,
-                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D11])
-{
-  mlk_poly_decompress_d11_native(r->coeffs, a);
-  mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
-}
-#endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D11 */
 
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 4 */
 
-#if !defined(MLK_USE_NATIVE_POLY_TOBYTES)
 /* Reference: `poly_tobytes()` in the reference implementation @[REF].
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
@@ -412,6 +403,15 @@ MLK_INTERNAL_API
 void mlk_poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const mlk_poly *a)
 {
   unsigned i;
+#if defined(MLK_USE_NATIVE_POLY_TOBYTES)
+  int ret;
+  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  ret = mlk_poly_tobytes_native(r, a->coeffs);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_TOBYTES */
   mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
 
   for (i = 0; i < MLKEM_N / 2; i++)
@@ -439,21 +439,20 @@ void mlk_poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const mlk_poly *a)
     r[3 * i + 2] = t1 >> 4;
   }
 }
-#else  /* !MLK_USE_NATIVE_POLY_TOBYTES */
-MLK_INTERNAL_API
-void mlk_poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const mlk_poly *a)
-{
-  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
-  mlk_poly_tobytes_native(r, a->coeffs);
-}
-#endif /* MLK_USE_NATIVE_POLY_TOBYTES */
 
-#if !defined(MLK_USE_NATIVE_POLY_FROMBYTES)
 /* Reference: `poly_frombytes()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
 {
   unsigned i;
+#if defined(MLK_USE_NATIVE_POLY_FROMBYTES)
+  int ret;
+  ret = mlk_poly_frombytes_native(r->coeffs, a);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_FROMBYTES */
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(
     invariant(i <= MLKEM_N / 2)
@@ -469,13 +468,6 @@ void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
   /* Note that the coefficients are not canonical */
   mlk_assert_bound(r, MLKEM_N, 0, MLKEM_UINT12_LIMIT);
 }
-#else  /* !MLK_USE_NATIVE_POLY_FROMBYTES */
-MLK_INTERNAL_API
-void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
-{
-  mlk_poly_frombytes_native(r->coeffs, a);
-}
-#endif /* MLK_USE_NATIVE_POLY_FROMBYTES */
 
 /* Reference: `poly_frommsg()` in the reference implementation @[REF].
  *            - We use a value barrier around the bit-selection mask to

--- a/crypto/fipsmodule/ml_kem/mlkem/kem.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/kem.c
@@ -36,8 +36,6 @@
  * This is to facilitate building multiple instances
  * of mlkem-native (e.g. with varying security levels)
  * within a single compilation unit. */
-#define mlk_check_pk MLK_ADD_PARAM_SET(mlk_check_pk)
-#define mlk_check_sk MLK_ADD_PARAM_SET(mlk_check_sk)
 #define mlk_check_pct MLK_ADD_PARAM_SET(mlk_check_pct)
 /* End of parameter set namespacing */
 
@@ -50,26 +48,11 @@ __contract__(
 );
 #endif /* CBMC */
 
-/*************************************************
- * Name:        mlk_check_pk
- *
- * Description: Implements modulus check mandated by FIPS 203,
- *              i.e., ensures that coefficients are in [0,q-1].
- *
- * Arguments:   - const uint8_t *pk: pointer to input public key
- *                (an already allocated array of MLKEM_INDCCA_PUBLICKEYBYTES
- *                 bytes)
- *
- * Returns: - 0 on success
- *          - -1 on failure
- *
- * Specification: Implements @[FIPS203, Section 7.2, 'modulus check']
- *
- **************************************************/
 
 /* Reference: Not implemented in the reference implementation @[REF]. */
+MLK_INTERNAL_API
 MLK_MUST_CHECK_RETURN_VALUE
-static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
+int crypto_kem_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
 {
   int res;
   mlk_polyvec p;
@@ -90,27 +73,11 @@ static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
   return res;
 }
 
-/*************************************************
- * Name:        mlk_check_sk
- *
- * Description: Implements public key hash check mandated by FIPS 203,
- *              i.e., ensures that
- *              sk[768𝑘+32 ∶ 768𝑘+64] = H(pk)= H(sk[384𝑘 : 768𝑘+32])
- *
- * Arguments:   - const uint8_t *sk: pointer to input private key
- *                (an already allocated array of MLKEM_INDCCA_SECRETKEYBYTES
- *                 bytes)
- *
- * Returns: - 0 on success
- *          - -1 on failure
- *
- * Specification: Implements @[FIPS203, Section 7.3, 'hash check']
- *
- **************************************************/
 
 /* Reference: Not implemented in the reference implementation @[REF]. */
+MLK_INTERNAL_API
 MLK_MUST_CHECK_RETURN_VALUE
-static int mlk_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
+int crypto_kem_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
 {
   int res;
   MLK_ALIGN uint8_t test[MLKEM_SYMBYTES];
@@ -213,12 +180,12 @@ int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
                               const uint8_t coins[2 * MLKEM_SYMBYTES])
 {
   mlk_indcpa_keypair_derand(pk, sk, coins);
-  memcpy(sk + MLKEM_INDCPA_SECRETKEYBYTES, pk, MLKEM_INDCCA_PUBLICKEYBYTES);
+  mlk_memcpy(sk + MLKEM_INDCPA_SECRETKEYBYTES, pk, MLKEM_INDCCA_PUBLICKEYBYTES);
   mlk_hash_h(sk + MLKEM_INDCCA_SECRETKEYBYTES - 2 * MLKEM_SYMBYTES, pk,
              MLKEM_INDCCA_PUBLICKEYBYTES);
   /* Value z for pseudo-random output on reject */
-  memcpy(sk + MLKEM_INDCCA_SECRETKEYBYTES - MLKEM_SYMBYTES,
-         coins + MLKEM_SYMBYTES, MLKEM_SYMBYTES);
+  mlk_memcpy(sk + MLKEM_INDCCA_SECRETKEYBYTES - MLKEM_SYMBYTES,
+             coins + MLKEM_SYMBYTES, MLKEM_SYMBYTES);
 
   /* Declassify public key */
   MLK_CT_TESTING_DECLASSIFY(pk, MLKEM_INDCCA_PUBLICKEYBYTES);
@@ -267,12 +234,12 @@ int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   MLK_ALIGN uint8_t kr[2 * MLKEM_SYMBYTES];
 
   /* Specification: Implements @[FIPS203, Section 7.2, Modulus check] */
-  if (mlk_check_pk(pk))
+  if (crypto_kem_check_pk(pk))
   {
     return -1;
   }
 
-  memcpy(buf, coins, MLKEM_SYMBYTES);
+  mlk_memcpy(buf, coins, MLKEM_SYMBYTES);
 
   /* Multitarget countermeasure for coins + contributory KEM */
   mlk_hash_h(buf + MLKEM_SYMBYTES, pk, MLKEM_INDCCA_PUBLICKEYBYTES);
@@ -281,7 +248,7 @@ int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   /* coins are in kr+MLKEM_SYMBYTES */
   mlk_indcpa_enc(ct, buf, pk, kr + MLKEM_SYMBYTES);
 
-  memcpy(ss, kr, MLKEM_SYMBYTES);
+  mlk_memcpy(ss, kr, MLKEM_SYMBYTES);
 
   /* Specification: Partially implements
    * @[FIPS203, Section 3.3, Destruction of intermediate values] */
@@ -329,7 +296,7 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
   const uint8_t *pk = sk + MLKEM_INDCPA_SECRETKEYBYTES;
 
   /* Specification: Implements @[FIPS203, Section 7.3, Hash check] */
-  if (mlk_check_sk(sk))
+  if (crypto_kem_check_sk(sk))
   {
     return -1;
   }
@@ -337,8 +304,9 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
   mlk_indcpa_dec(buf, ct, sk);
 
   /* Multitarget countermeasure for coins + contributory KEM */
-  memcpy(buf + MLKEM_SYMBYTES,
-         sk + MLKEM_INDCCA_SECRETKEYBYTES - 2 * MLKEM_SYMBYTES, MLKEM_SYMBYTES);
+  mlk_memcpy(buf + MLKEM_SYMBYTES,
+             sk + MLKEM_INDCCA_SECRETKEYBYTES - 2 * MLKEM_SYMBYTES,
+             MLKEM_SYMBYTES);
   mlk_hash_g(kr, buf, 2 * MLKEM_SYMBYTES);
 
   /* Recompute and compare ciphertext */
@@ -347,9 +315,9 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
   fail = mlk_ct_memcmp(ct, tmp, MLKEM_INDCCA_CIPHERTEXTBYTES);
 
   /* Compute rejection key */
-  memcpy(tmp, sk + MLKEM_INDCCA_SECRETKEYBYTES - MLKEM_SYMBYTES,
-         MLKEM_SYMBYTES);
-  memcpy(tmp + MLKEM_SYMBYTES, ct, MLKEM_INDCCA_CIPHERTEXTBYTES);
+  mlk_memcpy(tmp, sk + MLKEM_INDCCA_SECRETKEYBYTES - MLKEM_SYMBYTES,
+             MLKEM_SYMBYTES);
+  mlk_memcpy(tmp + MLKEM_SYMBYTES, ct, MLKEM_INDCCA_CIPHERTEXTBYTES);
   mlk_hash_j(ss, tmp, sizeof(tmp));
 
   /* Copy true key to return buffer if fail is 0 */
@@ -366,6 +334,4 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
 
 /* To facilitate single-compilation-unit (SCU) builds, undefine all macros.
  * Don't modify by hand -- this is auto-generated by scripts/autogen. */
-#undef mlk_check_pk
-#undef mlk_check_sk
 #undef mlk_check_pct

--- a/crypto/fipsmodule/ml_kem/mlkem/kem.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/kem.h
@@ -10,6 +10,11 @@
  *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
  *   National Institute of Standards and Technology
  *   https://csrc.nist.gov/pubs/fips/203/final
+ *
+ * - [REF]
+ *   CRYSTALS-Kyber C reference implementation
+ *   Bos, Ducas, Kiltz, Lepoint, Lyubashevsky, Schanck, Schwabe, Seiler, Stehlé
+ *   https://github.com/pq-crystals/kyber/tree/main/ref
  */
 
 #ifndef MLK_KEM_H
@@ -49,6 +54,56 @@
 #define crypto_kem_enc_derand MLK_NAMESPACE_K(enc_derand)
 #define crypto_kem_enc MLK_NAMESPACE_K(enc)
 #define crypto_kem_dec MLK_NAMESPACE_K(dec)
+#define crypto_kem_check_pk MLK_NAMESPACE_K(check_pk)
+#define crypto_kem_check_sk MLK_NAMESPACE_K(check_sk)
+
+
+
+/*************************************************
+ * Name:        crypto_kem_check_pk
+ *
+ * Description: Implements modulus check mandated by FIPS 203,
+ *              i.e., ensures that coefficients are in [0,q-1].
+ *
+ * Arguments:   - const uint8_t *pk: pointer to input public key
+ *                (an already allocated array of MLKEM_INDCCA_PUBLICKEYBYTES
+ *                 bytes)
+ *
+ * Returns: - 0 on success
+ *          - -1 on failure
+ *
+ * Specification: Implements @[FIPS203, Section 7.2, 'modulus check']
+ *
+ **************************************************/
+
+/* Reference: Not implemented in the reference implementation @[REF]. */
+MLK_INTERNAL_API
+MLK_MUST_CHECK_RETURN_VALUE
+int crypto_kem_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES]);
+
+
+/*************************************************
+ * Name:        crypto_kem_check_sk
+ *
+ * Description: Implements public key hash check mandated by FIPS 203,
+ *              i.e., ensures that
+ *              sk[768𝑘+32 ∶ 768𝑘+64] = H(pk)= H(sk[384𝑘 : 768𝑘+32])
+ *
+ * Arguments:   - const uint8_t *sk: pointer to input private key
+ *                (an already allocated array of MLKEM_INDCCA_SECRETKEYBYTES
+ *                 bytes)
+ *
+ * Returns: - 0 on success
+ *          - -1 on failure
+ *
+ * Specification: Implements @[FIPS203, Section 7.3, 'hash check']
+ *
+ **************************************************/
+
+/* Reference: Not implemented in the reference implementation @[REF]. */
+MLK_INTERNAL_API
+MLK_MUST_CHECK_RETURN_VALUE
+int crypto_kem_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES]);
 
 /*************************************************
  * Name:        crypto_kem_keypair_derand

--- a/crypto/fipsmodule/ml_kem/mlkem/mlkem_native_bcm.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/mlkem_native_bcm.c
@@ -150,6 +150,8 @@
 #undef MLK_NAMESPACE_K
 #undef MLK_NAMESPACE_PREFIX
 #undef MLK_NAMESPACE_PREFIX_K
+#undef mlk_memcpy
+#undef mlk_memset
 /* mlkem/src/indcpa.h */
 #undef MLK_INDCPA_H
 #undef mlk_gen_matrix
@@ -159,6 +161,8 @@
 /* mlkem/src/kem.h */
 #undef MLK_CONFIG_API_NO_SUPERCOP
 #undef MLK_KEM_H
+#undef crypto_kem_check_pk
+#undef crypto_kem_check_sk
 #undef crypto_kem_dec
 #undef crypto_kem_enc
 #undef crypto_kem_enc_derand
@@ -217,29 +221,6 @@
 #undef mlk_polyvec_reduce
 #undef mlk_polyvec_tobytes
 #undef mlk_polyvec_tomont
-/* mlkem/src/sys.h */
-#undef MLK_ALIGN
-#undef MLK_ALIGN_UP
-#undef MLK_ALWAYS_INLINE
-#undef MLK_CET_ENDBR
-#undef MLK_CT_TESTING_DECLASSIFY
-#undef MLK_CT_TESTING_SECRET
-#undef MLK_DEFAULT_ALIGN
-#undef MLK_HAVE_INLINE_ASM
-#undef MLK_INLINE
-#undef MLK_MUST_CHECK_RETURN_VALUE
-#undef MLK_RESTRICT
-#undef MLK_SYS_AARCH64
-#undef MLK_SYS_AARCH64_EB
-#undef MLK_SYS_BIG_ENDIAN
-#undef MLK_SYS_H
-#undef MLK_SYS_LITTLE_ENDIAN
-#undef MLK_SYS_PPC64LE
-#undef MLK_SYS_RISCV32
-#undef MLK_SYS_RISCV64
-#undef MLK_SYS_WINDOWS
-#undef MLK_SYS_X86_64
-#undef MLK_SYS_X86_64_AVX2
 
 #if !defined(MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS)
 /*
@@ -307,6 +288,31 @@
 #undef mlk_xof_x4_init
 #undef mlk_xof_x4_release
 #undef mlk_xof_x4_squeezeblocks
+/* mlkem/src/sys.h */
+#undef MLK_ALIGN
+#undef MLK_ALIGN_UP
+#undef MLK_ALWAYS_INLINE
+#undef MLK_CET_ENDBR
+#undef MLK_CT_TESTING_DECLASSIFY
+#undef MLK_CT_TESTING_SECRET
+#undef MLK_DEFAULT_ALIGN
+#undef MLK_HAVE_INLINE_ASM
+#undef MLK_INLINE
+#undef MLK_MUST_CHECK_RETURN_VALUE
+#undef MLK_RESTRICT
+#undef MLK_SYS_AARCH64
+#undef MLK_SYS_AARCH64_EB
+#undef MLK_SYS_APPLE
+#undef MLK_SYS_BIG_ENDIAN
+#undef MLK_SYS_H
+#undef MLK_SYS_LINUX
+#undef MLK_SYS_LITTLE_ENDIAN
+#undef MLK_SYS_PPC64LE
+#undef MLK_SYS_RISCV32
+#undef MLK_SYS_RISCV64
+#undef MLK_SYS_WINDOWS
+#undef MLK_SYS_X86_64
+#undef MLK_SYS_X86_64_AVX2
 /* mlkem/src/verify.h */
 #undef MLK_USE_ASM_VALUE_BARRIER
 #undef MLK_VERIFY_H
@@ -321,6 +327,8 @@
 /* mlkem/src/native/api.h */
 #undef MLK_INVNTT_BOUND
 #undef MLK_NATIVE_API_H
+#undef MLK_NATIVE_FUNC_FALLBACK
+#undef MLK_NATIVE_FUNC_SUCCESS
 #undef MLK_NTT_BOUND
 /* mlkem/src/native/meta.h */
 #undef MLK_NATIVE_META_H

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/meta.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/meta.h
@@ -22,77 +22,88 @@
 
 
 #if !defined(__ASSEMBLER__)
+#include "../api.h"
 #include "src/arith_native_aarch64.h"
 
-static MLK_INLINE void mlk_ntt_native(int16_t data[MLKEM_N])
+static MLK_INLINE int mlk_ntt_native(int16_t data[MLKEM_N])
 {
   mlk_ntt_asm(data, mlk_aarch64_ntt_zetas_layer12345,
               mlk_aarch64_ntt_zetas_layer67);
+  return MLK_NATIVE_FUNC_SUCCESS;
 }
 
-static MLK_INLINE void mlk_intt_native(int16_t data[MLKEM_N])
+static MLK_INLINE int mlk_intt_native(int16_t data[MLKEM_N])
 {
   mlk_intt_asm(data, mlk_aarch64_invntt_zetas_layer12345,
                mlk_aarch64_invntt_zetas_layer67);
+  return MLK_NATIVE_FUNC_SUCCESS;
 }
 
-static MLK_INLINE void mlk_poly_reduce_native(int16_t data[MLKEM_N])
+static MLK_INLINE int mlk_poly_reduce_native(int16_t data[MLKEM_N])
 {
   mlk_poly_reduce_asm(data);
+  return MLK_NATIVE_FUNC_SUCCESS;
 }
 
-static MLK_INLINE void mlk_poly_tomont_native(int16_t data[MLKEM_N])
+static MLK_INLINE int mlk_poly_tomont_native(int16_t data[MLKEM_N])
 {
   mlk_poly_tomont_asm(data);
+  return MLK_NATIVE_FUNC_SUCCESS;
 }
 
-static MLK_INLINE void mlk_poly_mulcache_compute_native(
-    int16_t x[MLKEM_N / 2], const int16_t y[MLKEM_N])
+static MLK_INLINE int mlk_poly_mulcache_compute_native(int16_t x[MLKEM_N / 2],
+                                                       const int16_t y[MLKEM_N])
 {
   mlk_poly_mulcache_compute_asm(x, y, mlk_aarch64_zetas_mulcache_native,
                                 mlk_aarch64_zetas_mulcache_twisted_native);
+  return MLK_NATIVE_FUNC_SUCCESS;
 }
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || MLKEM_K == 2
-static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
+static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
     int16_t r[MLKEM_N], const int16_t a[2 * MLKEM_N],
     const int16_t b[2 * MLKEM_N], const int16_t b_cache[2 * (MLKEM_N / 2)])
 {
   mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(r, a, b, b_cache);
+  return MLK_NATIVE_FUNC_SUCCESS;
 }
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 2 */
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || MLKEM_K == 3
-static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
+static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
     int16_t r[MLKEM_N], const int16_t a[3 * MLKEM_N],
     const int16_t b[3 * MLKEM_N], const int16_t b_cache[3 * (MLKEM_N / 2)])
 {
   mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(r, a, b, b_cache);
+  return MLK_NATIVE_FUNC_SUCCESS;
 }
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 3 */
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || MLKEM_K == 4
-static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
+static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
     int16_t r[MLKEM_N], const int16_t a[4 * MLKEM_N],
     const int16_t b[4 * MLKEM_N], const int16_t b_cache[4 * (MLKEM_N / 2)])
 {
   mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(r, a, b, b_cache);
+  return MLK_NATIVE_FUNC_SUCCESS;
 }
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 4 */
 
-static MLK_INLINE void mlk_poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
-                                               const int16_t a[MLKEM_N])
+static MLK_INLINE int mlk_poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
+                                              const int16_t a[MLKEM_N])
 {
   mlk_poly_tobytes_asm(r, a);
+  return MLK_NATIVE_FUNC_SUCCESS;
 }
 
 static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
 {
-  if (len != MLKEM_N || buflen % 24 != 0)
+  if (len != MLKEM_N ||
+      buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
   {
-    return -1;
+    return MLK_NATIVE_FUNC_FALLBACK;
   }
   return (int)mlk_rej_uniform_asm(r, buf, buflen, mlk_rej_uniform_table);
 }

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -31,8 +31,8 @@ extern const int16_t mlk_aarch64_zetas_mulcache_twisted_native[];
 extern const uint8_t mlk_rej_uniform_table[];
 
 #define mlk_ntt_asm MLK_NAMESPACE(ntt_asm)
-void mlk_ntt_asm(int16_t *p, const int16_t *twiddles12345,
-                 const int16_t *twiddles56)
+void mlk_ntt_asm(int16_t p[256], const int16_t twiddles12345[80],
+                 const int16_t twiddles56[384])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/arm/proofs/mlkem_ntt.ml */
 __contract__(
@@ -47,8 +47,8 @@ __contract__(
 );
 
 #define mlk_intt_asm MLK_NAMESPACE(intt_asm)
-void mlk_intt_asm(int16_t *p, const int16_t *twiddles12345,
-                  const int16_t *twiddles56)
+void mlk_intt_asm(int16_t p[256], const int16_t twiddles12345[80],
+                  const int16_t twiddles56[384])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/arm/proofs/mlkem_intt.ml */
 __contract__(
@@ -62,7 +62,7 @@ __contract__(
 );
 
 #define mlk_poly_reduce_asm MLK_NAMESPACE(poly_reduce_asm)
-void mlk_poly_reduce_asm(int16_t *p)
+void mlk_poly_reduce_asm(int16_t p[256])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml */
 __contract__(
@@ -72,7 +72,7 @@ __contract__(
 );
 
 #define mlk_poly_tomont_asm MLK_NAMESPACE(poly_tomont_asm)
-void mlk_poly_tomont_asm(int16_t *p)
+void mlk_poly_tomont_asm(int16_t p[256])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/arm/proofs/mlkem_poly_tomont.ml */
 __contract__(
@@ -82,9 +82,10 @@ __contract__(
 );
 
 #define mlk_poly_mulcache_compute_asm MLK_NAMESPACE(poly_mulcache_compute_asm)
-void mlk_poly_mulcache_compute_asm(int16_t *cache, const int16_t *mlk_poly,
-                                   const int16_t *zetas,
-                                   const int16_t *zetas_twisted)
+void mlk_poly_mulcache_compute_asm(int16_t cache[128],
+                                   const int16_t mlk_poly[256],
+                                   const int16_t zetas[128],
+                                   const int16_t zetas_twisted[128])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/arm/proofs/mlkem_poly_mulcache_compute.ml */
 __contract__(
@@ -97,7 +98,7 @@ __contract__(
 );
 
 #define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)
-void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a)
+void mlk_poly_tobytes_asm(uint8_t r[384], const int16_t a[256])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/arm/proofs/mlkem_poly_tobytes.ml */
 __contract__(
@@ -109,10 +110,9 @@ __contract__(
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k2 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t *r,
-                                                      const int16_t *a,
-                                                      const int16_t *b,
-                                                      const int16_t *b_cache)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(
+    int16_t r[256], const int16_t a[512], const int16_t b[512],
+    const int16_t b_cache[256])
 /* This must be kept in sync with the HOL-Light specification in
  * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml.
  */
@@ -127,10 +127,9 @@ __contract__(
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t *r,
-                                                      const int16_t *a,
-                                                      const int16_t *b,
-                                                      const int16_t *b_cache)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(
+    int16_t r[256], const int16_t a[768], const int16_t b[768],
+    const int16_t b_cache[384])
 /* This must be kept in sync with the HOL-Light specification in
  * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml.
  */
@@ -145,10 +144,9 @@ __contract__(
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
-                                                      const int16_t *a,
-                                                      const int16_t *b,
-                                                      const int16_t *b_cache)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(
+    int16_t r[256], const int16_t a[1024], const int16_t b[1024],
+    const int16_t b_cache[512])
 /* This must be kept in sync with the HOL-Light specification in
  * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml.
  */
@@ -162,8 +160,8 @@ __contract__(
 );
 
 #define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
-uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
-                             const uint8_t *table)
+uint64_t mlk_rej_uniform_asm(int16_t r[256], const uint8_t *buf,
+                             unsigned buflen, const uint8_t table[2048])
 /* This must be kept in sync with the HOL-Light specification
  * in proofs/hol_light/arm/proofs/mlkem_rej_uniform.ml. */
 __contract__(

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/intt.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/intt.S
@@ -19,7 +19,33 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM inverse NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
+/*yaml
+  Name: intt_asm
+  Description: AArch64 ML-KEM inverse NTT following @[NeonNTT] and @[SLOTHY_Paper]
+  Signature: void mlk_intt_asm(int16_t p[256], const int16_t twiddles12345[80], const int16_t twiddles56[384])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 512
+      permissions: read/write
+      c_parameter: int16_t p[256]
+      description: Input/output polynomial
+    x1:
+      type: buffer
+      size_bytes: 160
+      permissions: read-only
+      c_parameter: const int16_t twiddles12345[80]
+      description: Twiddle factors for layers 1-5
+    x2:
+      type: buffer
+      size_bytes: 768
+      permissions: read-only
+      c_parameter: const int16_t twiddles56[384]
+      description: Twiddle factors for layers 6-7
+  Stack:
+    bytes: 64
+    description: saving callee-saved Neon registers
+*/
 
 #include "_internal_s2n_bignum.h"
 

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/ntt.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/ntt.S
@@ -19,7 +19,33 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM forward NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
+/*yaml
+  Name: ntt_asm
+  Description: AArch64 ML-KEM forward NTT following @[NeonNTT] and @[SLOTHY_Paper]
+  Signature: void mlk_ntt_asm(int16_t p[256], const int16_t twiddles12345[80], const int16_t twiddles56[384])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 512
+      permissions: read/write
+      c_parameter: int16_t p[256]
+      description: Input/output polynomial
+    x1:
+      type: buffer
+      size_bytes: 160
+      permissions: read-only
+      c_parameter: const int16_t twiddles12345[80]
+      description: Twiddle factors for layers 1-5
+    x2:
+      type: buffer
+      size_bytes: 768
+      permissions: read-only
+      c_parameter: const int16_t twiddles56[384]
+      description: Twiddle factors for layers 6-7
+  Stack:
+    bytes: 64
+    description: saving callee-saved Neon registers
+*/
 
 #include "_internal_s2n_bignum.h"
 

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
@@ -3,6 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
+/*yaml
+  Name: poly_mulcache_compute_asm
+  Description: Compute multiplication cache for polynomial
+  Signature: void mlk_poly_mulcache_compute_asm(int16_t cache[128], const int16_t mlk_poly[256], const int16_t zetas[128], const int16_t zetas_twisted[128])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 256
+      permissions: write-only
+      c_parameter: int16_t cache[128]
+      description: Output cache
+    x1:
+      type: buffer
+      size_bytes: 512
+      permissions: read-only
+      c_parameter: const int16_t mlk_poly[256]
+      description: Input polynomial
+    x2:
+      type: buffer
+      size_bytes: 256
+      permissions: read-only
+      c_parameter: const int16_t zetas[128]
+      description: Zeta values
+    x3:
+      type: buffer
+      size_bytes: 256
+      permissions: read-only
+      c_parameter: const int16_t zetas_twisted[128]
+      description: Twisted zeta values
+  Stack:
+    bytes: 0
+*/
+
 #include "_internal_s2n_bignum.h"
 
 /*

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/poly_reduce_asm.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/poly_reduce_asm.S
@@ -3,6 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
+/*yaml
+  Name: poly_reduce_asm
+  Description: Barrett reduction of polynomial coefficients
+  Signature: void mlk_poly_reduce_asm(int16_t p[256])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 512
+      permissions: read/write
+      c_parameter: int16_t p[256]
+      description: Input/output polynomial
+  Stack:
+    bytes: 0
+*/
+
 #include "_internal_s2n_bignum.h"
 
 /*

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/poly_tobytes_asm.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/poly_tobytes_asm.S
@@ -3,6 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
+/*yaml
+  Name: poly_tobytes_asm
+  Description: Convert polynomial to byte representation
+  Signature: void mlk_poly_tobytes_asm(uint8_t r[384], const int16_t a[256])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 384
+      permissions: write-only
+      c_parameter: uint8_t r[384]
+      description: Output byte array
+    x1:
+      type: buffer
+      size_bytes: 512
+      permissions: read-only
+      c_parameter: const int16_t a[256]
+      description: Input polynomial
+  Stack:
+    bytes: 0
+*/
+
 #include "_internal_s2n_bignum.h"
 
 /*

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/poly_tomont_asm.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/poly_tomont_asm.S
@@ -3,6 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
+/*yaml
+  Name: poly_tomont_asm
+  Description: Convert polynomial to Montgomery domain
+  Signature: void mlk_poly_tomont_asm(int16_t p[256])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 512
+      permissions: read/write
+      c_parameter: int16_t p[256]
+      description: Input/output polynomial
+  Stack:
+    bytes: 0
+*/
+
 #include "_internal_s2n_bignum.h"
 
 /*

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -12,7 +12,39 @@
  *   https://eprint.iacr.org/2021/986
  */
 
-/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
+/*yaml
+  Name: polyvec_basemul_acc_montgomery_cached_asm_k2
+  Description: Re-implementation of asymmetric base multiplication following @[NeonNTT] for k=2
+  Signature: void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t r[256], const int16_t a[512], const int16_t b[512], const int16_t b_cache[256])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 512
+      permissions: write-only
+      c_parameter: int16_t r[256]
+      description: Output polynomial
+    x1:
+      type: buffer
+      size_bytes: 1024
+      permissions: read-only
+      c_parameter: const int16_t a[512]
+      description: Input polynomial vector a
+    x2:
+      type: buffer
+      size_bytes: 1024
+      permissions: read-only
+      c_parameter: const int16_t b[512]
+      description: Input polynomial vector b
+    x3:
+      type: buffer
+      size_bytes: 512
+      permissions: read-only
+      c_parameter: const int16_t b_cache[256]
+      description: Cached values for b
+  Stack:
+    bytes: 64
+    description: saving callee-saved Neon registers
+*/
 
 #include "_internal_s2n_bignum.h"
 

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -12,7 +12,39 @@
  *   https://eprint.iacr.org/2021/986
  */
 
-/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
+/*yaml
+  Name: polyvec_basemul_acc_montgomery_cached_asm_k3
+  Description: Re-implementation of asymmetric base multiplication following @[NeonNTT] for k=3
+  Signature: void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t r[256], const int16_t a[768], const int16_t b[768], const int16_t b_cache[384])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 512
+      permissions: write-only
+      c_parameter: int16_t r[256]
+      description: Output polynomial
+    x1:
+      type: buffer
+      size_bytes: 1536
+      permissions: read-only
+      c_parameter: const int16_t a[768]
+      description: Input polynomial vector a
+    x2:
+      type: buffer
+      size_bytes: 1536
+      permissions: read-only
+      c_parameter: const int16_t b[768]
+      description: Input polynomial vector b
+    x3:
+      type: buffer
+      size_bytes: 768
+      permissions: read-only
+      c_parameter: const int16_t b_cache[384]
+      description: Cached values for b
+  Stack:
+    bytes: 64
+    description: saving callee-saved Neon registers
+*/
 
 #include "_internal_s2n_bignum.h"
 

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -12,7 +12,39 @@
  *   https://eprint.iacr.org/2021/986
  */
 
-/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
+/*yaml
+  Name: polyvec_basemul_acc_montgomery_cached_asm_k4
+  Description: Re-implementation of asymmetric base multiplication following @[NeonNTT] for k=4
+  Signature: void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t r[256], const int16_t a[1024], const int16_t b[1024], const int16_t b_cache[512])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 512
+      permissions: write-only
+      c_parameter: int16_t r[256]
+      description: Output polynomial
+    x1:
+      type: buffer
+      size_bytes: 2048
+      permissions: read-only
+      c_parameter: const int16_t a[1024]
+      description: Input polynomial vector a
+    x2:
+      type: buffer
+      size_bytes: 2048
+      permissions: read-only
+      c_parameter: const int16_t b[1024]
+      description: Input polynomial vector b
+    x3:
+      type: buffer
+      size_bytes: 1024
+      permissions: read-only
+      c_parameter: const int16_t b_cache[512]
+      description: Cached values for b
+  Stack:
+    bytes: 64
+    description: saving callee-saved Neon registers
+*/
 
 #include "_internal_s2n_bignum.h"
 

--- a/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/rej_uniform_asm.S
+++ b/crypto/fipsmodule/ml_kem/mlkem/native/aarch64/src/rej_uniform_asm.S
@@ -3,21 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
-/*************************************************
- * Name:        mlk_rej_uniform_asm
- *
- * Description: Run rejection sampling on uniform random bytes to generate
- *              uniform random integers mod q
- *
- * Arguments:   - int16_t *r:          pointer to output buffer of MLKEM_N
- *                                     16-bit coefficients.
- *              - const uint8_t *buf:  pointer to input buffer
- *                                     (assumed to be uniform random bytes)
- *              - unsigned buflen:     length of input buffer in bytes.
- *                                     Must be a multiple of 24.
- *
- * Returns number of sampled 16-bit integers (at most MLKEM_N).
- **************************************************/
+/*yaml
+  Name: rej_uniform_asm
+  Description: Run rejection sampling on uniform random bytes to generate uniform random integers mod q
+  Signature: uint64_t mlk_rej_uniform_asm(int16_t r[256], const uint8_t *buf, unsigned buflen, const uint8_t table[2048])
+  ABI:
+    x0:
+      type: buffer
+      size_bytes: 512
+      permissions: write-only
+      c_parameter: int16_t r[256]
+      description: Output buffer
+    x1:
+      type: buffer
+      size_bytes: x2
+      permissions: read-only
+      c_parameter: const uint8_t *buf
+      description: Input buffer
+    x2:
+      type: scalar
+      c_parameter: unsigned buflen
+      description: Length of input buffer (must be multiple of 24)
+      test_with: 504  # MLKEM_GEN_MATRIX_NBLOCKS * MLK_XOF_RATE
+    x3:
+      type: buffer
+      size_bytes: 2048
+      permissions: read-only
+      c_parameter: const uint8_t table[2048]
+      description: Lookup table
+  Stack:
+    bytes: 576
+    description: register preservation and temporary storage
+*/
+
 #include "_internal_s2n_bignum.h"
 
 /*

--- a/crypto/fipsmodule/ml_kem/mlkem/poly.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/poly.c
@@ -29,9 +29,6 @@
 #include "symmetric.h"
 #include "verify.h"
 
-#if !defined(MLK_USE_NATIVE_POLY_TOMONT) ||           \
-    !defined(MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE) || \
-    !defined(MLK_USE_NATIVE_NTT) || !defined(MLK_USE_NATIVE_INTT)
 /*************************************************
  * Name:        mlk_fqmul
  *
@@ -68,10 +65,7 @@ __contract__(
   mlk_assert_abs_bound(&res, 1, MLKEM_Q);
   return res;
 }
-#endif /* !MLK_USE_NATIVE_POLY_TOMONT || !MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE \
-          || !MLK_USE_NATIVE_NTT || !MLK_USE_NATIVE_INTT */
 
-#if !defined(MLK_USE_NATIVE_POLY_REDUCE) || !defined(MLK_USE_NATIVE_INTT)
 /*************************************************
  * Name:        mlk_barrett_reduce
  *
@@ -118,15 +112,22 @@ __contract__(
   mlk_assert_abs_bound(&res, 1, MLKEM_Q_HALF);
   return res;
 }
-#endif /* !MLK_USE_NATIVE_POLY_REDUCE || !MLK_USE_NATIVE_INTT */
 
-#if !defined(MLK_USE_NATIVE_POLY_TOMONT)
 /* Reference: `poly_tomont()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_poly_tomont(mlk_poly *r)
 {
   unsigned i;
   const int16_t f = 1353; /* check-magic: 1353 == signed_mod(2^32, MLKEM_Q) */
+#if defined(MLK_USE_NATIVE_POLY_TOMONT)
+  int ret;
+  ret = mlk_poly_tomont_native(r->coeffs);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    mlk_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_TOMONT */
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
     invariant(i <= MLKEM_N)
@@ -137,16 +138,7 @@ void mlk_poly_tomont(mlk_poly *r)
 
   mlk_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
 }
-#else  /* !MLK_USE_NATIVE_POLY_TOMONT */
-MLK_INTERNAL_API
-void mlk_poly_tomont(mlk_poly *r)
-{
-  mlk_poly_tomont_native(r->coeffs);
-  mlk_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
-}
-#endif /* MLK_USE_NATIVE_POLY_TOMONT */
 
-#if !defined(MLK_USE_NATIVE_POLY_REDUCE)
 /************************************************************
  * Name: mlk_scalar_signed_to_unsigned_q
  *
@@ -189,6 +181,16 @@ MLK_INTERNAL_API
 void mlk_poly_reduce(mlk_poly *r)
 {
   unsigned i;
+#if defined(MLK_USE_NATIVE_POLY_REDUCE)
+  int ret;
+  ret = mlk_poly_reduce_native(r->coeffs);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_REDUCE */
+
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
     invariant(i <= MLKEM_N)
@@ -202,14 +204,6 @@ void mlk_poly_reduce(mlk_poly *r)
 
   mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
-#else  /* !MLK_USE_NATIVE_POLY_REDUCE */
-MLK_INTERNAL_API
-void mlk_poly_reduce(mlk_poly *r)
-{
-  mlk_poly_reduce_native(r->coeffs);
-  mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
-}
-#endif /* MLK_USE_NATIVE_POLY_REDUCE */
 
 /* Reference: `poly_add()` in the reference implementation @[REF].
  *            - We use destructive version (output=first input) to avoid
@@ -245,14 +239,8 @@ void mlk_poly_sub(mlk_poly *r, const mlk_poly *b)
   }
 }
 
-/* Include zeta table unless NTT, invNTT and mulcache computation
- * have been replaced by native implementations. */
-#if !defined(MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE) || \
-    !defined(MLK_USE_NATIVE_NTT) || !defined(MLK_USE_NATIVE_INTT)
 #include "zetas.inc"
-#endif
 
-#if !defined(MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE)
 /* Reference: Does not exist in the reference implementation @[REF].
  *            - The reference implementation does not use a
  *              multiplication cache ('mulcache'). This idea originates
@@ -261,13 +249,21 @@ MLK_INTERNAL_API
 void mlk_poly_mulcache_compute(mlk_poly_mulcache *x, const mlk_poly *a)
 {
   unsigned i;
+#if defined(MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE)
+  int ret;
+  ret = mlk_poly_mulcache_compute_native(x->coeffs, a->coeffs);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    return;
+  }
+#endif /* MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE */
   for (i = 0; i < MLKEM_N / 4; i++)
   __loop__(
     invariant(i <= MLKEM_N / 4)
     invariant(array_abs_bound(x->coeffs, 0, 2 * i, MLKEM_Q)))
   {
-    x->coeffs[2 * i + 0] = mlk_fqmul(a->coeffs[4 * i + 1], zetas[64 + i]);
-    x->coeffs[2 * i + 1] = mlk_fqmul(a->coeffs[4 * i + 3], -zetas[64 + i]);
+    x->coeffs[2 * i + 0] = mlk_fqmul(a->coeffs[4 * i + 1], mlk_zetas[64 + i]);
+    x->coeffs[2 * i + 1] = mlk_fqmul(a->coeffs[4 * i + 3], -mlk_zetas[64 + i]);
   }
 
   /*
@@ -278,15 +274,7 @@ void mlk_poly_mulcache_compute(mlk_poly_mulcache *x, const mlk_poly *a)
    */
   mlk_assert_abs_bound(x, MLKEM_N / 2, MLKEM_Q);
 }
-#else  /* !MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE */
-MLK_INTERNAL_API
-void mlk_poly_mulcache_compute(mlk_poly_mulcache *x, const mlk_poly *a)
-{
-  mlk_poly_mulcache_compute_native(x->coeffs, a->coeffs);
-}
-#endif /* MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE */
 
-#if !defined(MLK_USE_NATIVE_NTT)
 /*
  * Computes a block CT butterflies with a fixed twiddle factor,
  * using Montgomery multiplication.
@@ -378,7 +366,7 @@ __contract__(
     invariant(array_abs_bound(r, 0, start, layer * MLKEM_Q + MLKEM_Q))
     invariant(array_abs_bound(r, start, MLKEM_N, layer * MLKEM_Q)))
   {
-    int16_t zeta = zetas[k++];
+    int16_t zeta = mlk_zetas[k++];
     mlk_ntt_butterfly_block(r, zeta, start, len, layer * MLKEM_Q);
   }
 }
@@ -400,7 +388,21 @@ void mlk_poly_ntt(mlk_poly *p)
 {
   unsigned layer;
   int16_t *r;
+
   mlk_assert_abs_bound(p, MLKEM_N, MLKEM_Q);
+
+#if defined(MLK_USE_NATIVE_NTT)
+  {
+    int ret;
+    ret = mlk_ntt_native(p->coeffs);
+    if (ret == MLK_NATIVE_FUNC_SUCCESS)
+    {
+      mlk_assert_abs_bound(p, MLKEM_N, MLK_NTT_BOUND);
+      return;
+    }
+  }
+#endif /* MLK_USE_NATIVE_NTT */
+
   r = p->coeffs;
 
   for (layer = 1; layer <= 7; layer++)
@@ -414,18 +416,7 @@ void mlk_poly_ntt(mlk_poly *p)
   /* Check the stronger bound */
   mlk_assert_abs_bound(p, MLKEM_N, MLK_NTT_BOUND);
 }
-#else  /* !MLK_USE_NATIVE_NTT */
 
-MLK_INTERNAL_API
-void mlk_poly_ntt(mlk_poly *p)
-{
-  mlk_assert_abs_bound(p, MLKEM_N, MLKEM_Q);
-  mlk_ntt_native(p->coeffs);
-  mlk_assert_abs_bound(p, MLKEM_N, MLK_NTT_BOUND);
-}
-#endif /* MLK_USE_NATIVE_NTT */
-
-#if !defined(MLK_USE_NATIVE_INTT)
 
 /* Compute one layer of inverse NTT */
 
@@ -449,7 +440,7 @@ __contract__(
     invariant(2 * len * k + start == 2 * MLKEM_N - 2 * len))
   {
     unsigned j;
-    int16_t zeta = zetas[k--];
+    int16_t zeta = mlk_zetas[k--];
     for (j = start; j < start + len; j++)
     __loop__(
       invariant(start <= j && j <= start + len)
@@ -472,15 +463,24 @@ __contract__(
 MLK_INTERNAL_API
 void mlk_poly_invntt_tomont(mlk_poly *p)
 {
+  unsigned j, layer;
+  const int16_t f = 1441; /* check-magic: 1441 == pow(2,32 - 7,MLKEM_Q) */
+  int16_t *r = p->coeffs;
+#if defined(MLK_USE_NATIVE_INTT)
+  int ret;
+  ret = mlk_intt_native(p->coeffs);
+  if (ret == MLK_NATIVE_FUNC_SUCCESS)
+  {
+    mlk_assert_abs_bound(p, MLKEM_N, MLK_INVNTT_BOUND);
+    return;
+  }
+#endif /* MLK_USE_NATIVE_INTT */
+
   /*
    * Scale input polynomial to account for Montgomery factor
    * and NTT twist. This also brings coefficients down to
    * absolute value < MLKEM_Q.
    */
-  unsigned j, layer;
-  const int16_t f = 1441; /* check-magic: 1441 == pow(2,32 - 7,MLKEM_Q) */
-  int16_t *r = p->coeffs;
-
   for (j = 0; j < MLKEM_N; j++)
   __loop__(
     invariant(j <= MLKEM_N)
@@ -500,15 +500,6 @@ void mlk_poly_invntt_tomont(mlk_poly *p)
 
   mlk_assert_abs_bound(p, MLKEM_N, MLK_INVNTT_BOUND);
 }
-#else  /* !MLK_USE_NATIVE_INTT */
-
-MLK_INTERNAL_API
-void mlk_poly_invntt_tomont(mlk_poly *p)
-{
-  mlk_intt_native(p->coeffs);
-  mlk_assert_abs_bound(p, MLKEM_N, MLK_INVNTT_BOUND);
-}
-#endif /* MLK_USE_NATIVE_INTT */
 
 #else /* !MLK_CONFIG_MULTILEVEL_NO_SHARED */
 

--- a/crypto/fipsmodule/ml_kem/mlkem/poly_k.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/poly_k.c
@@ -83,8 +83,12 @@ void mlk_polyvec_tobytes(uint8_t r[MLKEM_POLYVECBYTES], const mlk_polyvec a)
   mlk_assert_bound_2d(a, MLKEM_K, MLKEM_N, 0, MLKEM_Q);
 
   for (i = 0; i < MLKEM_K; i++)
+  __loop__(
+    assigns(i, object_whole(r))
+    invariant(i <= MLKEM_K)
+  )
   {
-    mlk_poly_tobytes(r + i * MLKEM_POLYBYTES, &a[i]);
+    mlk_poly_tobytes(&r[i * MLKEM_POLYBYTES], &a[i]);
   }
 }
 
@@ -131,7 +135,6 @@ void mlk_polyvec_invntt_tomont(mlk_polyvec r)
   mlk_assert_abs_bound_2d(r, MLKEM_K, MLKEM_N, MLK_INVNTT_BOUND);
 }
 
-#if !defined(MLK_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED)
 /* Reference: `polyvec_basemul_acc_montgomery()` in the
  *            reference implementation @[REF].
  *            - We use a multiplication cache ('mulcache') here
@@ -150,6 +153,33 @@ void mlk_polyvec_basemul_acc_montgomery_cached(
 {
   unsigned i;
   mlk_assert_bound_2d(a, MLKEM_K, MLKEM_N, 0, MLKEM_UINT12_LIMIT);
+
+#if defined(MLK_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED)
+  {
+    int ret;
+    /* Omitting bounds assertion for cache since native implementations may
+     * decide not to use a mulcache. Note that the C backend implementation
+     * of poly_basemul_montgomery_cached() does still include the check. */
+#if MLKEM_K == 2
+    ret = mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
+        r->coeffs, (const int16_t *)a, (const int16_t *)b,
+        (const int16_t *)b_cache);
+#elif MLKEM_K == 3
+    ret = mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
+        r->coeffs, (const int16_t *)a, (const int16_t *)b,
+        (const int16_t *)b_cache);
+#elif MLKEM_K == 4
+    ret = mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
+        r->coeffs, (const int16_t *)a, (const int16_t *)b,
+        (const int16_t *)b_cache);
+#endif
+    if (ret == MLK_NATIVE_FUNC_SUCCESS)
+    {
+      return;
+    }
+  }
+#endif /* MLK_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED */
+
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(invariant(i <= MLKEM_N / 2))
   {
@@ -172,32 +202,6 @@ void mlk_polyvec_basemul_acc_montgomery_cached(
     r->coeffs[2 * i + 1] = mlk_montgomery_reduce(t[1]);
   }
 }
-
-#else /* !MLK_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED */
-MLK_INTERNAL_API
-void mlk_polyvec_basemul_acc_montgomery_cached(
-    mlk_poly *r, const mlk_polyvec a, const mlk_polyvec b,
-    const mlk_polyvec_mulcache b_cache)
-{
-  mlk_assert_bound_2d(a, MLKEM_K, MLKEM_N, 0, MLKEM_UINT12_LIMIT);
-  /* Omitting bounds assertion for cache since native implementations may
-   * decide not to use a mulcache. Note that the C backend implementation
-   * of poly_basemul_montgomery_cached() does still include the check. */
-#if MLKEM_K == 2
-  mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
-      r->coeffs, (const int16_t *)a, (const int16_t *)b,
-      (const int16_t *)b_cache);
-#elif MLKEM_K == 3
-  mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
-      r->coeffs, (const int16_t *)a, (const int16_t *)b,
-      (const int16_t *)b_cache);
-#elif MLKEM_K == 4
-  mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
-      r->coeffs, (const int16_t *)a, (const int16_t *)b,
-      (const int16_t *)b_cache);
-#endif
-}
-#endif /* MLK_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED */
 
 /* Reference: Does not exist in the reference implementation @[REF].
  *            - The reference implementation does not use a
@@ -306,10 +310,10 @@ void mlk_poly_getnoise_eta1_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
 {
   MLK_ALIGN uint8_t buf[4][MLK_ALIGN_UP(MLKEM_ETA1 * MLKEM_N / 4)];
   MLK_ALIGN uint8_t extkey[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 1)];
-  memcpy(extkey[0], seed, MLKEM_SYMBYTES);
-  memcpy(extkey[1], seed, MLKEM_SYMBYTES);
-  memcpy(extkey[2], seed, MLKEM_SYMBYTES);
-  memcpy(extkey[3], seed, MLKEM_SYMBYTES);
+  mlk_memcpy(extkey[0], seed, MLKEM_SYMBYTES);
+  mlk_memcpy(extkey[1], seed, MLKEM_SYMBYTES);
+  mlk_memcpy(extkey[2], seed, MLKEM_SYMBYTES);
+  mlk_memcpy(extkey[3], seed, MLKEM_SYMBYTES);
   extkey[0][MLKEM_SYMBYTES] = nonce0;
   extkey[1][MLKEM_SYMBYTES] = nonce1;
   extkey[2][MLKEM_SYMBYTES] = nonce2;
@@ -373,7 +377,7 @@ void mlk_poly_getnoise_eta2(mlk_poly *r, const uint8_t seed[MLKEM_SYMBYTES],
   MLK_ALIGN uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4];
   MLK_ALIGN uint8_t extkey[MLKEM_SYMBYTES + 1];
 
-  memcpy(extkey, seed, MLKEM_SYMBYTES);
+  mlk_memcpy(extkey, seed, MLKEM_SYMBYTES);
   extkey[MLKEM_SYMBYTES] = nonce;
   mlk_prf_eta2(buf, extkey);
 
@@ -409,10 +413,10 @@ void mlk_poly_getnoise_eta1122_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
   MLK_ALIGN uint8_t buf[4][MLK_ALIGN_UP(MLKEM_ETA1 * MLKEM_N / 4)];
   MLK_ALIGN uint8_t extkey[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 1)];
 
-  memcpy(extkey[0], seed, MLKEM_SYMBYTES);
-  memcpy(extkey[1], seed, MLKEM_SYMBYTES);
-  memcpy(extkey[2], seed, MLKEM_SYMBYTES);
-  memcpy(extkey[3], seed, MLKEM_SYMBYTES);
+  mlk_memcpy(extkey[0], seed, MLKEM_SYMBYTES);
+  mlk_memcpy(extkey[1], seed, MLKEM_SYMBYTES);
+  mlk_memcpy(extkey[2], seed, MLKEM_SYMBYTES);
+  mlk_memcpy(extkey[3], seed, MLKEM_SYMBYTES);
   extkey[0][MLKEM_SYMBYTES] = nonce0;
   extkey[1][MLKEM_SYMBYTES] = nonce1;
   extkey[2][MLKEM_SYMBYTES] = nonce2;

--- a/crypto/fipsmodule/ml_kem/mlkem/sampling.c
+++ b/crypto/fipsmodule/ml_kem/mlkem/sampling.c
@@ -124,8 +124,9 @@ __contract__(
 #if defined(MLK_USE_NATIVE_REJ_UNIFORM)
   if (offset == 0)
   {
-    int ret = mlk_rej_uniform_native(r, target, buf, buflen);
-    if (ret != -1)
+    int ret;
+    ret = mlk_rej_uniform_native(r, target, buf, buflen);
+    if (ret != MLK_NATIVE_FUNC_FALLBACK)
     {
       unsigned res = (unsigned)ret;
       mlk_assert_bound(r, res, 0, MLKEM_Q);
@@ -146,7 +147,8 @@ __contract__(
  *            - x4-batched version of `rej_uniform()` from the
  *              reference implementation, leveraging x4-batched Keccak-f1600. */
 MLK_INTERNAL_API
-void mlk_poly_rej_uniform_x4(mlk_poly *vec,
+void mlk_poly_rej_uniform_x4(mlk_poly *vec0, mlk_poly *vec1, mlk_poly *vec2,
+                             mlk_poly *vec3,
                              uint8_t seed[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 2)])
 {
   /* Temporary buffers for XOF output before rejection sampling */
@@ -167,10 +169,10 @@ void mlk_poly_rej_uniform_x4(mlk_poly *vec,
    */
   mlk_xof_x4_squeezeblocks(buf, MLKEM_GEN_MATRIX_NBLOCKS, &statex);
   buflen = MLKEM_GEN_MATRIX_NBLOCKS * MLK_XOF_RATE;
-  ctr[0] = mlk_rej_uniform(vec[0].coeffs, MLKEM_N, 0, buf[0], buflen);
-  ctr[1] = mlk_rej_uniform(vec[1].coeffs, MLKEM_N, 0, buf[1], buflen);
-  ctr[2] = mlk_rej_uniform(vec[2].coeffs, MLKEM_N, 0, buf[2], buflen);
-  ctr[3] = mlk_rej_uniform(vec[3].coeffs, MLKEM_N, 0, buf[3], buflen);
+  ctr[0] = mlk_rej_uniform(vec0->coeffs, MLKEM_N, 0, buf[0], buflen);
+  ctr[1] = mlk_rej_uniform(vec1->coeffs, MLKEM_N, 0, buf[1], buflen);
+  ctr[2] = mlk_rej_uniform(vec2->coeffs, MLKEM_N, 0, buf[2], buflen);
+  ctr[3] = mlk_rej_uniform(vec3->coeffs, MLKEM_N, 0, buf[3], buflen);
 
   /*
    * So long as not all matrix entries have been generated, squeeze
@@ -180,20 +182,27 @@ void mlk_poly_rej_uniform_x4(mlk_poly *vec,
   while (ctr[0] < MLKEM_N || ctr[1] < MLKEM_N || ctr[2] < MLKEM_N ||
          ctr[3] < MLKEM_N)
   __loop__(
-    assigns(ctr, statex, memory_slice(vec, sizeof(mlk_poly) * 4), object_whole(buf[0]),
-       object_whole(buf[1]), object_whole(buf[2]), object_whole(buf[3]))
+    assigns(ctr, statex,
+            memory_slice(vec0, sizeof(mlk_poly)),
+            memory_slice(vec1, sizeof(mlk_poly)),
+            memory_slice(vec2, sizeof(mlk_poly)),
+            memory_slice(vec3, sizeof(mlk_poly)),
+            object_whole(buf[0]),
+            object_whole(buf[1]),
+            object_whole(buf[2]),
+            object_whole(buf[3]))
     invariant(ctr[0] <= MLKEM_N && ctr[1] <= MLKEM_N)
     invariant(ctr[2] <= MLKEM_N && ctr[3] <= MLKEM_N)
-    invariant(array_bound(vec[0].coeffs, 0, ctr[0], 0, MLKEM_Q))
-    invariant(array_bound(vec[1].coeffs, 0, ctr[1], 0, MLKEM_Q))
-    invariant(array_bound(vec[2].coeffs, 0, ctr[2], 0, MLKEM_Q))
-    invariant(array_bound(vec[3].coeffs, 0, ctr[3], 0, MLKEM_Q)))
+    invariant(array_bound(vec0->coeffs, 0, ctr[0], 0, MLKEM_Q))
+    invariant(array_bound(vec1->coeffs, 0, ctr[1], 0, MLKEM_Q))
+    invariant(array_bound(vec2->coeffs, 0, ctr[2], 0, MLKEM_Q))
+    invariant(array_bound(vec3->coeffs, 0, ctr[3], 0, MLKEM_Q)))
   {
     mlk_xof_x4_squeezeblocks(buf, 1, &statex);
-    ctr[0] = mlk_rej_uniform(vec[0].coeffs, MLKEM_N, ctr[0], buf[0], buflen);
-    ctr[1] = mlk_rej_uniform(vec[1].coeffs, MLKEM_N, ctr[1], buf[1], buflen);
-    ctr[2] = mlk_rej_uniform(vec[2].coeffs, MLKEM_N, ctr[2], buf[2], buflen);
-    ctr[3] = mlk_rej_uniform(vec[3].coeffs, MLKEM_N, ctr[3], buf[3], buflen);
+    ctr[0] = mlk_rej_uniform(vec0->coeffs, MLKEM_N, ctr[0], buf[0], buflen);
+    ctr[1] = mlk_rej_uniform(vec1->coeffs, MLKEM_N, ctr[1], buf[1], buflen);
+    ctr[2] = mlk_rej_uniform(vec2->coeffs, MLKEM_N, ctr[2], buf[2], buflen);
+    ctr[3] = mlk_rej_uniform(vec3->coeffs, MLKEM_N, ctr[3], buf[3], buflen);
   }
 
   mlk_xof_x4_release(&statex);

--- a/crypto/fipsmodule/ml_kem/mlkem/sampling.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/sampling.h
@@ -65,8 +65,8 @@ void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4]);
  * Description: Generate four polynomials using rejection sampling
  *              on (pseudo-)uniformly random bytes sampled from a seed.
  *
- * Arguments:   - mlk_poly *vec:
- *                Pointer to an array of 4 polynomials to be sampled.
+ * Arguments:   - mlk_poly *vec0, *vec1, *vec2, *vec3:
+ *                Pointers to 4 polynomials to be sampled.
  *              - uint8_t seed[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 2)]:
  *                Pointer consecutive array of seed buffers of size
  *                MLKEM_SYMBYTES + 2 each, plus padding for alignment.
@@ -75,16 +75,23 @@ void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4]);
  *
  **************************************************/
 MLK_INTERNAL_API
-void mlk_poly_rej_uniform_x4(mlk_poly *vec,
+void mlk_poly_rej_uniform_x4(mlk_poly *vec0, mlk_poly *vec1, mlk_poly *vec2,
+                             mlk_poly *vec3,
                              uint8_t seed[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 2)])
 __contract__(
-  requires(memory_no_alias(vec, sizeof(mlk_poly) * 4))
+  requires(memory_no_alias(vec0, sizeof(mlk_poly)))
+  requires(memory_no_alias(vec1, sizeof(mlk_poly)))
+  requires(memory_no_alias(vec2, sizeof(mlk_poly)))
+  requires(memory_no_alias(vec3, sizeof(mlk_poly)))
   requires(memory_no_alias(seed, 4 * MLK_ALIGN_UP(MLKEM_SYMBYTES + 2)))
-  assigns(memory_slice(vec, sizeof(mlk_poly) * 4))
-  ensures(array_bound(vec[0].coeffs, 0, MLKEM_N, 0, MLKEM_Q))
-  ensures(array_bound(vec[1].coeffs, 0, MLKEM_N, 0, MLKEM_Q))
-  ensures(array_bound(vec[2].coeffs, 0, MLKEM_N, 0, MLKEM_Q))
-  ensures(array_bound(vec[3].coeffs, 0, MLKEM_N, 0, MLKEM_Q)));
+  assigns(memory_slice(vec0, sizeof(mlk_poly)))
+  assigns(memory_slice(vec1, sizeof(mlk_poly)))
+  assigns(memory_slice(vec2, sizeof(mlk_poly)))
+  assigns(memory_slice(vec3, sizeof(mlk_poly)))
+  ensures(array_bound(vec0->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
+  ensures(array_bound(vec1->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
+  ensures(array_bound(vec2->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
+  ensures(array_bound(vec3->coeffs, 0, MLKEM_N, 0, MLKEM_Q)));
 
 #define mlk_poly_rej_uniform MLK_NAMESPACE(poly_rej_uniform)
 /*************************************************

--- a/crypto/fipsmodule/ml_kem/mlkem/verify.h
+++ b/crypto/fipsmodule/ml_kem/mlkem/verify.h
@@ -431,7 +431,7 @@ __contract__(
   requires(memory_no_alias(ptr, len))
   assigns(memory_slice(ptr, len)))
 {
-  memset(ptr, 0, len);
+  mlk_memset(ptr, 0, len);
   /* This follows OpenSSL and seems sufficient to prevent the compiler
    * from optimizing away the memset.
    *

--- a/crypto/fipsmodule/ml_kem/mlkem/zetas.inc
+++ b/crypto/fipsmodule/ml_kem/mlkem/zetas.inc
@@ -15,7 +15,7 @@
  * Table of zeta values used in the reference NTT and inverse NTT.
  * See autogen for details.
  */
-static MLK_ALIGN const int16_t zetas[128] = {
+static MLK_ALIGN const int16_t mlk_zetas[128] = {
     -1044, -758,  -359,  -1517, 1493,  1422,  287,   202,  -171,  622,   1577,
     182,   962,   -1202, -1474, 1468,  573,   -1325, 264,  383,   -829,  1458,
     -1602, -130,  -681,  1017,  732,   608,   -1542, 411,  -205,  -1571, 1223,

--- a/crypto/fipsmodule/ml_kem/mlkem_native_config.h
+++ b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
@@ -66,6 +66,26 @@ static MLK_INLINE void mlk_randombytes(void *ptr, size_t len) {
 }
 #endif // !__ASSEMBLER__
 
+// Map memcpy function to the one used by AWS-LC
+#define MLK_CONFIG_CUSTOM_MEMCPY
+#if !defined(__ASSEMBLER__)
+#include <stdint.h>
+#include "mlkem/sys.h"
+static MLK_INLINE void *mlk_memcpy(void *dest, const void *src, size_t n) {
+    return OPENSSL_memcpy(dest, src, n);
+}
+#endif // !__ASSEMBLER__
+
+// Map memset function to the one used by AWS-LC
+#define MLK_CONFIG_CUSTOM_MEMSET
+#if !defined(__ASSEMBLER__)
+#include <stdint.h>
+#include "mlkem/sys.h"
+static MLK_INLINE void *mlk_memset(void *s, int c, size_t n) {
+    return OPENSSL_memset(s, c, n);
+}
+#endif // !__ASSEMBLER__
+
 #if defined(OPENSSL_NO_ASM)
 #define MLK_CONFIG_NO_ASM
 #endif


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

-----------

This PR updates crypto/fipsmodule/ml_kem by re-importing the latest mlkem-native `main` ([ed62d312](https://github.com/pq-code-package/mlkem-native/commit/ed62d31297bca103cbbf02e125646af098253872)). It also leverages recently added configuration options to use `OPENSSL_memset` and `OPENSSL_memcpy` where previously `memset/memcpy` were used.

This update is a prerequisite to @dkostic's integration of the x86_64 backend from mlkem-native.