### PR TITLE
Prepare v1.62.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0091 NEW)
 endif()
 
 set(SOFTWARE_NAME "awslc")
-set(SOFTWARE_VERSION "1.61.4")
+set(SOFTWARE_VERSION "1.62.0")
 set(ABI_VERSION 0)
 set(CRYPTO_LIB_NAME "crypto")
 set(SSL_LIB_NAME "ssl")

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.61.4"
+#define AWSLC_VERSION_NUMBER_STRING "1.62.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Prepare v1.62.0 release

#### What's Changed
* nginx now supports AWS-LC by @samuel40791765 in https://github.com/aws/aws-lc/pull/2714
* Fix tests that assume X25519 will be negotiated by @alexw91 in https://github.com/aws/aws-lc/pull/2682
* Fixing a bug in ML-DSA poly_uniform function by @dkostic in https://github.com/aws/aws-lc/pull/2721
* Migrate integration omnibus by @skmcgrail in https://github.com/aws/aws-lc/pull/2715
* Delete util/bot directory by @justsmth in https://github.com/aws/aws-lc/pull/2723
* Don't ignore CMAKE_C_FLAGS w/ MSVC by @justsmth in https://github.com/aws/aws-lc/pull/2722
* Bump urllib3 from 2.2.3 to 2.5.0 in /tests/ci by @dependabot[bot] in https://github.com/aws/aws-lc/pull/2551
* Type fix in mldsa by @manastasova in https://github.com/aws/aws-lc/pull/2308
* Centralize password handling tool-openssl by @kingstjo in https://github.com/aws/aws-lc/pull/2555
* crypto/pem: replace strncmp with CRYPTO_memcmp to fix -Wstring-compare error by @R3hankhan123 in https://github.com/aws/aws-lc/pull/2724
* Implement dgst CLI command by @nhatnghiho in https://github.com/aws/aws-lc/pull/2638
* Add ASN.1 decoding for ML-KEM private keys as seeds by @jakemas in https://github.com/aws/aws-lc/pull/2707
* Implement genrsa command by @kingstjo in https://github.com/aws/aws-lc/pull/2535
* Move udiv and sencond tweak calculations to when needed by @nebeid in https://github.com/aws/aws-lc/pull/2726
* Add null check on RSA key checks by @samuel40791765 in https://github.com/aws/aws-lc/pull/2727
* Implement workaround for FORTIFY_SOURCE warning with jitterentropy by @skmcgrail in https://github.com/aws/aws-lc/pull/2728
* Implement coverity suggestions by @skmcgrail in https://github.com/aws/aws-lc/pull/2730
* Add minimal EC CLI tool implementation by @kingstjo in https://github.com/aws/aws-lc/pull/2640
* Adding pkeyutl tool to the CLI by @smittals2 in https://github.com/aws/aws-lc/pull/2575
* Add CI dimensions for legacy AVX512 flags by @smittals2 in https://github.com/aws/aws-lc/pull/2732
* Fix Libwebsockets CI by @smittals2 in https://github.com/aws/aws-lc/pull/2737
* Add option ENABLE_SOURCE_MODIFICATION by @justsmth in https://github.com/aws/aws-lc/pull/2739
* Simple script to build/run tests by @justsmth in https://github.com/aws/aws-lc/pull/2736
* Add build-time option to opt-out of CPU Jitter Entropy by @torben-hansen in https://github.com/aws/aws-lc/pull/2733


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
