### PR TITLE
Setup OIDC for exchanging GitHub Token for AWS Credentials

### DIFF
--- a/tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py
@@ -1,0 +1,209 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+import itertools
+import typing
+
+from aws_cdk import (
+    aws_ecr as ecr,
+    aws_iam as iam,
+    Stack,
+    Environment,
+)
+from constructs import Construct
+
+from util.metadata import (
+    ECR_REPOS, GITHUB_REPO_OWNER, GITHUB_REPO_NAME, AWS_LC_METRIC_NS)
+from util.iam_policies import (
+    device_farm_access_policy_in_json
+)
+
+class AwsLcGitHubOidcStack(Stack):
+    """Define a stack used to execute AWS-LC self-hosted GitHub Actions Runners."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        env: typing.Union[Environment, typing.Dict[str, typing.Any]],
+        **kwargs
+    ) -> None:
+        super().__init__(scope, id, env=env, **kwargs)
+
+        # Configures GitHub OIDC provider in IAM
+        # https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws
+        self.oidc_provider = iam.CfnOIDCProvider(self, "AwsLcGitHubOidcProvider",
+                                                 client_id_list=[
+                                                     "sts.amazonaws.com"],
+                                                 url="https://token.actions.githubusercontent.com")
+
+        oidc_role_name = "AwsLcGitHubActionsOidcRole" 
+        # This role should only be granted necessary permissions to assume other roles
+        self.minimal_oidc_role = iam.Role(self, id=oidc_role_name, role_name=oidc_role_name,
+                                          assumed_by=iam.WebIdentityPrincipal(self.oidc_provider.attr_arn, {
+                                              "StringEquals": {
+                                                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                                              },
+                                              "StringLike": {
+                                                  # Check the subject claim is from our repository VERY IMPORTANT!
+                                                  # See https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims
+                                                  "token.actions.githubusercontent.com:sub": "repo:{}/{}:*".format(
+                                                      GITHUB_REPO_OWNER, GITHUB_REPO_NAME
+                                                  )
+                                              },
+                                          }))
+        
+        ecr_repos = [ecr.Repository.from_repository_name(self, x.replace('/', '-'), repository_name=x)
+                     for x in ECR_REPOS]
+
+        self.standard_github_actions_role = create_standard_github_actions_role(
+            self, "AwsLcGitHubActionStandardRole", env, self.minimal_oidc_role, ecr_repos)
+        self.standard_github_actions_role.grant_assume_role(
+            self.minimal_oidc_role)
+
+        self.device_farm_role = create_device_farm_role(
+            self, "AwsLcGitHubActionDeviceFarmRole", env, self.minimal_oidc_role)
+        self.device_farm_role.grant_assume_role(self.minimal_oidc_role)
+
+        self.docker_image_build_role = create_docker_image_build_role(
+            self, "AwsLcGitHubActionDockerImageBuildRole", env, self.minimal_oidc_role, ecr_repos)
+        self.docker_image_build_role.grant_assume_role(
+            self.minimal_oidc_role)
+
+
+def create_device_farm_role(scope: Construct, id: str,
+                            env: typing.Union[Environment, typing.Dict[str, typing.Any]],
+                            principal: iam.IPrincipal) -> iam.Role:
+    device_farm_policy = iam.PolicyDocument.from_json(
+        device_farm_access_policy_in_json(env)
+    )
+
+    device_farm_role = iam.Role(scope, id, role_name=id,
+                                assumed_by=iam.SessionTagsPrincipal(principal),
+                                inline_policies={
+                                    "device_farm_policy": device_farm_policy,
+                                })
+
+    return device_farm_role
+
+
+def create_docker_image_build_role(scope: Construct, id: str,
+                                   env: typing.Union[Environment, typing.Dict[str, typing.Any]],
+                                   principal: iam.IPrincipal,
+                                   repos: typing.List[ecr.IRepository]) -> iam.Role:
+
+    pull_through_caches = [ecr.Repository.from_repository_name(
+        scope, "quay-io", "quay.io/*")]
+
+    role = iam.Role(scope, id, role_name=id,
+                    assumed_by=iam.SessionTagsPrincipal(principal),
+                    inline_policies={
+                        "metrics_policy": iam.PolicyDocument(
+                            statements=[
+                                iam.PolicyStatement(
+                                    effect=iam.Effect.ALLOW,
+                                    actions=[
+                                        "cloudwatch:PutMetricData"
+                                    ],
+                                    resources=["*"],
+                                    conditions={
+                                        "StringEquals": {
+                                            "aws:RequestedRegion": [env.region],
+                                            "cloudwatch:namespace": [AWS_LC_METRIC_NS],
+                                        }
+                                    }
+                                ),
+                            ]
+                        ),
+                        "ecr": iam.PolicyDocument(
+                            statements=[
+                                iam.PolicyStatement(
+                                    effect=iam.Effect.ALLOW,
+                                    actions=[
+                                        "ecr:GetAuthorizationToken",
+                                    ],
+                                    resources=["*"],
+                                ),
+                                iam.PolicyStatement(
+                                    effect=iam.Effect.ALLOW,
+                                    actions=[
+                                        "ecr:BatchGetImage",
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                    ],
+                                    resources=[x for x in itertools.chain([
+                                        x.repository_arn for x in repos
+                                    ], [x.repository_arn for x in pull_through_caches])],
+                                ),
+                                iam.PolicyStatement(
+                                    effect=iam.Effect.ALLOW,
+                                    actions=[
+                                        "ecr:CompleteLayerUpload",
+                                        "ecr:InitiateLayerUpload",
+                                        "ecr:PutImage",
+                                        "ecr:UploadLayerPart",
+                                    ],
+                                    resources=[
+                                        x.repository_arn for x in repos],
+                                ),
+                                iam.PolicyStatement(
+                                    effect=iam.Effect.ALLOW,
+                                    actions=[
+                                        "ecr:BatchImportUpstreamImage",
+                                    ],
+                                    resources=[
+                                        x.repository_arn for x in pull_through_caches]
+                                ),
+                            ],
+                        ),
+                    })
+
+    return role
+
+
+def create_standard_github_actions_role(scope: Construct, id: str,
+                                        env: typing.Union[Environment, typing.Dict[str, typing.Any]],
+                                        principal: iam.IPrincipal,
+                                        repos: typing.List[ecr.IRepository]) -> iam.Role:
+    role = iam.Role(scope, id, role_name=id,
+                    assumed_by=iam.SessionTagsPrincipal(principal),
+                    inline_policies={
+                        "metrics_policy": iam.PolicyDocument(
+                            statements=[
+                                iam.PolicyStatement(
+                                    effect=iam.Effect.ALLOW,
+                                    actions=[
+                                        "cloudwatch:PutMetricData"
+                                    ],
+                                    resources=["*"],
+                                    conditions={
+                                        "StringEquals": {
+                                            "aws:RequestedRegion": [env.region],
+                                            "cloudwatch:namespace": [AWS_LC_METRIC_NS],
+                                        }
+                                    }
+                                ),
+                            ]
+                        ),
+                        "ecr": iam.PolicyDocument(
+                            statements=[
+                                iam.PolicyStatement(
+                                    effect=iam.Effect.ALLOW,
+                                    actions=[
+                                        "ecr:GetAuthorizationToken",
+                                    ],
+                                    resources=["*"],
+                                ),
+                                iam.PolicyStatement(
+                                    effect=iam.Effect.ALLOW,
+                                    actions=[
+                                        "ecr:BatchGetImage",
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                    ],
+                                    resources=[x.repository_arn for x in repos],
+                                ),
+                            ],
+                        ),
+                    })
+
+    return role

--- a/tests/ci/cdk/pipeline/github_actions_stage.py
+++ b/tests/ci/cdk/pipeline/github_actions_stage.py
@@ -8,6 +8,7 @@ from aws_cdk import (
 )
 from cdk.aws_lc_codebuild_fleets import AwsLcCodeBuildFleets
 from cdk.aws_lc_github_actions_stack import AwsLcGitHubActionsStack
+from cdk.aws_lc_github_oidc_stack import AwsLcGitHubOidcStack
 from constructs import Construct
 
 
@@ -32,8 +33,11 @@ class GitHubActionsStage(Stage):
         self.codebuild_fleets = AwsLcCodeBuildFleets(self, "aws-lc-codebuild-fleets",
                                                      env=deploy_environment,
                                                      stack_name="aws-lc-codebuild-fleets")
+        
+        self.odic_stack = AwsLcGitHubOidcStack(
+            self, "aws-lc-github-oidc", env=deploy_environment, **kwargs)
 
-        AwsLcGitHubActionsStack(
+        self.actions_stack = AwsLcGitHubActionsStack(
             self,
             "aws-lc-ci-github-actions",
             env=deploy_environment,

--- a/tests/ci/cdk/util/iam_policies.py
+++ b/tests/ci/cdk/util/iam_policies.py
@@ -3,6 +3,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
+from util.metadata import (AWS_LC_METRIC_NS, AWS_LC_FUZZ_METRIC_NS)
+
 
 def ec2_policies_in_json(
     ec2_role_name, ec2_security_group_id, ec2_subnet_id, ec2_vpc_id, env
@@ -136,7 +138,7 @@ def code_build_publish_metrics_in_json(env):
                 "Condition": {
                     "StringEquals": {
                         "aws:RequestedRegion": [env.region],
-                        "cloudwatch:namespace": ["AWS-LC-Fuzz", "AWS-LC"],
+                        "cloudwatch:namespace": [AWS_LC_FUZZ_METRIC_NS, AWS_LC_METRIC_NS],
                     }
                 },
             }

--- a/tests/ci/cdk/util/metadata.py
+++ b/tests/ci/cdk/util/metadata.py
@@ -41,6 +41,12 @@ WINDOWS_ECR_REPO = "aws-lc/windows"
 VERIFICATION_ECR_REPO = "aws-lc/verification"
 ANDROID_ECR_REPO = "aws-lc/android"
 
+ECR_REPOS = [UBUNTU_ECR_REPO, AMAZONLINUX_ECR_REPO, CENTOS_ECR_REPO,
+             FEDORA_ECR_REPO, WINDOWS_ECR_REPO, VERIFICATION_ECR_REPO, ANDROID_ECR_REPO]
+
+AWS_LC_METRIC_NS = "AWS-LC"
+AWS_LC_FUZZ_METRIC_NS = "AWS-LC-Fuzz"
+
 # Used when AWS CodeBuild needs to create web_hooks.
 GITHUB_REPO_OWNER = EnvUtil.get("GITHUB_REPO_OWNER", "aws")
 GITHUB_REPO_NAME = EnvUtil.get("GITHUB_REPO_NAME", "aws-lc")


### PR DESCRIPTION
### Description of changes: 
This change configures AWS IAM with OpenID Connect to support assuming a role in the AWS-LC team account by exchanging the GitHub token from a workflow for temporary AWS credentials, this allows those credentials to then be used to perform an assume role chain and use one of the predefined policies depending on what the workflow's intention is. This currently sets up three policies:

* A device farm role and policies which are analogous to the policy used in the android CodeBuild webhook today.
* A docker image builder role and policies that capture the permissions that are necessary for building and publishing our docker images to our private registries.
* A standard GitHub actions role and policies that allow permissions to pull images from our private docker registries and put metrics into our CloudWatch namespace.

### Call-outs:
Nothing will change at the moment for the existing actions executing on the AWS CodeBuild-managed GitHub Actions Runner environment. This is the initial step to be able to scope down the service role policy that implicitly gives workflows access to credentials for actions that aren't always necessary. This PR sets up policies that I will migrate the workflow files over to later, and then will revoke the permissions on the service role.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
