### PR TITLE
[FIPS 1.x 1MU] pkcs8: cap ciphertext length before allocating in pkcs8_pbe_decrypt

### DIFF
--- a/crypto/pkcs8/pkcs8.c
+++ b/crypto/pkcs8/pkcs8.c
@@ -388,14 +388,14 @@ int pkcs8_pbe_decrypt(uint8_t **out, size_t *out_len, CBS *algorithm,
     goto err;
   }
 
-  buf = OPENSSL_malloc(in_len);
-  if (buf == NULL) {
-    OPENSSL_PUT_ERROR(PKCS8, ERR_R_MALLOC_FAILURE);
+  if (in_len > INT_MAX) {
+    OPENSSL_PUT_ERROR(PKCS8, ERR_R_OVERFLOW);
     goto err;
   }
 
-  if (in_len > INT_MAX) {
-    OPENSSL_PUT_ERROR(PKCS8, ERR_R_OVERFLOW);
+  buf = OPENSSL_malloc(in_len);
+  if (buf == NULL) {
+    OPENSSL_PUT_ERROR(PKCS8, ERR_R_MALLOC_FAILURE);
     goto err;
   }
 


### PR DESCRIPTION
pkcs8_pbe_decrypt() allocates OPENSSL_malloc(in_len) where in_len is derived from attacker-influenced ASN.1 OCTET STRING lengths. The existing INT_MAX check only guards EVP_DecryptUpdate’s int parameter and occurs after the allocation.

We would like to thank Joshua Rogers (https://joshua.hu/) of AISLE Research Team (https://aisle.com/) for reporting this issue.

(cherry picked from commit e17506cdbde19ce68e21681b2fb9581b1fe93037)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
