### PR TITLE
Fix issues in `pass_util.cc` password handling

### DIFF
--- a/tool-openssl/internal.h
+++ b/tool-openssl/internal.h
@@ -55,7 +55,7 @@ private:
   // Helper method to securely clear current data
   void secure_clear() {
     if (!data_.empty()) {
-      OPENSSL_cleanse(&data_[0], data_.capacity());
+      OPENSSL_cleanse(&data_[0], data_.size());
     }
   }
 

--- a/tool-openssl/pass_util.cc
+++ b/tool-openssl/pass_util.cc
@@ -80,7 +80,7 @@ static bool ValidateSource(Password &passin, Password *passout = nullptr,
 
 static bool ExtractDirectPassword(Password &source) {
   // Check length before modification
-  if (source.get().length() - 5 >= PEM_BUFSIZE) {
+  if (source.get().length() >= 5 + PEM_BUFSIZE) {
     fprintf(stderr, "Password exceeds maximum allowed length (%d bytes)\n",
             PEM_BUFSIZE - 1);
     return false;


### PR DESCRIPTION

### Description of changes:
Addresses multiple issues in `tool-openssl/pass_util.cc` and the `Password` class:
- Ensured all temporary buffers holding passwords are properly cleansed, including the `buf` stack buffer in `ExtractPasswordFromStream` and a `std::string` replaced with `Password` for secure clearing.
- Fixed `fd:` parsing to use `strtoul` instead of `atoi`, avoiding undefined behavior on overflow.
- Removed incorrect rejection of colons in `pass:` passwords, matching OpenSSL behavior.
- Fixed off-by-one in password length limits for `pass:` and `env:` sources.
- Minor hardening: fixed `same_file` initialization, replaced unsigned subtraction with overflow-safe comparison in `ExtractDirectPassword`.

### Call-outs:
- Behavioral change: `pass:a:b` was previously rejected and now succeeds with password `a:b`.

### Testing:
All existing `PassUtilTest` tests pass. Updated `DirectPasswordEdgeCases` to cover passwords containing colons.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
