### PR TITLE
Windows/MSBuild doesn't provide 'all' target

### DIFF
--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -113,7 +113,7 @@ jobs:
           source-dir: 'path has spaces/aws-lc'
           build-dir: 'path has spaces/build'
       - name: Build Project
-        run: cmake --build "path has spaces/build" --target all
+        run: cmake --build "path has spaces/build" --target ssl
       - name: Run tests
         run: cmake --build "path has spaces/build" --target run_tests
       - name: Setup CMake FIPS


### PR DESCRIPTION
### Description of changes: 
The "all" target is not provided by some CMake generators.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
