### PR TITLE
Fix Keccak MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX flag

### DIFF
--- a/crypto/fipsmodule/sha/internal.h
+++ b/crypto/fipsmodule/sha/internal.h
@@ -342,14 +342,20 @@ void sha512_block_data_order_nohw(uint64_t state[8], const uint8_t *data,
                                   size_t num);
 #endif
 
-#if !defined(OPENSSL_NO_ASM) && \
-                    (defined(OPENSSL_AARCH64) || \
-                    (defined(OPENSSL_X86_64) && \
-                    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) && !defined(OPENSSL_WINDOWS)))
+#if !defined(OPENSSL_NO_ASM)
+#if defined(OPENSSL_AARCH64)
 #define KECCAK1600_ASM
 #if defined(OPENSSL_LINUX) || defined(OPENSSL_APPLE)
 #define KECCAK1600_S2N_BIGNUM_ASM
 #include "../../../third_party/s2n-bignum/s2n-bignum_aws-lc.h"
+#endif
+#endif
+#if defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
+#if defined(OPENSSL_LINUX) || defined(OPENSSL_APPLE)
+#define KECCAK1600_ASM
+#define KECCAK1600_S2N_BIGNUM_ASM
+#include "../../../third_party/s2n-bignum/s2n-bignum_aws-lc.h"
+#endif
 #endif
 #endif
 

--- a/crypto/fipsmodule/sha/internal.h
+++ b/crypto/fipsmodule/sha/internal.h
@@ -344,7 +344,8 @@ void sha512_block_data_order_nohw(uint64_t state[8], const uint8_t *data,
 
 #if !defined(OPENSSL_NO_ASM) && \
                     (defined(OPENSSL_AARCH64) || \
-                    (defined(OPENSSL_X86_64) && !defined(OPENSSL_WINDOWS)))
+                    (defined(OPENSSL_X86_64) && \
+                    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) && !defined(OPENSSL_WINDOWS)))
 #define KECCAK1600_ASM
 #if defined(OPENSSL_LINUX) || defined(OPENSSL_APPLE)
 #define KECCAK1600_S2N_BIGNUM_ASM

--- a/crypto/fipsmodule/sha/keccak1600.c
+++ b/crypto/fipsmodule/sha/keccak1600.c
@@ -371,8 +371,7 @@ void KeccakF1600(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS]) {
     keccak_log_dispatch(9); // kFlag_KeccakF1600_hw
     KeccakF1600_hw((uint64_t *) A);
 
-#elif defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) && \
-    defined(KECCAK1600_S2N_BIGNUM_ASM)
+#elif defined(OPENSSL_X86_64)
     sha3_keccak_f1600((uint64_t *)A, iotas);
 #endif
 }


### PR DESCRIPTION
### Issues:
Resolves #P299110829

### Description of changes: 
Update `KECCAK1600_ASM` for x86_64 platforms to only be defined when `!MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX`.

### Testing:
./crypto/crypto_test --gtest_filter=SHA3Test.*
./crypto/crypto_test --gtest_filter=All/PerKEMTest.KAT/*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
