### PR TITLE
Ensure no overflow in signed output length in do_buf

### DIFF
--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -203,11 +203,21 @@ static int do_buf(const unsigned char *buf, int buflen, int encoding,
         if (len < 0) {
           return -1;
         }
+
+        // Ensure addition doesn't overflow and corrupt the signed output length
+        if (len > INT_MAX - outlen) {
+          OPENSSL_PUT_ERROR(ASN1, ASN1_R_STRING_TOO_LONG);
+          return -1;
+        }
         outlen += len;
       }
     } else {
       int len = do_esc_char(c, flags, quotes, out, is_first, is_last);
       if (len < 0) {
+        return -1;
+      }
+      if (len > INT_MAX - outlen) {
+        OPENSSL_PUT_ERROR(ASN1, ASN1_R_STRING_TOO_LONG);
         return -1;
       }
       outlen += len;

--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -206,7 +206,7 @@ static int do_buf(const unsigned char *buf, int buflen, int encoding,
 
         // Ensure addition doesn't overflow and corrupt the signed output length
         if (len > INT_MAX - outlen) {
-          OPENSSL_PUT_ERROR(ASN1, ASN1_R_STRING_TOO_LONG);
+          OPENSSL_PUT_ERROR(ASN1, ERR_R_OVERFLOW);
           return -1;
         }
         outlen += len;
@@ -217,7 +217,7 @@ static int do_buf(const unsigned char *buf, int buflen, int encoding,
         return -1;
       }
       if (len > INT_MAX - outlen) {
-        OPENSSL_PUT_ERROR(ASN1, ASN1_R_STRING_TOO_LONG);
+        OPENSSL_PUT_ERROR(ASN1, ERR_R_OVERFLOW);
         return -1;
       }
       outlen += len;


### PR DESCRIPTION
### Description of changes: 

In some cases, `outlen` would be able to overflow. But it would require the string to be very long (hundreds of mbs). This is partially avoided by `ASN1_STRING_set()` ensuring strings are less than `ASN1_STRING_MAX`. Yet, one could use `ASN1_STRING_set0()` which doesn't require that. Latter is a void function and I can't tell what might or might not be using it. Instead just check for overflow inline. Printing function anyway.

### Call-outs:

Reported by Petr Praus

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
