### PR TITLE
Use CRYPTO_memcmp instead of OPENSSL_memcmp for tag verification

### DIFF
--- a/crypto/fipsmodule/cipher/e_aesccm.c
+++ b/crypto/fipsmodule/cipher/e_aesccm.c
@@ -629,7 +629,7 @@ static int cipher_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, uint8_t *out,
       return -1;
     }
     // Validate the tag and invalidate the output if it doesn't match.
-    if (OPENSSL_memcmp(cipher_ctx->tag, computed_tag, cipher_ctx->M)) {
+    if (CRYPTO_memcmp(cipher_ctx->tag, computed_tag, cipher_ctx->M)) {
       OPENSSL_cleanse(out, len);
       return -1;
     }


### PR DESCRIPTION
### Issues:

P386862509

### Description of changes: 

Use CRYPTO_memcmp instead of OPENSSL_memcmp for tag verification.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
