### PR TITLE
ci: add Windows CI for Fips builds with non-MSVC compilers

### DIFF
--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -67,6 +67,7 @@ jobs:
             CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
             CMAKE_BUILD_TYPE=Release \
             FIPS=1 \
+            BUILD_SHARED_LIBS=ON \
       - name: Build Project FIPS
         run: cmake --build "path has spaces/build-fips" --target all
       - name: Run tests FIPS
@@ -111,6 +112,7 @@ jobs:
             CMAKE_SYSTEM_PROCESSOR=x86_64 \
             CMAKE_BUILD_TYPE=Release \
             FIPS=1 \
+            BUILD_SHARED_LIBS=ON \
       - name: Build Project FIPS
         run: cmake --build ./build-fips --target all
       - name: Run tests FIPS
@@ -164,6 +166,7 @@ jobs:
           options: |
             CMAKE_BUILD_TYPE=Release \
             FIPS=1 \
+            BUILD_SHARED_LIBS=ON \
       - if: ${{ matrix.target  == 'x64' }}
         name: Build Project FIPS
         run: cmake --build ./build-fips --target all
@@ -229,6 +232,7 @@ jobs:
           options: |
             CMAKE_BUILD_TYPE=Release \
             FIPS=1 \
+            BUILD_SHARED_LIBS=ON \
       - if: ${{ matrix.target  == 'x64' }}
         name: Build Project FIPS
         run: cmake --build ./build-fips --target all
@@ -331,6 +335,7 @@ jobs:
             CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
             CMAKE_BUILD_TYPE=Release \
             FIPS=1 \
+            BUILD_SHARED_LIBS=ON \
       - name: Build Project FIPS
         shell: 'msys2 {0}'
         run: cmake --build ./build-fips --target all


### PR DESCRIPTION
### Issues:
Addresses https://github.com/aws/aws-lc/pull/2982#issuecomment-3842102625

### Description of changes: 
This adds CI for non-MSVC compilers to build FIPS on Windows.

### Call-outs:
Passing the builds requires merging https://github.com/aws/aws-lc/pull/2982

### Testing:
CI windows-alt.yml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
