### PR TITLE
Update CPU Jitter Entropy dependency to version 3.6.3

### DIFF
--- a/third_party/jitterentropy/META.yml
+++ b/third_party/jitterentropy/META.yml
@@ -1,5 +1,5 @@
 name: jitterentropy-library
 source: smuellerDD/jitterentropy-library.git
-commit: c7ef53cb5cfb7d9c8b89fcd5ac10c331b8c57a5d
-target: master
-imported-at: 2025-04-17T21:42:50+0000
+commit: c90ff465dcdb6a6949542c72a26a8ab496daa8cb
+target: v3.6.3
+imported-at: 2025-09-03T21:55:42+0000

--- a/third_party/jitterentropy/jitterentropy-library/CHANGES.md
+++ b/third_party/jitterentropy/jitterentropy-library/CHANGES.md
@@ -1,5 +1,7 @@
 3.6.3
  * Correct time stamp processing on AIX
+ * Use high-resolution time stamp on Apple Silicon
+ * GCD power-up test: consider OSR
 
 3.6.2
  * Fix RCT re-initialization in jent_read_entropy_safe (thanks to Joshua Hill for pointing this out)


### PR DESCRIPTION
### Description of changes: 

Update CPU Jitter Entropy to a tagged release `v3.6.3`. Only introduces non-material changes and no code changes at all.
This aligns with ESV certificate #E280.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
