### PR TITLE
Exclude .git from source size metric reporting

### DIFF
--- a/tests/ci/run_analytics.sh
+++ b/tests/ci/run_analytics.sh
@@ -28,7 +28,7 @@ function put_metric {
 
 # Return the size of an object or total for the folder (summarize)
 function size {
-  du --bytes --apparent-size --summarize "$@" | cut -f1
+  du --bytes --apparent-size --summarize --exclude=.git "$@" | cut -f1
 }
 
 SOURCE_CODE_SIZE=$(size "$SRC_ROOT")


### PR DESCRIPTION
### Description of changes: 
Previous metric reported on our dashboard included the `.git` directory in the size of the source code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
