### PR TITLE
Rename SHAKE128_Init_x4 to the more general SHAKE_Init_x4

### DIFF
--- a/crypto/fipsmodule/ml_kem/fips202x4_glue.h
+++ b/crypto/fipsmodule/ml_kem/fips202x4_glue.h
@@ -38,7 +38,7 @@ static MLK_INLINE void mlk_shake128x4_squeezeblocks(uint8_t *out0, uint8_t *out1
 static MLK_INLINE void mlk_shake128x4_init(mlk_shake128x4ctx *state) {
   // Return code check can be omitted
   // since mlkem-native adheres to call discipline
-  (void) SHAKE128_Init_x4(state);
+  (void) SHAKE_Init_x4(state);
 }
 
 static MLK_INLINE void mlk_shake128x4_release(mlk_shake128x4ctx *state) {

--- a/crypto/fipsmodule/sha/internal.h
+++ b/crypto/fipsmodule/sha/internal.h
@@ -567,11 +567,11 @@ int SHAKE_Final(uint8_t *md, KECCAK1600_CTX *ctx, size_t len);
  * detailed above each SHAKE128_x4_ function signature, is satisfied.
  */
 
-// SHAKE128_Init_x4 is a batched API that operates on four independent
+// SHAKE_Init_x4 is a batched API that operates on four independent
 // Keccak bitstates. It initialises all four |ctx| fields and returns
 // 1 on success and 0 on failure. When call-discipline is maintained,
 // this function never fails.
-OPENSSL_EXPORT int SHAKE128_Init_x4(KECCAK1600_CTX_x4 *ctx);
+OPENSSL_EXPORT int SHAKE_Init_x4(KECCAK1600_CTX_x4 *ctx);
 
 // SHAKE128_Absorb_once_x4 is a batched API that operates on four independent
 // Keccak bitstates. It absorbs all four inputs |data0|, |data1|, |data2|, |data3|

--- a/crypto/fipsmodule/sha/sha3.c
+++ b/crypto/fipsmodule/sha/sha3.c
@@ -454,7 +454,7 @@ int SHAKE_Squeeze(uint8_t *md, KECCAK1600_CTX *ctx, size_t len) {
 /*
  * SHAKE batched (x4) APIs implement SHAKE functionalities in batches of four on top of SHAKE API layer
  */
-int SHAKE128_Init_x4(KECCAK1600_CTX_x4 *ctx) {
+int SHAKE_Init_x4(KECCAK1600_CTX_x4 *ctx) {
   OPENSSL_memset(ctx, 0, sizeof(KECCAK1600_CTX_x4));
   return 1;
 }

--- a/crypto/fipsmodule/sha/sha3_test.cc
+++ b/crypto/fipsmodule/sha/sha3_test.cc
@@ -510,7 +510,7 @@ TEST(SHAKETest_x4, RandomMessages) {
   uint8_t digest[BATCHED_x4][RAND_OUT_BLCKS * SHAKE128_BLOCKSIZE];
   uint8_t digest_x4[BATCHED_x4][RAND_OUT_BLCKS * SHAKE128_BLOCKSIZE];
 
-  // Test |SHAKE128_Init_x4|, |SHAKE128_Absorb_once_x4|, and |SHAKE128_Squeezeblocks_x4| functions
+  // Test |SHAKE_Init_x4|, |SHAKE128_Absorb_once_x4|, and |SHAKE128_Squeezeblocks_x4| functions
   // Assert success when digest and digest_x4 values are equal
   for (int i = 0; i < NUM_TESTS; i++) {
     for (int j = 0; j < BATCHED_x4; j++) {
@@ -523,7 +523,7 @@ TEST(SHAKETest_x4, RandomMessages) {
     }
 
     // Compute one batched x4 SHAKE128
-    ASSERT_TRUE(SHAKE128_Init_x4(&ctx));
+    ASSERT_TRUE(SHAKE_Init_x4(&ctx));
     ASSERT_TRUE(SHAKE128_Absorb_once_x4(&ctx, random_in[0], random_in[1], random_in[2], random_in[3],
                                                                                           RAND_BYTES_x4));
     ASSERT_TRUE(SHAKE128_Squeezeblocks_x4(digest_x4[0], digest_x4[1], digest_x4[2], digest_x4[3],


### PR DESCRIPTION
### Issues:
mldsa-native import needs SHAKE256_* functions. SHAKE256_Absorb_once_x4 and SHAKE256_Squeezeblocks_x4 are already supported. SHAKE256_Init_x4 is missing, however, SHAKE128_Init_x4 can be reused as-is for both SHAKE128 and SHAKE256. Therefore, generalizing the function avoids duplicates.

### Description of changes: 
Rename SHAKE128_Init_x4 to the more general function SHAKE_Init_x4, covering both SHAKE security levels.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
