### PR TITLE
[Cherry-pick FIPS 2025] Make N1 cpucap a subset of that of V1 and V2 (#2815)

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -89,9 +89,13 @@ void OPENSSL_cpuid_setup(void) {
     }
     if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V1)) {
       OPENSSL_armcap_P |= ARMV8_NEOVERSE_V1;
+      // CPU capabilities of N1 are a subset of CPU capabilities of V1
+      OPENSSL_armcap_P |= ARMV8_NEOVERSE_N1;
     }
     if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V2)) {
       OPENSSL_armcap_P |= ARMV8_NEOVERSE_V2;
+      // CPU capabilities of N1 are a subset of CPU capabilities of V2
+      OPENSSL_armcap_P |= ARMV8_NEOVERSE_N1;
     }
   }
 

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -259,7 +259,10 @@ OPENSSL_INLINE int CRYPTO_is_ARMv8_RNDR_capable(void) {
 }
 
 OPENSSL_INLINE int CRYPTO_is_Neoverse_N1(void) {
-  return (OPENSSL_armcap_P & ARMV8_NEOVERSE_N1) != 0;
+  // It is Neoverse N1 if only ARMV8_NEOVERSE_N1 = 1 and
+  // ARMV8_NEOVERSE_<V1|V2> = 0.
+  return ((OPENSSL_armcap_P & ARMV8_NEOVERSE_N1) != 0 &&
+          (OPENSSL_armcap_P & (ARMV8_NEOVERSE_V1 | ARMV8_NEOVERSE_V2)) == 0);
 }
 
 OPENSSL_INLINE int CRYPTO_is_Neoverse_V1(void) {


### PR DESCRIPTION
Cherry-pick from main:
* https://github.com/aws/aws-lc/pull/2815
