### PR TITLE
Do no consider warnings fatal in CPU Jitter for LTO build

### DIFF
--- a/third_party/jitterentropy/CMakeLists.txt
+++ b/third_party/jitterentropy/CMakeLists.txt
@@ -32,6 +32,22 @@ else()
         # https://gcc.gnu.org/wiki/NewWconversion.
         set(JITTER_COMPILE_FLAGS "${JITTER_COMPILE_FLAGS} -Wconversion")
     endif()
+
+    # See t/P319995887.
+    # At the moment, CPU Jitter source code needs to disable all optimizations.
+    # This means we can't inherit FORTITY_SOURCE and we therefore undefine
+    # the flag through U_FORTIFY_SOURCE. If one were to use annobin as a plugin
+    # and, simultaneously use LTO, annobin will emit a warning if FORTIFY_SOURCE
+    # is undefined. This is fatal if all warnings are treated as errors.
+    #
+    # The correct signal to use for below is annobin. But since we know that
+    # annobin is not necessarily being enabled through -fplugin, match with LTO
+    # and disable turning warnings into errors. This is also kinda fragile; LTO
+    # could be defined through other means similar to annobin. But it's what we
+    # have to work with atm.
+    if ("lto" MATCHES "${CMAKE_CFLAGS}")
+        set(JITTER_COMPILE_FLAGS "${JITTER_COMPILE_FLAGS} -Wno-error")
+    endif()
 endif()
 
 if(BORINGSSL_PREFIX)


### PR DESCRIPTION
### Issues:

P319995887

### Description of changes: 

Generally, see comment in code.

### Call-outs:

Annobin man page: https://www.mankier.com/1/annobin

```
no-active-checks
[...]
  Currently the plugin checks for these issues:

  Missing FORTIFY_SOURCE
    This warning is generated when neither -D_FORTIFY_SOURCE=2 nor -D_FORTIFY_SOURCE=3 have been provided on the command line and the -flto option has been enabled.

    Nomrally this problem would be detected by the annocheck tool, but LTO compilation hides preprocessor options, so information about them cannot be passed on by the plugin.  This is why the plugin will generate a warning message when the _FORTIFY_SOURCE option is missing and LTO is enabled.
```

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
