### PR TITLE
Speed up legacy AVX CI

### DIFF
--- a/.github/workflows/linux_x86_omnibus.yml
+++ b/.github/workflows/linux_x86_omnibus.yml
@@ -171,15 +171,20 @@ jobs:
             ./tests/ci/run_legacy_build.sh
 
   legacy_avx_tests:
-    name: legacy-avx-${{ matrix.image }}-${{ matrix.build32 && 'x86' || 'x86_64' }}
+    name: legacy-${{ matrix.avx_config.type }}-${{ matrix.config.image }}-${{ matrix.config.build32 && 'x86' || 'x86_64' }}
     runs-on:
       - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
         image:linux-5.0
-        instance-size:large
+        instance-size:${{ matrix.config.build32 && 'xlarge' || 'large' }}
     strategy:
       fail-fast: false
       matrix:
-        include:
+        avx_config:
+          - type: avx
+            flag: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
+          - type: 512avx
+            flag: MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+        config:
           - image: amazonlinux:2
             compiler: gcc-7
           - image: centos:7
@@ -204,14 +209,14 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
       - uses: ./.github/actions/codebuild-docker-run
-        name: Run Container (${{ matrix.image }})
+        name: Run Container (${{ matrix.config.image }})
         env:
-          AWSLC_32BIT: ${{ matrix.build32 || 0 }}
+          AWSLC_32BIT: ${{ matrix.config.build32 || 0 }}
         with:
-          image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/${{ matrix.image }}
+          image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/${{ matrix.config.image }}
           env: |
             AWSLC_32BIT
           run: |
-            source /opt/compiler-env/setup-${{ matrix.compiler }}.sh
-            ./tests/ci/run_legacy_avx_tests.sh
+            source /opt/compiler-env/setup-${{ matrix.config.compiler }}.sh
+            ./tests/ci/run_legacy_avx_tests.sh ${{ matrix.avx_config.flag }}
           options: --privileged

--- a/tests/ci/run_legacy_avx_tests.sh
+++ b/tests/ci/run_legacy_avx_tests.sh
@@ -6,20 +6,22 @@ set -exo pipefail
 
 source tests/ci/common_posix_setup.sh
 
+AVX_FLAG="${1}"
+
+# Validate AVX_FLAG is provided
+if [[ -z "${AVX_FLAG}" ]]; then
+  echo "Usage: $0 <AVX_FLAG>"
+  echo "Valid values: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX, MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX"
+  exit 1
+fi
+
 # Lightly verify that uncommon build options does not break the build. First
 # define a list of typical build options to verify the special build option with
 build_options_to_test=("" "-DBUILD_SHARED_LIBS=1" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release" "-DENABLE_PRE_SONAME_BUILD=0")
 
-## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX
 for build_option in "${build_options_to_test[@]}"; do
-  build_and_test ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
-done
-
-## Build option: MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
-for build_option in "${build_options_to_test[@]}"; do
-  build_and_test ${build_option} -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON
+  build_and_test ${build_option} -D${AVX_FLAG}=ON
 done
 
 # When Go is disabled, a different test target is produced
-build_and_run_minimal_test -DDISABLE_PERL=ON -DDISABLE_GO=ON -DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON
-build_and_run_minimal_test -DDISABLE_PERL=ON -DDISABLE_GO=ON -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=ON
+build_and_run_minimal_test -DDISABLE_PERL=ON -DDISABLE_GO=ON -D${AVX_FLAG}=ON


### PR DESCRIPTION
Legacy AVX CI builds have been taking more 2 hours, especially for 32-bit runs. This is an attempt to speed things up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
