### PR TITLE
Fix image-build-windows workflow to only push on workflow_call and workflow_dispatch

### DIFF
--- a/.github/workflows/image-build-windows.yml
+++ b/.github/workflows/image-build-windows.yml
@@ -131,6 +131,7 @@ jobs:
 
   # TODO: For some odd reason instance-size needs to be set here otherwise it won't use the fleet?
   x86_64_push:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on:
       - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
         image:windows-ec2-2022


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
