### PR TITLE
Clean up on X509_STORE_CTX_add_custom_crit_oid error paths

### DIFF
--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -8362,6 +8362,31 @@ TEST(X509Test, X509MultipleCustomExtensions) {
   EXPECT_TRUE(X509_get_extension_flags(cert.get()) & EXFLAG_CRITICAL);
 }
 
+// Test that |X509_STORE_CTX_add_custom_crit_oid| does not leak memory. Under
+// ASAN/LSAN, this test will catch leaks on both the success path and the
+// cleanup path in |X509_STORE_CTX_cleanup|.
+TEST(X509Test, AddCustomCritOidNoLeak) {
+  bssl::UniquePtr<X509_STORE_CTX> ctx(X509_STORE_CTX_new());
+  ASSERT_TRUE(ctx);
+  bssl::UniquePtr<X509_STORE> store(X509_STORE_new());
+  ASSERT_TRUE(store);
+
+  // |X509_STORE_CTX_init| must be called before adding custom OIDs.
+  ASSERT_TRUE(X509_STORE_CTX_init(ctx.get(), store.get(), nullptr, nullptr));
+
+  // Add several OIDs. Each call duplicates the object internally.
+  bssl::UniquePtr<ASN1_OBJECT> oid1(OBJ_txt2obj("1.2.3.4.5", 1));
+  ASSERT_TRUE(oid1);
+  bssl::UniquePtr<ASN1_OBJECT> oid2(OBJ_txt2obj("1.2.3.4.6", 1));
+  ASSERT_TRUE(oid2);
+
+  EXPECT_TRUE(X509_STORE_CTX_add_custom_crit_oid(ctx.get(), oid1.get()));
+  EXPECT_TRUE(X509_STORE_CTX_add_custom_crit_oid(ctx.get(), oid2.get()));
+
+  // |X509_STORE_CTX_cleanup| (called by the destructor) must free all
+  // duplicated OIDs and the stack itself without leaking.
+}
+
 TEST(X509Test, StoreVerifyCallback) {
   bssl::UniquePtr<X509_STORE> store(X509_STORE_new());
   ASSERT_TRUE(store);

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1840,11 +1840,13 @@ int X509_STORE_CTX_add_custom_crit_oid(X509_STORE_CTX *ctx, ASN1_OBJECT *oid) {
   if (ctx->custom_crit_oids == NULL) {
     ctx->custom_crit_oids = sk_ASN1_OBJECT_new_null();
     if (ctx->custom_crit_oids == NULL) {
+      ASN1_OBJECT_free(oid_dup);
       return 0;
     }
   }
 
   if (!sk_ASN1_OBJECT_push(ctx->custom_crit_oids, oid_dup)) {
+    ASN1_OBJECT_free(oid_dup);
     return 0;
   }
   return 1;


### PR DESCRIPTION
Clean up on X509_STORE_CTX_add_custom_crit_oid error paths

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
