### PR TITLE
s_client: Add TLS 1.2 and 1.3 protocol selection flags

### DIFF
--- a/tool-openssl/s_client.cc
+++ b/tool-openssl/s_client.cc
@@ -30,6 +30,10 @@ static const argument_t kArguments[] = {
                 "ciphers that the client is willing to use during the SSL/TLS handshake." },
         { "-tls1_1", kBooleanArgument,
                 "Use TLS version 1.1 only." },
+        { "-tls1_2", kBooleanArgument,
+                "Use TLS version 1.2 only." },
+        { "-tls1_3", kBooleanArgument,
+                "Use TLS version 1.3 only." },
         { "", kOptionalArgument, "" },
 };
 

--- a/tool/client.cc
+++ b/tool/client.cc
@@ -583,9 +583,21 @@ bool DoClient(std::map<std::string, std::string> args_map, bool is_openssl_s_cli
 
   uint16_t max_version = TLS1_3_VERSION;
 
-  if (args_map.count("-tls1_1") != 0) {
-    max_version = TLS1_1_VERSION;
-    if (!SSL_CTX_set_min_proto_version(ctx.get(), TLS1_1_VERSION)) {
+  int tls_version_flags = 0;
+  uint16_t selected_version = 0;
+
+  if (args_map.count("-tls1_1") != 0) { tls_version_flags++; selected_version = TLS1_1_VERSION; }
+  if (args_map.count("-tls1_2") != 0) { tls_version_flags++; selected_version = TLS1_2_VERSION; }
+  if (args_map.count("-tls1_3") != 0) { tls_version_flags++; selected_version = TLS1_3_VERSION; }
+
+  if (tls_version_flags > 1) {
+    fprintf(stderr, "Cannot supply multiple protocol flags\n");
+    return false;
+  }
+
+  if (tls_version_flags == 1) {
+    max_version = selected_version;
+    if (!SSL_CTX_set_min_proto_version(ctx.get(), selected_version)) {
       return false;
     }
   }


### PR DESCRIPTION
### Changes

Add the `-tls1_2` and `-tls1_3` flags to the `s_client` tool.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
