### PR TITLE
Document and statically assert counters can't overflow

### DIFF
--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
@@ -74,6 +74,8 @@ struct tree_jitter_drbg_t {
 
   // reseed_calls_since_initialization is the number of seed/reseed calls made
   // on |drbg| since its initialization.
+  // We assume 2^64 - 1 is an upper bound on the number of reseeds. Type must
+  // support that.
   uint64_t reseed_calls_since_initialization;
 
   // generation_number caches the UBE generation number.

--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -45,6 +45,7 @@ struct ctr_drbg_state_st {
   uint8_t counter[16];
   uint64_t reseed_counter;
 };
+OPENSSL_STATIC_ASSERT((sizeof((struct ctr_drbg_state_st*)0)->reseed_counter) * 8 >= 48, value_can_overflow)
 
 // CTR_DRBG_init initialises |*drbg| given |CTR_DRBG_ENTROPY_LEN| bytes of
 // entropy in |entropy| and, optionally, a personalization string up to

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -24,6 +24,8 @@ struct rand_thread_local_state {
 
   // reseed_calls_since_initialization is the number of reseed calls made on
   // |drbg| since its initialization.
+  // We assume 2^64 - 1 is an upper bound on the number of reseeds. Type must
+  // support that.
   uint64_t reseed_calls_since_initialization;
 
   // generation_number caches the UBE generation number.
@@ -40,6 +42,7 @@ struct rand_thread_local_state {
   // process exit.
   CRYPTO_MUTEX state_clear_lock;
 };
+OPENSSL_STATIC_ASSERT((sizeof((struct rand_thread_local_state*)0)->generate_calls_since_seed) * 8 >= 48, value_can_overflow)
 
 DEFINE_BSS_GET(struct rand_thread_local_state *, thread_states_list_head)
 DEFINE_STATIC_MUTEX(thread_local_states_list_lock)


### PR DESCRIPTION
### Description of changes: 

2^48 is generally an upper bound on number of CTR-DRBG invocations without reseed. Statically assert type is large enough and for other counters document that 2^64 is the assumed strict upper bound.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
