### PR TITLE
Fix for zig build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,7 +494,7 @@ if(GCC OR CLANG)
     endif()
   endif()
 
-  if(MINGW)
+  if(MINGW AND NOT CLANG)
     # Some MinGW compilers set _WIN32_WINNT to an older version (Windows Server 2003)
     # See: https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
     # Support Windows 7 and later.


### PR DESCRIPTION
### Issues
* aws/aws-lc-rs#512

### Description of changes: 
Zig compiler looks like both MINGW and CLANG. When building with zig, it fails due to the definition being set here:
```
...
  <command line>:9:9: error: '_WIN32_WINNT' macro redefined [-Werror,-Wmacro-redefined]
      9 | #define _WIN32_WINNT _WIN32_WINNT_WIN7
        |         ^
  <command line>:2:9: note: previous definition is here
      2 | #define _WIN32_WINNT 0x0a00
        |         ^
  In file included from <built-in>:416:
  <command line>:9:9: error: '_WIN32_WINNT' macro redefined [-Werror,-Wmacro-redefined]
      9 | #define _WIN32_WINNT _WIN32_WINNT_WIN7
        |         ^
  <command line>:2:9: note: previous definition is here
      2 | #define _WIN32_WINNT 0x0a00
        |         ^
  1 error generated.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
