### PR TITLE
Fix tests that assume X25519 will be negotiated

### DIFF
--- a/ssl/extensions.cc
+++ b/ssl/extensions.cc
@@ -312,6 +312,10 @@ static const uint16_t kDefaultGroups[] = {
     SSL_GROUP_SECP384R1,
 };
 
+Span<const uint16_t> tls1_get_default_grouplist(void) {
+  return Span<const uint16_t>(kDefaultGroups);
+}
+
 Span<const uint16_t> tls1_get_grouplist(const SSL_HANDSHAKE *hs) {
   if (!hs->config->supported_group_list.empty()) {
     return hs->config->supported_group_list;

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -3638,6 +3638,9 @@ bool tls1_change_cipher_state(SSL_HANDSHAKE *hs,
 int tls1_generate_master_secret(SSL_HANDSHAKE *hs, uint8_t *out,
                                 Span<const uint8_t> premaster);
 
+// tls1_get_default_grouplist returns the default group list
+OPENSSL_EXPORT Span<const uint16_t> tls1_get_default_grouplist(void);
+
 // tls1_get_grouplist returns the locally-configured group preference list.
 Span<const uint16_t> tls1_get_grouplist(const SSL_HANDSHAKE *ssl);
 

--- a/ssl/ssl_encoding_test.cc
+++ b/ssl/ssl_encoding_test.cc
@@ -342,6 +342,7 @@ static size_t GetClientHelloLen(uint16_t max_version, uint16_t session_version,
   bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
   if (!ssl || !SSL_set_session(ssl.get(), session.get()) ||
       !SSL_set_strict_cipher_list(ssl.get(), "ECDHE-RSA-AES128-GCM-SHA256") ||
+      !SSL_set1_curves_list(ssl.get(), "x25519:P-256:P-384") ||
       !SSL_set_max_proto_version(ssl.get(), max_version)) {
     return 0;
   }

--- a/ssl/ssl_version_test.cc
+++ b/ssl/ssl_version_test.cc
@@ -2328,7 +2328,29 @@ TEST_P(SSLVersionTest, PeerTmpKey) {
     GTEST_SKIP();
   }
 
-  // Default should be using X5519 as the key exchange.
+  ASSERT_TRUE(Connect());
+  for (SSL *ssl : {client_.get(), server_.get()}) {
+    SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
+    EVP_PKEY *key = nullptr;
+    uint16_t preferred_group = tls1_get_default_grouplist()[0];
+    if (getVersionParam().version == TLS1_3_VERSION && preferred_group == SSL_GROUP_X25519_MLKEM768) {
+      // TLS 1.3 default should be using X25519MLKEM768 as the key exchange.
+      // We expect SSL_R_UNKNOWN_KEY_EXCHANGE_TYPE because there is no EVP_PKEY type
+      // for hybrid keys, only individual X25519 or MLKEM768 keys.
+      ERR_clear_error();
+      EXPECT_FALSE(SSL_get_peer_tmp_key(ssl, &key));
+      ErrorEquals(ERR_get_error(), ERR_LIB_SSL, SSL_R_UNKNOWN_KEY_EXCHANGE_TYPE);
+    } else {
+      // Otherwise x25519 should be used
+      EXPECT_TRUE(preferred_group == SSL_GROUP_X25519);
+      EXPECT_TRUE(SSL_get_peer_tmp_key(ssl, &key));
+      EXPECT_EQ(EVP_PKEY_id(key), EVP_PKEY_X25519);
+      bssl::UniquePtr<EVP_PKEY> pkey(key);
+    }
+  }
+
+  // Check that x25519 works.
+  ASSERT_TRUE(SSL_CTX_set1_groups_list(server_ctx_.get(), "x25519"));
   ASSERT_TRUE(Connect());
   for (SSL *ssl : {client_.get(), server_.get()}) {
     SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");

--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -8697,8 +8697,12 @@ func addExtensionTests() {
 		},
 		// This hostname just needs to be long enough to push the
 		// ClientHello into F5's danger zone between 256 and 511 bytes
-		// long.
-		flags: []string{"-host-name", "01234567890123456789012345678901234567890123456789012345678901234567890123456789.com"},
+		// long. Also override curves to just x25519 to remove any PQ
+		// KeyShares that might push ClientHello above 512 bytes.
+		flags: []string{
+			"-host-name", "01234567890123456789012345678901234567890123456789012345678901234567890123456789.com",
+			"-curves", strconv.Itoa(int(CurveX25519)),
+		},
 	})
 
 	// Test that illegal extensions in TLS 1.3 are rejected by the client if


### PR DESCRIPTION
### Issues:

### Description of changes: 
Fixes tests that assume X25519 will be negotiated and will break when the default TLS supported group is changed to X25519MLKEM768. 

Related to https://github.com/aws/aws-lc/pull/2531/files

### Call-outs:
None

### Testing:
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
