### PR TITLE
Make some more half-empty EVP_PKEY states impossible

### DIFF
--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -3644,6 +3644,24 @@ TEST(EVPExtraTest, SetNoneClearsKey) {
   EXPECT_EQ(EVP_PKEY_bits(pkey.get()), 0);
 }
 
+// EVP_PKEY_assign_FOO with NULL should fail without changing the key type.
+TEST(EVPExtraTest, NoHalfEmptyKeys) {
+  bssl::UniquePtr<EVP_PKEY> pkey(EVP_PKEY_new());
+  ASSERT_TRUE(pkey);
+
+  EXPECT_FALSE(EVP_PKEY_set1_RSA(pkey.get(), nullptr));
+  EXPECT_EQ(EVP_PKEY_id(pkey.get()), EVP_PKEY_NONE);
+
+  EXPECT_FALSE(EVP_PKEY_set1_EC_KEY(pkey.get(), nullptr));
+  EXPECT_EQ(EVP_PKEY_id(pkey.get()), EVP_PKEY_NONE);
+
+  EXPECT_FALSE(EVP_PKEY_set1_DH(pkey.get(), nullptr));
+  EXPECT_EQ(EVP_PKEY_id(pkey.get()), EVP_PKEY_NONE);
+
+  EXPECT_FALSE(EVP_PKEY_set1_DSA(pkey.get(), nullptr));
+  EXPECT_EQ(EVP_PKEY_id(pkey.get()), EVP_PKEY_NONE);
+}
+
 // Test that |EC_KEY|s using custom curves can be wrapped in |EVP_PKEY|. Callers
 // should not follow this code. This is maintained and tested only for
 // compatibility with one legacy application, and supported in only a limited

--- a/crypto/evp_extra/p_dh_asn1.c
+++ b/crypto/evp_extra/p_dh_asn1.c
@@ -180,9 +180,12 @@ int EVP_PKEY_set1_DH(EVP_PKEY *pkey, DH *key) {
 
 int EVP_PKEY_assign_DH(EVP_PKEY *pkey, DH *key) {
   SET_DIT_AUTO_RESET
+  if (key == NULL) {
+    return 0;
+  }
   evp_pkey_set_method(pkey, &dh_asn1_meth);
   pkey->pkey.dh = key;
-  return key != NULL;
+  return 1;
 }
 
 DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey) {

--- a/crypto/fipsmodule/evp/evp.c
+++ b/crypto/fipsmodule/evp/evp.c
@@ -388,11 +388,14 @@ int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, RSA *key) {
 
 int EVP_PKEY_assign_RSA(EVP_PKEY *pkey, RSA *key) {
   SET_DIT_AUTO_RESET;
+  if (key == NULL) {
+    return 0;
+  }
   const EVP_PKEY_ASN1_METHOD *meth = evp_pkey_asn1_find(EVP_PKEY_RSA);
   assert(meth != NULL);
   evp_pkey_set_method(pkey, meth);
   pkey->pkey.ptr = key;
-  return key != NULL;
+  return 1;
 }
 
 RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey) {
@@ -424,11 +427,14 @@ int EVP_PKEY_set1_DSA(EVP_PKEY *pkey, DSA *key) {
 
 int EVP_PKEY_assign_DSA(EVP_PKEY *pkey, DSA *key) {
   SET_DIT_AUTO_RESET;
+  if (key == NULL) {
+    return 0;
+  }
   const EVP_PKEY_ASN1_METHOD *meth = evp_pkey_asn1_find(EVP_PKEY_DSA);
   assert(meth != NULL);
   evp_pkey_set_method(pkey, meth);
   pkey->pkey.ptr = key;
-  return key != NULL;
+  return 1;
 }
 
 DSA *EVP_PKEY_get0_DSA(const EVP_PKEY *pkey) {
@@ -460,11 +466,14 @@ int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) {
 
 int EVP_PKEY_assign_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) {
   SET_DIT_AUTO_RESET;
+  if (key == NULL) {
+    return 0;
+  }
   const EVP_PKEY_ASN1_METHOD *meth = evp_pkey_asn1_find(EVP_PKEY_EC);
   assert(meth != NULL);
   evp_pkey_set_method(pkey, meth);
   pkey->pkey.ptr = key;
-  return key != NULL;
+  return 1;
 }
 
 EC_KEY *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey) {


### PR DESCRIPTION
### Description of changes: 
BoringSSL commit https://github.com/google/boringssl/commit/5b7171f2da10d5dad52d0a2e4426fbc71d4ff146: "Make some more half-empty EVP_PKEY states impossible"

Changes (3 files):

1. `crypto/fipsmodule/evp/evp.c` — `EVP_PKEY_assign_RSA`, `EVP_PKEY_assign_DSA`, `EVP_PKEY_assign_EC_KEY`: check for NULL key before calling `evp_pkey_set_method`, return 0 early instead of setting the method and then returning `key != NULL`

2. `crypto/evp_extra/p_dh_asn1.c` — Same fix for `EVP_PKEY_assign_DH`

3. `crypto/evp_extra/evp_extra_test.cc` — Added `NoHalfEmptyKeys` test verifying that `EVP_PKEY_set1_*(pkey, nullptr)` fails without changing the key type

### Adaptations for AWS-LC: 
AWS-LC didn't take RSA/DSA/EC_KEY out of the FIPS module (unlike BoringSSL's https://github.com/google/boringssl/commit/044fbc86ef5505d5fdab2befd476992ad1074665), so the changes go in `crypto/fipsmodule/evp/evp.c` rather than separate `p_*_asn1.cc` files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
