### PR TITLE
Fix typo in ssl_transfer_asn1

### DIFF
--- a/ssl/ssl_transfer_asn1.cc
+++ b/ssl/ssl_transfer_asn1.cc
@@ -412,7 +412,7 @@ static int SSL3_STATE_to_bytes(SSL3_STATE *in, uint16_t protocol_version,
     }
 
     if (in->pending_hs_data &&
-        (in->pending_hs_data->length > 0 || in->pending_hs_data->length > 0)) {
+        (in->pending_hs_data->length > 0 || in->pending_hs_data->max > 0)) {
       if (!serialize_buf_mem(in->pending_hs_data, kS3PendingHsDataTag, s3)) {
         OPENSSL_PUT_ERROR(SSL, ERR_R_MALLOC_FAILURE);
         return 0;


### PR DESCRIPTION
### Issues:
Resolves `P297115000`

### Description of changes: 
Static analysis actually found something where the same condition was being checked twice.

### Call-outs:
N/A

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
