### PR TITLE
Add NULL checks for MakeUnique in SSL cipher list inheritance

### DIFF
--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -717,11 +717,17 @@ SSL *SSL_new(SSL_CTX *ctx) {
 
   if (ctx->cipher_list) {
     ssl->config->cipher_list = MakeUnique<SSLCipherPreferenceList>();
-    ssl->config->cipher_list->Init(*ctx->cipher_list.get());
+    if (!ssl->config->cipher_list ||
+        !ssl->config->cipher_list->Init(*ctx->cipher_list.get())) {
+      return nullptr;
+    }
   }
   if (ctx->tls13_cipher_list) {
     ssl->config->tls13_cipher_list = MakeUnique<SSLCipherPreferenceList>();
-    ssl->config->tls13_cipher_list->Init(*ctx->tls13_cipher_list.get());
+    if (!ssl->config->tls13_cipher_list ||
+        !ssl->config->tls13_cipher_list->Init(*ctx->tls13_cipher_list.get())) {
+      return nullptr;
+    }
   }
 
   if (ctx->psk_identity_hint) {


### PR DESCRIPTION
### Description of changes: 
Add missing NULL checks after MakeUnique<SSLCipherPreferenceList>() and
Init() return value checks during cipher list inheritance from SSL_CTX
to SSL in SSL_new(). Under OOM, MakeUnique returns nullptr and the
subsequent Init() call would dereference it, causing a crash.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
