### PR TITLE
Run ACCP integration tests on aarch64

### DIFF
--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -265,14 +265,28 @@ jobs:
             run: ./tests/ci/integration/run_cyrus_sasl_integration.sh
 
           # Amazon Corretto Crypto Provider Integration Tests
-          - name: accp
+          - name: accp-aarch64
+            arch: aarch64
+            size: 2xlarge
+            image: ubuntu:22.04
+            compiler: gcc-12
+            accp_fips: false
+            run: ./tests/ci/integration/run_accp_integration.sh
+          - name: accp-fips-aarch64
+            arch: aarch64
+            size: 2xlarge
+            image: ubuntu:22.04
+            compiler: gcc-12
+            accp_fips: true
+            run: ./tests/ci/integration/run_accp_integration.sh
+          - name: accp-x86_64
             arch: x86_64
             size: 2xlarge
             image: ubuntu:22.04
             compiler: gcc-12
             accp_fips: false
             run: ./tests/ci/integration/run_accp_integration.sh
-          - name: accp-fips
+          - name: accp-fips-x86_64
             arch: x86_64
             size: 2xlarge
             image: ubuntu:22.04


### PR DESCRIPTION
### Issues:
n/a

### Description of changes: 

See title.

### Call-outs:

I followed existing pattern of manually specifying the target architecture. Should we just parameterize that whole test set over x86 and aarch64? That would allow us to rip out a few duplicative definitions, but would add some more tests (namely for those integrations that don't currently test aarch64).

### Testing:

- new CI jobs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
