### PR TITLE
AES-XTS Enc Dec test on rand incremental length inputs

### DIFF
--- a/crypto/fipsmodule/modes/xts_test.cc
+++ b/crypto/fipsmodule/modes/xts_test.cc
@@ -1268,11 +1268,13 @@ TEST(XTSTest, EncryptDecryptRand) {
     int len = 0;
     uint8_t *in_p = nullptr, *out_p = nullptr;
   #if defined(OPENSSL_LINUX)
+    std::unique_ptr<uint8_t[]> in, out;
+
     for (bool beg: {false, true}) {
       if (pagesize < (int)plaintext.size() && !beg) {
         // For small page sizes skip page bound edge cases
-        std::unique_ptr<uint8_t[]> in(new uint8_t[plaintext.size()]);
-        std::unique_ptr<uint8_t[]> out(new uint8_t[plaintext.size()]);
+        in.reset(new uint8_t[plaintext.size()]);
+        out.reset(new uint8_t[plaintext.size()]);
         in_p = in.get();
         out_p = out.get();
       } else if (pagesize < (int)plaintext.size() && beg) {


### PR DESCRIPTION
Add incremental length random input message tests for AES-XTS encryption/decryption

## Issues:
N/A

## Description of changes:
AWS-LC's current AES-XTS tests use fixed-size test vectors but do not systematically verify that encryption and decryption work correctly across different message lengths.

This PR adds a new test that generates random inputs of incremental lengths and verify that `encrypt(decrypt(input)) == input` for each length. This ensures that AES-XTS correctly handles messages of varying sizes, particularly:
- Messages at and above the minimum length (16 bytes)
- Messages that require ciphertext stealing (non-block-aligned sizes)
- Messages of various sizes up to the practical maximum

The tests also add explicit length equality checks between plaintext and ciphertext to catch potential length-related bugs early.

## Call-outs:
The test provides better confidence in correctness across different input sizes.

## Testing:
`./crypto/crypto_test --gtest_filter=XTSTest.EncryptDecryptRand.`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
