### PR TITLE
Add a test that arbitrary curves can be wrapped in EVP_PKEY

### DIFF
--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -3509,3 +3509,83 @@ TEST(EVPExtraTest, SetNoneClearsKey) {
   // Calling operations on the |EVP_PKEY| should cleanly fail.
   EXPECT_EQ(EVP_PKEY_bits(pkey.get()), 0);
 }
+
+// Test that |EC_KEY|s using custom curves can be wrapped in |EVP_PKEY|. Callers
+// should not follow this code. This is maintained and tested only for
+// compatibility with one legacy application, and supported in only a limited
+// form. (E.g. such keys cannot be serialized.)
+TEST(EVPExtraTest, CustomCurve) {
+  // Coefficients for brainpoolp256r1, not supported by BoringSSL.
+  static const char kP[] =
+      "a9fb57dba1eea9bc3e660a909d838d726e3bf623d52620282013481d1f6e5377";
+  static const char kA[] =
+      "7d5a0975fc2c3057eef67530417affe7fb8055c126dc5c6ce94a4b44f330b5d9";
+  static const char kB[] =
+      "26dc5c6ce94a4b44f330b5d9bbd77cbf958416295cf7e1ce6bccdc18ff8c07b6";
+  static const char kX[] =
+      "8bd2aeb9cb7e57cb2c4b482ffc81b7afb9de27e1e3bd23c23a4453bd9ace3262";
+  static const char kY[] =
+      "547ef835c3dac4fd97f8461a14611dc9c27745132ded8e545c1d54c72f046997";
+  static const char kN[] =
+      "a9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a7";
+  static const char kD[] =
+      "0da21d76fed40dd82ac3314cce91abb585b5c4246e902b238a839609ea1e7ce1";
+  static const char kQX[] =
+      "3a55e0341cab50452fe27b8a87e4775dec7a9daca94b0d84ad1e9f85b53ea513";
+  static const char kQY[] =
+      "40088146b33bbbe81b092b41146774b35dd478cf056437cfb35ef0df2d269339";
+
+  // Construct a custom group.
+  bssl::UniquePtr<BIGNUM> p = HexToBIGNUM(kP), a = HexToBIGNUM(kA),
+                          b = HexToBIGNUM(kB), x = HexToBIGNUM(kX),
+                          y = HexToBIGNUM(kY), n = HexToBIGNUM(kN),
+                          d = HexToBIGNUM(kD), qx = HexToBIGNUM(kQX),
+                          qy = HexToBIGNUM(kQY);
+  ASSERT_TRUE(p && a && b && x && y && n && d && qx && qy);
+  bssl::UniquePtr<EC_GROUP> group(
+      EC_GROUP_new_curve_GFp(p.get(), a.get(), b.get(), nullptr));
+  ASSERT_TRUE(group);
+  bssl::UniquePtr<EC_POINT> g(EC_POINT_new(group.get()));
+  ASSERT_TRUE(g);
+  ASSERT_TRUE(EC_POINT_set_affine_coordinates_GFp(group.get(), g.get(), x.get(),
+                                                  y.get(), nullptr));
+  ASSERT_TRUE(
+      EC_GROUP_set_generator(group.get(), g.get(), n.get(), BN_value_one()));
+
+  // Generate a key with it.
+  bssl::UniquePtr<EC_KEY> ec_key(EC_KEY_new());
+  ASSERT_TRUE(ec_key);
+  ASSERT_TRUE(EC_KEY_set_group(ec_key.get(), group.get()));
+  ASSERT_TRUE(EC_KEY_generate_key(ec_key.get()));
+
+  // Wrap it in an |EVP_PKEY|.
+  bssl::UniquePtr<EVP_PKEY> pkey(EVP_PKEY_new());
+  ASSERT_TRUE(pkey);
+  ASSERT_TRUE(EVP_PKEY_set1_EC_KEY(pkey.get(), ec_key.get()));
+
+  // Signing should work.
+  static const uint8_t msg[] = "hello";
+  bssl::ScopedEVP_MD_CTX ctx;
+  ASSERT_TRUE(EVP_DigestSignInit(ctx.get(), nullptr, EVP_sha256(), nullptr,
+                                 pkey.get()));
+  std::vector<uint8_t> sig(EVP_PKEY_size(pkey.get()));
+  size_t len = sig.size();
+  ASSERT_TRUE(
+      EVP_DigestSign(ctx.get(), sig.data(), &len, msg, sizeof(msg) - 1));
+  sig.resize(len);
+
+  // Verifying should work.
+  ctx.Reset();
+  ASSERT_TRUE(EVP_DigestVerifyInit(ctx.get(), nullptr, EVP_sha256(), nullptr,
+                                   pkey.get()));
+  ASSERT_TRUE(EVP_DigestVerify(ctx.get(), sig.data(), sig.size(), msg,
+                               sizeof(msg) - 1));
+
+  // We will not serialize arbitrary groups, so serialization should fail.
+  bssl::ScopedCBB cbb;
+  ASSERT_TRUE(CBB_init(cbb.get(), 0));
+  EXPECT_FALSE(EVP_marshal_public_key(cbb.get(), pkey.get()));
+  cbb.Reset();
+  ASSERT_TRUE(CBB_init(cbb.get(), 0));
+  EXPECT_FALSE(EVP_marshal_private_key(cbb.get(), pkey.get()));
+}

