### PR TITLE
Avoid cross-compilation build failure

### DIFF
--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -26,7 +26,7 @@
 #  if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #    define OPENSSL_BIG_ENDIAN
 #  endif
-#elif defined(__has_include)
+#elif !defined(_MSC_VER) && defined(__has_include)
 #  if __has_include(<endian.h>)
 #    include <endian.h>
 #  elif __has_include(<sys/param.h>)


### PR DESCRIPTION
### Issues:
Addresses aws/aws-lc-rs#1004

### Description of changes: 
When cross-compiling w/ MSVC via Wine on Linux (... yes, this appears to be possible ...), it might find an "endian.h" system include file on the host.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
