### PR TITLE
Bump FreeBSD testing to v14.2 and v15.0

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -714,14 +714,14 @@ jobs:
           - "x86-64"
           - "arm64"
         version:
-          - "13.5"
           - "14.2"
+          - "15.0"
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
       - name: Prepare VM
-        uses: cross-platform-actions/action@2d97d42e1972a17b045fd709a422f7e55a86230d
+        uses: cross-platform-actions/action@v0.32.0
         env:
           AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS: 5
           AWS_LC_GO_TEST_TIMEOUT: 90m


### PR DESCRIPTION
### Description of changes: 
* Bump FreeBSD testing to v14.2 and v15.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
