### PR TITLE
Implement dgst CLI command

### DIFF
--- a/tool-openssl/dgst_test.cc
+++ b/tool-openssl/dgst_test.cc
@@ -4,12 +4,8 @@
 #include <gtest/gtest.h>
 #include <openssl/pem.h>
 #include "../crypto/test/test_util.h"
+#include "internal.h"
 #include "test_util.h"
-
-// -------------------- MD5 OpenSSL Comparison Test ---------------------------
-
-// Comparison tests cannot run without set up of environment variables:
-// AWSLC_TOOL_PATH and OPENSSL_TOOL_PATH.
 
 class DgstComparisonTest : public ::testing::Test {
  protected:
@@ -17,26 +13,64 @@ class DgstComparisonTest : public ::testing::Test {
     // Skip gtests if env variables not set
     awslc_executable_path = getenv("AWSLC_TOOL_PATH");
     openssl_executable_path = getenv("OPENSSL_TOOL_PATH");
+
+    ASSERT_GT(createTempFILEpath(in_path), 0u);
+    ASSERT_GT(createTempFILEpath(out_path_awslc), 0u);
+    ASSERT_GT(createTempFILEpath(out_path_openssl), 0u);
+    ASSERT_GT(createTempFILEpath(sig_path_awslc), 0u);
+    ASSERT_GT(createTempFILEpath(sig_path_openssl), 0u);
+    ASSERT_GT(createTempFILEpath(key_path), 0u);
+    ASSERT_GT(createTempFILEpath(pubkey_path), 0u);
+    ASSERT_GT(createTempFILEpath(protected_key_path),
+              0u);  // TODO: update this to test passin
+
+    // Create and save a private key in PEM format
+    bssl::UniquePtr<EVP_PKEY> pkey(CreateTestKey(2048));
+    ASSERT_TRUE(pkey);
+
+    ScopedFILE key_file(fopen(key_path, "wb"));
+    ASSERT_TRUE(key_file);
+    ASSERT_TRUE(PEM_write_PrivateKey(key_file.get(), pkey.get(), nullptr,
+                                     nullptr, 0, nullptr, nullptr));
+
+    // Create a public key file
+    ScopedFILE pubkey_file(fopen(pubkey_path, "wb"));
+    ASSERT_TRUE(pubkey_file);
+    ASSERT_TRUE(PEM_write_PUBKEY(pubkey_file.get(), pkey.get()));
+
+    // Create a test input file with some data
+    ScopedFILE in_file(fopen(in_path, "wb"));
+    ASSERT_TRUE(in_file);
+    const char *test_data = "AWS_LC_TEST_STRING_INPUT";
+    ASSERT_EQ(fwrite(test_data, 1, strlen(test_data), in_file.get()),
+              strlen(test_data));
+
     if (awslc_executable_path == nullptr ||
         openssl_executable_path == nullptr) {
       GTEST_SKIP() << "Skipping test: AWSLC_TOOL_PATH and/or OPENSSL_TOOL_PATH "
                       "environment variables are not set";
     }
-    ASSERT_GT(createTempFILEpath(in_path), 0u);
-    ASSERT_GT(createTempFILEpath(out_path_awslc), 0u);
-    ASSERT_GT(createTempFILEpath(out_path_openssl), 0u);
   }
+
   void TearDown() override {
-    if (awslc_executable_path != nullptr &&
-        openssl_executable_path != nullptr) {
-      //      RemoveFile(in_path);
-      RemoveFile(out_path_awslc);
-      RemoveFile(out_path_openssl);
-    }
+    RemoveFile(in_path);
+    RemoveFile(out_path_awslc);
+    RemoveFile(out_path_openssl);
+    RemoveFile(sig_path_awslc);
+    RemoveFile(sig_path_openssl);
+    RemoveFile(key_path);
+    RemoveFile(pubkey_path);
+    RemoveFile(protected_key_path);
   }
+
   char in_path[PATH_MAX];
   char out_path_awslc[PATH_MAX];
   char out_path_openssl[PATH_MAX];
+  char sig_path_awslc[PATH_MAX];
+  char sig_path_openssl[PATH_MAX];
+  char key_path[PATH_MAX];
+  char pubkey_path[PATH_MAX];
+  char protected_key_path[PATH_MAX];
   const char *awslc_executable_path;
   const char *openssl_executable_path;
   std::string awslc_output_str;
@@ -49,23 +83,30 @@ std::string GetHash(const std::string &str) {
   if (pos == std::string::npos) {
     return "";
   }
-  return str.substr(pos + 1);
+  std::string result = str.substr(pos + 1);
+
+  // OpenSSL has inconsistent leading white space
+  size_t start = result.find_first_not_of(" ");
+  if (start == std::string::npos) {
+    return "";
+  }
+
+  if (start == 0) {
+    return result;
+  }
+
+  return result.substr(start);
 }
 
-// Test against OpenSSL output for "-hmac"
-TEST_F(DgstComparisonTest, HMAC_default_files) {
-  std::string input_file = std::string(in_path);
-  std::ofstream ofs(input_file);
-  ofs << "AWS_LC_TEST_STRING_INPUT";
-  ofs.close();
-
-  // Run -hmac against a single file.
+// -------------------- Dgst Options Test ---------------------------
+TEST_F(DgstComparisonTest, HMAC) {
   std::string awslc_command = std::string(awslc_executable_path) +
-                              " dgst -hmac test_key_string " + input_file +
-                              " > " + out_path_awslc;
+                              " dgst -hmac test_key_string -out " +
+                              out_path_awslc + " " + in_path;
+
   std::string openssl_command = std::string(openssl_executable_path) +
-                                " dgst -hmac test_key_string " + input_file +
-                                " > " + out_path_openssl;
+                                " dgst -hmac test_key_string -out " +
+                                out_path_openssl + " " + in_path;
 
   RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
                               out_path_openssl, awslc_output_str,
@@ -76,125 +117,275 @@ TEST_F(DgstComparisonTest, HMAC_default_files) {
 
   EXPECT_EQ(awslc_hash, openssl_hash);
 
-  // Run -hmac again against multiple files.
+  // binary output
+  awslc_command = std::string(awslc_executable_path) +
+                  " dgst -hmac test_key_string -binary -out " + out_path_awslc +
+                  " " + in_path;
+  openssl_command = std::string(openssl_executable_path) +
+                    " dgst -hmac test_key_string -binary -out " +
+                    out_path_openssl + " " + in_path;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
+                              out_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  EXPECT_EQ(awslc_output_str, openssl_output_str);
+}
+
+TEST_F(DgstComparisonTest, Digest) {
+  // default digest
+  std::string awslc_command = std::string(awslc_executable_path) +
+                              " dgst -out " + out_path_awslc + " " + in_path;
+
+  std::string openssl_command = std::string(openssl_executable_path) +
+                                " dgst -out " + out_path_openssl + " " +
+                                in_path;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
+                              out_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  std::string awslc_hash = GetHash(awslc_output_str);
+  std::string openssl_hash = GetHash(openssl_output_str);
+
+  EXPECT_EQ(awslc_hash, openssl_hash);
+
+  // non-default digest + binary
+  awslc_command = std::string(awslc_executable_path) +
+                  " dgst -sha1 -binary -out " + out_path_awslc + " " + in_path;
+  openssl_command = std::string(openssl_executable_path) +
+                    " dgst -sha1 -binary -out " + out_path_openssl + " " +
+                    in_path;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
+                              out_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  EXPECT_EQ(awslc_output_str, openssl_output_str);
+}
+
+TEST_F(DgstComparisonTest, SignAndVerify) {
+  // default binary output
+  std::string awslc_command = std::string(awslc_executable_path) +
+                              " dgst -sign " + key_path + " -out " +
+                              sig_path_awslc + " " + in_path;
+
+  std::string openssl_command = std::string(openssl_executable_path) +
+                                " dgst -sign " + key_path + " -out " +
+                                sig_path_openssl + " " + in_path;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, sig_path_awslc,
+                              sig_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  EXPECT_EQ(awslc_output_str, openssl_output_str);
+
+  awslc_command = std::string(awslc_executable_path) + " dgst -verify " +
+                  pubkey_path + " -signature " + sig_path_awslc +
+                  " -keyform PEM -out " + out_path_awslc + " " + in_path;
+
+  openssl_command = std::string(openssl_executable_path) + " dgst -verify " +
+                    pubkey_path + " -signature " + sig_path_openssl +
+                    " -keyform PEM -out " + out_path_openssl + " " + in_path;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
+                              out_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  EXPECT_EQ(awslc_output_str, openssl_output_str);
+
+  // sigopts
+  awslc_command =
+      std::string(awslc_executable_path) + " dgst -sign " + key_path +
+      " -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:0 -out " +
+      sig_path_awslc + " " + in_path;
+
+  openssl_command =
+      std::string(openssl_executable_path) + " dgst -sign " + key_path +
+      " -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:0 -out " +
+      sig_path_openssl + " " + in_path;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, sig_path_awslc,
+                              sig_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  EXPECT_EQ(awslc_output_str, openssl_output_str);
+
+  awslc_command =
+      std::string(awslc_executable_path) + " dgst -verify " + pubkey_path +
+      " -signature " + sig_path_awslc +
+      " -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:0 -out " +
+      out_path_awslc + " " + in_path;
+
+  openssl_command =
+      std::string(openssl_executable_path) + " dgst -verify " + pubkey_path +
+      " -signature " + sig_path_openssl +
+      " -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:0 -out " +
+      out_path_openssl + " " + in_path;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
+                              out_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  EXPECT_EQ(awslc_output_str, openssl_output_str);
+
+  // hex output
+  awslc_command = std::string(awslc_executable_path) + " dgst -sign " +
+                  key_path + " -hex -out " + sig_path_awslc + " " + in_path;
+
+  openssl_command = std::string(openssl_executable_path) + " dgst -sign " +
+                    key_path + " -hex -out " + sig_path_openssl + " " + in_path;
+
+  RunCommandsAndCompareOutput(awslc_command, openssl_command, sig_path_awslc,
+                              sig_path_openssl, awslc_output_str,
+                              openssl_output_str);
+
+  std::string awslc_hash = GetHash(awslc_output_str);
+  std::string openssl_hash = GetHash(openssl_output_str);
+
+  EXPECT_EQ(awslc_hash, openssl_hash);
+}
+
+class DgstTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_GT(createTempFILEpath(in_path), 0u);
+    ASSERT_GT(createTempFILEpath(out_path), 0u);
+    ASSERT_GT(createTempFILEpath(sig_path), 0u);
+    ASSERT_GT(createTempFILEpath(key_path), 0u);
+    ASSERT_GT(createTempFILEpath(pubkey_path), 0u);
+    ASSERT_GT(createTempFILEpath(protected_key_path), 0u);
+
+    // Create and save a private key in PEM format
+    bssl::UniquePtr<EVP_PKEY> pkey(CreateTestKey(2048));
+    ASSERT_TRUE(pkey);
+
+    ScopedFILE key_file(fopen(key_path, "wb"));
+    ASSERT_TRUE(key_file);
+    ASSERT_TRUE(PEM_write_PrivateKey(key_file.get(), pkey.get(), nullptr,
+                                     nullptr, 0, nullptr, nullptr));
+
+    // Create a public key file
+    ScopedFILE pubkey_file(fopen(pubkey_path, "wb"));
+    ASSERT_TRUE(pubkey_file);
+    ASSERT_TRUE(PEM_write_PUBKEY(pubkey_file.get(), pkey.get()));
+
+    // Create a test input file with some data
+    ScopedFILE in_file(fopen(in_path, "wb"));
+    ASSERT_TRUE(in_file);
+    const char *test_data = "Test data for signing and verification";
+    ASSERT_EQ(fwrite(test_data, 1, strlen(test_data), in_file.get()),
+              strlen(test_data));
+  }
+
+  void TearDown() override {
+    RemoveFile(in_path);
+    RemoveFile(out_path);
+    RemoveFile(sig_path);
+    RemoveFile(key_path);
+    RemoveFile(pubkey_path);
+    RemoveFile(protected_key_path);
+  }
+
+  char in_path[PATH_MAX];
+  char out_path[PATH_MAX];
+  char sig_path[PATH_MAX];
+  char key_path[PATH_MAX];
+  char pubkey_path[PATH_MAX];
+  char protected_key_path[PATH_MAX];
+  std::string awslc_output_str;
+  std::string openssl_output_str;
+};
+
+TEST_F(DgstTest, HMAC) {
+  args_list_t args = {"-hmac", "test_key_string", in_path};
+  EXPECT_TRUE(dgstTool(args));
+}
+
+TEST_F(DgstTest, Sign) {
+  args_list_t args = {"-sign", key_path, "-out", sig_path, in_path};
+  EXPECT_TRUE(dgstTool(args));
+}
+
+TEST_F(DgstTest, Verify) {
+  // First create signature
+  args_list_t sign_args = {"-sign", key_path, "-out", sig_path, in_path};
+  EXPECT_TRUE(dgstTool(sign_args));
+
+  // Then verify
+  args_list_t verify_args = {"-verify", pubkey_path, "-signature", sig_path,
+                             in_path};
+  EXPECT_TRUE(dgstTool(verify_args));
+}
+
+TEST_F(DgstTest, DigestSHA256) {
+  std::ofstream ofs(in_path);
+  ofs << "test data";
+  ofs.close();
+
+  args_list_t args = {"-sha256", in_path};
+  EXPECT_TRUE(dgstTool(args));
+}
+
+TEST_F(DgstTest, DigestSHA1) {
+  std::ofstream ofs(in_path);
+  ofs << "test data";
+  ofs.close();
+
+  args_list_t args = {"-sha1", in_path};
+  EXPECT_TRUE(dgstTool(args));
+}
+
+TEST_F(DgstTest, FileInput) {
+  // Single file input
+  args_list_t single_args = {in_path};
+  EXPECT_TRUE(dgstTool(single_args));
+
+  // Multiple file inputs
   char in_path2[PATH_MAX];
   ASSERT_GT(createTempFILEpath(in_path2), 0u);
-  std::string input_file2 = std::string(in_path2);
-  ofs.open(input_file2);
-  ofs << "AWS_LC_TEST_STRING_INPUT_2";
-  ofs.close();
+  std::ofstream ofs2(in_path2);
+  ofs2 << "AWS_LC_TEST_STRING_INPUT_2";
+  ofs2.close();
 
-  awslc_command = std::string(awslc_executable_path) +
-                  " dgst -hmac alternative_key_string " + input_file + " " +
-                  input_file2 + " > " + out_path_awslc;
-  openssl_command = std::string(openssl_executable_path) +
-                    " dgst -hmac alternative_key_string " + input_file + " " +
-                    input_file2 + +" > " + out_path_openssl;
+  args_list_t multi_args = {in_path, in_path2};
+  EXPECT_TRUE(dgstTool(multi_args));
 
-  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
-                              out_path_openssl, awslc_output_str,
-                              openssl_output_str);
-
-  awslc_hash = GetHash(awslc_output_str);
-  openssl_hash = GetHash(openssl_output_str);
-
-  EXPECT_EQ(awslc_hash, openssl_hash);
-
-  // Run -hmac with empty key
-  awslc_command = std::string(awslc_executable_path) +
-                  " dgst -hmac \"\" "
-                  " " +
-                  input_file + " " + input_file2 + " > " + out_path_awslc;
-  openssl_command = std::string(openssl_executable_path) + " dgst -hmac \"\" " +
-                    input_file + " " + input_file2 + +" > " + out_path_openssl;
-
-  RunCommandsAndCompareOutput(awslc_command, openssl_command, out_path_awslc,
-                              out_path_openssl, awslc_output_str,
-                              openssl_output_str);
-
-  awslc_hash = GetHash(awslc_output_str);
-  openssl_hash = GetHash(openssl_output_str);
-
-  EXPECT_EQ(awslc_hash, openssl_hash);
-
-  RemoveFile(input_file.c_str());
-  RemoveFile(input_file2.c_str());
+  RemoveFile(in_path2);
 }
 
