### PR TITLE
Nmap build needs liblinear

### DIFF
--- a/tests/ci/integration/run_nmap_integration.sh
+++ b/tests/ci/integration/run_nmap_integration.sh
@@ -6,6 +6,12 @@ set -exu
 
 source tests/ci/common_posix_setup.sh
 
+# Dependencies needed for nmap build
+if [ "$(id -u)" -eq 0 ]; then
+  apt-get update
+  apt-get install -y --no-install-recommends liblinear-dev
+fi
+
 # Set up environment.
 
 # SYS_ROOT


### PR DESCRIPTION
### Issues:
Resolves P368009630

### Description of changes: 
The nmap integration test was failing on the Ubuntu 22.04 CI runner because the `liblinear-dev` package was not installed. Nmap requires this library for certain functionality during its build process.

### Call-outs:
This change adds the missing dependency installation to `run_nmap_integration.sh`, following the existing pattern used by other integration scripts (e.g., `run_httpd_integration.sh`). The package is only installed when running as root, using the standard `apt-get` approach with `--no-install-recommends` to minimize footprint.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

