### PR TITLE
Use already defined macro for no inline

### DIFF
--- a/crypto/fipsmodule/service_indicator/service_indicator.c
+++ b/crypto/fipsmodule/service_indicator/service_indicator.c
@@ -24,12 +24,7 @@ int is_fips_build(void) {
 // This function is intentionally not inlined to ensure the __FILE__ string
 // literal reference stays close to the call site, avoiding the ±1MB PC-relative
 // addressing limit of the ARM64 ADR instruction.
-#if defined(_MSC_VER)
-__declspec(noinline)
-#else
-__attribute__((noinline))
-#endif
-static void put_set_thread_local_error(void) {
+static OPENSSL_NOINLINE void put_set_thread_local_error(void) {
   OPENSSL_PUT_ERROR(CRYPTO, ERR_R_INTERNAL_ERROR);
 }
 


### PR DESCRIPTION
### Description of changes: 

Use pre-defined macro for no inline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