+class DgstOptionUsageErrorsTest : public DgstTest {
+ protected:
+  void TestOptionUsageErrors(const std::vector<std::string> &args) {
+    args_list_t c_args;
+    for (const auto &arg : args) {
+      c_args.push_back(arg.c_str());
+    }
+    bool result = dgstTool(c_args);
+    ASSERT_FALSE(result);
+  }
+};
 
-TEST_F(DgstComparisonTest, HMAC_default_stdin) {
-  std::string tool_command = "echo hmac_this_string | " +
-                             std::string(awslc_executable_path) +
-                             " dgst -hmac key > " + out_path_awslc;
-  std::string openssl_command = "echo hmac_this_string | " +
-                                std::string(openssl_executable_path) +
-                                " dgst -hmac key > " + out_path_openssl;
+TEST_F(DgstOptionUsageErrorsTest, InvalidCombinations) {
+  std::vector<std::vector<std::string>> invalid_combos = {
+      // unsupported keyform
+      {"-verify", key_path, "-signature", sig_path, "-keyform", "ENGINE",
+       in_path},
+      // verify without sig file
+      {"-verify", key_path, "-keyform", "ENGINE", in_path},
+      // hmac, verify, and sign used together
+      {"-hmac", "test_key_string", "-verify", key_path, "-signature", sig_path,
+       in_path},
+      {"-hmac", "test_key_string", "-sign", pubkey_path, in_path},
+      {"-verify", key_path, "-sign", pubkey_path, in_path},
+      // wrong use of sigopt
+      {"-sign", pubkey_path, "-sigopt", "abc:xyz", in_path},
+      // unsupported digest
+      {"-sha3224", in_path},
+      // hex and binary both specified
+      {"-hex", "-binary", in_path}};
 
-  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_awslc,
-                              out_path_openssl, awslc_output_str,
-                              openssl_output_str);
-
-  std::string tool_hash = GetHash(awslc_output_str);
-  std::string openssl_hash = GetHash(openssl_output_str);
-
-  EXPECT_EQ(tool_hash, openssl_hash);
-}
-
-TEST_F(DgstComparisonTest, MD5_files) {
-  std::string input_file = std::string(in_path);
-  std::ofstream ofs(input_file);
-  ofs << "AWS_LC_TEST_STRING_INPUT";
-  ofs.close();
-
-  // Input file as pipe (stdin)
-  std::string tool_command = std::string(awslc_executable_path) + " md5 < " +
-                             input_file + " > " + out_path_awslc;
-  std::string openssl_command = std::string(openssl_executable_path) +
-                                " md5 < " + input_file + " > " +
-                                out_path_openssl;
-
-  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_awslc,
-                              out_path_openssl, awslc_output_str,
-                              openssl_output_str);
-
-  std::string tool_hash = GetHash(awslc_output_str);
-  std::string openssl_hash = GetHash(openssl_output_str);
-
-  EXPECT_EQ(tool_hash, openssl_hash);
-
-  // Input file as regular command line option.
-  tool_command = std::string(awslc_executable_path) + " md5 " + input_file +
-                 " > " + out_path_awslc;
-  openssl_command = std::string(openssl_executable_path) + " md5 " +
-                    input_file + " > " + out_path_openssl;
-
-  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_awslc,
-                              out_path_openssl, awslc_output_str,
-                              openssl_output_str);
-
-  tool_hash = GetHash(awslc_output_str);
-  openssl_hash = GetHash(openssl_output_str);
-
-  EXPECT_EQ(tool_hash, openssl_hash);
-
-  RemoveFile(input_file.c_str());
-}
-
-// Test against OpenSSL output with stdin.
-TEST_F(DgstComparisonTest, MD5_stdin) {
-  std::string tool_command = "echo hash_this_string | " +
-                             std::string(awslc_executable_path) + " md5 > " +
-                             out_path_awslc;
-  std::string openssl_command = "echo hash_this_string | " +
-                                std::string(openssl_executable_path) +
-                                " md5 > " + out_path_openssl;
-
-  RunCommandsAndCompareOutput(tool_command, openssl_command, out_path_awslc,
-                              out_path_openssl, awslc_output_str,
-                              openssl_output_str);
-
-  std::string tool_hash = GetHash(awslc_output_str);
-  std::string openssl_hash = GetHash(openssl_output_str);
-
-  EXPECT_EQ(tool_hash, openssl_hash);
+  for (const auto &args : invalid_combos) {
+    TestOptionUsageErrors(args);
+  }
 }

