### PR TITLE
Retain flag after custom critical extensions check

### DIFF
--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -8296,8 +8296,17 @@ TEST(X509Test, X509CustomExtensions) {
   EXPECT_EQ(X509_V_OK,
             Verify(cert.get(), {ca.get()}, {}, {}, /*flags=*/0,
                    set_custom_ext_with_callback));
-  // Check that |EXFLAG_CRITICAL| has been removed after validation.
-  EXPECT_FALSE(X509_get_extension_flags(cert.get()) & EXFLAG_CRITICAL);
+  // Check that |EXFLAG_CRITICAL| is preserved after validation.
+  EXPECT_TRUE(X509_get_extension_flags(cert.get()) & EXFLAG_CRITICAL);
+
+  // Check that verification is unsuccessful with the same cert without
+  // the callback.
+  EXPECT_EQ(X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION,
+            Verify(cert.get(), {ca.get()}, {}, {}, /*flags=*/0,
+                   set_no_custom_ext_with_callback));
+  EXPECT_EQ(X509_V_OK,
+            Verify(cert.get(), {ca.get()}, {}, {}, /*flags=*/0,
+                   set_custom_ext_with_callback));
 }
 
 TEST(X509Test, X509MultipleCustomExtensions) {
@@ -8346,8 +8355,8 @@ TEST(X509Test, X509MultipleCustomExtensions) {
   };
   EXPECT_EQ(X509_V_OK, Verify(cert.get(), {ca.get()}, {}, {},
                               /*flags=*/0, set_custom_exts_with_callback));
-  // Check that |EXFLAG_CRITICAL| has been removed after validation.
-  EXPECT_FALSE(X509_get_extension_flags(cert.get()) & EXFLAG_CRITICAL);
+  // Check that |EXFLAG_CRITICAL| is preserved after validation.
+  EXPECT_TRUE(X509_get_extension_flags(cert.get()) & EXFLAG_CRITICAL);
 }
 
 TEST(X509Test, StoreVerifyCallback) {

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -625,10 +625,6 @@ static int check_custom_critical_extensions(X509_STORE_CTX *ctx, X509 *x) {
     return 0;
   }
 
-  // Remove the |EXFLAG_CRITICAL| flag from |x|, now that all unknown
-  // critical extensions have been handled.
-  x->ex_flags &= ~EXFLAG_CRITICAL;
-
   sk_ASN1_OBJECT_pop_free(found_exts, ASN1_OBJECT_free);
   return 1;
 }


### PR DESCRIPTION
### Description of changes: 
`check_custom_critical_extensions` previously cleared the `EXFLAG_CRITICAL` bit from a certificate's cached `ex_flags `after successfully validating custom critical extensions. The original intent was to record that the certificate's critical extensions had been handled, preserving that outcome for the certificate going forward. 
However, custom critical extension validation is a property of the verification context, not the certificate itself. This change removes the flag clearing so that the custom extension check is evaluated during each verification rather than permanently mutated on the `cert`. This ensures that re-verifying the same `X509` object without a custom callback correctly reports `X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION`.

### Call-outs:
N/A

### Testing:
Tweak and add minor test that checks the behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
