### PR TITLE
Replicate OpenSSL 1.1.1 behavior for BIO_s_mem BIO_NOCLOSE

### DIFF
--- a/crypto/bio/bio_mem.c
+++ b/crypto/bio/bio_mem.c
@@ -129,7 +129,11 @@ static int mem_new(BIO *bio) {
   return 1;
 }
 
-static int mem_free(BIO *bio) {
+static int mem_buf_free(BIO *bio) {
+  if (bio == NULL) {
+    return 0;
+  }
+
   if (!bio->shutdown || !bio->init || bio->ptr == NULL) {
     return 1;
   }
@@ -141,8 +145,19 @@ static int mem_free(BIO *bio) {
     b->data = NULL;
   }
   BUF_MEM_free(b);
-  bio->ptr = NULL;
 
+  return 1;
+}
+
+static int mem_free(BIO *bio) {
+  if (bio == NULL) {
+    return 0;
+  }
+  BIO_BUF_MEM *bbm = (BIO_BUF_MEM *)bio->ptr;
+  if (!mem_buf_free(bio)) {
+    return 0;
+  }
+  bio->ptr = NULL;
   OPENSSL_free(bbm);
   return 1;
 }


### PR DESCRIPTION
### Description of changes: 
OpenSSL allows a `BIO_s_mem` to be configure with `BIO_NOCLOSE` flag, which prevents freeing of the `BUF_MEM` allocated memory, allowing for it to be used safely after freeing the other BIO related resources for `BIO_s_mem`. While OpenSSL does not free the `BUF_MEM` when this flag is set, it does free the `BIO_BUF_MEM` which contained and "owned the `BUF_MEM` reference. This behavior was not occurring in AWS-LC, which actually causes the `BIO_BUF_MEM` to "leak", as the consuming application is never given a reference to it to free itself. This PR updates the behavior to align with OpenSSL and prevent a memory leak:

Valgrind output to demonstrate this test case, based on the OpenSSL one, without the fix:
```
Note: Google Test filter = BIOTest.BioGetMemLeak
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from BIOTest
[ RUN      ] BIOTest.BioGetMemLeak
[       OK ] BIOTest.BioGetMemLeak (12 ms)
[----------] 1 test from BIOTest (19 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (44 ms total)
[  PASSED  ] 1 test.
==1760109== 24 bytes in 1 blocks are definitely lost in loss record 1 of 3
==1760109==    at 0x747186F: malloc (vg_replace_malloc.c:381)
==1760109==    by 0x8215C0: OPENSSL_malloc (crypto/mem.c:191)
==1760109==    by 0x8215C0: OPENSSL_zalloc (crypto/mem.c:208)
==1760109==    by 0x7F6700: mem_new (crypto/bio/bio_mem.c:109)
==1760109==    by 0x7F477A: BIO_new (crypto/bio/bio.c:198)
==1760109==    by 0x4A9F17: BIOTest_BioGetMemLeak_Test::TestBody() (crypto/bio/bio_test.cc:448)
==1760109==    by 0x7C690A: HandleExceptionsInMethodIfSupported<testing::Test, void> (third_party/googletest/src/gtest.cc:0)
==1760109==    by 0x7C690A: testing::Test::Run() (third_party/googletest/src/gtest.cc:2680)
==1760109==    by 0x7C7B78: testing::TestInfo::Run() (third_party/googletest/src/gtest.cc:2858)
==1760109==    by 0x7C853D: testing::TestSuite::Run() (third_party/googletest/src/gtest.cc:3012)
==1760109==    by 0x7D4BE8: testing::internal::UnitTestImpl::RunAllTests() (third_party/googletest/src/gtest.cc:5724)
==1760109==    by 0x7D454B: HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (third_party/googletest/src/gtest.cc:0)
==1760109==    by 0x7D454B: testing::UnitTest::Run() (third_party/googletest/src/gtest.cc:5307)
==1760109==    by 0x7B0614: RUN_ALL_TESTS (third_party/googletest/include/gtest/gtest.h:2486)
==1760109==    by 0x7B0614: main (crypto/test/gtest_main.cc:48)
==1760109==
crypto/crypto_test --gtest_filter=BIOTest.BioGetMemLeak
crypto/crypto_test failed to complete: exit status 99

1 of 1 tests failed:
        crypto/crypto_test --gtest_filter=BIOTest.BioGetMemLeak
exit status 1
```

### Testing:
Implemented an equivalent test-case to OpenSSL's found here: https://github.com/openssl/openssl/blob/abcf402a6cef8bdebf45b3cd8129e0e84da20f60/test/bio_memleak_test.c#L43-L69

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
