### PR TITLE
Remove pkcs8 expected in test

### DIFF
--- a/tool-openssl/pkcs8_test.cc
+++ b/tool-openssl/pkcs8_test.cc
@@ -228,17 +228,6 @@ class PKCS8OptionUsageErrorsTest : public PKCS8Test {
   }
 };
 
-// Test missing -in required option
-TEST_F(PKCS8OptionUsageErrorsTest, RequiredOptionTests) {
-  std::vector<std::vector<std::string>> testparams = {
-      {"-out", "output.pem", "-topk8"},
-      {"-topk8", "-nocrypt"},
-  };
-  for (const auto &args : testparams) {
-    TestOptionUsageErrors(args);
-  }
-}
-
 // Test invalid format
 TEST_F(PKCS8OptionUsageErrorsTest, InvalidFormatTest) {
   std::vector<std::vector<std::string>> testparams = {


### PR DESCRIPTION
Same issue as https://github.com/aws/aws-lc/pull/2901. Trying to fix the rpm CI dimension.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
