### PR TITLE
Fix the libwebsockets integration test script

### DIFF
--- a/tests/ci/integration/libwebsockets_patch/libwebsocket_master.patch
+++ b/tests/ci/integration/libwebsockets_patch/libwebsocket_master.patch
@@ -1,18 +1,3 @@
-diff --git a/CMakeLists-implied-options.txt b/CMakeLists-implied-options.txt
-index f9381454..b0e39341 100644
---- a/CMakeLists-implied-options.txt
-+++ b/CMakeLists-implied-options.txt
-@@ -340,10 +340,6 @@ if (NOT LWS_WITHOUT_EXTENSIONS OR LWS_WITH_ZIP_FOPS)
- 	set(LWS_WITH_ZLIB 1)
- endif()
-
--if (LWS_WITH_SECURE_STREAMS)
--	set(LWS_WITH_SECURE_STREAMS_SYS_AUTH_API_AMAZON_COM 1)
--endif()
--
- if (NOT (LWS_WITH_STATIC OR LWS_WITH_SHARED))
- 	message(FATAL_ERROR "Makes no sense to compile with neither static nor shared libraries.")
- endif()
 diff --git a/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/CMakeLists.txt b/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/CMakeLists.txt
 index 3f9b3ba8..3f762b0b 100644
 --- a/minimal-examples-lowlevel/secure-streams/minimal-secure-streams-testsfail/CMakeLists.txt


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
The libwebsockets integration test is failing to apply a patch:
```
+ echo 'Apply patch /codebuild/output/src2930001107/src/actions-runner/_work/aws-lc/aws-lc/tests/ci/integration/libwebsockets_patch/libwebsocket_master.patch...'
+ patch -p1 --quiet -i /codebuild/output/src2930001107/src/actions-runner/_work/aws-lc/aws-lc/tests/ci/integration/libwebsockets_patch/libwebsocket_master.patch
Using libwebsockets version: v4.5.2
Apply patch /codebuild/output/src2930001107/src/actions-runner/_work/aws-lc/aws-lc/tests/ci/integration/libwebsockets_patch/libwebsocket_master.patch...
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
1 out of 1 hunk ignored -- saving rejects to file CMakeLists-implied-options.txt.rej
Error: Process completed with exit code 1.
```
I added `--forward` option to the `patch` command to skip applying the patch if it's not needed.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
