### PR TITLE
Adjust image-build-android concurrency group

### DIFF
--- a/.github/workflows/image-build-android.yml
+++ b/.github/workflows/image-build-android.yml
@@ -18,7 +18,11 @@ on:
       - .github/docker_images/aws-lc/android/Dockerfile
       - .github/docker_images/scripts/**
 concurrency:
-  group: ${{ inputs.concurrency_prefix || github.workflow }}-${{ github.ref_name }}
+  group: >
+    ${{ inputs.concurrency_prefix || github.workflow }}-
+    ${{ github.event_name == 'pull_request_target'
+      && format('pr-{0}', github.event.pull_request.number)
+      || format('{0}-{1}', github.ref_type || 'ref', github.ref_name || github.ref) }}
   cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org,direct


### PR DESCRIPTION
### Description of changes:
Concurrency groups can be problematic with similarly named branches, especially with `pull_request_target`, this adjusts the concurrency group so that it behaves consistently. Will make this adjustment to other workflows as I move them to `pull_request_target` in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
