### PR TITLE
Fix macOS FIPS build w/ clang-20

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -94,11 +94,25 @@ jobs:
         os:
           - "macos-14"
           - "macos-15"
+        clang:
+          - 20
+          - 0 # default
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.18'
+      - if: matrix.clang == 20
+        run: |
+          brew install llvm@20
+          echo "CC=/opt/homebrew/opt/llvm@20/bin/clang" >> $GITHUB_ENV
+          echo "CXX=/opt/homebrew/opt/llvm@20/bin/clang++" >> $GITHUB_ENV
+          echo "LDFLAGS=-L/opt/homebrew/opt/llvm@20/lib/c++ -L/opt/homebrew/opt/llvm@20/lib -lc++abi" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I/opt/homebrew/opt/llvm@20/include" >> $GITHUB_ENV
+          echo "CFLAGS=-I/opt/homebrew/opt/llvm@20/include" >> $GITHUB_ENV
+          echo "CXXFLAGS=-I/opt/homebrew/opt/llvm@20/include -stdlib=libc++" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=/opt/homebrew/opt/llvm@20/lib" >> $GITHUB_ENV
+          echo '/opt/homebrew/opt/llvm@20/bin' >> $GITHUB_PATH
       - name: Build ${{ env.PACKAGE_NAME }} with FIPS mode
         run: |
           ./tests/ci/run_fips_tests.sh
@@ -184,6 +198,7 @@ jobs:
 
   compiler-tests:
     name: ${{ matrix.compiler }}, FIPS=${{ matrix.fips }}
+    needs: [sanity-test-run]
     env:
       GOFLAGS: "-buildvcs=false"
     strategy:
@@ -278,6 +293,7 @@ jobs:
 
   pedantic-tests:
     name: pedantic - ${{ matrix.compiler }}, FIPS=${{ matrix.fips }}
+    needs: [sanity-test-run]
     env:
       GOFLAGS: "-buildvcs=false"
     strategy:
@@ -396,6 +412,7 @@ jobs:
       - name: Build using pre-generated assembly
         run: |
           docker run -v "${{ github.workspace }}:/awslc" "gcc-4.8"
+
 
   alpine-linux-x86:
     needs: [sanity-test-run]

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ symbols.txt
 /CMakePresets.json
 /compile_commands.json
 /scratch
