### PR TITLE
Key state consistency in PQDSA_KEY setter functions

### DIFF
--- a/crypto/fipsmodule/pqdsa/pqdsa.c
+++ b/crypto/fipsmodule/pqdsa/pqdsa.c
@@ -48,9 +48,9 @@ int PQDSA_KEY_init(PQDSA_KEY *key, const PQDSA *pqdsa) {
   PQDSA_KEY_clear(key);
 
   key->pqdsa = pqdsa;
-  key->public_key = OPENSSL_malloc(pqdsa->public_key_len);
-  key->private_key = OPENSSL_malloc(pqdsa->private_key_len);
-  key->seed = OPENSSL_malloc(pqdsa->keygen_seed_len);
+  key->public_key = OPENSSL_zalloc(pqdsa->public_key_len);
+  key->private_key = OPENSSL_zalloc(pqdsa->private_key_len);
+  key->seed = OPENSSL_zalloc(pqdsa->keygen_seed_len);
   if (key->public_key == NULL || key->private_key == NULL || key->seed == NULL) {
     PQDSA_KEY_clear(key);
     return 0;
@@ -67,6 +67,9 @@ void PQDSA_KEY_free(PQDSA_KEY *key) {
 }
 
 const PQDSA *PQDSA_KEY_get0_dsa(PQDSA_KEY* key) {
+  if (key == NULL) {
+    return NULL;
+  }
   return key->pqdsa;
 }
 
@@ -153,8 +156,10 @@ int PQDSA_KEY_set_raw_private_key(PQDSA_KEY *key, CBS *in) {
   // Success: transfer ownership to key.
   OPENSSL_free(key->public_key);
   OPENSSL_free(key->private_key);
+  OPENSSL_free(key->seed);
   key->public_key = public_key;
   key->private_key = private_key;
+  key->seed = NULL;
   public_key = NULL;
   private_key = NULL;
   ret = 1;


### PR DESCRIPTION
### Description of changes:
The `PQDSA_KEY` setter functions could leave the key structure in an inconsistent state where stale fields no longer corresponded to the current key material.

- `PQDSA_KEY_set_raw_private_key`: Did not clear `key->seed` on success. If the key previously held a seed (or had an uninitialized seed buffer from `PQDSA_KEY_init`), `pqdsa_priv_encode` would serialize stale or uninitialized seed bytes, since it gates on `key->seed != NULL`.
- `PQDSA_KEY_init`: Used `OPENSSL_malloc` (uninitialized) for all three buffers. Changed to `OPENSSL_zalloc` as a defense-in-depth measure.
- `PQDSA_KEY_get0_dsa`: Added a NULL check on the input, consistent with other functions in this file.

### Call-outs:
The primary fix is in `PQDSA_KEY_set_raw_private_key`. Current code paths through the public API are not affected because `EVP_PKEY_pqdsa_set_params` uses `PQDSA_KEY_new` (which zero-initializes all fields), but these functions are exposed via `internal.h` and the inconsistency could be triggered by internal callers.

Separately, `pqdsa_priv_decode` currently ignores the `pubkey` parameter from `OneAsymmetricKey`, unlike the Ed25519 implementation which validates the provided public key against the derived one. This could be addressed as a follow-up.

### Testing:
All existing ML-DSA/PQDSA tests pass (76 tests).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
