### PR TITLE
[FIPS] Fix prefix jitterentropy

### DIFF
--- a/third_party/jitterentropy/CMakeLists.txt
+++ b/third_party/jitterentropy/CMakeLists.txt
@@ -35,7 +35,11 @@ else()
 endif()
 
 if(BORINGSSL_PREFIX)
-  set(JITTER_ENETROPY_PREFIX_INCLUDE "--include=${PROJECT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h")
+  if(MSVC)
+    set(JITTER_ENETROPY_PREFIX_INCLUDE "/FI ${PROJECT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h")
+  else()
+    set(JITTER_ENETROPY_PREFIX_INCLUDE "--include=${PROJECT_BINARY_DIR}/symbol_prefix_include/openssl/boringssl_prefix_symbols.h")
+  endif()
 endif()
 
 set(JITTER_COMPILE_FLAGS "${JITTER_COMPILE_FLAGS} ${JITTER_ENETROPY_PREFIX_INCLUDE}")


### PR DESCRIPTION
Cherry-picking to fips branch: https://github.com/aws/aws-lc/pull/2684
----
### Description of changes: 
For MSVC, the `/FI` option should be used for force-includes: https://learn.microsoft.com/en-us/cpp/build/reference/fi-name-forced-include-file?view=msvc-170

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
