### PR TITLE
Fix CI: gcc-4.8

### DIFF
--- a/.github/docker_images/gcc-4.8/Dockerfile
+++ b/.github/docker_images/gcc-4.8/Dockerfile
@@ -1,24 +1,37 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
-FROM gcc:4.8.5
+FROM ubuntu:18.04
 
 VOLUME ["/awslc"]
+
+# Use kernel.org mirror for more reliable package access
+RUN sed -i 's|archive.ubuntu.com|mirrors.edge.kernel.org|g' /etc/apt/sources.list && \
+    sed -i 's|security.ubuntu.com|mirrors.edge.kernel.org|g' /etc/apt/sources.list
+
+RUN apt-get update && \
+    apt-get install -y \
+      ca-certificates \
+      cmake \
+      curl \
+      build-essential \
+      gcc-4.8 \
+      g++-4.8 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100 && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.8 100 && \
+    apt-get clean
 
 COPY awslc_build.sh /
 COPY entry.sh /
 
 WORKDIR /
 
-RUN curl -LOk "https://github.com/Kitware/CMake/releases/download/v3.6.3/cmake-3.6.3-Linux-x86_64.tar.gz"
-RUN sha256sum cmake-3.6.3-Linux-x86_64.tar.gz | grep -q "9d915d505c07d84b610e1be6242c7cad68b4b7a4090ce85ecf9cec5effa47c43"
-RUN tar -C /usr/local -xzf cmake-3.6.3-Linux-x86_64.tar.gz
-RUN rm cmake-3.6.3-Linux-x86_64.tar.gz
 RUN curl -LOk "https://go.dev/dl/go1.18.10.linux-amd64.tar.gz"
 RUN sha256sum go1.18.10.linux-amd64.tar.gz | grep -q "5e05400e4c79ef5394424c0eff5b9141cb782da25f64f79d54c98af0a37f8d49"
 RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.10.linux-amd64.tar.gz
 RUN rm go1.18.10.linux-amd64.tar.gz
 
-ENV PATH="${PATH}:/usr/local/cmake-3.6.3-Linux-x86_64/bin:/usr/local/go/bin"
+ENV PATH="${PATH}:/usr/local/go/bin"
 
 ENTRYPOINT ["/entry.sh"]


### PR DESCRIPTION
### Description of changes:

The `gcc-4_8` CI job was failing because the `gcc:4.8.5` Docker Hub image can no longer be pulled (fails Docker image manifest validation). This updates the Dockerfile to use `ubuntu:18.04` as the base image and installs `gcc-4.8`/`g++-4.8` from apt. The manually downloaded CMake 3.6.3 binary is also replaced with the apt-provided CMake (3.10.2), as the pre-built binary had a runtime dependency (`libidn.so.11`) not present in the new base image.

### Call-outs:

Uses `mirrors.edge.kernel.org` instead of the default Ubuntu archive mirrors for reliable access to EOL Ubuntu 18.04 packages (same approach used in [aws-lc-rs](https://github.com/aws/aws-lc-rs/blob/main/.github/workflows/compilers.yml#L196-L197)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
