### PR TITLE
Fix tpm2-tss CI

### DIFF
--- a/tests/ci/integration/run_tpm2_tss_integration.sh
+++ b/tests/ci/integration/run_tpm2_tss_integration.sh
@@ -47,7 +47,7 @@ function curl_build() {
 }
 
 function tpm2_tss_build() {
-  git apply "${SCRIPT_DIR}/tpm2_tss_patch/aws-lc-tpm2-tss.patch"
+  patch -p1 --quiet -i "${SCRIPT_DIR}/tpm2_tss_patch/aws-lc-tpm2-tss.patch"
   export PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig:${CURL_INSTALL_FOLDER}/lib/pkgconfig"
   /bin/sh ./bootstrap
   ./configure --enable-unit --with-crypto=ossl --prefix="${TPM2_TSS_INSTALL_FOLDER}"
@@ -67,7 +67,7 @@ function tpm2_abrmd_build() {
 }
 
 function tpm2_tools_build() {
-  git apply "${SCRIPT_DIR}/tpm2_tools_patch/aws-lc-tpm2-tools.patch"
+  patch -p1 --quiet -i "${SCRIPT_DIR}/tpm2_tools_patch/aws-lc-tpm2-tools.patch"
   export PKG_CONFIG_PATH="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig:${TPM2_TSS_INSTALL_FOLDER}/lib/pkgconfig:${TPM2_ABRMD_INSTALL_FOLDER}/lib/pkgconfig"
   /bin/sh ./bootstrap
   ./configure --with-crypto=ossl

--- a/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
+++ b/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
@@ -70,15 +70,6 @@ index 75e81141..79f77fdf 100644
      size_t ui;
      AUTHORITY_INFO_ACCESS *info = NULL;
      ASN1_IA5STRING *uri = NULL;
-@@ -463,7 +463,7 @@ ifapi_get_curl_buffer(unsigned char * url, unsigned char ** buffer,
-         goto out_easy_cleanup;
-     }
- 
--    rc = curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
-+    rc = curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-     if (rc != CURLE_OK) {
-         LOG_ERROR("curl_easy_setopt for CURLOPT_FOLLOWLOCATION failed: %s",
-                   curl_easy_strerror(rc));
 diff --git a/src/tss2-fapi/ifapi_verify_cert_chain.c b/src/tss2-fapi/ifapi_verify_cert_chain.c
 index b495e512..c741c8ad 100644
 --- a/src/tss2-fapi/ifapi_verify_cert_chain.c


### PR DESCRIPTION
### Issues:
Resolves `P316739151`

### Description of changes: 
Upstream updated their patch to use `1L` instead. The current patching mechanism with `git apply` is also harder to debug, so I've changed it to use `patch` instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
