### PR TITLE
Specify EC private key curve per RFC 5915

### DIFF
--- a/crypto/evp_extra/p_ec_asn1.c
+++ b/crypto/evp_extra/p_ec_asn1.c
@@ -185,11 +185,7 @@ static int eckey_priv_decode(EVP_PKEY *out, CBS *oid, CBS *params, CBS *key, CBS
 static int eckey_priv_encode(CBB *out, const EVP_PKEY *key) {
   const EC_KEY *ec_key = key->pkey.ec;
 
-  // Omit the redundant copy of the curve name. This contradicts RFC 5915 but
-  // aligns with PKCS #11. SEC 1 only says they may be omitted if known by other
-  // means. Both OpenSSL and NSS omit the redundant parameters, so we omit them
-  // as well.
-  unsigned enc_flags = EC_KEY_get_enc_flags(ec_key) | EC_PKEY_NO_PARAMETERS;
+  unsigned enc_flags = EC_KEY_get_enc_flags(ec_key);
 
   // See RFC 5915.
   CBB pkcs8, algorithm, oid, private_key;


### PR DESCRIPTION

# Notes

[RFC 5915](https://www.rfc-editor.org/rfc/rfc5915.html) stipulates the following ASN.1 structure for `ECPrivateKey`, which is wrapped by an [outer PrivateKeyInfo](https://datatracker.ietf.org/doc/html/rfc5208#section-5)'s curve AlgorithmIdentifier

```
   ECPrivateKey ::= SEQUENCE {
     version        INTEGER { ecPrivkeyVer1(1) } (ecPrivkeyVer1),
     privateKey     OCTET STRING,
     parameters [0] ECParameters {{ NamedCurve }} OPTIONAL,
     publicKey  [1] BIT STRING OPTIONAL
   }
...
                                         Though the ASN.1 indicates that
      the parameters field is OPTIONAL, implementations that conform to
      this document MUST always include the parameters field.
```

Annoyingly, this contradicts [PKCS #11](https://www.cryptsoft.com/pkcs11doc/STANDARD/pkcs-11v2-11r1.pdf) (p. 272):


> EC (also related with ECDSA) private keys are BER-encoded according to SECG SEC 1 ECPrivateKey ASN.1 type:
>
> ```
> ECPrivateKey ::= SEQUENCE {
>    Version INTEGER { ecPrivkeyVer1(1) }
>       (ecPrivkeyVer1),
>    privateKey OCTET STRING,
>    parameters [0] Parameters OPTIONAL,
>    publicKey [1] BIT STRING OPTIONAL
>}
>```
>
> Since the EC domain parameters are placed in the PKCS #8’s privateKeyAlgorithm field, the optional parameters field in an ECPrivateKey must be omitted.

AWS-LC currently elides the redundant inner named curve as does OpenSSL. BouncyCastle includes it. Including the redundant curve name adds 12 bytes of overhead to the outer PrivateKeyInfo structure.

This PR changes the default key encoding to include the redundant curve name. Callers can override this behavior and exclude it by calling `EC_KEY_set_enc_flags` with `EC_PKEY_NO_PARAMETERS`.

# Alternatives

Because this change affects all AWS-LC consumers, and we're only seeking Java-like (BouncyCastle + SunJCE) behavior, we may want to make an equivalent this change downstream in ACCP instead of here.

# Testing
- CI

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
