### PR TITLE
Fix socat integration test

### DIFF
--- a/tests/ci/integration/run_socat_integration.sh
+++ b/tests/ci/integration/run_socat_integration.sh
@@ -49,7 +49,7 @@ function build_and_test_socat() {
   # test 506 CHDIR_ON_SHELL: GHA does not specify expected shell environment variables
   # test 508 UMASK_ON_SYSTEM: GHA does not specify expected shell environment variables
   # test 528 PROCAN_CTTY: GHA does not support tty
-  ./test.sh -d -v --expect-fail 146,216,309,310,399,467,468,478,492,498,499,500,501,502,503,506,508,528
+  ./test.sh -d --expect-fail 146,216,309,310,399,467,468,478,492,498,499,500,501,502,503,506,508,528
   popd
 }
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Socat removed `-v` option from one of their test scripts
that we use in our integration test, so I removed the flag
from our invocation.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