--- a/crypto/fipsmodule/bn/bn_test.cc
+++ b/crypto/fipsmodule/bn/bn_test.cc
@@ -96,7 +96,7 @@
 #include "../../test/wycheproof_util.h"
 
 
-static int HexToBIGNUM(bssl::UniquePtr<BIGNUM> *out, const char *in) {
+static int HexToBIGNUMWithReturn(bssl::UniquePtr<BIGNUM> *out, const char *in) {
   BIGNUM *raw = NULL;
   int ret = BN_hex2bn(&raw, in);
   out->reset(raw);
@@ -140,7 +140,7 @@ class BIGNUMFileTest {
     }
 
     bssl::UniquePtr<BIGNUM> ret;
-    if (HexToBIGNUM(&ret, hex.c_str()) != static_cast<int>(hex.size())) {
+    if (HexToBIGNUMWithReturn(&ret, hex.c_str()) != static_cast<int>(hex.size())) {
       t_->PrintLine("Could not decode '%s'.", hex.c_str());
       return nullptr;
     }
@@ -1274,27 +1274,27 @@ TEST_F(BNTest, Dec2BN) {
 
 TEST_F(BNTest, Hex2BN) {
   bssl::UniquePtr<BIGNUM> bn;
-  int ret = HexToBIGNUM(&bn, "0");
+  int ret = HexToBIGNUMWithReturn(&bn, "0");
   ASSERT_EQ(1, ret);
   EXPECT_TRUE(BN_is_zero(bn.get()));
   EXPECT_FALSE(BN_is_negative(bn.get()));
 
-  ret = HexToBIGNUM(&bn, "256");
+  ret = HexToBIGNUMWithReturn(&bn, "256");
   ASSERT_EQ(3, ret);
   EXPECT_TRUE(BN_is_word(bn.get(), 0x256));
   EXPECT_FALSE(BN_is_negative(bn.get()));
 
-  ret = HexToBIGNUM(&bn, "-42");
+  ret = HexToBIGNUMWithReturn(&bn, "-42");
   ASSERT_EQ(3, ret);
   EXPECT_TRUE(BN_abs_is_word(bn.get(), 0x42));
   EXPECT_TRUE(BN_is_negative(bn.get()));
 
-  ret = HexToBIGNUM(&bn, "-0");
+  ret = HexToBIGNUMWithReturn(&bn, "-0");
   ASSERT_EQ(2, ret);
   EXPECT_TRUE(BN_is_zero(bn.get()));
   EXPECT_FALSE(BN_is_negative(bn.get()));
 
-  ret = HexToBIGNUM(&bn, "abctrailing garbage is ignored");
+  ret = HexToBIGNUMWithReturn(&bn, "abctrailing garbage is ignored");
   ASSERT_EQ(3, ret);
   EXPECT_TRUE(BN_is_word(bn.get(), 0xabc));
   EXPECT_FALSE(BN_is_negative(bn.get()));
@@ -1828,7 +1828,7 @@ TEST_F(BNTest, SetGetU64) {
     bssl::UniquePtr<BIGNUM> bn(BN_new()), expected;
     ASSERT_TRUE(bn);
     ASSERT_TRUE(BN_set_u64(bn.get(), test.value));
-    ASSERT_TRUE(HexToBIGNUM(&expected, test.hex));
+    ASSERT_TRUE(HexToBIGNUMWithReturn(&expected, test.hex));
     EXPECT_BIGNUMS_EQUAL("BN_set_u64", expected.get(), bn.get());
 
     uint64_t tmp;
@@ -2404,7 +2404,7 @@ TEST_F(BNTest, PrimeChecking) {
   };
   for (const char *str : kPrimesHex) {
     SCOPED_TRACE(str);
-    EXPECT_NE(0, HexToBIGNUM(&p, str));
+    EXPECT_NE(0, HexToBIGNUMWithReturn(&p, str));
 
     ASSERT_TRUE(BN_primality_test(
         &is_probably_prime_1, p.get(), BN_prime_checks_for_generation, ctx(),
@@ -2932,7 +2932,7 @@ TEST_F(BNTest, GetMinimalWidth) {
 
   for (const auto& test : kTests) {
     SCOPED_TRACE(test.hex);
-    HexToBIGNUM(&bn, test.hex);
+    HexToBIGNUMWithReturn(&bn, test.hex);
 #if defined(OPENSSL_32_BIT)
     EXPECT_EQ(test.expected_32bit, BN_get_minimal_width(bn.get()));
 #elif defined(OPENSSL_64_BIT)

--- a/crypto/fipsmodule/ec/ec_test.cc
+++ b/crypto/fipsmodule/ec/ec_test.cc
@@ -1385,12 +1385,6 @@ TEST(ECTest, EmptyKey) {
   EXPECT_FALSE(EC_KEY_get0_private_key(key.get()));
 }
 
-static bssl::UniquePtr<BIGNUM> HexToBIGNUM(const char *hex) {
-  BIGNUM *bn = nullptr;
-  BN_hex2bn(&bn, hex);
-  return bssl::UniquePtr<BIGNUM>(bn);
-}
-
 // Test that point arithmetic works with custom curves using an arbitrary |a|,
 // rather than -3, as is common (and more efficient).
 TEST(ECTest, BrainpoolP256r1) {

--- a/crypto/fipsmodule/ecdsa/ecdsa_test.cc
+++ b/crypto/fipsmodule/ecdsa/ecdsa_test.cc
@@ -70,12 +70,6 @@
 #include "../../test/test_util.h"
 
 
-static bssl::UniquePtr<BIGNUM> HexToBIGNUM(const char *hex) {
-  BIGNUM *bn = nullptr;
-  BN_hex2bn(&bn, hex);
-  return bssl::UniquePtr<BIGNUM>(bn);
-}
-
 // Though we do not support secp160r1, it is reachable from the deprecated
 // custom curve APIs and has some unique properties (n is larger than p with the
 // difference crossing a word boundary on 32-bit), so test it explicitly.

--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -18,6 +18,7 @@
 #include <ostream>
 #include <inttypes.h>
 
+#include <openssl/bn.h>
 #include <openssl/err.h>
 
 #include <thread>
@@ -390,4 +391,10 @@ bool addressSanitizerIsEnabled(void) {
 #else
   return false;
 #endif
+}
+
+bssl::UniquePtr<BIGNUM> HexToBIGNUM(const char *hex) {
+  BIGNUM *bn = nullptr;
+  BN_hex2bn(&bn, hex);
+  return bssl::UniquePtr<BIGNUM>(bn);
 }

--- a/crypto/test/test_util.h
+++ b/crypto/test/test_util.h
@@ -152,6 +152,10 @@ void CustomDataFree(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
 // |reason|.
 testing::AssertionResult ErrorEquals(uint32_t err, int lib, int reason);
 
+// HexToBIGNUM decodes |hex| as a hexadecimal, big-endian, unsigned integer and
+// returns it as a |BIGNUM|, or nullptr on error.
+bssl::UniquePtr<BIGNUM> HexToBIGNUM(const char *hex);
+
 // ExpectParse does a d2i parse using the corresponding template and function
 // pointer.
 template <typename T>


### PR DESCRIPTION
### Description of changes: 
BoringSSL commit https://github.com/google/boringssl/commit/4d48736c2acd6878caa93ac0a628b46bda1227b0: 
"Add a test that arbitrary curves can be wrapped in EVP_PKEY"

Changes made (6 files):

1. crypto/test/test_util.h / test_util.cc — Added shared `HexToBIGNUM(const char*)` helper (declaration + implementation + #include <openssl/bn.h>)

2. crypto/fipsmodule/ec/ec_test.cc — Removed duplicate local `HexToBIGNUM` (now uses the shared one from test_util.h, already included)

3. crypto/fipsmodule/ecdsa/ecdsa_test.cc — Same removal of duplicate

4. crypto/fipsmodule/bn/bn_test.cc — Renamed the different-signature `HexToBIGNUM(UniquePtr<BIGNUM>*, const char*)` → `HexToBIGNUMWithReturn` to avoid conflict (this one returns the 
BN_hex2bn return value, so it's a distinct function)

5. crypto/evp_extra/evp_extra_test.cc — Added the new `TEST(EVPExtraTest, CustomCurve)` test

### Adaptations for AWS-LC:
- Path: crypto/evp_extra/ instead of BoringSSL's crypto/evp/
- Replaced `bssl::StringAsBytes("hello")` (doesn't exist in AWS-LC) with a plain `static const uint8_t msg[] = "hello" + sizeof(msg) - 1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
