### PR TITLE
Increase SSLBuffer size to INT_MAX

### DIFF
--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -1394,8 +1394,8 @@ enum SSL_BUFFER_SERDE_VERSION {
 const unsigned kSSLBufferMaxSerDeVersion = SSL_BUFFER_SERDE_VERSION_TWO;
 
 #define SSLBUFFER_READ_AHEAD_MIN_CAPACITY 512
-#define SSLBUFFER_MAX_CAPACITY UINT16_MAX
-class SSLBuffer {
+#define SSLBUFFER_MAX_CAPACITY INT_MAX
+class OPENSSL_EXPORT SSLBuffer {
  public:
   SSLBuffer() {}
   ~SSLBuffer() { Clear(); }
@@ -1461,11 +1461,11 @@ class SSLBuffer {
   // header length used to calculate initial offset
   size_t header_len_ = 0;
   // offset_ is the offset into |buf_| which the buffer contents start at, and is moved as contents are consumed
-  uint16_t offset_ = 0;
+  int offset_ = 0;
   // size_ is the size of the buffer contents from |buf_| + |offset_|.
-  uint16_t size_ = 0;
+  int size_ = 0;
   // cap_ is how much memory beyond |buf_| + |offset_| is available.
-  uint16_t cap_ = 0;
+  int cap_ = 0;
   // inline_buf_ is a static buffer for short reads.
   uint8_t inline_buf_[SSL3_RT_HEADER_LENGTH];
     

--- a/tests/ci/integration/run_curl_integration.sh
+++ b/tests/ci/integration/run_curl_integration.sh
@@ -32,7 +32,7 @@ cd ${SCRATCH_FOLDER}
 
 function curl_build() {
   autoreconf -fi
-  ./configure --enable-warnings --enable-werror --with-openssl=${AWS_LC_INSTALL_FOLDER} --without-libpsl
+  ./configure --enable-warnings --enable-werror --with-openssl=${AWS_LC_INSTALL_FOLDER} --without-libpsl --enable-debug
   make -j "$NUM_CPU_THREADS"
   make -j "$NUM_CPU_THREADS" examples
 }


### PR DESCRIPTION
### Issues:
Addresses https://github.com/aws/aws-lc/issues/2650

### Description of changes: 
Curl is setting a buffer size larger than the maximum buffer length that AWS-LC allows.  `0x401e * 4` is inherently `65656`, which is larger than the allowed `65535` and AWS-LC directly uses the largest size available (`65535`) if the consuming application sets a value larger than that. This limitation's due to a buffer size we inherited from upstream: https://github.com/aws/aws-lc/blob/5a834ecb8725fb4d5e00d43582d3604c1c92e6e7/ssl/ssl_buffer.cc#L32-L34.

I've tested against the test that was failing for curl and the test seems to pass now (for all instances I've ran it). Running `pytest -n auto -v ./http/test_10_proxy.py::TestProxy::test_10_08_upload_seq_large -rA` had been failing 5/10 times prior to this change and it passes every time that I run it now.
* https://github.com/curl/curl/blob/c70f7b7a7cdf04067ef2b4be8cc2d92996bdd36d/tests/http/test_10_proxy.py#L213

### Call-outs:
N/A

### Testing:
New serde tests and buffer limit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
