### PR TITLE
Remove redundant CPython 3.9 integration test

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -90,19 +90,6 @@ jobs:
         run: |
           pushd "${GITHUB_WORKSPACE}/aws-lc"
           ./tests/ci/integration/run_rust_openssl_integration.sh
-  python-39:
-    if: github.repository_owner == 'aws'
-    runs-on: ubuntu-latest
-    name: Python 3.9
-    steps:
-      - name: Install OS Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
-      - uses: actions/checkout@v3
-      - name: Build AWS-LC, build python, run tests
-        run: |
-          ./tests/ci/integration/run_python_integration.sh 3.9
   apache-httpd:
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest


### PR DESCRIPTION

### Description of changes: 

3.9 is covered in the omnibus [here](https://github.com/aws/aws-lc/blob/36c64dc6151dc2f4ed1f635b9e022fbe3a17fedc/.github/workflows/integration_omnibus.yml#L425).

### Testing:
- CI

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
