### PR TITLE
Migrate from CodeBuild account actor filter to pull request comment filter based on GitHub permissions

### DIFF
--- a/tests/ci/cdk/cdk/aws_lc_android_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_android_ci_stack.py
@@ -77,6 +77,9 @@ class AwsLcAndroidCIStack(AwsLcBaseCiStack):
             ),
             build_spec=BuildSpecLoader.load(spec_file_path, env),
         )
+        cfn_project = project.node.default_child
+        cfn_project.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)
+
         project.enable_batch_builds()
 
         PruneStaleGitHubBuilds(

--- a/tests/ci/cdk/cdk/aws_lc_android_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_android_ci_stack.py
@@ -78,7 +78,7 @@ class AwsLcAndroidCIStack(AwsLcBaseCiStack):
             build_spec=BuildSpecLoader.load(spec_file_path, env),
         )
         cfn_project = project.node.default_child
-        cfn_project.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)
+        cfn_project.add_property_override("Triggers.PullRequestBuildPolicy", self.pull_request_policy)
 
         project.enable_batch_builds()
 

--- a/tests/ci/cdk/cdk/aws_lc_base_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_base_ci_stack.py
@@ -57,12 +57,12 @@ class AwsLcBaseCiStack(Stack):
             webhook_triggers_batch_build=True,
         )
         # P292389560
-        self.pull_request_policy = codebuild.CfnProject.PullRequestBuildPolicyProperty(
-            requires_comment_approval="ALL_PULL_REQUESTS",
-            approver_roles=[
+        self.pull_request_policy = {
+            "RequiresCommentApproval": "ALL_PULL_REQUESTS",
+            "ApproverRoles": [
                 "GITHUB_ADMIN",
-                "GITHUB_MAINTAINER",
+                "GITHUB_MAINTAIN",
                 "GITHUB_WRITE",
-                "GITHUB_TRIAGE"
-            ]
-        )
+                "GITHUB_TRIAGE",
+            ],
+        }

--- a/tests/ci/cdk/cdk/aws_lc_base_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_base_ci_stack.py
@@ -49,16 +49,20 @@ class AwsLcBaseCiStack(Stack):
                     codebuild.EventAction.PULL_REQUEST_CREATED,
                     codebuild.EventAction.PULL_REQUEST_UPDATED,
                     codebuild.EventAction.PULL_REQUEST_REOPENED,
-                    # Temporarily allowlist the webhook to members of the Github teams:
-                    # https://github.com/orgs/aws/teams/aws-lc-dev
-                    # https://github.com/orgs/aws/teams/aws-lc-contributor
-                ).and_actor_account_is(
-                    "^(215225139|549813|3589880|11924508|25055813|38119460|41167468|50673096|66388554|69484052|"
-                    "103147162|107728331|159580656|3596374|7552310|7660279|13040499|26892988|44320407|68056884|218846309)$"
                 ),
                 codebuild.FilterGroup.in_event_of(
                     codebuild.EventAction.PUSH
                 ).and_branch_is(GITHUB_PUSH_CI_BRANCH_TARGETS),
             ],
             webhook_triggers_batch_build=True,
+        )
+        # P292389560
+        self.pull_request_policy = codebuild.CfnProject.PullRequestBuildPolicyProperty(
+            requires_comment_approval="ALL_PULL_REQUESTS",
+            approver_roles=[
+                "GITHUB_ADMIN",
+                "GITHUB_MAINTAINER",
+                "GITHUB_WRITE",
+                "GITHUB_TRIAGE"
+            ]
         )

--- a/tests/ci/cdk/cdk/aws_lc_ec2_test_framework_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_ec2_test_framework_ci_stack.py
@@ -168,6 +168,9 @@ class AwsLcEC2TestingCIStack(AwsLcBaseCiStack):
                 "EC2_VPC_ID": codebuild.BuildEnvironmentVariable(value=vpc.vpc_id),
             },
         )
+        cfn_project = project.node.default_child
+        cfn_project.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)
+
         project.enable_batch_builds()
 
         PruneStaleGitHubBuilds(

--- a/tests/ci/cdk/cdk/aws_lc_ec2_test_framework_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_ec2_test_framework_ci_stack.py
@@ -169,7 +169,7 @@ class AwsLcEC2TestingCIStack(AwsLcBaseCiStack):
             },
         )
         cfn_project = project.node.default_child
