### PR TITLE
AWS CodeBuild Fleets Setup

### DIFF
--- a/tests/ci/cdk/cdk/aws_lc_codebuild_fleets.py
+++ b/tests/ci/cdk/cdk/aws_lc_codebuild_fleets.py
@@ -1,0 +1,209 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+import pathlib
+import typing
+from typing import Dict, Optional
+
+from aws_cdk import (
+    aws_codebuild as codebuild,
+    aws_ec2 as ec2,
+    Environment,
+    Stack,
+    Tags
+)
+from constructs import Construct
+
+from util.fleet_config_loader import (
+    FleetConfigLoader,
+    FleetConfiguration,
+    FleetConfigurationFile,
+    validate_fleet_config
+)
+
+
+class CodeBuildFleet(Construct):
+    """A construct that creates and manages a single CodeBuild fleet with scaling configuration."""
+    
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        fleet_config: FleetConfiguration,
+        **kwargs
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+        
+        self.fleet_config = fleet_config
+        self.fleet_name = fleet_config.name
+        
+        # Create the CodeBuild fleet
+        self.fleet = self._create_fleet()
+        
+        # Configure auto-scaling if enabled
+        if fleet_config.scaling_configuration.enabled:
+            self._configure_scaling()
+        
+        # Apply tags
+        self._apply_tags()
+    
+    def _create_fleet(self) -> codebuild.IFleet:
+        """Create the CodeBuild fleet based on configuration."""
+        fleet_props = {
+            "fleet_name": self.fleet_name,
+            "base_capacity": self.fleet_config.base_capacity,
+            "environment_type": self._get_environment_type(),
+        }
+        
+        # Add compute configuration based on type
+        compute_config = self._get_compute_configuration()
+        fleet_props.update(compute_config)
+        
+        fleet_props["overflow_behavior"] = codebuild.FleetOverflowBehavior.QUEUE
+
+        fleet = codebuild.Fleet(self, f"{self.fleet_name}-Fleet", **fleet_props)
+                
+        return fleet
+    
+    def _get_environment_type(self) -> str:
+        """Get the CDK environment type from configuration."""
+        return codebuild.EnvironmentType[self.fleet_config.environment_type]
+    
+    def _get_compute_configuration(self) -> Dict[str, typing.Any]:
+        """Get the compute configuration for the fleet based on type."""
+        config = self.fleet_config
+        
+        if config.compute_type:
+            # Fixed compute type (e.g., BUILD_GENERAL1_SMALL)
+            return {
+                "compute_type": codebuild.FleetComputeType[config.compute_type],
+            }
+        elif config.custom_instance_type:
+            # Custom instance type (e.g., m5.large)
+            return {
+                "compute_type": codebuild.FleetComputeType.CUSTOM_INSTANCE_TYPE,
+                "compute_configuration": {
+                    "instance_type": ec2.InstanceType(config.custom_instance_type),
+                },
+            }
+        elif config.attribute_based_compute:
+            # Attribute-based compute with specific requirements
+            attr = config.attribute_based_compute
+            return {
+                "compute_type": codebuild.FleetComputeType.ATTRIBUTE_BASED,  # Base type for attribute-based
+                "compute_configuration": {
+                    "vcpus": attr.vcpus,
+                    "memory": attr.memory,
+                    "disk": attr.storage
+                },
+            }
+        else:
+            raise ValueError(f"No compute type specified for fleet {self.fleet_name}")
+    
+    def _configure_scaling(self) -> None:
+        """Configure auto-scaling for the fleet."""
+        scaling_config = self.fleet_config.scaling_configuration
+        
+        if not scaling_config.enabled:
+            return
+        
+        fleet_cn: codebuild.CfnFleet = self.fleet.node.default_child
+
+        optional_props = {}
+
+        if scaling_config.utilization_rate:
+            optional_props["target_tracking_scaling_configs"] = \
+                [codebuild.CfnFleet.TargetTrackingScalingConfigurationProperty(
+                    metric_type="FLEET_UTILIZATION_RATE",
+                    target_value=scaling_config.utilization_rate)]
+
+        scaling_configuration_input = codebuild.CfnFleet.ScalingConfigurationInputProperty(
+            scaling_type="TARGET_TRACKING_SCALING",
+            max_capacity=scaling_config.max_capacity,
+            **optional_props,
+        )
+
+        fleet_cn.scaling_configuration = scaling_configuration_input
+            
+    def _apply_tags(self) -> None:
+        """Apply tags to the fleet and related resources."""
+        for key, value in self.fleet_config.tags.items():
+            Tags.of(self).add(key, value)
+
+
+class AwsLcCodeBuildFleets(Stack):
+    """CDK Stack for managing multiple CodeBuild fleets with configurable compute types and scaling."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        env: typing.Union[Environment, typing.Dict[str, typing.Any]],
+        config_path: Optional[str] = None,
+        **kwargs
+    ) -> None:
+        super().__init__(scope, id, env=env, **kwargs)
+        
+        # Load configuration
+        self.config = self._load_configuration(config_path)
+        
+        # Validate all fleet configurations
+        self._validate_configurations()
+        
+        # Create fleets
+        self.fleets: Dict[str, CodeBuildFleet] = {}
+        self._create_fleets()
+    
+    def _load_configuration(self, config_path: Optional[str]) -> FleetConfigurationFile:
+        """Load fleet configuration from YAML file."""
+        if config_path:
+            config_file_path = pathlib.Path(config_path)
+        else:
+            config_file_path = FleetConfigLoader.get_default_config_path()
+        
+        try:
+            return FleetConfigLoader.load_config(config_file_path)
+        except Exception as e:
+            raise ValueError(f"Failed to load fleet configuration: {e}")
+    
+    def _validate_configurations(self) -> None:
+        """Validate all fleet configurations."""
+        all_errors = []
+        fleet_names = set()
+        
+        for fleet_config in self.config.fleets:
+            # Check for duplicate fleet names
+            if fleet_config.name in fleet_names:
+                all_errors.append(f"Duplicate fleet name: {fleet_config.name}")
+            fleet_names.add(fleet_config.name)
+            
+            # Validate individual fleet configuration
+            errors = validate_fleet_config(fleet_config)
+            all_errors.extend(errors)
+        
+        if all_errors:
+            error_message = "Fleet configuration validation failed:\n" + "\n".join(all_errors)
+            raise ValueError(error_message)
+    
+    def _create_fleets(self) -> None:
+        """Create all CodeBuild fleets based on configuration."""
+        for fleet_config in self.config.fleets:
+            fleet_construct = CodeBuildFleet(
+                self,
+                f"aws-lc-fleet-{fleet_config.name}",
+                fleet_config=fleet_config
+            )
+            
+            self.fleets[fleet_config.name] = fleet_construct
+    
+    def get_fleet_arn(self, fleet_name: str) -> str:
+        """Get the ARN of a specific fleet."""
+        if fleet_name not in self.fleets:
+            raise ValueError(f"Fleet '{fleet_name}' not found")
+        return self.fleets[fleet_name].fleet.attr_arn
+    
+    def get_all_fleet_arns(self) -> Dict[str, str]:
+        """Get ARNs of all fleets."""
+        return {
+            name: fleet.fleet.attr_arn 
+            for name, fleet in self.fleets.items()
+        }

--- a/tests/ci/cdk/config/codebuild-fleets.yaml
+++ b/tests/ci/cdk/config/codebuild-fleets.yaml
@@ -1,0 +1,35 @@
+# CodeBuild Fleet Configuration
+# This file defines the configuration for multiple CodeBuild fleets with different compute types and scaling options
+
+fleets:
+  # 8 vCPUs, 16 GB
+  - name: linux-graviton2-c6g-2xlarge
+    baseCapacity: 1
+    environmentType: ARM_CONTAINER
+    customInstanceType: c6g.2xlarge
+    scalingConfiguration:
+      enabled: true
+      utilizationRate: 70
+  # 8 vCPUs, 64 GB
+  - name: linux-graviton4-r8g-2xlarge
+    baseCapacity: 1
+    environmentType: ARM_CONTAINER
+    customInstanceType: r8g.2xlarge
+    scalingConfiguration:
+      enabled: true
+      utilizationRate: 70
+  # 8 vCPUs, 16 GB
+  - name: windows-image-build-large
+    baseCapacity: 1
+    environmentType: WINDOWS_EC2
+    computeType: LARGE
+    scalingConfiguration:
+      enabled: true
+      utilizationRate: 70
+
+# Global configuration options
+globalSettings:
+  # Default tags applied to all fleets
+  defaultTags:
+    Project: "aws-lc"
+    ManagedBy: "cdk"

--- a/tests/ci/cdk/pipeline/github_actions_stage.py
+++ b/tests/ci/cdk/pipeline/github_actions_stage.py
@@ -6,6 +6,7 @@ from aws_cdk import (
     Stack,
     pipelines,
 )
+from cdk.aws_lc_codebuild_fleets import AwsLcCodeBuildFleets
 from cdk.aws_lc_github_actions_stack import AwsLcGitHubActionsStack
 from constructs import Construct
 
@@ -27,6 +28,10 @@ class GitHubActionsStage(Stage):
             env=pipeline_environment,
             **kwargs,
         )
+
+        self.codebuild_fleets = AwsLcCodeBuildFleets(self, "aws-lc-codebuild-fleets",
+                                                     env=deploy_environment,
+                                                     stack_name="aws-lc-codebuild-fleets")
 
         AwsLcGitHubActionsStack(
             self,

--- a/tests/ci/cdk/util/fleet_config_loader.py
+++ b/tests/ci/cdk/util/fleet_config_loader.py
@@ -1,0 +1,200 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+import os
+import pathlib
+import typing
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+import yaml
+
+
+@dataclass
+class ScalingConfiguration:
+    """Configuration for fleet auto-scaling."""
+    enabled: bool = False
+    utilization_rate: Optional[int] = None
+    max_capacity: Optional[int] = None
+
+
+@dataclass
+class AttributeBasedCompute:
+    """Configuration for attribute-based compute specifications."""
+    vcpus: int
+    memory: int  # in MB
+    storage: int  # in GB
+
+
+@dataclass
+class FleetConfiguration:
+    """Configuration for a single CodeBuild fleet."""
+    name: str
+    base_capacity: int
+    environment_type: str
+    scaling_configuration: ScalingConfiguration
+    tags: Dict[str, str]
+    
+    # Compute type options (mutually exclusive)
+    compute_type: Optional[str] = None
+    custom_instance_type: Optional[str] = None
+    attribute_based_compute: Optional[AttributeBasedCompute] = None
+    
+    def __post_init__(self):
+        """Validate that exactly one compute type is specified."""
+        compute_options = [
+            self.compute_type,
+            self.custom_instance_type,
+            self.attribute_based_compute
+        ]
+        specified_options = [opt for opt in compute_options if opt is not None]
+        
+        if len(specified_options) != 1:
+            raise ValueError(
+                f"Fleet '{self.name}' must specify exactly one compute type: "
+                f"computeType, customInstanceType, or attributeBasedCompute"
+            )
+
+
+@dataclass
+class GlobalSettings:
+    """Global configuration settings for all fleets."""
+    default_tags: Dict[str, str]
+
+
+@dataclass
+class FleetConfigurationFile:
+    """Complete configuration file structure."""
+    fleets: List[FleetConfiguration]
+    global_settings: GlobalSettings
+
+
+class FleetConfigLoader:
+    """Utility class to load and validate fleet configurations from YAML."""
+    
+    @staticmethod
+    def load_config(config_path: Union[str, pathlib.Path]) -> FleetConfigurationFile:
+        """
+        Load fleet configuration from YAML file.
+        
+        Args:
+            config_path: Path to the YAML configuration file
+            
+        Returns:
+            FleetConfigurationFile: Parsed and validated configuration
+            
+        Raises:
+            FileNotFoundError: If config file doesn't exist
+            yaml.YAMLError: If YAML parsing fails
+            ValueError: If configuration validation fails
+        """
+        config_path = pathlib.Path(config_path)
+        
+        if not config_path.exists():
+            raise FileNotFoundError(f"Configuration file not found: {config_path}")
+        
+        with open(config_path, 'r') as file:
+            raw_config = yaml.safe_load(file)
+        
+        return FleetConfigLoader._parse_config(raw_config)
+    
+    @staticmethod
+    def _parse_config(raw_config: Dict) -> FleetConfigurationFile:
+        """Parse raw YAML configuration into structured objects."""
+        # Parse global settings
+        global_settings_raw = raw_config.get('globalSettings', {})
+        global_settings = GlobalSettings(
+            default_tags=global_settings_raw.get('defaultTags', {})
+        )
+        
+        # Parse fleet configurations
+        fleets = []
+        for fleet_raw in raw_config.get('fleets', []):
+            fleet = FleetConfigLoader._parse_fleet(fleet_raw, global_settings)
+            fleets.append(fleet)
+        
+        return FleetConfigurationFile(
+            fleets=fleets,
+            global_settings=global_settings
+        )
+    
+    @staticmethod
+    def _parse_fleet(fleet_raw: Dict, global_settings: GlobalSettings) -> FleetConfiguration:
+        """Parse a single fleet configuration."""
+        # Parse scaling configuration
+        scaling_raw = fleet_raw.get('scalingConfiguration', {})
+        scaling_config = ScalingConfiguration(
+            enabled=scaling_raw.get('enabled', False),
+            utilization_rate=scaling_raw.get('utilizationRate'),
+            max_capacity=scaling_raw.get('maxCapacity', None),
+        )
+        
+        # Parse attribute-based compute if present
+        attribute_compute = None
+        if 'attributeBasedCompute' in fleet_raw:
+            attr_raw = fleet_raw['attributeBasedCompute']
+            attribute_compute = AttributeBasedCompute(
+                vcpus=attr_raw['vcpus'],
+                memory=attr_raw['memory'],
+                storage=attr_raw['storage']
+            )
+        
+        # Merge tags with global defaults
+        fleet_tags = fleet_raw.get('tags', {})
+        merged_tags = {**global_settings.default_tags, **fleet_tags}
+        
+        return FleetConfiguration(
+            name=fleet_raw['name'],
+            base_capacity=fleet_raw['baseCapacity'],
+            environment_type=fleet_raw['environmentType'],
+            scaling_configuration=scaling_config,
+            tags=merged_tags,
+            compute_type=fleet_raw.get('computeType'),
+            custom_instance_type=fleet_raw.get('customInstanceType'),
+            attribute_based_compute=attribute_compute
+        )
+    
+    @staticmethod
+    def get_default_config_path() -> pathlib.Path:
+        """Get the default path to the fleet configuration file."""
+        # Assume we're running from the CDK directory
+        current_dir = pathlib.Path(__file__).parent.parent
+        return current_dir / 'config' / 'codebuild-fleets.yaml'
+
+
+def validate_fleet_config(config: FleetConfiguration) -> List[str]:
+    """
+    Validate a fleet configuration and return list of validation errors.
+    
+    Args:
+        config: Fleet configuration to validate
+        
+    Returns:
+        List of validation error messages (empty if valid)
+    """
+    errors = []
+    
+    # Validate capacity values
+    if config.base_capacity < 0:
+        errors.append(f"Base capacity must be >= 0 for fleet '{config.name}'")
+    
+    # Validate scaling configuration
+    scaling = config.scaling_configuration
+    if scaling.enabled:
+        if scaling.utilization_rate is not None and (scaling.utilization_rate < 0 or scaling.utilization_rate > 100):
+            errors.append(
+                f"Utilization rate ({scaling.utilization_rate}) must be >= 0 and <= 100"
+                f"for fleet '{config.name}'"
+            )
+
+    # Validate attribute-based compute
+    if config.attribute_based_compute:
+        attr = config.attribute_based_compute
+        if attr.vcpus <= 0:
+            errors.append(f"vCPUs must be > 0 for fleet '{config.name}'")
+        if attr.memory <= 0:
+            errors.append(f"Memory must be > 0 for fleet '{config.name}'")
+        if attr.storage <= 0:
+            errors.append(f"Storage must be > 0 for fleet '{config.name}'")
+    
+    return errors

--- a/tests/ci/setup.py
+++ b/tests/ci/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
 
     install_requires=[
         # CDK dependencies.
-        "aws-cdk-lib==2.215.0",
+        "aws-cdk-lib==2.220.0",
         "constructs==10.4.2",
         # PyYAML is a YAML parser and emitter for Python. Used to read build_spec.yaml.
         "pyyaml==6.0.2",


### PR DESCRIPTION
### Description of changes: 
This adds a stack and configuration mechanism for setting up CodeBuild fleets with auto-scaling capabilities. This will be used in subsequent pull requests to migrate the graviton2 and graviton4 testing done with the EC2 test framework, and allow for migration of Windows image builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
