### PR TITLE
Prepare v1.68.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0091 NEW)
 endif()
 
 set(SOFTWARE_NAME "awslc")
-set(SOFTWARE_VERSION "1.67.0")
+set(SOFTWARE_VERSION "1.68.0")
 set(ABI_VERSION 0)
 set(CRYPTO_LIB_NAME "crypto")
 set(SSL_LIB_NAME "ssl")

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -125,7 +125,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "1.67.0"
+#define AWSLC_VERSION_NUMBER_STRING "1.68.0"
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
### Description of changes: 
* Bump urllib3 from 2.6.0 to 2.6.3 in /tests/ci by @dependabot[bot] in https://github.com/aws/aws-lc/pull/2932
* Add weekly automated check for outdated third-party test vectors by @sgmenda in https://github.com/aws/aws-lc/pull/2933
* Enable Hybrid PQ KeyShares by default by @alexw91 in https://github.com/aws/aws-lc/pull/2531
* Remove AVX conditional from cmake script by @torben-hansen in https://github.com/aws/aws-lc/pull/2958
* openssl-ca command implementation for self-sign certificates by @skmcgrail in https://github.com/aws/aws-lc/pull/2937
* Initial Framework for Using Doxygen to Document Public Header Files by @m271828 in https://github.com/aws/aws-lc/pull/2908
* Move md4 out of FIPS module by @torben-hansen in https://github.com/aws/aws-lc/pull/2956
* Fix image-build-windows workflow to only push on workflow_call and workflow_dispatch by @skmcgrail in https://github.com/aws/aws-lc/pull/2961
* Remove FIPS counter framework and other tidying up by @torben-hansen in https://github.com/aws/aws-lc/pull/2947
* Model Device Farm CI Resources in CDK by @skmcgrail in https://github.com/aws/aws-lc/pull/2965
* Adds a new randomness generation API by @torben-hansen in https://github.com/aws/aws-lc/pull/2963
* Migrate Android Testing to GitHub Actions by @skmcgrail in https://github.com/aws/aws-lc/pull/2969
* Ensure pkcs7 checks ASN1_TYPE->type by @skmcgrail in https://github.com/aws/aws-lc/pull/2968
* Fix checkout logic for android-omnibus by @skmcgrail in https://github.com/aws/aws-lc/pull/2970
* Add missing env vars to check-vectors workflow step by @sgmenda in https://github.com/aws/aws-lc/pull/2962
* Shorten Windows Build Directory Path by @skmcgrail in https://github.com/aws/aws-lc/pull/2974
* Bump mysql cluster version by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2967
* Integrate Wycheproof ML-DSA test vectors by @sgmenda in https://github.com/aws/aws-lc/pull/2973
* Simplify FIPS conditional in top-level build script by @torben-hansen in https://github.com/aws/aws-lc/pull/2976
* Fix aws-lc-rs CI job by @justsmth in https://github.com/aws/aws-lc/pull/2966
* Add method to get type of ML-DSA instance configured under EVP PKEY by @torben-hansen in https://github.com/aws/aws-lc/pull/2980
* Nmap build needs liblinear by @justsmth in https://github.com/aws/aws-lc/pull/2985
* Disable SLP vectorizer for FIPS shared library builds on GCC 14+ by @geedo0 in https://github.com/aws/aws-lc/pull/2977
* Update Wycheproof ECDSA test vectors and fix workflow typo by @sgmenda in https://github.com/aws/aws-lc/pull/2972
* Address some CMake findings by @skmcgrail in https://github.com/aws/aws-lc/pull/2979
* Bump bytes from 1.7.1 to 1.11.1 in /tests/ci/lambda by @dependabot[bot] in https://github.com/aws/aws-lc/pull/2983
* Support GCC 4.8 for aarch64 by @justsmth in https://github.com/aws/aws-lc/pull/2964
* Free potential memory before assigning new pointer by @torben-hansen in https://github.com/aws/aws-lc/pull/2989
* Add PyOpenSSL integration test by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2992
* Ensure index argument is not negative in ASN1_BIT_STRING_set_bit by @torben-hansen in https://github.com/aws/aws-lc/pull/2987
* Ensure no overflow in signed output length in do_buf by @torben-hansen in https://github.com/aws/aws-lc/pull/2988
* Remove redundant CPython 3.9 integration test by @WillChilds-Klein in https://github.com/aws/aws-lc/pull/2996
* Ensure public key is set before verifying through ML-DSA verify by @torben-hansen in https://github.com/aws/aws-lc/pull/2990
* Correct CCM nids in object definition by @torben-hansen in https://github.com/aws/aws-lc/pull/2991
* Address Reported Bug Findings by @skmcgrail in https://github.com/aws/aws-lc/pull/3000
* Fix CI: gcc-4.8 by @justsmth in https://github.com/aws/aws-lc/pull/3011
* Fix Windows CI: use `cd /d` in run_windows_tests.bat to handle cross-drive paths by @justsmth in https://github.com/aws/aws-lc/pull/3012
* Fix OPENSSL_memchr per C23 by @justsmth in https://github.com/aws/aws-lc/pull/3008
* Fix argument order in `hmac_copy` by @justsmth in https://github.com/aws/aws-lc/pull/3014
* Miscellaneous CI improvements by @skmcgrail in https://github.com/aws/aws-lc/pull/2978
* Fix CI: mariadb by @justsmth in https://github.com/aws/aws-lc/pull/3015
* Update Ubuntu 24:04 image compiler verification by @skmcgrail in https://github.com/aws/aws-lc/pull/3017
* Support WASM/Emscripten by @justsmth in https://github.com/aws/aws-lc/pull/2959
* Generate Rust Bindings by @justsmth in https://github.com/aws/aws-lc/pull/2999

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
