### PR TITLE
Free potential memory before assigning new pointer

### DIFF
--- a/crypto/fipsmodule/pqdsa/pqdsa.c
+++ b/crypto/fipsmodule/pqdsa/pqdsa.c
@@ -77,6 +77,7 @@ int PQDSA_KEY_set_raw_public_key(PQDSA_KEY *key, CBS *in) {
     return 0;
   }
 
+  OPENSSL_free(key->public_key);
   key->public_key = OPENSSL_memdup(CBS_data(in), key->pqdsa->public_key_len);
   if (key->public_key == NULL) {
     return 0;


### PR DESCRIPTION
### Description of changes: 

If a pointer has already been assigned and `PQDSA_KEY_set_raw_public_key` is called, we will leak memory. The function is not exported and both uses internally only use a fresh object as argument. So, no current issue. Ensure no leak will happen in the future.

### Call-outs:

Reported by Petr Praus

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
