### PR TITLE
Fix PKCS12_verify_mac OOB read with invalid password_len

### DIFF
--- a/crypto/pkcs8/pkcs8_x509.c
+++ b/crypto/pkcs8/pkcs8_x509.c
@@ -922,6 +922,8 @@ int PKCS12_verify_mac(const PKCS12 *p12, const char *password,
     if (password_len != 0) {
       return 0;
     }
+  } else if (password_len < -1) {
+    return 0;
   } else if (password_len != -1 &&
              (password[password_len] != 0 ||
               OPENSSL_memchr(password, 0, password_len) != NULL)) {

--- a/include/openssl/pkcs8.h
+++ b/include/openssl/pkcs8.h
@@ -209,8 +209,10 @@ OPENSSL_EXPORT int PKCS12_set_mac(PKCS12 *p12, const char *password,
 // and zero otherwise. Since |PKCS12_parse| doesn't take a length parameter,
 // it's not actually possible to use a non-NUL-terminated password to actually
 // get anything from a |PKCS12|. Thus |password| and |password_len| may be
-// |NULL| and zero, respectively, or else |password_len| may be -1, or else
-// |password[password_len]| must be zero and no other NUL bytes may appear in
+// |NULL| and zero, respectively, or else |password_len| may be -1 to indicate
+// that |password| is a NUL-terminated C string whose length is determined via
+// |strlen|, or else |password_len| must be non-negative,
+// |password[password_len]| must be zero, and no other NUL bytes may appear in
 // |password|. If the |password_len| checks fail, zero is returned
 // immediately.
 OPENSSL_EXPORT int PKCS12_verify_mac(const PKCS12 *p12, const char *password,


### PR DESCRIPTION
### Description of changes: 
Reject negative password_len values (other than -1) early in
PKCS12_verify_mac before they are used as an array index or cast
to size_t for OPENSSL_memchr. Update the public header comment to
clarify that -1 means the password is a NUL-terminated C string.

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
