### PR TITLE
Prepare AWS-LC v1.61.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0091 NEW)
 endif()
 
 set(SOFTWARE_NAME "awslc")
-set(SOFTWARE_VERSION "1.60.0")
+set(SOFTWARE_VERSION "1.61.0")
 set(ABI_VERSION 0)
 set(CRYPTO_LIB_NAME "crypto")
 set(SSL_LIB_NAME "ssl")

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.60.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.61.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Prepare AWS-LC v1.61.0.

### Changes
* Apply additional X509 validation checks on certificates sourced from trust store  by @skmcgrail in https://github.com/aws/aws-lc/pull/2230
* Reorganizing compatability tests, rework certificates for better groking by @skmcgrail in https://github.com/aws/aws-lc/pull/2305
* Additional X.509 Behavior Compatability Tests by @skmcgrail in https://github.com/aws/aws-lc/pull/2312
* Merge main into x509 by @skmcgrail in https://github.com/aws/aws-lc/pull/2351
* Add Support for IPv4 and IPv6 X.509 Certificate Name Constraints by @skmcgrail in https://github.com/aws/aws-lc/pull/2340
* Merge main to x509 by @skmcgrail in https://github.com/aws/aws-lc/pull/2390
* Reintroduce support for validating DNS commonName subjects when name constraints are present. by @skmcgrail in https://github.com/aws/aws-lc/pull/2376
* Support client-side hostname checks with leading . by @skmcgrail in https://github.com/aws/aws-lc/pull/2403
* Verify leaf certificate public key rather then leaving it to the caller by @skmcgrail in https://github.com/aws/aws-lc/pull/2438
* Merge main into x509 by @skmcgrail in https://github.com/aws/aws-lc/pull/2613
* Support for explicit curve parameter on EC public keys where parameters match supported curves by @skmcgrail in https://github.com/aws/aws-lc/pull/2642
* Add x86 Keccak implementation by @manastasova in https://github.com/aws/aws-lc/pull/2619
* Gate EC explicit curve parameters for X.509 behind flag by @skmcgrail in https://github.com/aws/aws-lc/pull/2648
* Update CPU Jitter Entropy dependency to version 3.6.3 by @torben-hansen in https://github.com/aws/aws-lc/pull/2654
* Fix benchmarking issues with FIPS main by @samuel40791765 in https://github.com/aws/aws-lc/pull/2655
* Add standalone MLKEM supported groups by @alexw91 in https://github.com/aws/aws-lc/pull/2589
* Merge main into x509 by @skmcgrail in https://github.com/aws/aws-lc/pull/2657
* Document and statically assert counters can't overflow by @torben-hansen in https://github.com/aws/aws-lc/pull/2658
* TLS Transfer Serialization Improvements by @skmcgrail in https://github.com/aws/aws-lc/pull/2616
* Fix ternary operator in github workflow by @torben-hansen in https://github.com/aws/aws-lc/pull/2653
* Merge x509 branch into main by @skmcgrail in https://github.com/aws/aws-lc/pull/2660
* Address clang-ci comments on new x509 code by @skmcgrail in https://github.com/aws/aws-lc/pull/2662
* Implement snapsafe fallback entropy source by @torben-hansen in https://github.com/aws/aws-lc/pull/2651
* Rand small fixes by @torben-hansen in https://github.com/aws/aws-lc/pull/2664
* Import s2n-bignum 2025-09-05-04 by @dkostic in https://github.com/aws/aws-lc/pull/2667
* Refactor iOS CI script by @justsmth in https://github.com/aws/aws-lc/pull/2637
* Re-import mlkem-native for addition of CFI directives by @hanno-becker in https://github.com/aws/aws-lc/pull/2659
* Fix typo in ssl_transfer_asn1 by @samuel40791765 in https://github.com/aws/aws-lc/pull/2665
* Fix for zig build by @justsmth in https://github.com/aws/aws-lc/pull/2668
* Update SSLProxy patch by @skmcgrail in https://github.com/aws/aws-lc/pull/2663
* ML-DSA service indicator by @jakemas in https://github.com/aws/aws-lc/pull/2666
* Add aes-xts AArch64 implementation that will eventually be imported from s2n-bignum. by @nebeid in https://github.com/aws/aws-lc/pull/2632
* Fix Keccak MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX flag by @manastasova in https://github.com/aws/aws-lc/pull/2670
* Increase SSLBuffer size to INT_MAX by @samuel40791765 in https://github.com/aws/aws-lc/pull/2673
* Wrap compiler when FIPS w/ clang v20+ by @justsmth in https://github.com/aws/aws-lc/pull/2671
* Test ACCP in FIPS mode as well as non-FIPS by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2669
* fix: Allow zero-length passwords in PEM key decryption by @kingstjo in https://github.com/aws/aws-lc/pull/2677

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