--- a/tool-openssl/internal.h
+++ b/tool-openssl/internal.h
@@ -111,6 +111,16 @@ static inline ordered_args_map_t::const_iterator FindArg(
       });
 }
 
+static inline void FindAll(std::vector<std::string> &result,
+                           const std::string &arg_name,
+                           const ordered_args_map_t &args) {
+  for (const auto &pair : args) {
+    if (pair.first == arg_name) {
+      result.push_back(pair.second);
+    }
+  }
+}
+
 // Parse arguments in order of appearance
 bool ParseOrderedKeyValueArguments(ordered_args_map_t &out_args,
                                    args_list_t &extra_args,
@@ -124,6 +134,10 @@ bool GetString(std::string *out, const std::string &arg_name,
                std::string default_value, const ordered_args_map_t &args);
 bool GetBoolArgument(bool *out, const std::string &arg_name,
                      const ordered_args_map_t &args);
+
+bool GetExclusiveBoolArgument(std::string *out_arg, const argument_t *templates,
+                              std::string default_out_arg,
+                              const ordered_args_map_t &args);
 }  // namespace ordered_args
 
 #endif  // TOOL_OPENSSL_INTERNAL_H

--- a/tool-openssl/ordered_args.cc
+++ b/tool-openssl/ordered_args.cc
@@ -23,6 +23,8 @@ bool ParseOrderedKeyValueArguments(ordered_args_map_t &out_args,
   out_args.clear();
   extra_args.clear();
 
+  std::vector<std::string> exclusive_boolean_args;
+
   for (size_t i = 0; i < args.size(); i++) {
     const std::string &arg = args[i];
     const argument_t *templ = nullptr;
@@ -45,20 +47,34 @@ bool ParseOrderedKeyValueArguments(ordered_args_map_t &out_args,
     // Check for duplicate arguments - allowed for order preservation
     // but warn about it when debugging
 #ifndef NDEBUG
-    if (HasArgument(out_args, arg)) {
+    if (templ->type != kDuplicateArgument && HasArgument(out_args, arg)) {
       fprintf(stderr, "Warning: Duplicate argument: %s\n", arg.c_str());
     }
 #endif
 
-    if (templ->type == kBooleanArgument) {
+    if (templ->type == kBooleanArgument ||
+        templ->type == kExclusiveBooleanArgument) {
       out_args.push_back(std::pair<std::string, std::string>(arg, ""));
+      if (templ->type == kExclusiveBooleanArgument) {
+        exclusive_boolean_args.push_back(arg);
+      }
     } else {
       if (i + 1 >= args.size()) {
         fprintf(stderr, "Missing argument for option: %s\n", arg.c_str());
         return false;
       }
+
       out_args.push_back(std::pair<std::string, std::string>(arg, args[++i]));
     }
+  }
+
+  if (exclusive_boolean_args.size() > 1) {
+    fprintf(stderr, "These arguments cannot be used together: ");
+    for (size_t i = 0; i < exclusive_boolean_args.size(); ++i) {
+      fprintf(stderr, "%s%s", exclusive_boolean_args[i].c_str(),
+              (i < exclusive_boolean_args.size() - 1) ? ", " : "\n");
+    }
+    return false;
   }
 
   for (size_t j = 0; templates[j].name[0] != 0; j++) {
@@ -130,4 +146,22 @@ bool GetBoolArgument(bool *out, const std::string &arg_name,
   return true;
 }
 
+bool GetExclusiveBoolArgument(std::string *out_arg, const argument_t *templates,
+                              std::string default_out_arg,
+                              const ordered_args_map_t &args) {
+  *out_arg = default_out_arg;
+
+  for (size_t i = 0; templates[i].name[0] != 0; i++) {
+    const argument_t *templ = &templates[i];
+    if (templ->type == kExclusiveBooleanArgument) {
+      auto it = FindArg(args, templ->name);
+      if (it != args.end()) {
+        *out_arg = templ->name;
+        break;
+      }
+    }
+  }
+
+  return true;
+}
 }  // namespace ordered_args

--- a/tool-openssl/test_util.h
+++ b/tool-openssl/test_util.h
@@ -19,20 +19,23 @@
 // comparison output
 static inline std::string &trim(std::string &s) {
   s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
-      return !std::isspace(static_cast<unsigned char>(ch));
-  }));
-  s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
-      return !std::isspace(static_cast<unsigned char>(ch));
-  }).base(), s.end());
+            return !std::isspace(static_cast<unsigned char>(ch));
+          }));
+  s.erase(std::find_if(s.rbegin(), s.rend(),
+                       [](unsigned char ch) {
+                         return !std::isspace(static_cast<unsigned char>(ch));
+                       })
+              .base(),
+          s.end());
   return s;
 }
 
 // Helper function to read file content into a string
