### PR TITLE
Add OPENSSL_NO_UI_CONSOLE macro

### DIFF
--- a/include/openssl/opensslconf.h
+++ b/include/openssl/opensslconf.h
@@ -75,6 +75,7 @@ extern "C" {
 #define OPENSSL_NO_STATIC_ENGINE
 #define OPENSSL_NO_STORE
 #define OPENSSL_NO_TS
+#define OPENSSL_NO_UI_CONSOLE
 #define OPENSSL_NO_WHIRLPOOL
 
 


### PR DESCRIPTION
### Issues:
`CryptoAlg-3367`

### Description of changes: 
Add OPENSSL_NO_UI_CONSOLE macro to enable conditionals disabling UI support by default in consumer libraries.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
