### PR TITLE
Fix gRPC integration

### DIFF
--- a/tests/ci/integration/run_grpc_integration.sh
+++ b/tests/ci/integration/run_grpc_integration.sh
@@ -37,7 +37,13 @@ aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD
 
 mkdir -p "${GRPC_SRC_FOLDER}/cmake/build"
 cd "${GRPC_SRC_FOLDER}/cmake/build"
-time cmake -GNinja -DgRPC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release  -DgRPC_SSL_PROVIDER=package  -DBUILD_SHARED_LIBS=ON  -DOPENSSL_ROOT_DIR="${AWS_LC_INSTALL_FOLDER}" ../..
+# gRPC gates BoringSSL-specific features (e.g. SSL_PRIVATE_KEY_METHOD for private
+# key offload, optimized session caching) behind #ifdef OPENSSL_IS_BORINGSSL.
+# AWS-LC is a BoringSSL fork that supports these APIs but defines OPENSSL_IS_AWSLC
+# instead, so we set OPENSSL_IS_BORINGSSL explicitly to enable those code paths.
+time cmake -GNinja -DgRPC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release  -DgRPC_SSL_PROVIDER=package\
+      -DBUILD_SHARED_LIBS=ON -DOPENSSL_ROOT_DIR="${AWS_LC_INSTALL_FOLDER}" \
+      -DCMAKE_C_FLAGS="-DOPENSSL_IS_BORINGSSL=1" -DCMAKE_CXX_FLAGS="-DOPENSSL_IS_BORINGSSL=1" ../..
 grpc_tests=$(grep add_executable ../../CMakeLists.txt | grep _test | grep -E '(tls|ssl|cert)' | cut -d '(' -f2)
 echo Building $grpc_tests
 time ninja $grpc_tests


### PR DESCRIPTION
### Description of changes:
gRPC recently landed a TLS Private Key Offload feature (grpc/grpc#41606) that gates BoringSSL-specific code paths behind `#ifdef OPENSSL_IS_BORINGSSL`. AWS-LC defines `OPENSSL_IS_AWSLC` instead, so gRPC doesn't recognize it as BoringSSL-compatible. This causes all 11 `TlsPrivateKeyOffloadTest` tests to fail at setup time because `grpc_tls_identity_pairs_add_pair_with_signer` returns `UnimplementedError`.

Since AWS-LC is a BoringSSL fork and supports all the relevant APIs (e.g. `SSL_PRIVATE_KEY_METHOD`), we pass `-DOPENSSL_IS_BORINGSSL=1` via `CMAKE_C_FLAGS`/`CMAKE_CXX_FLAGS` when building gRPC. This enables the BoringSSL code paths that are correct for AWS-LC, including private key offload, optimized session caching, and type macros.

### Call-outs:
All `OPENSSL_IS_BORINGSSL` checks in gRPC are preprocessor-level guards inside source files — there's no CMake-level source file selection based on BoringSSL detection, so the CFLAGS approach is safe.

### Testing:
The gRPC integration test itself validates the fix — the 11 `TlsPrivateKeyOffloadTest` tests that were failing should now pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
