### PR TITLE
Fix  error reporting and document EC explicit params single-cert beha…

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -683,6 +683,9 @@ static int check_chain_extensions(X509_STORE_CTX *ctx) {
       }
     }
 
+    // The |num > 1| condition intentionally skips this check for single-certificate chains
+    // (e.g., a self-signed leaf or a partial chain with only the target certificate). This
+    // maintains consistency with OpenSSL 1.1.1 behavior.
     if (num > 1 && (ctx->param->awslc_flags&AWSLC_V_ENABLE_EC_KEY_EXPLICIT_PARAMS) == 0) {
       // In OpenSSL 1.1.1 this check was done if |X509_V_FLAG_X509_STRICT| was enabled.
       // We did not perform this check explicitly before, but the behavior was baked into
@@ -1564,7 +1567,7 @@ static int internal_verify(X509_STORE_CTX *ctx) {
   EVP_PKEY *pkey = X509_get0_pubkey(xs);
   if(pkey == NULL) {
     ctx->error = X509_V_UNABLE_TO_GET_CERTS_PUBLIC_KEY;
-    ctx->current_cert = xi;
+    ctx->current_cert = xs;
     ok = 0;
     goto end;
   }


### PR DESCRIPTION
### Description of changes:
Two small fixes in `crypto/x509/x509_vfy.c`:

1. In `internal_verify`, the post-loop leaf public key check was setting `ctx->current_cert = xi` (the issuer) instead of `xs` (the subject). The chain was still correctly rejected — just the diagnostic metadata pointed at the wrong cert. Fixed to `xs`.

2. Added a comment explaining why the EC explicit params check in `check_chain_extensions` intentionally skips single-cert chains (`num > 1`). This matches OpenSSL 1.1.1 behavior and is fine because single-cert chains are already in the trust store. No behavioral change.

### Call-outs:
Neither issue is a security vulnerability. One is a one-line code fix, the other is comment-only.

### Testing:
All existing X509 tests pass. `X509Test.SignatureVerification` and `X509CompatTest.LeafCertificateWithExplicitECParams` both cover the relevant code paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
