### PR TITLE
Windows 7 support

### DIFF
--- a/crypto/rand_extra/windows.c
+++ b/crypto/rand_extra/windows.c
@@ -26,7 +26,7 @@ OPENSSL_MSVC_PRAGMA(warning(push, 3))
 
 #include <windows.h>
 
-// ProcessPrng` (from `bcryptprimitives.dll`) is only available on Windows 8+.
+// ProcessPrng (from `bcryptprimitives.dll`) is only available on Windows 8+.
 #if !defined(__MINGW32__) && defined(_WIN32_WINNT) && _WIN32_WINNT <= _WIN32_WINNT_WIN7
 #define AWSLC_WINDOWS_7_COMPAT
 #endif


### PR DESCRIPTION
### Issues:
Addresses #1997

### Description of changes: 
`ProcessPrng` (from `bcryptprimitives.dll`) is only available on Windows 8+. So the current code fails at runtime on Windows 7 because `GetProcAddress` returns `NULL` and causes an `abort()`.

This change defines `AWSLC_WINDOWS_7_COMPAT` when `_WIN32_WINNT <= _WIN32_WINNT_WIN7`. Then uses the existing `BCryptGenRandom` logic when it's is defined.

* Related: aws/aws-lc-rs#1000

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
