### PR TITLE
Match req CLI behavior with OpenSSL

### DIFF
--- a/tool-openssl/req.cc
+++ b/tool-openssl/req.cc
@@ -531,17 +531,19 @@ static bool LoadConfig(const std::string &config_path,
 static bool AddCertExtensions(X509 *cert, CONF *req_conf,
                               std::string &ext_section) {
   // Set up X509V3 context for certificate
-  bool result = false;
+  bool result = true;
   X509V3_CTX ext_ctx;
   X509V3_set_ctx(&ext_ctx, cert, cert, NULL, NULL,
                  X509V3_CTX_REPLACE);  // self-signed
 
-  if (req_conf != NULL && !ext_section.empty()) {
+  if (req_conf != NULL) {
     X509V3_set_nconf(&ext_ctx, req_conf);
 
     // Add extensions from config to the certificate
-    result = X509V3_EXT_add_nconf(req_conf, &ext_ctx, ext_section.c_str(),
-                                  cert) != 0;
+    if (!ext_section.empty()) {
+      result = X509V3_EXT_add_nconf(req_conf, &ext_ctx, ext_section.c_str(),
+                                    cert) != 0;
+    }
 
     /* Prevent X509_V_ERR_MISSING_SUBJECT_KEY_IDENTIFIER */
     if (!AdaptKeyIDExtension(cert, &ext_ctx, "subjectKeyIdentifier", "hash",
@@ -593,7 +595,7 @@ static bool AddCertExtensions(X509 *cert, CONF *req_conf,
 static bool AddReqExtensions(X509_REQ *req, CONF *req_conf,
                              std::string &ext_section) {
   // Set up X509V3 context for certificate
-  bool result = false;
+  bool result = true;
   X509V3_CTX ext_ctx;
   X509V3_set_ctx(&ext_ctx, NULL, NULL, req, NULL,
                  X509V3_CTX_REPLACE);  // self-signed

--- a/tool-openssl/req_test.cc
+++ b/tool-openssl/req_test.cc
@@ -1378,16 +1378,15 @@ TEST_F(ReqComparisonTest, ReqExtentionsFromEmptyConfig) {
           "\n");
   fclose(config_file.release());
 
-  std::string subject = "/CN=req-ext-test.example.com";
-  std::string awslc_command =
-      std::string(tool_executable_path) + " req -new " + "-config " +
-      config_path + " -newkey rsa:2048 -nodes -keyout " + key_path_awslc +
-      " -out " + csr_path_awslc + " -subj \"" + subject + "\"";
+  std::string awslc_command = std::string(tool_executable_path) + " req -new " +
+                              "-config " + config_path +
+                              " -newkey rsa:2048 -nodes -keyout " +
+                              key_path_awslc + " -out " + csr_path_awslc;
 
-  std::string openssl_command =
-      std::string(openssl_executable_path) + " req -new " + "-config " +
-      config_path + " -newkey rsa:2048 -nodes -keyout " + key_path_openssl +
-      " -out " + csr_path_openssl + " -subj \"" + subject + "\"";
+  std::string openssl_command = std::string(openssl_executable_path) +
+                                " req -new " + "-config " + config_path +
+                                " -newkey rsa:2048 -nodes -keyout " +
+                                key_path_openssl + " -out " + csr_path_openssl;
 
   ASSERT_EQ(ExecuteCommand(awslc_command), 0);
   ASSERT_EQ(ExecuteCommand(openssl_command), 0);
@@ -1413,18 +1412,15 @@ TEST_F(ReqComparisonTest, X509ExtensionsFromEmptyConfig) {
           "\n");
   fclose(config_file.release());
 
-  std::string subject = "/CN=x509-ext-test.example.com";
   std::string awslc_command = std::string(tool_executable_path) +
                               " req -x509 -new " + "-config " + config_path +
                               " -newkey rsa:2048 -nodes -days 365 -keyout " +
-                              key_path_awslc + " -out " + cert_path_awslc +
-                              " -subj \"" + subject + "\"";
+                              key_path_awslc + " -out " + cert_path_awslc;
 
-  std::string openssl_command =
-      std::string(openssl_executable_path) + " req -x509 -new " + "-config " +
-      config_path + " -newkey rsa:2048 -nodes -days 365 -keyout " +
-      key_path_openssl + " -out " + cert_path_openssl + " -subj \"" + subject +
-      "\"";
+  std::string openssl_command = std::string(openssl_executable_path) +
+                                " req -x509 -new " + "-config " + config_path +
+                                " -newkey rsa:2048 -nodes -days 365 -keyout " +
+                                key_path_openssl + " -out " + cert_path_openssl;
 
   ASSERT_EQ(ExecuteCommand(awslc_command), 0);
   ASSERT_EQ(ExecuteCommand(openssl_command), 0);


### PR DESCRIPTION
### Description of changes: 
Some of our current implementation doesn't match the OpenSSL default behavior, resulting in some package failures. The fixes include:
- Suppress private key write when `-keyout` is not provided and the config has no default output path
- Use default extensions when no valid extension section is found in config
- Add a fallback when no `req` section is found in config

### Testing:
Cleaned up and added extra tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
