### PR TITLE
Add CI dimensions for legacy AVX512 flags

### DIFF
--- a/.github/workflows/linux_x86_omnibus.yml
+++ b/.github/workflows/linux_x86_omnibus.yml
@@ -465,3 +465,41 @@ jobs:
         with:
           image: ${{ steps.ecr.outputs.AWS_ECR_REPO_LINUX_X86 }}:${{ matrix.image }}
           run: ./tests/ci/run_fips_callback_tests.sh
+
+  legacy_avx_tests:
+    name: legacy-avx-${{ matrix.image }}-${{ matrix.build32 && 'x86' || 'x86_64' }}
+    runs-on:
+      - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
+        image:linux-5.0
+        instance-size:large 
+        buildspec-override:true
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - centos-7_gcc-4x_latest
+          - centos-8_gcc-8x_latest
+          - amazonlinux-2_gcc-7x_latest
+          - ubuntu-16.04_gcc-5x_latest
+          - ubuntu-18.04_clang-6x_latest
+        build32: [0]
+        include:
+          - image: centos-7_gcc-4x_latest
+            build32: 1
+          - image: ubuntu-16.04_gcc-5x_latest
+            build32: 1
+    steps:
+      - uses: actions/checkout@v5
+      - name: Get ECR Repository URL
+        id: ecr
+        run: echo AWS_ECR_REPO_LINUX_X86=${AWS_ECR_REPO_LINUX_X86} >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/codebuild-docker-run
+        name: Run Container (${{ matrix.image }})
+        env:
+          AWSLC_32BIT: ${{ matrix.build32 || 0 }}
+        with:
+          image: ${{ steps.ecr.outputs.AWS_ECR_REPO_LINUX_X86 }}:${{ matrix.image }}
+          env: |
+            AWSLC_32BIT
+          run: ./tests/ci/run_legacy_avx_tests.sh
+          options: --privileged

--- a/tests/ci/run_legacy_avx_tests.sh
+++ b/tests/ci/run_legacy_avx_tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -exo pipefail
+
+source tests/ci/common_posix_setup.sh
+
+# Lightly verify that uncommon build options does not break the build. First
+# define a list of typical build options to verify the special build option with
+build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DENABLE_PRE_SONAME_BUILD=0")
+
+## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
+for build_option in "${build_options_to_test[@]}"; do
+  build_and_test ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
+done
+
+## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+for build_option in "${build_options_to_test[@]}"; do
+  build_and_test ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON
+done
+
+# When Go is disabled, a different test target is produced
+build_and_run_minimal_test -DDISABLE_PERL=ON -DDISABLE_GO=ON -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
+build_and_run_minimal_test -DDISABLE_PERL=ON -DDISABLE_GO=ON -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON

--- a/tests/ci/run_posix_tests.sh
+++ b/tests/ci/run_posix_tests.sh
@@ -36,17 +36,3 @@ build_and_test -DDISABLE_PERL=ON
 
 echo "Testing building with AArch64 Data-Independent Timing (DIT) on."
 build_and_test -DENABLE_DATA_INDEPENDENT_TIMING=ON -DCMAKE_BUILD_TYPE=Release
-
-# Lightly verify that uncommon build options does not break the build. Fist
-# define a list of typical build options to verify the special build option with
-build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DDISABLE_PERL=ON -DDISABLE_GO=ON" "-DENABLE_PRE_SONAME_BUILD=0")
-
-## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
-for build_option in "${build_options_to_test[@]}"; do
-  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
-done
-
-## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-for build_option in "${build_options_to_test[@]}"; do
-  run_build ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON
-done


### PR DESCRIPTION
### Issues:
`P299607876`

### Description of changes: 
 We were previously only running the build, but not tests when options MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX or MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX were enabled. This PR moves this testing to its own dimension and enables running the tests.

Instead of the "run_tests" target, when GO is disabled, "run_tests_minimal" is produced. Refactors to support this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
