### PR TITLE
Add support for Big Endian in ACVP tool

### DIFF
--- a/util/fipstools/acvp/acvptool/subprocess/drbg.go
+++ b/util/fipstools/acvp/acvptool/subprocess/drbg.go
@@ -15,7 +15,6 @@
 package subprocess
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -117,7 +116,7 @@ func (d *drbg) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 
 			outLen := group.RetBits / 8
 			var outLenBytes [4]byte
-			binary.LittleEndian.PutUint32(outLenBytes[:], uint32(outLen))
+			NativeEndian.PutUint32(outLenBytes[:], uint32(outLen))
 
 			var result [][]byte
 			if group.PredictionResistance {

--- a/util/fipstools/acvp/acvptool/subprocess/hash.go
+++ b/util/fipstools/acvp/acvptool/subprocess/hash.go
@@ -15,7 +15,6 @@
 package subprocess
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -165,7 +164,7 @@ func (h *hashPrimitive) Process(vectorSet []byte, m Transactable) (interface{}, 
 						}
 
 						digest = result[0]
-						outLenByteArr = uint32le(uint32(binary.LittleEndian.Uint32(result[1])))
+						outLenByteArr = uint32le(uint32(NativeEndian.Uint32(result[1])))
 						testResponse.MCTResults = append(testResponse.MCTResults, hashMCTResult{hex.EncodeToString(digest), uint64(len(digest) * 8)})
 					}
 				}
@@ -185,7 +184,7 @@ func (h *hashPrimitive) Process(vectorSet []byte, m Transactable) (interface{}, 
 				}
 
 				timesByteArr := make([]byte, 8)
