### PR TITLE
Use existing session context if new is actually NULL

### DIFF
--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -2856,7 +2856,8 @@ SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx) {
   if (!ssl->config) {
     return NULL;
   }
-  if (ssl->ctx.get() == ctx) {
+
+  if (!ctx || ssl->ctx.get() == ctx) {
     return ssl->ctx.get();
   }
 


### PR DESCRIPTION
### Issues:

P369474299

### Description of changes: 

`SSL_set_SSL_CTX()` doesn't currently tolerate the `ctx` argument being `NULL` (it would just crash in some cases). I was pondering handling this by just explicitly error out if it was `NULL`. But I realised upstream OpenSSL has a different behaviour: falls back to existing session context from `ssl`.

This is unnecessary complexity, but in the name of interoperability I did that instead of flipping to an error state.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
