### PR TITLE
Fix error return values for no-op UI_xxx stub functions

### DIFF
--- a/crypto/ui/ui.c
+++ b/crypto/ui/ui.c
@@ -19,17 +19,17 @@ void UI_free(UI *ui) {
 
 int UI_add_input_string(UI *ui, const char *prompt, int flags,
         char *result_buf, int minsize, int maxsize) {
-  return 0;
+  return -1;
 }
 int UI_add_verify_string(UI *ui, const char *prompt, int flags,
         char *result_buf, int minsize, int maxsize, const char *test_buf) {
-  return 0;
+  return -1;
 }
 
 int UI_add_info_string(UI *ui, const char *text) {
-  return 0;
+  return -1;
 }
 
 int UI_process(UI *ui) {
-  return 0;
+  return -1;
 }

--- a/include/openssl/ui.h
+++ b/include/openssl/ui.h
@@ -22,18 +22,18 @@ OPENSSL_EXPORT OPENSSL_DEPRECATED UI *UI_new(void);
 /// UI_free invokes OPENSSL_free on its parameter.
 OPENSSL_EXPORT OPENSSL_DEPRECATED void UI_free(UI *ui);
 
-/// UI_add_input_string does nothing, always returns 0.
+/// UI_add_input_string does nothing, always returns -1 for failure.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int UI_add_input_string(UI *ui, const char *prompt, int flags,
         char *result_buf, int minsize, int maxsize);
 
-/// UI_add_verify_string does nothing, always returns 0.
+/// UI_add_verify_string does nothing, always returns -1 for failure.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int UI_add_verify_string(UI *ui, const char *prompt, int flags,
         char *result_buf, int minsize, int maxsize, const char *test_buf);
 
-/// UI_add_info_string does nothing, always returns 0.
+/// UI_add_info_string does nothing, always returns -1 for failure.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int UI_add_info_string(UI *ui, const char *text);
 
-/// UI_process does nothing, always returns 0.
+/// UI_process does nothing, always returns -1 for failure.
 OPENSSL_EXPORT OPENSSL_DEPRECATED int UI_process(UI *ui);
 
 #endif //UI_H


### PR DESCRIPTION
### Description of changes: 
AWS-LC provides no-op stub implementations of several OpenSSL `UI_xxx` functions to allow compilation of projects that reference them for non-essential operations. These stubs always fail at runtime since the UI API is unsupported.

Previously, `UI_add_input_string`, `UI_add_verify_string`, `UI_add_info_string`, and `UI_process` all returned `0`. In OpenSSL's UI API, `-1` indicates failure:

- `UI_add_input_string`, `UI_add_verify_string`, and `UI_add_info_string` all delegate to [`general_allocate_string()`](https://github.com/openssl/openssl/blob/06cff36e641c39f1859f78adcf20d0d977ea0088/crypto/ui/ui_lib.c#L118), which returns a positive index on success and `-1` on error.
- [`UI_process`](https://github.com/openssl/openssl/blob/06cff36e641c39f1859f78adcf20d0d977ea0088/crypto/ui/ui_lib.c#L327) returns `0` on success and `-1` on error.

In practice, callers should already be checking the `NULL` return from `UI_new` and never reaching these functions. This change simply corrects the return values to be consistent with the OpenSSL API contract, and updates the corresponding header documentation to match.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
