### PR TITLE
Prepare release v1.64.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0091 NEW)
 endif()
 
 set(SOFTWARE_NAME "awslc")
-set(SOFTWARE_VERSION "1.63.0")
+set(SOFTWARE_VERSION "1.64.0")
 set(ABI_VERSION 0)
 set(CRYPTO_LIB_NAME "crypto")
 set(SSL_LIB_NAME "ssl")

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.63.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.64.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
Prepare release v1.64.0.


### What's Changed
* Update max polyz value by @jakemas in https://github.com/aws/aws-lc/pull/2787
* ECR Repositories for Android and Formal Verification Images by @skmcgrail in https://github.com/aws/aws-lc/pull/2794
* Support more "openssl rsa" options by @justsmth in https://github.com/aws/aws-lc/pull/2777
* Remove python codebuild patches by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2793
* Additional options for "openssl c_client" by @justsmth in https://github.com/aws/aws-lc/pull/2791
* GitHub-based Formal Verification Image Build by @skmcgrail in https://github.com/aws/aws-lc/pull/2796
* Use C++11 atomics to update session stats by @justsmth in https://github.com/aws/aws-lc/pull/2786
* Support "openssl dhparam" by @justsmth in https://github.com/aws/aws-lc/pull/2790
* Add scrutinice pull permissions for aws-lc/amazonlinux repository by @skmcgrail in https://github.com/aws/aws-lc/pull/2799
* Use GitHub-based Verification Images by @skmcgrail in https://github.com/aws/aws-lc/pull/2798
* Remove dead code by @torben-hansen in https://github.com/aws/aws-lc/pull/2797
* Rename snapsafe to VM UBE by @torben-hansen in https://github.com/aws/aws-lc/pull/2800
* Bump MySQL version tag to 9.5.0 by @samuel40791765 in https://github.com/aws/aws-lc/pull/2768
* Migrate to macos-15-intel by @samuel40791765 in https://github.com/aws/aws-lc/pull/2802
* Use right compiler with ruby CI by @samuel40791765 in https://github.com/aws/aws-lc/pull/2801
* Migrate analytics job to be GitHub triggered by @skmcgrail in https://github.com/aws/aws-lc/pull/2779
* Support NetBSD by @justsmth in https://github.com/aws/aws-lc/pull/2754
* Make poly_chknorm constant flow by @jakemas in https://github.com/aws/aws-lc/pull/2788
* Rename fork to fork UBE by @torben-hansen in https://github.com/aws/aws-lc/pull/2803
* Extend grv asan timeout for Golang to allow completion by @torben-hansen in https://github.com/aws/aws-lc/pull/2805

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
