### PR TITLE
Fix benchmarking issues with FIPS main

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_arm_omnibus.yaml
@@ -412,7 +412,7 @@ batch:
           AWS_LC_SSL_RUNNER_START_INDEX: 4001
           AWS_LC_CI_TARGET: "tests/ci/run_ssl_runner_valgrind_tests.sh"
 
-    - identifier: ubuntu2004_clang7x_aarch_benchmark
+    - identifier: benchmarking_framework_aarch
       buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
       env:
         type: ARM_CONTAINER

--- a/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_linux_x86_omnibus.yaml
@@ -624,7 +624,7 @@ batch:
         variables:
           AWS_LC_CI_TARGET: "tests/ci/run_minimal_tests.sh"
 
-    - identifier: ubuntu2004_clang7x_x86_64_benchmark
+    - identifier: benchmarking_framework_x86_64
       buildspec: ./tests/ci/codebuild/common/run_simple_target.yml
       env:
         type: LINUX_CONTAINER

--- a/tests/ci/run_benchmark_build_tests.sh
+++ b/tests/ci/run_benchmark_build_tests.sh
@@ -85,6 +85,7 @@ run_build -DASAN=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DC
 aws-lc-fips-2021:${install_dir}/aws-lc-fips-2021-10-20;\
 aws-lc-fips-2022:${install_dir}/aws-lc-fips-2022-11-02;\
 aws-lc-fips-2024:${install_dir}/aws-lc-fips-2024-09-27;\
+aws-lc-fips-main:${install_dir}/aws-lc-fips;\
 open102:${install_dir}/openssl-${openssl_1_0_2_branch};\
 open111:${install_dir}/openssl-${openssl_1_1_1_branch};\
 open31:${install_dir}/openssl-${openssl_3_1_branch};\
@@ -94,7 +95,8 @@ boringssl:${install_dir}/boringssl;"
 
 LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2021-10-20/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2021" -timeout_ms 10 -chunks 1,2,16,256,20000
 LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2022-11-02/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10 -chunks 1,2,16,256,20000
-LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2024-09-27/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2022" -timeout_ms 10 -chunks 1,2,16,256,20000
+LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-2024-09-27/lib" "${BUILD_ROOT}/tool/aws-lc-fips-2024" -timeout_ms 10 -chunks 1,2,16,256,20000
+LD_LIBRARY_PATH="${install_dir}/aws-lc-fips-main/lib" "${BUILD_ROOT}/tool/aws-lc-fips-main" -timeout_ms 10 -chunks 1,2,16,256,20000
 LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_1_0_2_branch}/lib" "${BUILD_ROOT}/tool/open102" -timeout_ms 10 -chunks 1,2,16,256,20000
 LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_1_1_1_branch}/lib" "${BUILD_ROOT}/tool/open111" -timeout_ms 10 -chunks 1,2,16,256,20000
 LD_LIBRARY_PATH="${install_dir}/openssl-${openssl_3_1_branch}/lib64" "${BUILD_ROOT}/tool/open31" -timeout_ms 10 -chunks 1,2,16,256,20000

--- a/tool/speed.cc
+++ b/tool/speed.cc
@@ -39,6 +39,7 @@
 #if defined(OPENSSL_IS_AWSLC)
 #include "bssl_bm.h"
 #include "../crypto/internal.h"
+#include "../third_party/jitterentropy/jitterentropy-library/jitterentropy.h"
 #include <thread>
 #include <sstream>
 #elif defined(OPENSSL_IS_BORINGSSL)


### PR DESCRIPTION
### Issues:
Resolves `P296550391`

### Description of changes: 
Turns out we never run against FIPS with main in our own benchmarking CI tests. It took breaking the benchmarking canary for us to notice this. This PR fixes the issue and adds the CI code path to ensure that this doesn't break in the future. Also made some minor adjustments to fix naming misalignments and a bug where we weren't running the right benchmarking binary for the FIPS 2024 branch.

### Call-outs:
Original error:
```
o-omit-frame-pointer -O2 -g -DNDEBUG -fPIE -Wno-deprecated-declarations -std=gnu++17 -MD -MT tool/CMakeFiles/aws-lc-fips-main.dir/speed.cc.o -MF tool/CMakeFiles/aws-lc-fips-main.dir/speed.cc.o.d -o tool/CMakeFiles/aws-lc-fips-main.dir/speed.cc.o -c /home/ubuntu/workplace/aws-lc/tool/speed.cc
/home/ubuntu/workplace/aws-lc/tool/speed.cc:2509:65: error: use of undeclared identifier 'JENT_FORCE_FIPS'
  struct rand_data *jitter_ec = jent_entropy_collector_alloc(0, JENT_FORCE_FIPS);
                                                                ^
/home/ubuntu/workplace/aws-lc/tool/speed.cc:2516:13: error: use of undeclared identifier 'jent_read_entropy'
            jent_read_entropy(jitter_ec, input.get(), chunk_size);
            ^
/home/ubuntu/workplace/aws-lc/tool/speed.cc:2522:5: error: use of undeclared identifier 'jent_entropy_collector_free'
    jent_entropy_collector_free(jitter_ec);
    ^
/home/ubuntu/workplace/aws-lc/tool/speed.cc:2528:3: error: use of undeclared identifier 'jent_entropy_collector_free'
  jent_entropy_collector_free(jitter_ec);
  ^
4 errors generated.
[121/647] Building CXX object CMakeFiles/boringssl_gtest.dir/third_party/googletest/src/gtest-all.cc.o
ninja: build stopped: subcommand failed.
```

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
