### PR TITLE
Ensure index argument is not negative in ASN1_BIT_STRING_set_bit

### DIFF
--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -212,6 +212,10 @@ int ASN1_BIT_STRING_set_bit(ASN1_BIT_STRING *a, int n, int value) {
   int w, v, iv;
   unsigned char *c;
 
+  // n is an index, cannot be negative
+  if (n < 0) {
+    return 0;
+  }
   w = n / 8;
   v = 1 << (7 - (n & 0x07));
   iv = ~v;


### PR DESCRIPTION
### Description of changes: 

If `n` is negative, calculations in `ASN1_BIT_STRING_set_bit` is corrupted. `n` is an index and therefore shouldn't be negative though. Just ensure that programatically.

### Call-outs:

Reported by Petr Praus

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
