### PR TITLE
Grant OIDC Token Permissions to Top-Level Image Build Workflow

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -20,8 +20,10 @@ runs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         role-to-assume: arn:aws:iam::${{ steps.env.outputs.aws_account_id }}:role/AwsLcGitHubActionsOidcRole
+        role-session-name: ${{ github.run_id }}-${{ github.run_attempt }}
     - name: Retrieve GitHub Actions Role Credentials
       uses: aws-actions/configure-aws-credentials@v5
       with:
         role-to-assume: arn:aws:iam::${{ steps.env.outputs.aws_account_id }}:role/${{ inputs.roleName }}
+        role-session-name: ${{ github.run_id }}-${{ github.run_attempt }}
         role-chaining: true

--- a/.github/workflows/image-build-android.yml
+++ b/.github/workflows/image-build-android.yml
@@ -23,6 +23,7 @@ concurrency:
 env:
   GOPROXY: https://proxy.golang.org,direct
   DOCKER_BUILD_RECORD_UPLOAD: false
+# Critical: Caution must be used when expanding permissions beyond these as we checkout untrusted pull request code
 permissions:
   id-token: write
   contents: read
@@ -37,6 +38,8 @@ jobs:
       android: ${{ steps.images.outputs.latest }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.ref }}
       - name: Query Environment
         id: env
         run: |
@@ -70,7 +73,7 @@ jobs:
             ./.github/docker_images/scripts/verify-go-version.sh 1.25
 
   push:
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request_target' }}
     runs-on:
       codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
       image:linux-5.0

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -13,6 +13,7 @@ on:
   schedule:
     - cron: '30 15 * * 1'
 permissions:
+  id-token: write
   contents: read
 
 jobs:


### PR DESCRIPTION
### Description of changes: 
Android Image Build workflow Uses OIDC, since I use that workflow as a reusable workflow in a top-level workflow, that top-level workflow itself must also have OIDC token permissions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
