### PR TITLE
Set SSL_R_NO_CIPHER_MATCH when failing to set ciphers

### DIFF
--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2247,6 +2247,7 @@ int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str) {
   if (!ssl_create_cipher_list(&ctx->cipher_list, has_aes_hw, str,
                                 false /* not strict */,
                                 false /* don't configure TLSv1.3 ciphers */)) {
+    OPENSSL_PUT_ERROR(SSL, SSL_R_NO_CIPHER_MATCH);
     return 0;
   }
 
@@ -2259,6 +2260,7 @@ int SSL_CTX_set_strict_cipher_list(SSL_CTX *ctx, const char *str) {
   if (!ssl_create_cipher_list(&ctx->cipher_list, has_aes_hw, str,
                                 true /* strict */,
                                 false /* don't configure TLSv1.3 ciphers */)) {
+    OPENSSL_PUT_ERROR(SSL, SSL_R_NO_CIPHER_MATCH);
     return 0;
   }
 
@@ -2291,6 +2293,7 @@ int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str) {
   if (!ssl_create_cipher_list(&ctx->tls13_cipher_list, has_aes_hw, str,
                                 false /* not strict */,
                                 true /* only configure TLSv1.3 ciphers */)) {
+    OPENSSL_PUT_ERROR(SSL, SSL_R_NO_CIPHER_MATCH);
     return 0;
   }
 
@@ -2307,6 +2310,7 @@ int SSL_set_ciphersuites(SSL *ssl, const char *str) {
   if (!ssl_create_cipher_list(&ssl->config->tls13_cipher_list,
                                 has_aes_hw, str, false /* not strict */,
                                 true /* configure TLSv1.3 ciphers */)) {
+    OPENSSL_PUT_ERROR(SSL, SSL_R_NO_CIPHER_MATCH);
     return 0;
   }
 


### PR DESCRIPTION
### Description of changes: 

OpenSSL 1.1.1 has logic [here](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/ssl/ssl_lib.c#L2588) to set an error code to indicate that no cipher match was found if zero ciphers are set given a cipher configuration string. This adds an error code to similarly to match this scenario when attempting set a user provided cipher configuration string, rather then the just the presence of the vague "INVALID_COMMAND" that comes internally from the cipher string parser.

#### Before
```
./openssl s_client -connect amazon:443 -cipher LOW:KEY
Failed setting cipher list
902517376:error:1000009e:SSL routines:OPENSSL_internal:INVALID_COMMAND:/home/mcgrails/workspace/aws-lc/ssl/ssl_cipher.cc:1172:
```

#### After
```
./openssl s_client -connect amazon:443 -cipher LOW:KEY
Failed setting cipher list
902517376:error:1000009e:SSL routines:OPENSSL_internal:INVALID_COMMAND:/home/mcgrails/workspace/aws-lc/ssl/ssl_cipher.cc:1172:
902517376:error:100000b1:SSL routines:OPENSSL_internal:NO_CIPHER_MATCH:/home/mcgrails/workspace/aws-lc/ssl/ssl_lib.cc:2263:
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
