### PR TITLE
crypto/pem: replace strncmp with CRYPTO_memcmp to fix -Wstring-compare error

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -679,7 +679,11 @@ int PEM_read_bio(BIO *bp, char **name, char **header, unsigned char **data,
     if (!BUF_MEM_grow(headerB, hl + i + 9)) {
       goto err;
     }
-    if (strncmp(buf, "-----END ", 9) == 0) {
+    // To resolve following error:
+    // /home/runner/work/aws-lc-rs/aws-lc-rs/aws-lc-sys/aws-lc/crypto/pem/pem_lib.c:707:11: error: 'strncmp' of strings of length 1 and 9 and bound of 9 evaluates to nonzero [-Werror=string-compare]
+    //       707 |       if (strncmp(buf, "-----END ", 9) == 0) {
+    //           |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    if (CRYPTO_memcmp(buf, "-----END ", 9) == 0) {
       nohead = 1;
       break;
     }
@@ -709,7 +713,7 @@ int PEM_read_bio(BIO *bp, char **name, char **header, unsigned char **data,
       if (i != 65) {
         end = 1;
       }
-      if (strncmp(buf, "-----END ", 9) == 0) {
+      if (CRYPTO_memcmp(buf, "-----END ", 9) == 0) {
         break;
       }
       if (i > 65) {
@@ -744,7 +748,7 @@ int PEM_read_bio(BIO *bp, char **name, char **header, unsigned char **data,
     bl = hl;
   }
   i = strlen(nameB->data);
-  if ((strncmp(buf, "-----END ", 9) != 0) ||
+  if ((CRYPTO_memcmp(buf, "-----END ", 9) != 0) ||
       (strncmp(nameB->data, &(buf[9]), i) != 0) ||
       (strncmp(&(buf[9 + i]), "-----\n", 6) != 0)) {
     OPENSSL_PUT_ERROR(PEM, PEM_R_BAD_END_LINE);


### PR DESCRIPTION

### Issues:
Resolves #2719 

### Description of changes: 
The code previously used:
    `if (strncmp(buf, "-----END ", 9) == 0) { ... }`
If buf is a string with length < 9, or even just one character, GCC knows at compile time that this comparison can never return 0 (i.e. never match). So, GCC is giving out a warning here.. But because of `-Werror=string-compare` this warning is getting converted to an error which causing build failures in some platforms like s390x and riscv64

### Testing:
Build Logs:
```
[root@b314lp50 build]# make -j$(nproc)
[  1%] Generating crypto_test_data.cc
[  1%] Building CXX object CMakeFiles/boringssl_gtest.dir/third_party/googletest/src/gtest-all.cc.o
[  1%] Built target boringssl_prefix_symbols
[  1%] Generating err_data.c
[  1%] Building C object third_party/jitterentropy/CMakeFiles/jitterentropy.dir/jitterentropy-library/src/jitterentropy-base.c.o
[  1%] Building C object third_party/jitterentropy/CMakeFiles/jitterentropy.dir/jitterentropy-library/src/jitterentropy-health.c.o
[  2%] Building C object third_party/jitterentropy/CMakeFiles/jitterentropy.dir/jitterentropy-library/src/jitterentropy-gcd.c.o
[  2%] Building C object crypto/fipsmodule/CMakeFiles/fipsmodule.dir/bcm.c.o
[  2%] Building C object third_party/jitterentropy/CMakeFiles/jitterentropy.dir/jitterentropy-library/src/jitterentropy-noise.c.o
[  2%] Building C object third_party/jitterentropy/CMakeFiles/jitterentropy.dir/jitterentropy-library/src/jitterentropy-sha3.c.o
[  2%] Building C object third_party/jitterentropy/CMakeFiles/jitterentropy.dir/jitterentropy-library/src/jitterentropy-timer.c.o
[  2%] Building C object crypto/fipsmodule/CMakeFiles/fipsmodule.dir/cpucap/cpucap.c.o
[  3%] Building C object crypto/fipsmodule/CMakeFiles/fipsmodule.dir/fips_shared_support.c.o
[  3%] Built target jitterentropy
[  3%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_bool.c.o
[  3%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_bitstr.c.o
[  4%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_dup.c.o
[  4%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_d2i_fp.c.o
[  4%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_i2d_fp.c.o
[  4%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_gentm.c.o
[  4%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_mbstr.c.o
[  4%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_int.c.o
[  5%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_object.c.o
[  5%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_strex.c.o
[  5%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_octet.c.o
[  5%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_strnid.c.o
[  5%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_time.c.o
[  5%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_utf8.c.o
[  6%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_type.c.o
[  6%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/asn1_lib.c.o
[  6%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/asn1_par.c.o
[  7%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/asn_pack.c.o
[  7%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/a_utctm.c.o
[  7%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/f_int.c.o
[  7%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/f_string.c.o
[  7%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/tasn_enc.c.o
[  7%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/tasn_dec.c.o
[  8%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/tasn_new.c.o
[  8%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/tasn_fre.c.o
[  8%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/tasn_utl.c.o
[  8%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/tasn_typ.c.o
[  8%] Building C object crypto/CMakeFiles/crypto_objects.dir/asn1/posix_time.c.o
[  8%] Building C object crypto/CMakeFiles/crypto_objects.dir/base64/base64.c.o
[  9%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/bio.c.o
[  9%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/bio_addr.c.o
[  9%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/bio_mem.c.o
[  9%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/connect.c.o
[  9%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/dgram.c.o
[ 10%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/errno.c.o
[ 10%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/fd.c.o
[ 10%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/md.c.o
[ 10%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/hexdump.c.o
[ 10%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/file.c.o
[ 10%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/pair.c.o
[ 11%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/printf.c.o
[ 11%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/socket.c.o
[ 11%] Building C object crypto/CMakeFiles/crypto_objects.dir/bio/socket_helper.c.o
[ 11%] Building C object crypto/CMakeFiles/crypto_objects.dir/blake2/blake2.c.o
[ 11%] Building C object crypto/CMakeFiles/crypto_objects.dir/bn_extra/bn_asn1.c.o
[ 11%] Building C object crypto/CMakeFiles/crypto_objects.dir/buf/buf.c.o
[ 11%] Building C object crypto/CMakeFiles/crypto_objects.dir/bytestring/asn1_compat.c.o
[ 11%] Building C object crypto/CMakeFiles/crypto_objects.dir/bytestring/ber.c.o
[ 11%] Building C object crypto/CMakeFiles/crypto_objects.dir/bytestring/unicode.c.o
[ 12%] Building C object crypto/CMakeFiles/crypto_objects.dir/bytestring/cbs.c.o
[ 12%] Building C object crypto/CMakeFiles/crypto_objects.dir/bytestring/cbb.c.o
[ 12%] Building C object crypto/CMakeFiles/crypto_objects.dir/chacha/chacha.c.o
[ 13%] Building C object crypto/CMakeFiles/crypto_objects.dir/bn_extra/convert.c.o
[ 13%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/cipher_extra.c.o
[ 13%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_aesctrhmac.c.o
[ 13%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/derive_key.c.o
[ 14%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_aesgcmsiv.c.o
[ 14%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_chacha20poly1305.c.o
[ 14%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_aes_cbc_hmac_sha1.c.o
[ 14%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_aes_cbc_hmac_sha256.c.o
[ 14%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_des.c.o
[ 15%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_null.c.o
[ 15%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_rc2.c.o
[ 15%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_rc4.c.o
[ 15%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/e_tls.c.o
[ 16%] Building C object crypto/CMakeFiles/crypto_objects.dir/conf/conf.c.o
[ 16%] Building C object crypto/CMakeFiles/crypto_objects.dir/console/console.c.o
[ 16%] Building C object crypto/CMakeFiles/crypto_objects.dir/cipher_extra/tls_cbc.c.o
[ 16%] Building C object crypto/CMakeFiles/crypto_objects.dir/crypto.c.o
[ 16%] Building C object crypto/CMakeFiles/crypto_objects.dir/des/des.c.o
[ 16%] Building C object crypto/CMakeFiles/crypto_objects.dir/dh_extra/params.c.o
[ 17%] Building C object crypto/CMakeFiles/crypto_objects.dir/dh_extra/dh_asn1.c.o
[ 17%] Building C object crypto/CMakeFiles/crypto_objects.dir/digest_extra/digest_extra.c.o
[ 17%] Building C object crypto/CMakeFiles/crypto_objects.dir/dsa/dsa.c.o
[ 17%] Building C object crypto/CMakeFiles/crypto_objects.dir/dsa/dsa_asn1.c.o
[ 17%] Building C object crypto/CMakeFiles/crypto_objects.dir/ecdh_extra/ecdh_extra.c.o
[ 17%] Building C object crypto/CMakeFiles/crypto_objects.dir/ecdsa_extra/ecdsa_asn1.c.o
[ 18%] Building C object crypto/CMakeFiles/crypto_objects.dir/ec_extra/ec_asn1.c.o
[ 18%] Building C object crypto/CMakeFiles/crypto_objects.dir/ec_extra/hash_to_curve.c.o
[ 18%] Building C object crypto/CMakeFiles/crypto_objects.dir/ec_extra/ec_derive.c.o
[ 18%] Building C object crypto/CMakeFiles/crypto_objects.dir/err_data.c.o
[ 19%] Building C object crypto/CMakeFiles/crypto_objects.dir/engine/engine.c.o
[ 19%] Building C object crypto/CMakeFiles/crypto_objects.dir/err/err.c.o
[ 19%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/evp_asn1.c.o
[ 19%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_dh_asn1.c.o
[ 19%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_dh.c.o
[ 19%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_dsa.c.o
[ 19%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_ec_asn1.c.o
[ 20%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_dsa_asn1.c.o
[ 20%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_ed25519_asn1.c.o
[ 20%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_hmac_asn1.c.o
[ 20%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_kem_asn1.c.o
[ 20%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_pqdsa_asn1.c.o
[ 21%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_rsa_asn1.c.o
[ 21%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_x25519.c.o
[ 21%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_x25519_asn1.c.o
[ 21%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/p_methods.c.o
[ 22%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/scrypt.c.o
[ 22%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/print.c.o
[ 22%] Building C object crypto/CMakeFiles/crypto_objects.dir/evp_extra/sign.c.o
[ 22%] Building C object crypto/CMakeFiles/crypto_objects.dir/ex_data.c.o
[ 22%] Building C object crypto/CMakeFiles/crypto_objects.dir/hrss/hrss.c.o
[ 22%] Building C object crypto/CMakeFiles/crypto_objects.dir/kyber/pqcrystals_kyber_ref_common/fips202.c.o
[ 23%] Building C object crypto/CMakeFiles/crypto_objects.dir/kyber/kyber512r3_ref.c.o
[ 23%] Building C object crypto/CMakeFiles/crypto_objects.dir/kyber/kem_kyber.c.o
[ 23%] Building C object crypto/CMakeFiles/crypto_objects.dir/kyber/kyber768r3_ref.c.o
[ 23%] Building C object crypto/CMakeFiles/crypto_objects.dir/kyber/kyber1024r3_ref.c.o
[ 23%] Building C object crypto/CMakeFiles/crypto_objects.dir/lhash/lhash.c.o
[ 23%] Building C object crypto/CMakeFiles/crypto_objects.dir/hpke/hpke.c.o
[ 24%] Building C object crypto/CMakeFiles/crypto_objects.dir/mem.c.o
[ 24%] Building C object crypto/CMakeFiles/crypto_objects.dir/obj/obj.c.o
[ 24%] Building C object crypto/CMakeFiles/crypto_objects.dir/obj/obj_xref.c.o
[ 24%] Building C object crypto/CMakeFiles/crypto_objects.dir/ocsp/ocsp_client.c.o
[ 24%] Building C object crypto/CMakeFiles/crypto_objects.dir/ocsp/ocsp_asn.c.o
[ 25%] Building C object crypto/CMakeFiles/crypto_objects.dir/ocsp/ocsp_extension.c.o
[ 25%] Building C object crypto/CMakeFiles/crypto_objects.dir/ocsp/ocsp_http.c.o
[ 25%] Building C object crypto/CMakeFiles/crypto_objects.dir/ocsp/ocsp_lib.c.o
[ 26%] Building C object crypto/CMakeFiles/crypto_objects.dir/ocsp/ocsp_verify.c.o
[ 26%] Building C object crypto/CMakeFiles/crypto_objects.dir/ocsp/ocsp_print.c.o
[ 26%] Building C object crypto/CMakeFiles/crypto_objects.dir/pem/pem_all.c.o
[ 26%] Building C object crypto/CMakeFiles/crypto_objects.dir/ocsp/ocsp_server.c.o
[ 26%] Building C object crypto/CMakeFiles/crypto_objects.dir/pem/pem_info.c.o
[ 26%] Building C object crypto/CMakeFiles/crypto_objects.dir/pem/pem_oth.c.o
[ 26%] Building C object crypto/CMakeFiles/crypto_objects.dir/pem/pem_lib.c.o
[ 27%] Building C object crypto/CMakeFiles/crypto_objects.dir/pem/pem_pk8.c.o
[ 27%] Building C object crypto/CMakeFiles/crypto_objects.dir/pem/pem_pkey.c.o
[ 27%] Building C object crypto/CMakeFiles/crypto_objects.dir/pem/pem_x509.c.o
[ 27%] Building C object crypto/CMakeFiles/crypto_objects.dir/pem/pem_xaux.c.o
[ 27%] Building C object crypto/CMakeFiles/crypto_objects.dir/pkcs7/pkcs7.c.o
[ 27%] Building C object crypto/CMakeFiles/crypto_objects.dir/pkcs7/bio/cipher.c.o
[ 28%] Building C object crypto/CMakeFiles/crypto_objects.dir/pkcs7/pkcs7_asn1.c.o
[ 28%] Building C object crypto/CMakeFiles/crypto_objects.dir/pkcs7/pkcs7_x509.c.o
[ 28%] Building C object crypto/CMakeFiles/crypto_objects.dir/pkcs8/pkcs8.c.o
[ 29%] Building C object crypto/CMakeFiles/crypto_objects.dir/poly1305/poly1305.c.o
[ 29%] Building C object crypto/CMakeFiles/crypto_objects.dir/pkcs8/pkcs8_x509.c.o
[ 29%] Building C object crypto/CMakeFiles/crypto_objects.dir/pkcs8/p5_pbev2.c.o
[ 29%] Building C object crypto/CMakeFiles/crypto_objects.dir/pool/pool.c.o
[ 29%] Building C object crypto/CMakeFiles/crypto_objects.dir/poly1305/poly1305_arm.c.o
[ 29%] Building C object crypto/CMakeFiles/crypto_objects.dir/poly1305/poly1305_vec.c.o
[ 29%] Building C object crypto/CMakeFiles/crypto_objects.dir/rand_extra/ccrandomgeneratebytes.c.o
[ 30%] Building C object crypto/CMakeFiles/crypto_objects.dir/rand_extra/deterministic.c.o
[ 30%] Building C object crypto/CMakeFiles/crypto_objects.dir/rand_extra/getentropy.c.o
[ 30%] Building C object crypto/CMakeFiles/crypto_objects.dir/rand_extra/snapsafe_fallback.c.o
[ 30%] Building C object crypto/CMakeFiles/crypto_objects.dir/rand_extra/rand_extra.c.o
[ 30%] Building C object crypto/CMakeFiles/crypto_objects.dir/rand_extra/windows.c.o
[ 30%] Building C object crypto/CMakeFiles/crypto_objects.dir/rand_extra/urandom.c.o
[ 30%] Building C object crypto/CMakeFiles/crypto_objects.dir/refcount_c11.c.o
[ 30%] Building C object crypto/CMakeFiles/crypto_objects.dir/refcount_lock.c.o
[ 31%] Building C object crypto/CMakeFiles/crypto_objects.dir/rc4/rc4.c.o
[ 31%] Building C object crypto/CMakeFiles/crypto_objects.dir/refcount_win.c.o
[ 31%] Building C object crypto/CMakeFiles/crypto_objects.dir/rsa_extra/rsa_asn1.c.o
[ 32%] Building C object crypto/CMakeFiles/crypto_objects.dir/rsa_extra/rsassa_pss_asn1.c.o
[ 32%] Building C object crypto/CMakeFiles/crypto_objects.dir/rsa_extra/rsa_crypt.c.o
[ 32%] Building C object crypto/CMakeFiles/crypto_objects.dir/stack/stack.c.o
[ 32%] Building C object crypto/CMakeFiles/crypto_objects.dir/rsa_extra/rsa_print.c.o
[ 32%] Building C object crypto/CMakeFiles/crypto_objects.dir/siphash/siphash.c.o
[ 32%] Building C object crypto/CMakeFiles/crypto_objects.dir/thread.c.o
[ 33%] Building C object crypto/CMakeFiles/crypto_objects.dir/spake25519/spake25519.c.o
[ 33%] Building C object crypto/CMakeFiles/crypto_objects.dir/thread_none.c.o
[ 33%] Building C object crypto/CMakeFiles/crypto_objects.dir/thread_win.c.o
[ 33%] Building C object crypto/CMakeFiles/crypto_objects.dir/thread_pthread.c.o
[ 33%] Building C object crypto/CMakeFiles/crypto_objects.dir/trust_token/pmbtoken.c.o
[ 34%] Building C object crypto/CMakeFiles/crypto_objects.dir/trust_token/trust_token.c.o
[ 34%] Building C object crypto/CMakeFiles/crypto_objects.dir/trust_token/voprf.c.o
[ 34%] Building C object crypto/CMakeFiles/crypto_objects.dir/ube/ube.c.o
[ 34%] Building C object crypto/CMakeFiles/crypto_objects.dir/ube/fork_detect.c.o
[ 34%] Building C object crypto/CMakeFiles/crypto_objects.dir/ube/snapsafe_detect.c.o
[ 35%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/a_digest.c.o
[ 35%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/a_sign.c.o
[ 35%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/algorithm.c.o
[ 35%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/a_verify.c.o
[ 35%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/asn1_gen.c.o
[ 36%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/by_dir.c.o
[ 36%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/by_file.c.o
[ 36%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/i2d_pr.c.o
[ 36%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/name_print.c.o
[ 36%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/policy.c.o
[ 37%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/rsa_pss.c.o
[ 37%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/t_crl.c.o
[ 37%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/t_req.c.o
[ 37%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/t_x509.c.o
[ 37%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/t_x509a.c.o
[ 37%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_akey.c.o
[ 38%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_akeya.c.o
[ 38%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_alt.c.o
[ 38%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_bitst.c.o
[ 38%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_bcons.c.o
[ 38%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_conf.c.o
[ 39%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_cpols.c.o
[ 39%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_crld.c.o
[ 39%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_enum.c.o
[ 39%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_extku.c.o
[ 39%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_genn.c.o
[ 40%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_ia5.c.o
[ 40%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_info.c.o
[ 40%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_int.c.o
[ 40%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_lib.c.o
[ 40%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_ncons.c.o
[ 40%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_ocsp.c.o
[ 41%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_pcons.c.o
[ 41%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_pmaps.c.o
[ 41%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_prn.c.o
[ 41%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_purp.c.o
[ 41%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_skey.c.o
[ 42%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/v3_utl.c.o
[ 42%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_algor.c.o
[ 42%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_all.c.o
[ 42%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_attrib.c.o
[ 42%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_crl.c.o
[ 42%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_name.c.o
[ 43%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_exten.c.o
[ 43%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_req.c.o
[ 43%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_pubkey.c.o
[ 43%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_sig.c.o
[ 43%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_spki.c.o
[ 43%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_x509.c.o
[ 44%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_val.c.o
[ 44%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x_x509a.c.o
[ 44%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_att.c.o
[ 44%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_cmp.c.o
[ 45%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_d2.c.o
[ 45%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_def.c.o
[ 45%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_lu.c.o
[ 45%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_ext.c.o
[ 45%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_obj.c.o
[ 46%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_req.c.o
[ 46%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_set.c.o
[ 46%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_trs.c.o
[ 46%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_txt.c.o
[ 46%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_v3.c.o
[ 46%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_vpm.c.o
[ 47%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509_vfy.c.o
[ 47%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509.c.o
[ 47%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509cset.c.o
[ 47%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509name.c.o
[ 47%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509rset.c.o
[ 48%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/bio/base64_bio.c.o
[ 48%] Building C object crypto/CMakeFiles/crypto_objects.dir/x509/x509spki.c.o
[ 48%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/blowfish/blowfish.c.o
[ 48%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/cast/cast.c.o
[ 48%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/cast/cast_tables.c.o
[ 49%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/cfb/cfb.c.o
[ 49%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/dh/dh_decrepit.c.o
[ 49%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/evp/evp_do_all.c.o
[ 49%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/obj/obj_decrepit.c.o
[ 49%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/ripemd/ripemd.c.o
[ 50%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/rsa/rsa_decrepit.c.o
[ 50%] Building C object crypto/CMakeFiles/crypto_objects.dir/decrepit/x509/x509_decrepit.c.o
[ 50%] Built target crypto_objects
[ 50%] Building CXX object CMakeFiles/crypto_test_data.dir/crypto_test_data.cc.o
[ 50%] Linking CXX static library libboringssl_gtest.a
[ 50%] Built target boringssl_gtest
[ 50%] Built target fipsmodule
[ 50%] Linking C static library libcrypto.a
[ 50%] Built target crypto
[ 50%] Building CXX object crypto/test/CMakeFiles/test_support_lib.dir/abi_test.cc.o
[ 50%] Building C object crypto/CMakeFiles/dynamic_loading_test.dir/dynamic_loading_test.c.o
[ 50%] Building CXX object crypto/test/CMakeFiles/test_support_lib.dir/test_util.cc.o
[ 50%] Building CXX object crypto/CMakeFiles/rwlock_static_init.dir/rwlock_static_init.cc.o
[ 50%] Building CXX object crypto/test/CMakeFiles/test_support_lib.dir/file_test.cc.o
[ 50%] Building CXX object crypto/test/CMakeFiles/test_support_lib.dir/malloc.cc.o
[ 50%] Building CXX object crypto/test/CMakeFiles/test_support_lib.dir/wycheproof_util.cc.o
[ 51%] Building CXX object ssl/CMakeFiles/ssl.dir/bio_ssl.cc.o
[ 51%] Building CXX object ssl/CMakeFiles/ssl.dir/custom_extensions.cc.o
[ 51%] Building CXX object ssl/CMakeFiles/ssl.dir/d1_both.cc.o
[ 51%] Building CXX object ssl/CMakeFiles/ssl.dir/d1_pkt.cc.o
[ 51%] Building CXX object ssl/CMakeFiles/ssl.dir/d1_lib.cc.o
[ 52%] Building CXX object ssl/CMakeFiles/ssl.dir/d1_srtp.cc.o
[ 52%] Building CXX object ssl/CMakeFiles/ssl.dir/dtls_method.cc.o
[ 52%] Building CXX object ssl/CMakeFiles/ssl.dir/dtls_record.cc.o
[ 52%] Building CXX object ssl/CMakeFiles/ssl.dir/encrypted_client_hello.cc.o
[ 52%] Building CXX object ssl/CMakeFiles/ssl.dir/handoff.cc.o
[ 53%] Building CXX object ssl/CMakeFiles/ssl.dir/handshake_client.cc.o
[ 53%] Building CXX object ssl/CMakeFiles/ssl.dir/handshake.cc.o
[ 53%] Building CXX object ssl/CMakeFiles/ssl.dir/handshake_server.cc.o
[ 53%] Building CXX object ssl/CMakeFiles/ssl.dir/s3_both.cc.o
[ 53%] Building CXX object ssl/CMakeFiles/ssl.dir/extensions.cc.o
[ 53%] Building CXX object ssl/CMakeFiles/ssl.dir/s3_lib.cc.o
[ 53%] Linking C executable dynamic_loading_test
[ 53%] Built target dynamic_loading_test
[ 54%] Building CXX object ssl/CMakeFiles/ssl.dir/s3_pkt.cc.o
[ 54%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_aead_ctx.cc.o
[ 54%] Linking CXX executable rwlock_static_init
[ 54%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_asn1.cc.o
[ 54%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_buffer.cc.o
[ 54%] Built target rwlock_static_init
[ 54%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_cert.cc.o
[ 55%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_cipher.cc.o
[ 55%] Building C object ssl/CMakeFiles/ssl.dir/ssl_decrepit.c.o
[ 55%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_file.cc.o
[ 55%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_key_share.cc.o
[ 55%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_lib.cc.o
[ 55%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_privkey.cc.o
[ 56%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_session.cc.o
[ 56%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_stat.cc.o
[ 56%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_transcript.cc.o
[ 56%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_text.cc.o
[ 56%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_transfer_asn1.cc.o
[ 57%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_versions.cc.o
[ 57%] Building CXX object ssl/CMakeFiles/ssl.dir/ssl_x509.cc.o
[ 57%] Building CXX object ssl/CMakeFiles/ssl.dir/tls_method.cc.o
[ 57%] Building CXX object ssl/CMakeFiles/ssl.dir/t1_enc.cc.o
[ 57%] Building CXX object ssl/CMakeFiles/ssl.dir/tls_record.cc.o
[ 57%] Building CXX object ssl/CMakeFiles/ssl.dir/tls13_client.cc.o
[ 58%] Building CXX object ssl/CMakeFiles/ssl.dir/tls13_both.cc.o
[ 58%] Building CXX object ssl/CMakeFiles/ssl.dir/tls13_enc.cc.o
[ 58%] Building CXX object ssl/CMakeFiles/ssl.dir/tls13_server.cc.o
[ 59%] Linking CXX static library libtest_support_lib.a
[ 59%] Built target test_support_lib
[ 59%] Building CXX object crypto/test/CMakeFiles/boringssl_gtest_main.dir/gtest_main.cc.o
[ 59%] Building CXX object crypto/CMakeFiles/urandom_test.dir/rand_extra/urandom_test.cc.o
[ 59%] Built target crypto_test_data
[ 59%] Linking CXX static library libboringssl_gtest_main.a
[ 59%] Linking CXX static library libssl.a
[ 59%] Built target boringssl_gtest_main
[ 60%] Linking CXX executable urandom_test
[ 60%] Building CXX object crypto/CMakeFiles/mem_set_test.dir/mem_set_test.cc.o
[ 60%] Building CXX object crypto/CMakeFiles/mem_test.dir/mem_test.cc.o
[ 60%] Building CXX object crypto/CMakeFiles/rand_isolated_test.dir/fipsmodule/rand/rand_isolated_test.cc.o
[ 60%] Building CXX object crypto/CMakeFiles/tree_drbg_jitter_entropy_isolated_test.dir/fipsmodule/rand/entropy/tree_drbg_jitter_entropy_isolated_test.cc.o
[ 60%] Building CXX object crypto/CMakeFiles/crypto_test.dir/base64/base64_test.cc.o
[ 60%] Building CXX object crypto/CMakeFiles/crypto_test.dir/abi_self_test.cc.o
[ 60%] Building CXX object crypto/CMakeFiles/crypto_test.dir/asn1/asn1_test.cc.o
[ 60%] Building CXX object crypto/CMakeFiles/crypto_test.dir/bio/bio_md_test.cc.o
[ 60%] Building CXX object crypto/CMakeFiles/crypto_test.dir/bio/bio_socket_test.cc.o
[ 61%] Building CXX object crypto/CMakeFiles/crypto_test.dir/bio/bio_test.cc.o
[ 61%] Building CXX object crypto/CMakeFiles/crypto_test.dir/buf/buf_test.cc.o
[ 61%] Building CXX object crypto/CMakeFiles/crypto_test.dir/bytestring/bytestring_test.cc.o
[ 61%] Building CXX object crypto/CMakeFiles/crypto_test.dir/cipher_extra/cipher_test.cc.o
[ 62%] Building CXX object crypto/CMakeFiles/crypto_test.dir/cipher_extra/aead_test.cc.o
[ 62%] Building CXX object crypto/CMakeFiles/crypto_test.dir/compiler_test.cc.o
[ 62%] Building CXX object crypto/CMakeFiles/crypto_test.dir/conf/conf_test.cc.o
[ 62%] Building CXX object crypto/CMakeFiles/crypto_test.dir/chacha/chacha_test.cc.o
[ 62%] Building CXX object crypto/CMakeFiles/crypto_test.dir/constant_time_test.cc.o
[ 63%] Building CXX object crypto/CMakeFiles/crypto_test.dir/console/console_test.cc.o
[ 63%] Building CXX object crypto/CMakeFiles/crypto_test.dir/crypto_test.cc.o
[ 63%] Building CXX object crypto/CMakeFiles/crypto_test.dir/blake2/blake2_test.cc.o
[ 63%] Building CXX object crypto/CMakeFiles/crypto_test.dir/ecdh_extra/ecdh_test.cc.o
[ 63%] Built target urandom_test
[ 63%] Building CXX object crypto/CMakeFiles/crypto_test.dir/decrepit/blowfish/blowfish_test.cc.o
[ 63%] Built target ssl
[ 64%] Building CXX object ssl/CMakeFiles/integration_test.dir/__/crypto/ocsp/ocsp_integration_test.cc.o
[ 65%] Linking CXX executable mem_set_test
[ 65%] Building CXX object crypto/CMakeFiles/crypto_test.dir/decrepit/cast/cast_test.cc.o
[ 66%] Building CXX object crypto/CMakeFiles/crypto_test.dir/decrepit/cfb/cfb_test.cc.o
[ 66%] Building CXX object crypto/CMakeFiles/crypto_test.dir/decrepit/evp/evp_test.cc.o
[ 66%] Building CXX object crypto/CMakeFiles/crypto_test.dir/decrepit/ripemd/ripemd_test.cc.o
[ 66%] Building CXX object crypto/CMakeFiles/crypto_test.dir/dh_extra/dh_test.cc.o
[ 66%] Linking CXX executable mem_test
[ 66%] Building CXX object crypto/CMakeFiles/crypto_test.dir/digest_extra/digest_test.cc.o
[ 67%] Building CXX object crypto/CMakeFiles/crypto_test.dir/dsa/dsa_test.cc.o
[ 67%] Building CXX object crypto/CMakeFiles/crypto_test.dir/des/des_test.cc.o
[ 67%] Built target mem_set_test
[ 68%] Building CXX object ssl/CMakeFiles/ssl_test.dir/__/crypto/test/file_util.cc.o
[ 68%] Built target mem_test
[ 68%] Building CXX object ssl/test/CMakeFiles/bssl_shim.dir/async_bio.cc.o
[ 68%] Linking CXX executable rand_isolated_test
[ 68%] Building CXX object crypto/CMakeFiles/crypto_test.dir/endian_test.cc.o
[ 68%] Building CXX object ssl/test/CMakeFiles/bssl_shim.dir/bssl_shim.cc.o
[ 68%] Building CXX object ssl/CMakeFiles/ssl_test.dir/span_test.cc.o
[ 68%] Building CXX object ssl/test/CMakeFiles/bssl_shim.dir/handshake_util.cc.o
[ 68%] Linking CXX executable tree_drbg_jitter_entropy_isolated_test
[ 68%] Built target rand_isolated_test
[ 68%] Building CXX object crypto/CMakeFiles/crypto_test.dir/evp_extra/evp_extra_test.cc.o
[ 68%] Building CXX object crypto/CMakeFiles/crypto_test.dir/err/err_test.cc.o
[ 69%] Building CXX object crypto/CMakeFiles/crypto_test.dir/evp_extra/evp_test.cc.o
[ 69%] Building CXX object ssl/test/CMakeFiles/handshaker.dir/async_bio.cc.o
[ 69%] Building CXX object crypto/CMakeFiles/crypto_test.dir/evp_extra/p_pqdsa_test.cc.o
[ 69%] Building CXX object ssl/CMakeFiles/integration_test.dir/__/tool/transport_common.cc.o
[ 69%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_test.cc.o
[ 69%] Built target tree_drbg_jitter_entropy_isolated_test
[ 69%] Building CXX object ssl/CMakeFiles/integration_test.dir/__/tool/fd.cc.o
[ 69%] Building CXX object tool/CMakeFiles/bssl.dir/args.cc.o
[ 69%] Building CXX object ssl/test/CMakeFiles/handshaker.dir/handshake_util.cc.o
[ 69%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/__/tool/args.cc.o
[ 69%] Building CXX object crypto/CMakeFiles/crypto_test.dir/evp_extra/p_kem_test.cc.o
[ 69%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/__/tool/file.cc.o
[ 70%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/__/tool/fd.cc.o
[ 71%] Building CXX object tool/CMakeFiles/bssl.dir/ciphers.cc.o
[ 71%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/__/tool/client.cc.o
[ 71%] Building CXX object crypto/CMakeFiles/crypto_test.dir/evp_extra/scrypt_test.cc.o
[ 71%] Building CXX object tool/CMakeFiles/bssl.dir/client.cc.o
[ 71%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fips_callback_test.cc.o
[ 71%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_client_hello_test.cc.o
[ 72%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/aes/aes_test.cc.o
[ 72%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/bn/bn_test.cc.o
[ 72%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/bn/bn_assert_test.cc.o
[ 72%] Building CXX object tool/CMakeFiles/bssl.dir/const.cc.o
[ 72%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/cmac/cmac_test.cc.o
[ 72%] Building CXX object ssl/test/CMakeFiles/bssl_shim.dir/mock_quic_transport.cc.o
[ 72%] Building C object ssl/CMakeFiles/ssl_test.dir/ssl_c_test.c.o
[ 72%] Linking CXX executable integration_test
[ 72%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/curve25519/ed25519_test.cc.o
[ 72%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/__/tool/transport_common.cc.o
[ 72%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_key_share_test.cc.o
[ 72%] Building CXX object tool/CMakeFiles/bssl.dir/digest.cc.o
[ 72%] Building CXX object ssl/test/CMakeFiles/handshaker.dir/handshaker.cc.o
[ 72%] Building CXX object tool/CMakeFiles/bssl.dir/fd.cc.o
[ 72%] Building CXX object ssl/test/CMakeFiles/handshaker.dir/mock_quic_transport.cc.o
[ 73%] Building CXX object ssl/test/CMakeFiles/bssl_shim.dir/packeted_bio.cc.o
[ 73%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/curve25519/x25519_test.cc.o
[ 73%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/crl.cc.o
[ 74%] Building CXX object tool/CMakeFiles/bssl.dir/file.cc.o
[ 74%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/dgst.cc.o
[ 75%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/ec/ec_test.cc.o
[ 76%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/pkcs8.cc.o
[ 76%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/pkey.cc.o
[ 76%] Building CXX object ssl/test/CMakeFiles/bssl_shim.dir/settings_writer.cc.o
[ 76%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/rehash.cc.o
[ 76%] Built target integration_test
[ 76%] Building CXX object ssl/test/CMakeFiles/bssl_shim.dir/ssl_transfer.cc.o
[ 76%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/ec/p256-nistz_test.cc.o
[ 76%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/ecdsa/ecdsa_test.cc.o
[ 76%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/evp/evp_ctx_test.cc.o
[ 77%] Building CXX object ssl/test/CMakeFiles/handshaker.dir/packeted_bio.cc.o
[ 77%] Building CXX object tool/CMakeFiles/bssl.dir/generate_ech.cc.o
[ 77%] Building CXX object ssl/test/CMakeFiles/bssl_shim.dir/test_config.cc.o
[ 77%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/kdf/kdf_test.cc.o
[ 78%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_alps_test.cc.o
[ 79%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/md5/md5_test.cc.o
[ 79%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_common_test.cc.o
[ 79%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_misc_test.cc.o
[ 79%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/req.cc.o
[ 79%] Building CXX object ssl/test/CMakeFiles/bssl_shim.dir/test_state.cc.o
[ 79%] Building CXX object ssl/test/CMakeFiles/handshaker.dir/settings_writer.cc.o
[ 79%] Building CXX object ssl/test/CMakeFiles/handshaker.dir/test_config.cc.o
[ 79%] Building CXX object ssl/test/CMakeFiles/handshaker.dir/test_state.cc.o
[ 79%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/ml_kem/ml_kem_test.cc.o
[ 79%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/ordered_args.cc.o
[ 80%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/rsa.cc.o
[ 80%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/modes/gcm_test.cc.o
[ 80%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/modes/xts_test.cc.o
[ 80%] Building CXX object tool/CMakeFiles/bssl.dir/generate_ed25519.cc.o
[ 80%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/pbkdf/pbkdf_test.cc.o
[ 81%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/rand/ctrdrbg_test.cc.o
[ 81%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/rand/cpu_jitter_test.cc.o
[ 81%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/s_client.cc.o
[ 81%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/tool.cc.o
[ 81%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/verify.cc.o
[ 81%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/rand/rand_test.cc.o
[ 81%] Building CXX object tool/CMakeFiles/bssl.dir/genrsa.cc.o
[ 81%] Building CXX object tool/CMakeFiles/bssl.dir/pkcs12.cc.o
[ 81%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_version_test.cc.o
[ 82%] Building CXX object tool/CMakeFiles/bssl.dir/rand.cc.o
[ 82%] Building CXX object tool/CMakeFiles/bssl.dir/server.cc.o
[ 82%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_ech_test.cc.o
[ 82%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/version.cc.o
[ 82%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/rand/entropy/entropy_source_test.cc.o
[ 82%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/service_indicator/service_indicator_test.cc.o
[ 82%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/sha/sha_test.cc.o
[ 83%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/sha/sha3_test.cc.o
[ 84%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_quic_test.cc.o
[ 84%] Building CXX object tool-openssl/CMakeFiles/openssl.dir/x509.cc.o
[ 84%] Building CXX object tool/CMakeFiles/bssl.dir/sign.cc.o
[ 84%] Building CXX object tool/CMakeFiles/bssl.dir/speed.cc.o
[ 84%] Building CXX object tool/CMakeFiles/bssl.dir/tool.cc.o
[ 84%] Building CXX object tool/CMakeFiles/bssl.dir/transport_common.cc.o
[ 85%] Linking CXX executable bssl_shim
[ 85%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_hybrid_handshake_test.cc.o
[ 85%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/cpucap/cpu_arm_linux_test.cc.o
[ 85%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/cpucap/cpu_aarch64_dit_test.cc.o
[ 85%] Built target bssl_shim
[ 85%] Linking CXX executable handshaker
[ 85%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_encoding_test.cc.o
[ 85%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/hkdf/hkdf_test.cc.o
[ 85%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_ciphers_test.cc.o
[ 85%] Building CXX object crypto/CMakeFiles/crypto_test.dir/fipsmodule/sshkdf/sshkdf_test.cc.o
[ 86%] Building CXX object crypto/CMakeFiles/crypto_test.dir/hpke/hpke_test.cc.o
[ 86%] Building CXX object crypto/CMakeFiles/crypto_test.dir/hmac_extra/hmac_test.cc.o
[ 86%] Building CXX object ssl/CMakeFiles/ssl_test.dir/ssl_handshake_test.cc.o
[ 86%] Building CXX object crypto/CMakeFiles/crypto_test.dir/hrss/hrss_test.cc.o
[ 86%] Building CXX object crypto/CMakeFiles/crypto_test.dir/impl_dispatch_test.cc.o
[ 87%] Linking CXX executable openssl
[ 87%] Building CXX object crypto/CMakeFiles/crypto_test.dir/lhash/lhash_test.cc.o
[ 88%] Building CXX object crypto/CMakeFiles/crypto_test.dir/obj/obj_test.cc.o
[ 88%] Built target handshaker
[ 88%] Building CXX object crypto/CMakeFiles/crypto_test.dir/ocsp/ocsp_test.cc.o
[ 88%] Building CXX object crypto/CMakeFiles/crypto_test.dir/pem/pem_test.cc.o
[ 88%] Building CXX object crypto/CMakeFiles/crypto_test.dir/pkcs7/bio/bio_cipher_test.cc.o
[ 88%] Built target openssl
[ 88%] Building CXX object crypto/CMakeFiles/crypto_test.dir/pkcs7/pkcs7_test.cc.o
[ 88%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/__/tool/args.cc.o
[ 88%] Building CXX object crypto/CMakeFiles/crypto_test.dir/pkcs8/pkcs8_test.cc.o
[ 88%] Building CXX object crypto/CMakeFiles/crypto_test.dir/poly1305/poly1305_test.cc.o
[ 89%] Building CXX object crypto/CMakeFiles/crypto_test.dir/pkcs8/pkcs12_test.cc.o
[ 89%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/__/tool/file.cc.o
[ 89%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/__/tool/fd.cc.o
[ 89%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/__/crypto/test/test_util.cc.o
[ 89%] Building CXX object crypto/CMakeFiles/crypto_test.dir/pool/pool_test.cc.o
[ 89%] Building CXX object crypto/CMakeFiles/crypto_test.dir/rand_extra/ccrandomgeneratebytes_test.cc.o
[ 89%] Building CXX object crypto/CMakeFiles/crypto_test.dir/rand_extra/getentropy_test.cc.o
[ 90%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/__/tool/client.cc.o
[ 91%] Building CXX object crypto/CMakeFiles/crypto_test.dir/rand_extra/snapsafe_fallback_test.cc.o
[ 91%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/__/tool/transport_common.cc.o
[ 91%] Building CXX object crypto/CMakeFiles/crypto_test.dir/refcount_test.cc.o
[ 91%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/crl.cc.o
[ 91%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/crl_test.cc.o
[ 91%] Building CXX object crypto/CMakeFiles/crypto_test.dir/rsa_extra/rsa_test.cc.o
[ 91%] Building CXX object crypto/CMakeFiles/crypto_test.dir/rsa_extra/rsassa_pss_asn1_test.cc.o
[ 91%] Building CXX object crypto/CMakeFiles/crypto_test.dir/self_test.cc.o
[ 92%] Building CXX object crypto/CMakeFiles/crypto_test.dir/stack/stack_test.cc.o
[ 92%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/dgst.cc.o
[ 92%] Building CXX object crypto/CMakeFiles/crypto_test.dir/siphash/siphash_test.cc.o
[ 92%] Building CXX object crypto/CMakeFiles/crypto_test.dir/spake25519/spake25519_test.cc.o
[ 93%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/dgst_test.cc.o
[ 93%] Building CXX object crypto/CMakeFiles/crypto_test.dir/test/file_util.cc.o
[ 93%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/pkcs8.cc.o
[ 93%] Building CXX object crypto/CMakeFiles/crypto_test.dir/test/file_test_gtest.cc.o
[ 93%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/pkcs8_test.cc.o
[ 94%] Building CXX object crypto/CMakeFiles/crypto_test.dir/test/x509_util.cc.o
[ 94%] Building CXX object crypto/CMakeFiles/crypto_test.dir/thread_test.cc.o
[ 94%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/pkey.cc.o
[ 94%] Building CXX object crypto/CMakeFiles/crypto_test.dir/trust_token/trust_token_test.cc.o
[ 95%] Linking CXX executable bssl
[ 95%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/pkey_test.cc.o
[ 95%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/rehash.cc.o
[ 96%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/rehash_test.cc.o
[ 96%] Building CXX object crypto/CMakeFiles/crypto_test.dir/ube/fork_detect_test.cc.o
[ 96%] Building CXX object crypto/CMakeFiles/crypto_test.dir/ube/ube_test.cc.o
[ 96%] Built target bssl
[ 96%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/req.cc.o
[ 96%] Building CXX object crypto/CMakeFiles/crypto_test.dir/ube/snapsafe_detect_test.cc.o
[ 97%] Building CXX object crypto/CMakeFiles/crypto_test.dir/x509/tab_test.cc.o
[ 97%] Building CXX object crypto/CMakeFiles/crypto_test.dir/x509/x509_test.cc.o
[ 97%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/req_test.cc.o
[ 97%] Building CXX object crypto/CMakeFiles/crypto_test.dir/x509/x509_compat_test.cc.o
[ 97%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/rsa.cc.o
[ 97%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/rsa_test.cc.o
[ 97%] Building CXX object crypto/CMakeFiles/crypto_test.dir/x509/x509_time_test.cc.o
[ 98%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/s_client.cc.o
[ 98%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/ordered_args.cc.o
[ 98%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/verify.cc.o
[ 98%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/verify_test.cc.o
[ 98%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/x509.cc.o
[ 99%] Linking CXX executable ssl_test
[100%] Building CXX object tool-openssl/CMakeFiles/tool_openssl_test.dir/x509_test.cc.o
[100%] Built target ssl_test
[100%] Linking CXX executable tool_openssl_test
[100%] Built target tool_openssl_test
[100%] Linking CXX executable crypto_test
[100%] Built target crypto_test
```

To verify the build I ran the following test
```
[root@b314lp50 build]#  ./crypto/crypto_test --gtest_filter=EndianTest.*
Note: Google Test filter = EndianTest.*
[==========] Running 20 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 20 tests from EndianTest
[ RUN      ] EndianTest.u16Operations
[       OK ] EndianTest.u16Operations (0 ms)
[ RUN      ] EndianTest.u32Operations
[       OK ] EndianTest.u32Operations (0 ms)
[ RUN      ] EndianTest.u64Operations
[       OK ] EndianTest.u64Operations (0 ms)
[ RUN      ] EndianTest.wordOperations
[       OK ] EndianTest.wordOperations (0 ms)
[ RUN      ] EndianTest.TestRotate32
[       OK ] EndianTest.TestRotate32 (0 ms)
[ RUN      ] EndianTest.TestRotate64
[       OK ] EndianTest.TestRotate64 (0 ms)
[ RUN      ] EndianTest.TestStructUnion
[       OK ] EndianTest.TestStructUnion (0 ms)
[ RUN      ] EndianTest.Shifting
[       OK ] EndianTest.Shifting (0 ms)
[ RUN      ] EndianTest.Swap
[       OK ] EndianTest.Swap (0 ms)
[ RUN      ] EndianTest.BN_bin2bn
[       OK ] EndianTest.BN_bin2bn (0 ms)
[ RUN      ] EndianTest.BN_le2bn
[       OK ] EndianTest.BN_le2bn (0 ms)
[ RUN      ] EndianTest.BN_le2bn_255
[       OK ] EndianTest.BN_le2bn_255 (0 ms)
[ RUN      ] EndianTest.BN_bn2bin
[       OK ] EndianTest.BN_bn2bin (0 ms)
[ RUN      ] EndianTest.BN_bn2le_padded
[       OK ] EndianTest.BN_bn2le_padded (0 ms)
[ RUN      ] EndianTest.BN_bn2le_padded_255
[       OK ] EndianTest.BN_bn2le_padded_255 (0 ms)
[ RUN      ] EndianTest.BN_bn2le_padded_much
[       OK ] EndianTest.BN_bn2le_padded_much (0 ms)
[ RUN      ] EndianTest.BN_bn2bin_padded
[       OK ] EndianTest.BN_bn2bin_padded (0 ms)
[ RUN      ] EndianTest.AES
[       OK ] EndianTest.AES (0 ms)
[ RUN      ] EndianTest.memcpy
[       OK ] EndianTest.memcpy (0 ms)
[ RUN      ] EndianTest.masking
[       OK ] EndianTest.masking (0 ms)
[----------] 20 tests from EndianTest (0 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 20 tests.
```

```
[root@b314lp50 build]# ./crypto/crypto_test --gtest_filter=BNTest.*
Note: Google Test filter = BNTest.*
[==========] Running 39 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 39 tests from BNTest
[ RUN      ] BNTest.ExpTestVectors
[       OK ] BNTest.ExpTestVectors (1 ms)
[ RUN      ] BNTest.GCDTestVectors
[       OK ] BNTest.GCDTestVectors (11529 ms)
[ RUN      ] BNTest.ModExpTestVectors
[       OK ] BNTest.ModExpTestVectors (54271 ms)
[ RUN      ] BNTest.ModExp2TestVectors
[       OK ] BNTest.ModExp2TestVectors (5836 ms)
[ RUN      ] BNTest.ModInvTestVectors
[       OK ] BNTest.ModInvTestVectors (2124 ms)
[ RUN      ] BNTest.ModMulTestVectors
[       OK ] BNTest.ModMulTestVectors (407 ms)
[ RUN      ] BNTest.ModSqrtTestVectors
[       OK ] BNTest.ModSqrtTestVectors (77 ms)
[ RUN      ] BNTest.ProductTestVectors
[       OK ] BNTest.ProductTestVectors (235 ms)
[ RUN      ] BNTest.QuotientTestVectors
[       OK ] BNTest.QuotientTestVectors (3629 ms)
[ RUN      ] BNTest.ShiftTestVectors
[       OK ] BNTest.ShiftTestVectors (34 ms)
[ RUN      ] BNTest.SumTestVectors
[       OK ] BNTest.SumTestVectors (106 ms)
[ RUN      ] BNTest.BN2BinPadded
[       OK ] BNTest.BN2BinPadded (39 ms)
[ RUN      ] BNTest.LittleEndian
[       OK ] BNTest.LittleEndian (0 ms)
[ RUN      ] BNTest.Dec2BN
[       OK ] BNTest.Dec2BN (0 ms)
[ RUN      ] BNTest.Hex2BN
[       OK ] BNTest.Hex2BN (0 ms)
[ RUN      ] BNTest.ASC2BN
[       OK ] BNTest.ASC2BN (0 ms)
[ RUN      ] BNTest.MPI
[       OK ] BNTest.MPI (0 ms)
[ RUN      ] BNTest.Rand
[       OK ] BNTest.Rand (7491 ms)
[ RUN      ] BNTest.RandRange
[       OK ] BNTest.RandRange (123 ms)
[ RUN      ] BNTest.ASN1
[       OK ] BNTest.ASN1 (0 ms)
[ RUN      ] BNTest.NegativeZero
[       OK ] BNTest.NegativeZero (0 ms)
[ RUN      ] BNTest.BadModulus
[       OK ] BNTest.BadModulus (0 ms)
[ RUN      ] BNTest.ExpZeroModOne
[       OK ] BNTest.ExpZeroModOne (0 ms)
[ RUN      ] BNTest.SmallPrime
[       OK ] BNTest.SmallPrime (3 ms)
[ RUN      ] BNTest.CmpWord
[       OK ] BNTest.CmpWord (0 ms)
[ RUN      ] BNTest.BN2Dec
[       OK ] BNTest.BN2Dec (0 ms)
[ RUN      ] BNTest.SetGetU64
[       OK ] BNTest.SetGetU64 (0 ms)
[ RUN      ] BNTest.Pow2
[       OK ] BNTest.Pow2 (57 ms)
[ RUN      ] BNTest.PrimeChecking
[       OK ] BNTest.PrimeChecking (66022 ms)
[ RUN      ] BNTest.MillerRabinIteration
[       OK ] BNTest.MillerRabinIteration (335 ms)
[ RUN      ] BNTest.NumBitsWord
[       OK ] BNTest.NumBitsWord (4 ms)
[ RUN      ] BNTest.LessThanWords
[       OK ] BNTest.LessThanWords (6 ms)
[ RUN      ] BNTest.NonMinimal
[       OK ] BNTest.NonMinimal (0 ms)
[ RUN      ] BNTest.CountLowZeroBits
[       OK ] BNTest.CountLowZeroBits (4 ms)
[ RUN      ] BNTest.WriteIntoNegative
[       OK ] BNTest.WriteIntoNegative (0 ms)
[ RUN      ] BNTest.ModSqrtInvalid
[       OK ] BNTest.ModSqrtInvalid (0 ms)
[ RUN      ] BNTest.MontgomeryLarge
[       OK ] BNTest.MontgomeryLarge (0 ms)
[ RUN      ] BNTest.FormatWord
[       OK ] BNTest.FormatWord (0 ms)
[ RUN      ] BNTest.GetMinimalWidth
[       OK ] BNTest.GetMinimalWidth (0 ms)
[----------] 39 tests from BNTest (152334 ms total)

[----------] Global test environment tear-down
[==========] 39 tests from 1 test suite ran. (152334 ms total)
[  PASSED  ] 39 tests.

  YOU HAVE 1 DISABLED TEST
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
