### PR TITLE
clean up pass_util namespace and _WIN32 macro

### DIFF
--- a/tool-openssl/internal.h
+++ b/tool-openssl/internal.h
@@ -36,7 +36,7 @@ enum class Source : uint8_t {
   kFile,   // Password from file with file: prefix
   kEnv,    // Password from environment with env: prefix
   kStdin,  // Password from stdin
-#ifndef _WIN32
+#if !defined(OPENSSL_WINDOWS)
   kFd,  // Password from file descriptor with fd: prefix (Unix only)
 #endif
 };

--- a/tool-openssl/pass_util_test.cc
+++ b/tool-openssl/pass_util_test.cc
@@ -7,19 +7,14 @@
 #include <openssl/mem.h>
 #include <openssl/pem.h>
 #include <string>
-#ifndef _WIN32
-#include <fcntl.h>
-#include <unistd.h>
+#include <stdlib.h>
+#if !defined(_OPENSSL_WINDOWS)
+  #include <fcntl.h>
+  #include <unistd.h>
 #endif
-#ifdef _WIN32
-#include <stdlib.h>  // for _putenv_s
-#include <windows.h> // for CreatePipe, SetStdHandle
-#endif
+
 #include "internal.h"
 #include "test_util.h"
-
-// Use PEM_BUFSIZE (defined in openssl/pem.h) for password buffer size testing
-// to match the implementation in pass_util.cc
 
 namespace {
 // Helper functions to encapsulate common operations
@@ -44,7 +39,7 @@ void WriteTestFile(const char *path, const char *content,
 }
 
 void SetTestEnvVar(const char *name, const char *value) {
-#ifdef _WIN32
+#if defined(_OPENSSL_WINDOWS)
   _putenv_s(name, value);
 #else
   setenv(name, value, 1);
@@ -52,7 +47,7 @@ void SetTestEnvVar(const char *name, const char *value) {
 }
 
 void UnsetTestEnvVar(const char *name) {
-#ifdef _WIN32
+#if defined(_OPENSSL_WINDOWS)
   _putenv_s(name, "");
 #else
   unsetenv(name);
@@ -466,7 +461,7 @@ TEST_F(PassUtilTest, ExtractPasswordsSameFileEdgeCases) {
   EXPECT_EQ(*passout, "line2");
 }
 
-#ifndef _WIN32
+#ifndef OPENSSL_WINDOWS
 TEST_F(PassUtilTest, FdExtraction) {
   int fd = open(pass_path, O_RDONLY);
   ASSERT_GE(fd, 0);
@@ -487,7 +482,7 @@ TEST_F(PassUtilTest, FdExtraction) {
 }
 #endif
 
-#ifndef _WIN32
+#ifndef OPENSSL_WINDOWS
 TEST_F(PassUtilTest, StdinExtraction) {
   int pipefd[2];
   ASSERT_EQ(pipe(pipefd), 0);
@@ -529,7 +524,7 @@ TEST_F(PassUtilTest, StdinExtraction) {
 }
 #endif
 
-#ifndef _WIN32
+#ifndef OPENSSL_WINDOWS
 TEST_F(PassUtilTest, StdinExtractPasswords) {
   int pipefd[2];
   ASSERT_EQ(pipe(pipefd), 0);

--- a/tool-openssl/req.cc
+++ b/tool-openssl/req.cc
@@ -280,7 +280,7 @@ static const char *PromptField(const ReqField &field, char *buffer,
     buffer[len - 1] = '\0';
     len--;
   }
-#if defined(_WIN32)
+#if defined(OPENSSL_WINDOWS)
   if (len > 0 && buffer[len - 1] == '\r') {
     buffer[len - 1] = '\0';
     len--;

--- a/tool-openssl/x509.cc
+++ b/tool-openssl/x509.cc
@@ -167,7 +167,7 @@ static bool SetSerial(X509 *cert, const std::string &ca_file_path) {
       len--;
     }
 
-#if defined(_WIN32)
+#if defined(OPENSSL_WINDOWS)
     if (len > 0 && buf[len - 1] == '\r') {
       buf[len - 1] = '\0';
       len--;


### PR DESCRIPTION
1. The `pass_util.cc` was calling it's own namespace as a separate file, when it could be consolidated into one. I'm skeptical if a namespace is even needed though, it seems a bit redundant, but I won't tweak this part for now.
2. Use the existing `OPENSSL_WINDOWS` macro instead of `_WIN32` in tool-openssl.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
