### PR TITLE
Add authorization environments

### DIFF
--- a/.github/actions/check-authorization/action.yml
+++ b/.github/actions/check-authorization/action.yml
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+name: 'check-authorization'
+description: 'A helper action to determine the authorization level of a pull request for running CI'
+outputs:
+  approval-env:
+    description: 'The target environment to use for the workflow'
+    value: ${{ steps.collab-check.outputs.result }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Collaborator Check
+      uses: actions/github-script@v8
+      id: collab-check
+      with:
+        result-encoding: string
+        script: |
+          try {
+            const permissionResponse = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.pull_request.user.login,
+            });
+            const permission = permissionResponse.data.permission;
+            const hasWriteAccess = ['write', 'admin'].includes(permission);
+            if (!hasWriteAccess) {
+              console.log(`User ${context.payload.pull_request.user.login} does not have write access to the repository (permission: ${permission})`);
+              return "manual-approval"
+            } else {
+              console.log(`Verifed ${context.payload.pull_request.user.login} has write access. Auto Approving PR Checks.`)
+              return "auto-approve"
+            }
+          } catch (error) {
+            console.log(`${context.payload.pull_request.user.login} does not have write access. Requiring Manual Approval to run PR Checks.`)
+            return "manual-approval"
+          }

--- a/.github/workflows/image-build-android.yml
+++ b/.github/workflows/image-build-android.yml
@@ -29,7 +29,21 @@ permissions:
   contents: read
 
 jobs:
+  authorization-check:
+    outputs:
+      approval-env: ${{ steps.authz.outputs.approval-env }}
+    runs-on:
+      - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
+        image:linux-5.0
+        instance-size:small
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/check-authorization
+        id: authz 
+
   build:
+    needs: [authorization-check]
+    environment: ${{ needs.authorization-check.outputs.approval-env }}
     runs-on:
       codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
       image:linux-5.0
@@ -39,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
       - name: Query Environment
         id: env
         run: |
@@ -74,11 +88,13 @@ jobs:
 
   push:
     if: ${{ github.event_name != 'pull_request_target' }}
+    environment: ${{ needs.authorization-check.outputs.approval-env }}
     runs-on:
       codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
       image:linux-5.0
       instance-size:small
     needs:
+      - authorization-check
       - build
     outputs:
       android: ${{ steps.images.outputs.android }}


### PR DESCRIPTION
### Issues:
Addresses V2002959392

### Description of changes: 
Implements the guidance provided by internal tooling by using a GitHub "deployment" environment for manually approving workflow runs on GitHub workflows that use `pull_request_target` in order to get elevated credentials in our AWS CodeBuild-managed GitHub Actions runner environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