-        cfn_project.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)
+        cfn_project.add_property_override("Triggers.PullRequestBuildPolicy", self.pull_request_policy)
 
         project.enable_batch_builds()
 

--- a/tests/ci/cdk/cdk/aws_lc_github_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_ci_stack.py
@@ -103,7 +103,7 @@ class AwsLcGitHubCIStack(AwsLcBaseCiStack):
             "ResourceAccessRole", resource_access_role.role_arn
         )
 
-        cfn_project.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)
+        cfn_project.add_property_override("Triggers.PullRequestBuildPolicy", self.pull_request_policy)
 
         project.enable_batch_builds()
 

--- a/tests/ci/cdk/cdk/aws_lc_github_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_ci_stack.py
@@ -102,6 +102,9 @@ class AwsLcGitHubCIStack(AwsLcBaseCiStack):
         cfn_project.add_property_override(
             "ResourceAccessRole", resource_access_role.role_arn
         )
+
+        cfn_project.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)
+
         project.enable_batch_builds()
 
         PruneStaleGitHubBuilds(

--- a/tests/ci/cdk/cdk/aws_lc_github_ci_x509_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_ci_x509_stack.py
@@ -90,4 +90,4 @@ class AwsLcGitHubX509CIStack(AwsLcBaseCiStack):
         )
 
         cfn_project = self.project.node.default_child
-        cfn_project.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)
+        cfn_project.add_property_override("Triggers.PullRequestBuildPolicy", self.pull_request_policy)

--- a/tests/ci/cdk/cdk/aws_lc_github_ci_x509_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_ci_x509_stack.py
@@ -88,3 +88,6 @@ class AwsLcGitHubX509CIStack(AwsLcBaseCiStack):
                 include_build_id=False,
             ),
         )
+
+        cfn_project = self.project.node.default_child
+        cfn_project.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)

--- a/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
@@ -154,7 +154,7 @@ class AwsLcGitHubFuzzCIStack(AwsLcBaseCiStack):
             ],
         )
 
-        cfn_codebuild.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)
+        cfn_codebuild.add_property_override("Triggers.PullRequestBuildPolicy", self.pull_request_policy)
 
         PruneStaleGitHubBuilds(
             scope=self,

--- a/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_fuzz_ci_stack.py
@@ -154,6 +154,8 @@ class AwsLcGitHubFuzzCIStack(AwsLcBaseCiStack):
             ],
         )
 
+        cfn_codebuild.add_property_override("Source.PullRequestBuildPolicy", self.pull_request_policy)
+
         PruneStaleGitHubBuilds(
             scope=self,
             id="PruneStaleGitHubBuilds",


### PR DESCRIPTION
### Issues:
Addresses P292389560

### Description of changes: 
Instead of managing an opaque list of GitHub account IDs this migrates the CI to he new [CodeBuild pull request comment approval](https://docs.aws.amazon.com/codebuild/latest/userguide/pull-request-build-policy.html). Any user that has admin, write, triage, or maintainer permission to the repository will have the CI run automatically when they open a PR. If any other user opens a pull request the CodeBuild jobs will not run until someone in the above permission list comments on the PR with `codebuild_run(<SHA_OF_THE_LATEST_COMMIT>)` e.g. `codebuild_run(0faf56fee7b72f842408930bfbdab9e90e4d174d)`.

### Call-outs:
As far as I can tell this isn't modeled in the CDK yet which requires manually configuring the CFN property on each job. This also isn't a property of `codebuild.Source.git_hub` but is a property of the overall [CFN Project object](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_codebuild/CfnProject.html#aws_cdk.aws_codebuild.CfnProject.PullRequestBuildPolicyProperty) which means we have to configure it on every project we create.  

### Testing:
Verified locally the CloudFormation template looks like what I expect:
```
      Source:
        BuildSpec: tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
        Location: https://github.com/aws/aws-lc.git
        ReportBuildStatus: true
        Type: GITHUB
        PullRequestBuildPolicy:
          requiresCommentApproval: ALL_PULL_REQUESTS
          approverRoles:
            - GITHUB_ADMIN
            - GITHUB_MAINTAINER
            - GITHUB_WRITE
            - GITHUB_TRIAGE
```

I am going to verify this change in pre-prod before merging this. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
