### PR TITLE
Correct purpose setting for OCSP_request_verify

### DIFF
--- a/crypto/ocsp/ocsp_verify.c
+++ b/crypto/ocsp/ocsp_verify.c
@@ -201,6 +201,8 @@ static int ocsp_check_ids(STACK_OF(OCSP_SINGLERESP) *sresp, OCSP_CERTID **ret) {
   return 1;
 }
 
+// Returns -1 on fatal error, 0 if there is no match and 1 if there is a
+// match.
 static int ocsp_match_issuerid(X509 *cert, OCSP_CERTID *cid,
                                STACK_OF(OCSP_SINGLERESP) *sresp) {
   if (cert == NULL) {
@@ -232,13 +234,14 @@ static int ocsp_match_issuerid(X509 *cert, OCSP_CERTID *cid,
         return 0;
       }
     }
-    if (OPENSSL_memcmp(md, cid->issuerNameHash->data, mdlen) != 0) {
+    if (0 != OPENSSL_memcmp(md, cid->issuerNameHash->data, mdlen)) {
       return 0;
     }
     if (1 != X509_pubkey_digest(cert, dgst, md, NULL)) {
-      if (OPENSSL_memcmp(md, cid->issuerKeyHash->data, mdlen) != 0) {
-        return 0;
-      }
+      return -1;
+    }
+    if (0 != OPENSSL_memcmp(md, cid->issuerKeyHash->data, mdlen)) {
+      return 0;
     }
     return 1;
 
@@ -473,8 +476,8 @@ int OCSP_request_verify(OCSP_REQUEST *req, STACK_OF(X509) *certs,
   int ret = 0;
   if (!IS_OCSP_FLAG_SET(flags, OCSP_NOVERIFY)) {
     // Initialize and set purpose of |ctx| for verification.
-    if (!X509_STORE_CTX_init(ctx, store, signer, NULL) ||
-        !X509_STORE_CTX_set_purpose(ctx, X509_PURPOSE_OCSP_HELPER)) {
+    if (1 != X509_STORE_CTX_init(ctx, store, signer, NULL) ||
+        1 != X509_STORE_CTX_set_purpose(ctx, X509_PURPOSE_OCSP_HELPER)) {
       OPENSSL_PUT_ERROR(OCSP, ERR_R_X509_LIB);
       goto end;
     }


### PR DESCRIPTION
Fixes a logic error from `&&` → `||` in `OCSP_request_verify` when initializing the store context and setting its purpose. With `&&`, a `set_purpose` failure is silently ignored when `init` succeeds, so `X509_verify_cert` runs without `X509_PURPOSE_OCSP_HELPER`.

`OCSP_HELPER` is already intentionally permissive (skips leaf EKU checks, uses basic self-signed root trust), and the default path without it behaves nearly the same way. The signature is already validated before this point.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
