### PR TITLE
Fix PKCS8_encrypt crash when pass is NULL with negative pass_len_in

### DIFF
--- a/crypto/pkcs8/pkcs8_x509.c
+++ b/crypto/pkcs8/pkcs8_x509.c
@@ -188,7 +188,9 @@ X509_SIG *PKCS8_encrypt(int pbe_nid, const EVP_CIPHER *cipher, const char *pass,
                         int pass_len_in, const uint8_t *salt, size_t salt_len,
                         int iterations, PKCS8_PRIV_KEY_INFO *p8inf) {
   size_t pass_len;
-  if (pass_len_in < 0 && pass != NULL) {
+  if (pass == NULL) {
+    pass_len = 0;
+  } else if (pass_len_in < 0) {
     pass_len = strlen(pass);
   } else {
     pass_len = (size_t)pass_len_in;

--- a/include/openssl/pkcs8.h
+++ b/include/openssl/pkcs8.h
@@ -74,9 +74,11 @@ extern "C" {
 //
 // |pass| is used as the password. If a PBES1 scheme from PKCS #12 is used, this
 // will be converted to a raw byte string as specified in B.1 of PKCS #12. If
-// |pass| is NULL, it will be encoded as the empty byte string rather than two
-// zero bytes, the PKCS #12 encoding of the empty string. If |pass_len| is
-// negative and |pass| is non-NULL, |strlen(pass)| is used.
+// |pass| is NULL, it is treated as an empty password and |pass_len| is ignored.
+// This will be encoded as the empty byte string rather than two zero bytes, the
+// PKCS #12 encoding of the empty string. If |pass| is non-NULL and |pass_len|
+// is negative, |strlen(pass)| is used. If |pass| is non-NULL and |pass_len| is
+// non-negative, |pass_len| bytes are used as the password.
 //
 // If |salt| is NULL, a random salt of |salt_len| bytes is generated. If
 // |salt_len| is zero, a default salt length is used instead.


### PR DESCRIPTION
### Description of changes: 
When pass is NULL and pass_len_in is negative, the cast to size_t wraps
to a huge value, causing a NULL pointer dereference downstream in HMAC
key setup. Handle pass==NULL first by setting pass_len=0, consistent
with the documented empty byte string semantics for NULL passwords.

### Call-outs:
N/A

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
