### PR TITLE
Prepare v1.66.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0091 NEW)
 endif()
 
 set(SOFTWARE_NAME "awslc")
-set(SOFTWARE_VERSION "1.65.1")
+set(SOFTWARE_VERSION "1.66.0")
 set(ABI_VERSION 0)
 set(CRYPTO_LIB_NAME "crypto")
 set(SSL_LIB_NAME "ssl")

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -122,7 +122,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.65.1"
+#define AWSLC_VERSION_NUMBER_STRING "1.66.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
## What's Changed
* Add encap/decapKeyCheck support in ACVP by @samuel40791765 in https://github.com/aws/aws-lc/pull/2872
* Clarify comments and API behaviour for equal-preference for TLS 1.3  by @torben-hansen in https://github.com/aws/aws-lc/pull/2873
* Add support for external contexts in ML-DSA ACVP by @samuel40791765 in https://github.com/aws/aws-lc/pull/2880
* Route ML-DSA ACVP to the right APIs by @samuel40791765 in https://github.com/aws/aws-lc/pull/2884
* Add sha1 CLI by @nhatnghiho in https://github.com/aws/aws-lc/pull/2885
* Fix openssl comparison tests by @justsmth in https://github.com/aws/aws-lc/pull/2888
* tool-openssl: pkcs8 error output on decrypt by @justsmth in https://github.com/aws/aws-lc/pull/2883
* Add RSA_X931_PADDING to rsa.h by @justsmth in https://github.com/aws/aws-lc/pull/2889
* Bump urllib3 from 2.5.0 to 2.6.0 in /tests/ci by @dependabot[bot] in https://github.com/aws/aws-lc/pull/2886
* Run ACCP integration tests on aarch64 by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2894
* Blowfish OFB Block Cipher Mode Support by @skmcgrail in https://github.com/aws/aws-lc/pull/2892

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
