### PR TITLE
Fix ternary operator in github workflow

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -245,7 +245,7 @@ jobs:
         run: |
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
-      - name: Setup ${{ (matrix.fips == 1 && '') || 'non-' }}FIPS Build
+      - name: Setup ${{ (matrix.fips == 1 && ' ') || 'non-' }}FIPS Build
         run:
           cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=${{matrix.fips}}
       - name: Build Project

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -245,7 +245,7 @@ jobs:
         run: |
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
-      - name: Setup ${{ (matrix.fips == 1 && ' ') || 'non-' }}FIPS Build
+      - name: Setup ${{ (matrix.fips == 1 && 'FIPS') || 'non-FIPS' }} Build
         run:
           cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=${{matrix.fips}}
       - name: Build Project


### PR DESCRIPTION
### Description of changes: 

The constructed ternary: `A && B || C` equivalent to `A ? B : C`. In Github action `B` must evaluate to True for this to work. See https://github.com/actions/runner/issues/409#issuecomment-752775072

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
