### PR TITLE
Remove Docker Image build infrastructure from CodePipeline

### DIFF
--- a/tests/ci/cdk/pipeline/ci_stage.py
+++ b/tests/ci/cdk/pipeline/ci_stage.py
@@ -94,22 +94,6 @@ class CiStage(Stage):
 
         env = env or {}
 
-        prebuild_check_step = pipelines.CodeBuildStep(
-            "PrebuildCheck",
-            input=input,
-            commands=[
-                "cd tests/ci/cdk/pipeline/scripts",
-                'trigger_conditions=$(./check_trigger_conditions.sh --build-type ci --stacks "${STACKS}")',
-                r"export NEED_REBUILD=$(echo $trigger_conditions | sed -n 's/.*\(NEED_REBUILD=[0-9]*\).*/\1/p' | cut -d'=' -f2 )",
-            ],
-            env={
-                **env,
-                "STACKS": " ".join(stack_names),
-            },
-            role=role,
-            timeout=Duration.minutes(60),
-        )
-
         batch_timeout = max([stack.timeout for stack in self.stacks]) * (max_retry + 1)
         batch_build_jobs = {
             "build-list": [
@@ -142,14 +126,11 @@ class CiStage(Stage):
             env={
                 **env,
                 "MAX_RETRY": max_retry,
-                "NEED_REBUILD": prebuild_check_step.exported_variable("NEED_REBUILD"),
             },
         )
-
-        ci_run_step.add_step_dependency(prebuild_check_step)
 
         pipeline.add_stage(
             self,
             pre=[private_repo_sync_step] if private_repo_sync_step else None,
-            post=[prebuild_check_step, ci_run_step],
+            post=[ci_run_step],
         )


### PR DESCRIPTION
### Description of changes: 
File cleanups will come later, just getting this out of the pipeline so the velocity of deployment can keep pace. These images are only relevant to the FIPS branches at this point that still reference them, and the Android device farm build. Both of those will be solved soon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
