### PR TITLE
[DRAFT] Support CRYPTO_ctr128_encrypt

### DIFF
--- a/crypto/cipher_extra/e_aesctrhmac.c
+++ b/crypto/cipher_extra/e_aesctrhmac.c
@@ -165,9 +165,11 @@ static void aead_aes_ctr_hmac_sha256_crypt(
                                 partial_block_buffer, &partial_block_offset,
                                 aes_ctx->ctr);
   } else {
+OPENSSL_BEGIN_ALLOW_DEPRECATED
     CRYPTO_ctr128_encrypt(in, out, len, &aes_ctx->ks.ks, counter,
                           partial_block_buffer, &partial_block_offset,
                           aes_ctx->block);
+OPENSSL_END_ALLOW_DEPRECATED
   }
 }
 

--- a/crypto/fipsmodule/aes/mode_wrappers.c
+++ b/crypto/fipsmodule/aes/mode_wrappers.c
@@ -93,8 +93,10 @@ void AES_ctr128_encrypt(const uint8_t *in, uint8_t *out, size_t len,
     CRYPTO_ctr128_encrypt_ctr32(in, out, len, key, ivec, ecount_buf, num,
                                 vpaes_ctr32_encrypt_blocks_wrapper);
 #else
+OPENSSL_BEGIN_ALLOW_DEPRECATED
     CRYPTO_ctr128_encrypt(in, out, len, key, ivec, ecount_buf, num,
                           vpaes_encrypt_wrapper);
+OPENSSL_END_ALLOW_DEPRECATED
 #endif
   } else {
     CRYPTO_ctr128_encrypt_ctr32(in, out, len, key, ivec, ecount_buf, num,

--- a/crypto/fipsmodule/cipher/e_aes.c
+++ b/crypto/fipsmodule/cipher/e_aes.c
@@ -281,8 +281,10 @@ static int aes_ctr_cipher(EVP_CIPHER_CTX *ctx, uint8_t *out, const uint8_t *in,
     CRYPTO_ctr128_encrypt_ctr32(in, out, len, &dat->ks.ks, ctx->iv, ctx->buf,
                                 &ctx->num, dat->stream.ctr);
   } else {
+    OPENSSL_BEGIN_ALLOW_DEPRECATED
     CRYPTO_ctr128_encrypt(in, out, len, &dat->ks.ks, ctx->iv, ctx->buf,
                           &ctx->num, dat->block);
+    OPENSSL_END_ALLOW_DEPRECATED
   }
   return 1;
 }

--- a/crypto/fipsmodule/cipher/e_aesccm.c
+++ b/crypto/fipsmodule/cipher/e_aesccm.c
@@ -235,8 +235,10 @@ static int ccm128_encrypt(const struct ccm128_context *ctx,
     CRYPTO_ctr128_encrypt_ctr32(in, out, len, key, state->nonce, partial_buf,
                                 &num, ctx->ctr);
   } else {
+OPENSSL_BEGIN_ALLOW_DEPRECATED
     CRYPTO_ctr128_encrypt(in, out, len, key, state->nonce, partial_buf, &num,
                           ctx->block);
+OPENSSL_END_ALLOW_DEPRECATED
   }
   return 1;
 }


### PR DESCRIPTION
### Description of changes: 
* Exposes our `CRYPTO_ctr128_encrypt` implementation via the "crypto.h" header

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
