### PR TITLE
Shorten Windows Build Directory Path

### DIFF
--- a/tests/ci/run_windows_tests.bat
+++ b/tests/ci/run_windows_tests.bat
@@ -1,6 +1,6 @@
 @echo on
 set SRC_ROOT=%cd%
-set BUILD_DIR=%SRC_ROOT%\test_build_dir
+set BUILD_DIR=%TEMP%\awslc
 
 @rem %1 contains the path to the setup batch file for the version of of visual studio that was passed in from the build spec file.
 @rem %2 specifies the architecture option to build against: https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line


### PR DESCRIPTION
### Description of changes: 
Resolves rather long paths that can happen based off the codebuild folder and the name of the repository. Currently seeing issues with this over in the private staging repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
