### PR TITLE
Migrate Graviton2 and Graviton4 from EC2 Test Framework

### DIFF
--- a/.github/workflows/linux_arm_omnibus.yml
+++ b/.github/workflows/linux_arm_omnibus.yml
@@ -10,6 +10,65 @@ concurrency:
 env:
   GOPROXY: https://proxy.golang.org,direct
 jobs:
+  graviton2:
+    name: graviton2-${{ matrix.name }}
+    runs-on:
+      - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
+        image:arm-3.0
+        fleet:linux-graviton2-c6g-2xlarge
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: asan-tests
+            options: --privileged
+            run: ./tests/ci/run_posix_sanitizers.sh
+          - name: fips-tests
+            run: ./tests/ci/run_fips_tests.sh
+    steps:
+      - uses: actions/checkout@v5
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - uses: ./.github/actions/codebuild-docker-run
+        name: Run Container
+        with:
+          image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/amazonlinux:2023
+          options: ${{ matrix.options || '' }}
+          run: |
+            source /opt/compiler-env/setup-clang-15.sh
+            ${{ matrix.run }}
+
+  graviton4:
+    name: graviton4-${{ matrix.name }}
+    runs-on:
+      - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
+        image:arm-3.0
+        fleet:linux-graviton4-r8g-2xlarge
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: asan-tests
+            options: --privileged
+            run: ./tests/ci/run_posix_sanitizers.sh
+          - name: fips-tests
+            run: ./tests/ci/run_fips_tests.sh
+    steps:
+      - uses: actions/checkout@v5
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - uses: ./.github/actions/codebuild-docker-run
+        name: Run Container
+        with:
+          image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/amazonlinux:2023
+          options: ${{ matrix.options || '' }}
+          run: |
+            source /opt/compiler-env/setup-clang-15.sh
+            ${{ matrix.run }}
+
+
   # BoringSSL has 7k+ ssl runner tests, and the total number of the runner tests keep increasing.
   # When ASAN enabled, the tests take more than 1 hour to finish. The cause relates to https://github.com/google/sanitizers/issues/1331,
   # https://github.com/google/sanitizers/issues/703, and fixed in https://reviews.llvm.org/D60243 which is pending a review.

--- a/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/ec2_test_framework_omnibus.yaml
@@ -6,56 +6,10 @@ version: 0.2
 # Doc for batch https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html#build-spec.batch.build-list
 batch:
   build-list:
-    # Actual tests are ran on an Graviton2 ec2 instance via SSM Commands.
-    - identifier: graviton2_tests_asan
-      buildspec: ./tests/ci/codebuild/common/run_ec2_target.yml
+    - identifier: migrated
+      buildspec: ./tests/ci/codebuild/common/no_op.yml
       env:
         type: LINUX_CONTAINER
         privileged-mode: false
         compute-type: BUILD_GENERAL1_SMALL
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
-        variables:
-          EC2_AMI: "ami-0e8c824f386e1de06"
-          EC2_INSTANCE_TYPE: "c6g.2xlarge"
-          ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"
-          TARGET_TEST_SCRIPT: "./tests/ci/run_posix_sanitizers.sh"
-
-    - identifier: graviton2_tests_fips
-      buildspec: ./tests/ci/codebuild/common/run_ec2_target.yml
-      env:
-        type: LINUX_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_SMALL
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
-        variables:
-          EC2_AMI: "ami-0e8c824f386e1de06"
-          EC2_INSTANCE_TYPE: "c6g.4xlarge"
-          ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"
-          TARGET_TEST_SCRIPT: "./tests/ci/run_fips_tests.sh"
-
-    # Actual tests are ran on an Graviton4 ec2 instance via SSM Commands.
-    - identifier: graviton4_tests_asan
-      buildspec: ./tests/ci/codebuild/common/run_ec2_target.yml
-      env:
-        type: LINUX_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_SMALL
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
-        variables:
-          EC2_AMI: "ami-0e8c824f386e1de06"
-          EC2_INSTANCE_TYPE: "r8g.2xlarge"
-          ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"
-          TARGET_TEST_SCRIPT: "./tests/ci/run_posix_sanitizers.sh"
-
-    - identifier: graviton4_tests_fips
-      buildspec: ./tests/ci/codebuild/common/run_ec2_target.yml
-      env:
-        type: LINUX_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_SMALL
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-linux-x86:ubuntu-20.04_clang-7x-bm-framework_latest
-        variables:
-          EC2_AMI: "ami-0e8c824f386e1de06"
-          EC2_INSTANCE_TYPE: "r8g.2xlarge"
-          ECR_DOCKER_TAG: "amazonlinux-2023_clang-15x_sanitizer"
-          TARGET_TEST_SCRIPT: "./tests/ci/run_fips_tests.sh"
+        image: aws/codebuild/standard:7.0


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
