### PR TITLE
Prepare NetOS FIPS v1.29.1 release

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator_test.cc
+++ b/crypto/fipsmodule/service_indicator/service_indicator_test.cc
@@ -4289,7 +4289,7 @@ TEST(ServiceIndicatorTest, DRBG) {
 // Since this is running in FIPS mode it should end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.29.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC FIPS 1.29.1");
 }
 
 #else
@@ -4332,6 +4332,6 @@ TEST(ServiceIndicatorTest, BasicTest) {
 // Since this is not running in FIPS mode it shouldn't end in FIPS
 // Update this when the AWS-LC version number is modified
 TEST(ServiceIndicatorTest, AWSLCVersionString) {
-  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.29.0");
+  ASSERT_STREQ(awslc_version_string(), "AWS-LC 1.29.1");
 }
 #endif // AWSLC_FIPS

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.29.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.29.1"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 

Prepare release of NetOS FIPS v1.29.1. The versioning scheme is a bit broken because the NetOS codepoint does not match any of the FIPSv releases. We cannot allocate v1.30.0 to this either, because that tag is taken by mainline AWS-LC.

Repurposing v1.29.1 is the least invasive we can do IMO. It's only meant to have an immutable reference to a codepoint intended for policy references and a release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
