### PR TITLE
Add randomized unit testing for EVP_CIPHERs

### DIFF
--- a/crypto/cipher_extra/cipher_test.cc
+++ b/crypto/cipher_extra/cipher_test.cc
@@ -1521,7 +1521,7 @@ TEST_P(RandomizedCipherTest, EncryptDecrypt) {
   const bool is_xts = mode == EVP_CIPH_XTS_MODE;
 
   for (size_t pt_len = 0; pt_len <= max_input_size; pt_len++) {
-    // Filter based on cipher mode constraints
+    // Filter based on cipher mode constraints.
     if (is_xts && pt_len < 16) {
       continue;  // XTS requires at least 16 bytes
     }


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Added a unit test that performs end-to-end testing of all
EVP_CIPHERs with random key, IV, plaintext, aad.

### Call-outs:
Locally, I reverted the XTS fix (https://github.com/aws/aws-lc/commit/3f282aa6fd16f6afce9e7d0d10ed5d9fdb713efa) and verified that this new unit test would catch the bug.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
