### PR TITLE
[Cherry-pick FIPS NetOS]Add support for Big Endian in ACVP tool

### DIFF
--- a/util/fipstools/acvp/acvptool/subprocess/drbg.go
+++ b/util/fipstools/acvp/acvptool/subprocess/drbg.go
@@ -15,7 +15,6 @@
 package subprocess
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -117,7 +116,7 @@ func (d *drbg) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 
 			outLen := group.RetBits / 8
 			var outLenBytes [4]byte
-			binary.LittleEndian.PutUint32(outLenBytes[:], uint32(outLen))
+			NativeEndian.PutUint32(outLenBytes[:], uint32(outLen))
 
 			var result [][]byte
 			if group.PredictionResistance {

--- a/util/fipstools/acvp/acvptool/subprocess/hash.go
+++ b/util/fipstools/acvp/acvptool/subprocess/hash.go
@@ -15,7 +15,6 @@
 package subprocess
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -165,7 +164,7 @@ func (h *hashPrimitive) Process(vectorSet []byte, m Transactable) (interface{}, 
 						}
 
 						digest = result[0]
-						outLenByteArr = uint32le(uint32(binary.LittleEndian.Uint32(result[1])))
+						outLenByteArr = uint32le(uint32(NativeEndian.Uint32(result[1])))
 						testResponse.MCTResults = append(testResponse.MCTResults, hashMCTResult{hex.EncodeToString(digest), uint64(len(digest) * 8)})
 					}
 				}
@@ -185,7 +184,7 @@ func (h *hashPrimitive) Process(vectorSet []byte, m Transactable) (interface{}, 
 				}
 
 				timesByteArr := make([]byte, 8)
-				binary.LittleEndian.PutUint64(timesByteArr, times)
+				NativeEndian.PutUint64(timesByteArr, times)
 				result, err := m.Transact(h.algo+"/LDT", 1, content, timesByteArr)
 				if err != nil {
 					panic(h.algo + " LDT hash operation failed: " + err.Error())

--- a/util/fipstools/acvp/acvptool/subprocess/kdf-components.go
+++ b/util/fipstools/acvp/acvptool/subprocess/kdf-components.go
@@ -15,7 +15,6 @@
 package subprocess
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -203,7 +202,7 @@ func HandleTLS(test kdfCompTest, k *kdfComp, m Transactable, method string, grou
 	)
 
 	var outLenBytes [4]byte
-	binary.LittleEndian.PutUint32(outLenBytes[:], uint32(masterSecretLength))
+	NativeEndian.PutUint32(outLenBytes[:], uint32(masterSecretLength))
 	var result [][]byte
 	switch k.algo {
 	case "kdf-components":
@@ -216,7 +215,7 @@ func HandleTLS(test kdfCompTest, k *kdfComp, m Transactable, method string, grou
 	if err != nil {
 		return err
 	}
-	binary.LittleEndian.PutUint32(outLenBytes[:], uint32(group.KeyBlockBits/8))
+	NativeEndian.PutUint32(outLenBytes[:], uint32(group.KeyBlockBits/8))
 	// TLS 1.0, 1.1, and 1.2 use a different order for the client and server
 	// randoms when computing the key block.
 	result2, err := m.Transact(method, 1, outLenBytes[:], result[0], []byte(keyBlockLabel), serverRandom, clientRandom)

--- a/util/fipstools/acvp/acvptool/subprocess/xts.go
+++ b/util/fipstools/acvp/acvptool/subprocess/xts.go
@@ -15,7 +15,6 @@
 package subprocess
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -112,7 +111,7 @@ func (h *xts) Process(vectorSet []byte, m Transactable) (interface{}, error) {
 				// Sector numbers (or "sequence numbers", as NIST calls them) are turned
 				// into tweak values by encoding them in little-endian form. See IEEE
 				// 1619-2007, section 5.1.
-				binary.LittleEndian.PutUint64(tweak[:8], *test.SectorNum)
+				NativeEndian.PutUint64(tweak[:8], *test.SectorNum)
 			} else {
 				return nil, fmt.Errorf("neither sector number nor explicit tweak in test case %d/%d", group.ID, test.ID)
 			}


### PR DESCRIPTION
(cherry picked from commit d82aea4e7d85ff3c2f61825a4e5ab0b457559e3a). This change is not in the FIPS boundary and does not impact
the integrity hash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
