### PR TITLE
[SCRUTINICE] Avoid NULL dereference

### DIFF
--- a/tool-openssl/test_util.cc
+++ b/tool-openssl/test_util.cc
@@ -193,8 +193,9 @@ bool CompareCSRs(X509_REQ *csr1, X509_REQ *csr2) {
     ASN1_STRING *data2 = X509_NAME_ENTRY_get_data(entry2);
 
     if (ASN1_STRING_cmp(data1, data2) != 0) {
+      const char* long_name = OBJ_nid2ln(OBJ_obj2nid(obj1));
       std::cout << "CSRs have different values for entry "
-                << OBJ_nid2ln(OBJ_obj2nid(obj1)) << std::endl;
+                << (long_name ? long_name : "<UNKNOWN>")  << std::endl;
       return false;
     }
   }


### PR DESCRIPTION
### Issues:
Addresses: P334723467

### Description of changes: 
Avoid potential dereferenceof NULL return from `OBJ_nid2ln`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