+awslcTestTmpFile*

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -551,14 +551,17 @@ elseif(FIPS_SHARED)
         set(OSX_VERSION_MIN_FLAG "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
       endif()
     endif()
+    if(CMAKE_OSX_SYSROOT)
+      set(FIPS_EXTRA_FLAGS -isysroot \"${CMAKE_OSX_SYSROOT}\")
+    endif()
     add_custom_command(
       OUTPUT fips_apple_start.o
-      COMMAND ${CMAKE_C_COMPILER} -arch ${CMAKE_SYSTEM_PROCESSOR} -isysroot ${CMAKE_OSX_SYSROOT} ${OSX_VERSION_MIN_FLAG} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_shared_library_marker.c -DAWSLC_FIPS_SHARED_START -o fips_apple_start.o
+      COMMAND ${CMAKE_C_COMPILER} -arch ${CMAKE_SYSTEM_PROCESSOR} ${FIPS_EXTRA_FLAGS} ${OSX_VERSION_MIN_FLAG} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_shared_library_marker.c -DAWSLC_FIPS_SHARED_START -o fips_apple_start.o
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fips_shared_library_marker.c
     )
     add_custom_command(
       OUTPUT fips_apple_end.o
-      COMMAND ${CMAKE_C_COMPILER} -arch ${CMAKE_SYSTEM_PROCESSOR} -isysroot ${CMAKE_OSX_SYSROOT} ${OSX_VERSION_MIN_FLAG} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_shared_library_marker.c -DAWSLC_FIPS_SHARED_END -o fips_apple_end.o
+      COMMAND ${CMAKE_C_COMPILER} -arch ${CMAKE_SYSTEM_PROCESSOR} ${FIPS_EXTRA_FLAGS} ${OSX_VERSION_MIN_FLAG} -c ${CMAKE_CURRENT_SOURCE_DIR}/fips_shared_library_marker.c -DAWSLC_FIPS_SHARED_END -o fips_apple_end.o
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fips_shared_library_marker.c
     )
     add_custom_command(

--- a/util/fipstools/inject_hash/macho_parser/tests/macho_tests.h
+++ b/util/fipstools/inject_hash/macho_parser/tests/macho_tests.h
@@ -55,36 +55,32 @@ protected:
 
         uint32_t header_sizeofcmds = sizeof(struct segment_command_64) + 2 * sizeof(struct section_64) + sizeof(struct symtab_command);
         uint32_t header_ncmds = 2;
-        struct mach_header_64 test_header = {
-            .magic = MH_MAGIC_64,
-            .ncmds = header_ncmds,
-            .sizeofcmds = header_sizeofcmds,
-        };
+        struct mach_header_64 test_header = {};
+        test_header.magic = MH_MAGIC_64;
+        test_header.ncmds = header_ncmds;
+        test_header.sizeofcmds = header_sizeofcmds;
 
         uint32_t text_segment_cmdsize = sizeof(struct segment_command_64) + 2 * sizeof(struct section_64);
         uint32_t text_segment_nsects = 2;
-        struct segment_command_64 test_text_segment = {
-            .cmd = LC_SEGMENT_64,
-            .cmdsize = text_segment_cmdsize,
-            .segname = "__TEXT",
-            .nsects = text_segment_nsects,
-        };
+        struct segment_command_64 test_text_segment = {};
+        test_text_segment.cmd = LC_SEGMENT_64;
+        test_text_segment.cmdsize = text_segment_cmdsize;
+        strncpy(test_text_segment.segname, "__TEXT", sizeof(test_text_segment.segname));
+        test_text_segment.nsects = text_segment_nsects;
 
         uint32_t text_section_offset = sizeof(struct mach_header_64) + sizeof(struct segment_command_64) + 2 * sizeof(struct section_64) + sizeof(struct symtab_command);
         uint64_t text_section_size = TEXT_DATA_SIZE; // {0xC3}
-        struct section_64 test_text_section = {
-            .sectname = "__text",
-            .size = text_section_size, 
-            .offset = text_section_offset,
-        };
+        struct section_64 test_text_section = {};
+        strncpy(test_text_section.sectname, "__text", sizeof(test_text_section.sectname));
+        test_text_section.size = text_section_size;
+        test_text_section.offset = text_section_offset;
 
         uint32_t const_section_offset = text_section_offset + text_section_size;
         uint64_t const_section_size = CONST_DATA_SIZE;  // "hi"
-        struct section_64 test_const_section = {
-            .sectname = "__const",
-            .size = const_section_size,
-            .offset = const_section_offset,
-        };
+        struct section_64 test_const_section = {};
+        strncpy(test_const_section.sectname, "__const", sizeof(test_const_section.sectname));
+        test_const_section.size = const_section_size;
+        test_const_section.offset = const_section_offset;
 
         uint32_t symtab_command_symoff = const_section_offset + const_section_size;
         uint32_t symtab_command_stroff = symtab_command_symoff + NUM_SYMS * sizeof(struct nlist_64);


### PR DESCRIPTION
### Description of changes: 
Fix MacOS FIPS build when using Clang-20

### Call-out
MacOS FIPS build w/ clang-20 was failing with the following error:
```
...
FAILED: [code=1] crypto/fipsmodule/fips_apple_end.o /var/folders/bd/5rrlftjx2098f44h7jbj3n400000gr/T/tmp.iTYkPA1vWf/AWS-LC-BUILD/crypto/fipsmodule/fips_apple_end.o
cd /var/folders/bd/5rrlftjx2098f44h7jbj3n400000gr/T/tmp.iTYkPA1vWf/AWS-LC-BUILD/crypto/fipsmodule && /usr/bin/cc -arch arm64 -isysroot -c /Users/justsmth/repos/aws-lc/crypto/fipsmodule/fips_shared_library_marker.c -DAWSLC_FIPS_SHARED_END -o fips_apple_end.o
clang: warning: no such sysroot directory: '-c' [-Wmissing-sysroot]
/Users/justsmth/repos/aws-lc/crypto/fipsmodule/fips_shared_library_marker.c:17:10: fatal error: 'stdio.h' file not found
   17 | #include <stdio.h>
      |          ^~~~~~~~~
1 error generated.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
