### PR TITLE
fix: Allow zero-length passwords in PEM key decryption

### DIFF
--- a/crypto/fipsmodule/evp/evp.c
+++ b/crypto/fipsmodule/evp/evp.c
@@ -171,7 +171,7 @@ int EVP_read_pw_string_min(char *buf, int min_length, int length,
   int ret = -1;
   char verify_buf[1024];
 
-  if (!buf || min_length <= 0 || min_length >= length) {
+  if (!buf || min_length < 0 || min_length >= length) {
     return -1;
   }
 

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -109,7 +109,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
       cb = PEM_def_callback;
     }
     int pass_len = cb(psbuf, PEM_BUFSIZE, 0, u);
-    if (pass_len <= 0) {
+    if (pass_len < 0) {
       OPENSSL_PUT_ERROR(PEM, PEM_R_BAD_PASSWORD_READ);
       X509_SIG_free(p8);
       goto err;


### PR DESCRIPTION
### Issues:
N/A - Update for password handling compatibility

### Description of changes:
Currently, AWS-LC rejects zero-length passwords in PEM key decryption by using '<= 0' validation in both EVP_read_pw_string_min and PEM_read_bio_PrivateKey functions. This differs from OpenSSL behavior and prevents proper interactive password prompting.

This change modifies the password length validation from '<= 0' to '< 0' in:
- crypto/fipsmodule/evp/evp.c: EVP_read_pw_string_min function
- crypto/pem/pem_pkey.c: PEM_read_bio_PrivateKey function

This enables proper interactive password prompting when no password is provided via -passin, allowing users to enter empty passwords or be prompted interactively for encrypted PEM keys, matching OpenSSL behavior.

### Call-outs:
This is a minimal change that only affects password length validation logic. The change maintains backward compatibility while enabling OpenSSL-compatible behavior for zero-length passwords.

### Testing:
The change has been tested to ensure that:
- Zero-length passwords are now accepted
- Interactive password prompting works correctly
- Existing functionality remains unaffected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.