### PR TITLE
Fix librelp integration CI

### DIFF
--- a/tests/ci/integration/run_librelp_integration.sh
+++ b/tests/ci/integration/run_librelp_integration.sh
@@ -26,7 +26,7 @@ AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
 
 function librelp_build() {
   autoreconf -fi  
-  PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig" ./configure --enable-tls-openssl
+  PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig" ./configure --enable-tls-openssl --enable-compile-warnings=yes
   make -j ${NUM_CPU_THREADS}
 }
 


### PR DESCRIPTION
### Issues:
Resolves P322305594

### Description of changes: 
We switched over to new Docker images recently with #2752. The new `ubuntu:22.04` image has the `autoconf-archive` package that will activate some strict autoconf macros, resulting in `-Werror` being added. Therefore, our CI has been failing, partly due to functions that we deprecated and partly due to librelp code itself.

Most of librelp's CI overrides these macros using `--enable-compile-warnings=yes`, so this PR is adding the same thing to best mimic the testing environment for librelp.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.