-inline std::string ReadFileToString(const std::string& file_path) {
+inline std::string ReadFileToString(const std::string &file_path) {
   if (file_path.empty()) {
     return "";
   }
-  
+
   // Check if file exists first
   struct stat stat_buffer;
   if (stat(file_path.c_str(), &stat_buffer) != 0) {
@@ -43,16 +46,19 @@ inline std::string ReadFileToString(const std::string& file_path) {
   if (!file_stream.is_open()) {
     return "";
   }
-  
+
   std::ostringstream output_buffer;
   output_buffer << file_stream.rdbuf();
-  
+
   return output_buffer.str();
 }
 
-inline void RunCommandsAndCompareOutput(const std::string &tool_command, const std::string &openssl_command,
-                                        const std::string &out_path_tool, const std::string &out_path_openssl,
-                                        std::string &tool_output_str, std::string &openssl_output_str) {
+inline void RunCommandsAndCompareOutput(const std::string &tool_command,
+                                        const std::string &openssl_command,
+                                        const std::string &out_path_tool,
+                                        const std::string &out_path_openssl,
+                                        std::string &tool_output_str,
+                                        std::string &openssl_output_str) {
   int tool_result = system(tool_command.c_str());
   ASSERT_EQ(tool_result, 0) << "AWS-LC tool command failed: " << tool_command;
 
@@ -60,15 +66,20 @@ inline void RunCommandsAndCompareOutput(const std::string &tool_command, const s
   ASSERT_EQ(openssl_result, 0) << "OpenSSL command failed: " << openssl_command;
 
   std::ifstream tool_output(out_path_tool);
-  tool_output_str = std::string((std::istreambuf_iterator<char>(tool_output)), std::istreambuf_iterator<char>());
+  tool_output_str = std::string((std::istreambuf_iterator<char>(tool_output)),
+                                std::istreambuf_iterator<char>());
   std::ifstream openssl_output(out_path_openssl);
-  openssl_output_str = std::string((std::istreambuf_iterator<char>(openssl_output)), std::istreambuf_iterator<char>());
+  openssl_output_str =
+      std::string((std::istreambuf_iterator<char>(openssl_output)),
+                  std::istreambuf_iterator<char>());
 
-  std::cout << "AWS-LC tool output:" << std::endl << tool_output_str << std::endl;
-  std::cout << "OpenSSL output:" << std::endl << openssl_output_str << std::endl;
+  std::cout << "AWS-LC tool output:" << std::endl
+            << tool_output_str << std::endl;
+  std::cout << "OpenSSL output:" << std::endl
+            << openssl_output_str << std::endl;
 }
 
-inline void RemoveFile(const char* path) {
+inline void RemoveFile(const char *path) {
   struct stat buffer;
   if (path != nullptr && stat(path, &buffer) == 0) {
     if (remove(path) != 0) {
@@ -78,6 +89,6 @@ inline void RemoveFile(const char* path) {
 }
 
 // OpenSSL versions 3.1.0 and later change from "(stdin)= " to "MD5(stdin) ="
-std::string GetHash(const std::string& str);
+std::string GetHash(const std::string &str);
 
-#endif //TEST_UTIL_H
+#endif  // TEST_UTIL_H


### PR DESCRIPTION
### Issues:
Resolves #CryptoAlg-3383

### Description of changes: 
Re-implement dgst cli commands with the following options:
-binary
-sha256 (and a handful of other digest algorithms)
-sigopt
-passin
-sign
-out
-verify
-signature
-keyform

### Call-outs:
Waiting for https://github.com/aws/aws-lc/pull/2555 to implement `-passin`

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