-				binary.LittleEndian.PutUint64(timesByteArr, times)
+				NativeEndian.PutUint64(timesByteArr, times)
 				result, err := m.Transact(h.algo+"/LDT", 1, content, timesByteArr)
 				if err != nil {
 					panic(h.algo + " LDT hash operation failed: " + err.Error())

--- a/util/fipstools/acvp/acvptool/subprocess/kdf-components.go
+++ b/util/fipstools/acvp/acvptool/subprocess/kdf-components.go
@@ -15,7 +15,6 @@
 package subprocess
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -203,7 +202,7 @@ func HandleTLS(test kdfCompTest, k *kdfComp, m Transactable, method string, grou
 	)
 
 	var outLenBytes [4]byte
-	binary.LittleEndian.PutUint32(outLenBytes[:], uint32(masterSecretLength))
+	NativeEndian.PutUint32(outLenBytes[:], uint32(masterSecretLength))
 	var result [][]byte
 	switch k.algo {
 	case "kdf-components":
@@ -216,7 +215,7 @@ func HandleTLS(test kdfCompTest, k *kdfComp, m Transactable, method string, grou
 	if err != nil {
 		return err
 	}
-	binary.LittleEndian.PutUint32(outLenBytes[:], uint32(group.KeyBlockBits/8))
+	NativeEndian.PutUint32(outLenBytes[:], uint32(group.KeyBlockBits/8))
 	// TLS 1.0, 1.1, and 1.2 use a different order for the client and server
 	// randoms when computing the key block.
 	result2, err := m.Transact(method, 1, outLenBytes[:], result[0], []byte(keyBlockLabel), serverRandom, clientRandom)

--- a/util/fipstools/acvp/acvptool/subprocess/subprocess.go
+++ b/util/fipstools/acvp/acvptool/subprocess/subprocess.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"unsafe"
 )
 
 // Transactable provides an interface to allow test injection of transactions
@@ -50,6 +51,19 @@ type Subprocess struct {
 	pendingReads chan pendingRead
 	// readerFinished is a channel that is closed if `readerRoutine` has finished (e.g. because of a read error).
 	readerFinished chan struct{}
+}
+
+// TODO: Migrate to directly use binary.NativeEndian when we can upgrade to go1.21+.
+// represents the platform's Endian type.
+var	NativeEndian binary.ByteOrder
+
+func init() {
+	var i uint16 = 0x0001
+    if *(*byte)(unsafe.Pointer(&i)) == 0x01 {
+        NativeEndian = binary.LittleEndian
+    } else {
+        NativeEndian = binary.BigEndian
+    }
 }
 
 // pendingRead represents an expected response from the modulewrapper.
@@ -182,8 +196,8 @@ func (m *Subprocess) flush() error {
 
 	const cmd = "flush"
 	buf := make([]byte, 8, 8+len(cmd))
-	binary.LittleEndian.PutUint32(buf, 1)
-	binary.LittleEndian.PutUint32(buf[4:], uint32(len(cmd)))
+	NativeEndian.PutUint32(buf, 1)
+	NativeEndian.PutUint32(buf[4:], uint32(len(cmd)))
 	buf = append(buf, []byte(cmd)...)
 
 	if _, err := m.stdin.Write(buf); err != nil {
@@ -233,10 +247,10 @@ func (m *Subprocess) TransactAsync(cmd string, expectedNumResults int, args [][]
 	}
 
 	buf := make([]byte, 4*(2+len(args)), 4*(2+len(args))+argLength)
-	binary.LittleEndian.PutUint32(buf, uint32(1+len(args)))
-	binary.LittleEndian.PutUint32(buf[4:], uint32(len(cmd)))
+	NativeEndian.PutUint32(buf, uint32(1+len(args)))
+	NativeEndian.PutUint32(buf[4:], uint32(len(cmd)))
 	for i, arg := range args {
-		binary.LittleEndian.PutUint32(buf[4*(i+2):], uint32(len(arg)))
+		NativeEndian.PutUint32(buf[4*(i+2):], uint32(len(arg)))
 	}
 	buf = append(buf, []byte(cmd)...)
 	for _, arg := range args {
@@ -323,7 +337,7 @@ func (m *Subprocess) readResult(cmd string, expectedNumResults int) ([][]byte, e
 		return nil, err
 	}
 
-	numResults := binary.LittleEndian.Uint32(buf)
+	numResults := NativeEndian.Uint32(buf)
 	if int(numResults) != expectedNumResults {
 		return nil, fmt.Errorf("expected %d results from %q but got %d", expectedNumResults, cmd, numResults)
 	}
@@ -335,7 +349,7 @@ func (m *Subprocess) readResult(cmd string, expectedNumResults int) ([][]byte, e
 
 	var resultsLength uint64
 	for i := uint32(0); i < numResults; i++ {
-		resultsLength += uint64(binary.LittleEndian.Uint32(buf[4*i:]))
+		resultsLength += uint64(NativeEndian.Uint32(buf[4*i:]))
 	}
 
 	if resultsLength > (1 << 30) {
@@ -350,7 +364,7 @@ func (m *Subprocess) readResult(cmd string, expectedNumResults int) ([][]byte, e
 	ret := make([][]byte, 0, numResults)
 	var offset int
 	for i := uint32(0); i < numResults; i++ {
-		length := binary.LittleEndian.Uint32(buf[4*i:])
+		length := NativeEndian.Uint32(buf[4*i:])
 		ret = append(ret, results[offset:offset+int(length)])
 		offset += int(length)
 	}
@@ -408,7 +422,7 @@ type primitive interface {
 
 func uint32le(n uint32) []byte {
 	var ret [4]byte
-	binary.LittleEndian.PutUint32(ret[:], n)
+	NativeEndian.PutUint32(ret[:], n)
 	return ret[:]
 }
 

--- a/util/fipstools/acvp/acvptool/subprocess/xts.go
+++ b/util/fipstools/acvp/acvptool/subprocess/xts.go
@@ -15,7 +15,6 @@
 package subprocess
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -112,7 +111,7 @@ func (h *xts) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 				// Sector numbers (or "sequence numbers", as NIST calls them) are turned
 				// into tweak values by encoding them in little-endian form. See IEEE
 				// 1619-2007, section 5.1.
-				binary.LittleEndian.PutUint64(tweak[:8], *test.SectorNum)
+				NativeEndian.PutUint64(tweak[:8], *test.SectorNum)
 			} else {
 				return nil, fmt.Errorf("neither sector number nor explicit tweak in test case %d/%d", group.ID, test.ID)
 			}


### PR DESCRIPTION
### Issues:
This was change needed to move forward with ACVP testing on powerpc64 for NetOS.

### Description of changes: 
Our ACVP tool was not working properly on the PowerPC Big Endian platform that NetOS needs to support. go1.21 has support for `binary.NativeEndian`, but we can't use the newer version yet. This uses a workaround with `unsafe.Pointer` until we can upgrade.

### Call-outs:
This is harder to test, but it might be doable by recompiling the cross compilation tool chain we have [here](https://github.com/aws/aws-lc/blob/d91d05ddb5d4a8d19eb57d57a7402148004c85d2/.github/workflows/cross-test.yml#L24) with gccgo enabled. It's harder to branch out the logic within the script to account for the different behavior though, might do so in a follow up PR.

### Testing:
Works on the powerpc host NetOS lent us. Built with `gccgo` from gcc-12 with a powerpc64 cross compilation toolchain:
```
CC=powerpc64-unknown-linux-gnu-gcc \
GCCGO=powerpc64-unknown-linux-gnu-gccgo \
CGO_ENABLED=1 \
GOOS=linux \
GOARCH=ppc64 \
go build -compiler gccgo \
    -gccgoflags '-static -mcpu=e6500' \
    -o acvptool
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
