### PR TITLE
Disable old Windows jobs

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/github_ci_windows_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/github_ci_windows_x86_omnibus.yaml
@@ -6,61 +6,10 @@ version: 0.2
 # Doc for batch https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html#build-spec.batch.build-list
 batch:
   build-list:
-    - identifier: windows_msvc2015_x64
-      buildspec: ./tests/ci/codebuild/windows/run_windows_target.yml
+    - identifier: migrated
+      buildspec: ./tests/ci/codebuild/common/no_op.yml
       env:
-        # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html
-        type: WINDOWS_SERVER_2022_CONTAINER
+        type: LINUX_CONTAINER
         privileged-mode: false
-        compute-type: BUILD_GENERAL1_LARGE
-        # Build failure on Docker image `vs2015_latest`, tracked in CryptoAlg-741.
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-windows-x86:windows-2022_vs2015_latest
-        variables:
-          MSVC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat'
-          ARCH_OPTION: x64
-
-    - identifier: windows_msvc2017_x64
-      buildspec: ./tests/ci/codebuild/windows/run_windows_target.yml
-      env:
-        type: WINDOWS_SERVER_2022_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-windows-x86:windows-2022_vs2017_latest
-        variables:
-          # vcvarsall will set the required lib and libpath for MSVC to compile everything
-          MSVC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat'
-          ARCH_OPTION: x64
-
-    - identifier: windows_msvc2019_x64
-      buildspec: ./tests/ci/codebuild/windows/run_windows_target.yml
-      env:
-        type: WINDOWS_SERVER_2022_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-windows-x86:windows-2022_vs2019_latest
-        variables:
-          MSVC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat'
-          ARCH_OPTION: x64
-
-    - identifier: windows_msvc2022_x64
-      buildspec: ./tests/ci/codebuild/windows/run_windows_target.yml
-      env:
-        type: WINDOWS_SERVER_2022_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_LARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-windows-x86:windows-2022_vs2022_latest
-        variables:
-          MSVC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat'
-          ARCH_OPTION: x64
-
-    - identifier: windows_msvc2022_sde_x64
-      buildspec: ./tests/ci/codebuild/windows/run_windows_target.yml
-      env:
-        type: WINDOWS_SERVER_2022_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_2XLARGE
-        image: 620771051181.dkr.ecr.us-west-2.amazonaws.com/aws-lc-docker-images-windows-x86:windows-2022_vs2022_latest
-        variables:
-          MSVC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat'
-          ARCH_OPTION: x64
-          RUN_SDE: true
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/standard:7.0


### PR DESCRIPTION
### Description of changes: 
Forgot to turn these off when I migrated the Windows jobs to the GitHub Workflow file. For now this will be a stub echo job like all the others in order to avoid failing the current webhook. This will be cleaned up and removed once we migrate the FIPS branches over.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
