### PR TITLE
Fix Windows CI: use `cd /d` in run_windows_tests.bat to handle cross-drive paths

### DIFF
--- a/tests/ci/run_windows_tests.bat
+++ b/tests/ci/run_windows_tests.bat
@@ -80,10 +80,10 @@ exit /b 0
 :build
 @echo on
 @echo  LOG: %date%-%time% %1 %2 build started with cmake generation started
-cd %SRC_ROOT%
+cd /d %SRC_ROOT%
 rmdir /s /q %BUILD_DIR%
 mkdir %BUILD_DIR%
-cd %BUILD_DIR%
+cd /d %BUILD_DIR%
 
 cmake -GNinja -DCMAKE_BUILD_TYPE=%~1 %~2 %SRC_ROOT% || goto error
 


### PR DESCRIPTION
### Description of changes: 
* The `actions-ci` Windows "Build/Test (x64)" step fails on the shared library build (`-DBUILD_SHARED_LIBS=1`) with `STATUS_DLL_NOT_FOUND` (`0xc0000135`) when the SSL test runner attempts to execute `bssl_shim.exe`.
* Changes `cd` to `cd /d` in the `:build` function so that drive changes are handled correctly, ensuring the build happens in the intended out-of-source directory.

### Call-outs:
- The `cd` (without `/d`) limitation only manifests when the source and temp directories are on different drives, which is the case on GitHub Actions Windows runners.
- Static library builds were unaffected because they don't require DLLs at runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
