### PR TITLE
Migrate to macos-15-intel

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-13"
+          - "macos-15-intel"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-13"
+          - "macos-15-intel"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION
### Issues:
Addresses https://github.com/actions/runner-images/issues/13046. We'll need to update or we will be missing MacOS x86_64 coverage until then.

### Description of changes: 
macos-13 labels are being deprecated in favor of a new label. 

"The new label will run on macOS 15 and will be available from now until August 2027. This will be the last available x86_64 image from Actions, and after that date the x86_64 architecture will not be supported on GitHub Actions"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
