### PR TITLE
Fix test issues with run_minimal_tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1301,18 +1301,18 @@ if(BUILD_TESTING)
     if(BUILD_LIBSSL)
       add_custom_target(
           run_minimal_tests
-          COMMAND crypto_test
-          COMMAND urandom_test
-          COMMAND ssl_test
-          WORKING_DIRECTORY ${AWSLC_SOURCE_DIR}
+          COMMAND crypto/crypto_test
+          COMMAND crypto/urandom_test
+          COMMAND ssl/ssl_test
+          WORKING_DIRECTORY ${AWSLC_BINARY_DIR}
           DEPENDS all_tests
           ${MAYBE_USES_TERMINAL})
     else()
       add_custom_command(
           run_minimal_tests
-          COMMAND crypto_test
-          COMMAND urandom_test
-          WORKING_DIRECTORY ${AWSLC_SOURCE_DIR}
+          COMMAND crypto/crypto_test
+          COMMAND crypto/urandom_test
+          WORKING_DIRECTORY ${AWSLC_BINARY_DIR}
           DEPENDS all_tests
           ${MAYBE_USES_TERMINAL}
       )


### PR DESCRIPTION
### Issues:
Addresses `AWS-LC-902`

### Description of changes: 
There were some issues with the 32-bit build run in https://github.com/aws/aws-lc/pull/2679, this attempts to resolve that.

### Call-outs:
N/A

### Testing:
Existing CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
