### PR TITLE
Update target.h to support Loongarch64 ABI1.0 architecture

### DIFF
--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -72,7 +72,7 @@
 #  if defined(OPENSSL_64_BIT)
 #    define OPENSSL_RISCV64
 #  endif
-#elif defined(__loongarch_lp64)
+#elif defined(__loongarch_lp64) || defined(__loongarch__)
 #define OPENSSL_LOONGARCH64
 #elif defined(__pnacl__)
 #define OPENSSL_PNACL

--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -72,7 +72,8 @@
 #  if defined(OPENSSL_64_BIT)
 #    define OPENSSL_RISCV64
 #  endif
-#elif defined(__loongarch_lp64) || defined(__loongarch__)
+#elif defined(__loongarch_lp64) || \
+      (defined(__loongarch__) && defined(OPENSSL_64_BIT))
 #define OPENSSL_LOONGARCH64
 #elif defined(__pnacl__)
 #define OPENSSL_PNACL


### PR DESCRIPTION
When I was compiling my Rust program, an error occurred.

Then I modified this part of the file, and the program could be compiled and run.

### Error

```shell
warning: aws-lc-sys@0.38.0: Environment Variable found 'CARGO_ENCODED_RUSTFLAGS': ''
warning: aws-lc-sys@0.38.0: Emitting configuration: cargo:rustc-cfg=universal
warning: aws-lc-sys@0.38.0: Building with: CC
warning: aws-lc-sys@0.38.0: Symbol Prefix: Some("aws_lc_0_38_0")
warning: aws-lc-sys@0.38.0: Target platform: 'loongarch64-unknown-linux-gnu'
warning: aws-lc-sys@0.38.0: No target-specific source found: linux-loongarch64
warning: aws-lc-sys@0.38.0: Compilation of 'c11.c' succeeded - Ok(["/local/usr/source/zhhxj/target/debug/build/aws-lc-sys-99d8092b8a485d3e/out/out-c11/7dfda64fdf5a526c-c11.o"]).
warning: aws-lc-sys@0.38.0: Compilation of 'stdalign_check.c' succeeded - Ok(["/local/usr/source/zhhxj/target/debug/build/aws-lc-sys-99d8092b8a485d3e/out/out-stdalign_check/7dfda64fdf5a526c-stdalign_check.o"]).
warning: aws-lc-sys@0.38.0: Compilation of 'builtin_swap_check.c' succeeded - Ok(["/local/usr/source/zhhxj/target/debug/build/aws-lc-sys-99d8092b8a485d3e/out/out-builtin_swap_check/7dfda64fdf5a526c-builtin_swap_check.o"]).
warning: aws-lc-sys@0.38.0: Compilation of 'linux_random_h.c' succeeded - Ok(["/local/usr/source/zhhxj/target/debug/build/aws-lc-sys-99d8092b8a485d3e/out/out-linux_random_h/7dfda64fdf5a526c-linux_random_h.o"]).
warning: aws-lc-sys@0.38.0: In file included from /home/test/.cargo/registry/src/mirrors.aliyun.com-0671735e7cc7f5e7/aws-lc-sys-0.38.0/aws-lc/include/openssl/base.h:81,
warning: aws-lc-sys@0.38.0:                  from /home/test/.cargo/registry/src/mirrors.aliyun.com-0671735e7cc7f5e7/aws-lc-sys-0.38.0/aws-lc/include/openssl/crypto.h:18,
warning: aws-lc-sys@0.38.0:                  from /home/test/.cargo/registry/src/mirrors.aliyun.com-0671735e7cc7f5e7/aws-lc-sys-0.38.0/aws-lc/third_party/jitterentropy/jitterentropy-library/jitterentropy-base-user.h:85,
warning: aws-lc-sys@0.38.0:                  from /home/test/.cargo/registry/src/mirrors.aliyun.com-0671735e7cc7f5e7/aws-lc-sys-0.38.0/aws-lc/third_party/jitterentropy/jitterentropy-library/jitterentropy.h:168,
warning: aws-lc-sys@0.38.0:                  from /home/test/.cargo/registry/src/mirrors.aliyun.com-0671735e7cc7f5e7/aws-lc-sys-0.38.0/aws-lc/third_party/jitterentropy/jitterentropy-library/src/jitterentropy-internal.h:45,
warning: aws-lc-sys@0.38.0:                  from /home/test/.cargo/registry/src/mirrors.aliyun.com-0671735e7cc7f5e7/aws-lc-sys-0.38.0/aws-lc/third_party/jitterentropy/jitterentropy-library/src/jitterentropy-gcd.h:23,
warning: aws-lc-sys@0.38.0:                  from /home/test/.cargo/registry/src/mirrors.aliyun.com-0671735e7cc7f5e7/aws-lc-sys-0.38.0/aws-lc/third_party/jitterentropy/jitterentropy-library/src/jitterentropy-base.c:33:
warning: aws-lc-sys@0.38.0: /home/test/.cargo/registry/src/mirrors.aliyun.com-0671735e7cc7f5e7/aws-lc-sys-0.38.0/aws-lc/include/openssl/target.h:97:2: error: #error "Unknown target CPU"
warning: aws-lc-sys@0.38.0:  #error "Unknown target CPU"
warning: aws-lc-sys@0.38.0:   ^~~~~
```

### CPU Info

```shell
Architecture:        loongarch64
Byte Order:          Little Endian
CPU(s):              8
On-line CPU(s) list: 0-7
Thread(s) per core:  2
Core(s) per socket:  4
Socket(s):           1
NUMA node(s):        1
CPU family:          Loongson-64bit
Model name:          Loongson-3A6000
CPU MHz:             2500.00
CPU max MHz:         2500.0000
CPU min MHz:         312.0000
BogoMIPS:            5000.00
L1d cache:           256 KiB
L1i cache:           256 KiB
L2 cache:            1 MiB
L3 cache:            16 MiB
NUMA node0 CPU(s):   0-7
Flags:               cpucfg lam ual fpu lsx lasx crc32 lvz lbt_x86 lbt_arm lbt_mips
```

### OS Program Info

```
[test@localhost .cargo]$ LANG=en_US.UTF-8 readelf -h /bin/sh
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              DYN (Shared object file)
  Machine:                           LoongArch
  Version:                           0x1
  Entry point address:               0x40620
  Start of program headers:          64 (bytes into file)
  Start of section headers:          1220200 (bytes into file)
  Flags:                             0x3, LP64
  Size of this header:               64 (bytes)
  Size of program headers:           56 (bytes)
  Number of program headers:         9
  Size of section headers:           64 (bytes)
  Number of section headers:         26
  Section header string table index: 25
```