### PR TITLE
Fix modulewrapper memory leak

### DIFF
--- a/util/fipstools/acvp/modulewrapper/modulewrapper.cc
+++ b/util/fipstools/acvp/modulewrapper/modulewrapper.cc
@@ -2970,16 +2970,20 @@ static bool RSASignaturePrimitive(const Span<const uint8_t> args[],
   const Span<const uint8_t> e_bytes = args[2];
   const Span<const uint8_t> msg = args[3];
 
-  BIGNUM *d = BN_new();
-  BIGNUM *n = BN_new();
-  BIGNUM *e = BN_new();
+  bssl::UniquePtr<BIGNUM> d(BN_new());
+  bssl::UniquePtr<BIGNUM> n(BN_new());
+  bssl::UniquePtr<BIGNUM> e(BN_new());
   bssl::UniquePtr<RSA> key(RSA_new());
-  if (!BN_bin2bn(n_bytes.data(), n_bytes.size(), n) ||
-      !BN_bin2bn(e_bytes.data(), e_bytes.size(), e) ||
-      !BN_bin2bn(d_bytes.data(), d_bytes.size(), d) ||
-      !RSA_set0_key(key.get(), n, e, d)) {
+  if (!BN_bin2bn(n_bytes.data(), n_bytes.size(), n.get()) ||
+      !BN_bin2bn(e_bytes.data(), e_bytes.size(), e.get()) ||
+      !BN_bin2bn(d_bytes.data(), d_bytes.size(), d.get()) ||
+      !RSA_set0_key(key.get(), n.get(), e.get(), d.get())) {
     return false;
   }
+  // RSA_set0_key took ownership of n, e, d.
+  n.release();
+  e.release();
+  d.release();
 
   std::vector<uint8_t> sig(RSA_size(key.get()));
   size_t sig_len = 0;
@@ -3004,17 +3008,26 @@ static bool RSADecryptionPrimitive(const Span<const uint8_t> args[],
   const Span<const uint8_t> n_bytes = args[2];
   const Span<const uint8_t> e_bytes = args[3];
 
-  BIGNUM *d = BN_new();
-  BIGNUM *n = BN_new();
-  BIGNUM *e = BN_new();
+  bssl::UniquePtr<BIGNUM> d(BN_new());
+  bssl::UniquePtr<BIGNUM> n(BN_new());
+  bssl::UniquePtr<BIGNUM> e(BN_new());
   bssl::UniquePtr<RSA> key(RSA_new());
 
   uint8_t success_flag[1] = {0};
   RSA_set_flags(key.get(), RSA_FLAG_LARGE_PUBLIC_EXPONENT);
-  if (!BN_bin2bn(n_bytes.data(), n_bytes.size(), n) ||
-      !BN_bin2bn(e_bytes.data(), e_bytes.size(), e) ||
-      !BN_bin2bn(d_bytes.data(), d_bytes.size(), d) ||
-      !RSA_set0_key(key.get(), n, e, d) || !RSA_check_key(key.get())) {
+  if (!BN_bin2bn(n_bytes.data(), n_bytes.size(), n.get()) ||
+      !BN_bin2bn(e_bytes.data(), e_bytes.size(), e.get()) ||
+      !BN_bin2bn(d_bytes.data(), d_bytes.size(), d.get()) ||
+      !RSA_set0_key(key.get(), n.get(), e.get(), d.get())) {
+    return write_reply(
+        {Span<const uint8_t>(success_flag), Span<const uint8_t>()});
+  }
+  // RSA_set0_key took ownership of n, e, d.
+  n.release();
+  e.release();
+  d.release();
+
+  if (!RSA_check_key(key.get())) {
     return write_reply(
         {Span<const uint8_t>(success_flag), Span<const uint8_t>()});
   }
@@ -3047,29 +3060,30 @@ static bool RSADecryptionPrimitiveCRT(const Span<const uint8_t> args[],
   const Span<const uint8_t> n_bytes = args[7];
   const Span<const uint8_t> e_bytes = args[8];
 
-  BIGNUM *d = BN_new();
-  BIGNUM *n = BN_new();
-  BIGNUM *e = BN_new();
-  BIGNUM *p = BN_new();
-  BIGNUM *q = BN_new();
-  BIGNUM *dmp1 = BN_new();
-  BIGNUM *dmq1 = BN_new();
-  BIGNUM *iqmp = BN_new();
+  bssl::UniquePtr<BIGNUM> d(BN_new());
+  bssl::UniquePtr<BIGNUM> n(BN_new());
+  bssl::UniquePtr<BIGNUM> e(BN_new());
+  bssl::UniquePtr<BIGNUM> p(BN_new());
+  bssl::UniquePtr<BIGNUM> q(BN_new());
+  bssl::UniquePtr<BIGNUM> dmp1(BN_new());
+  bssl::UniquePtr<BIGNUM> dmq1(BN_new());
+  bssl::UniquePtr<BIGNUM> iqmp(BN_new());
 
   uint8_t success_flag[1] = {0};
 
-  if (!BN_bin2bn(n_bytes.data(), n_bytes.size(), n) ||
-      !BN_bin2bn(e_bytes.data(), e_bytes.size(), e) ||
-      !BN_bin2bn(d_bytes.data(), d_bytes.size(), d) ||
-      !BN_bin2bn(p_bytes.data(), p_bytes.size(), p) ||
-      !BN_bin2bn(q_bytes.data(), q_bytes.size(), q) ||
-      !BN_bin2bn(dmp1_bytes.data(), dmp1_bytes.size(), dmp1) ||
-      !BN_bin2bn(dmq1_bytes.data(), dmq1_bytes.size(), dmq1) ||
-      !BN_bin2bn(iqmp_bytes.data(), iqmp_bytes.size(), iqmp)) {
+  if (!BN_bin2bn(n_bytes.data(), n_bytes.size(), n.get()) ||
+      !BN_bin2bn(e_bytes.data(), e_bytes.size(), e.get()) ||
+      !BN_bin2bn(d_bytes.data(), d_bytes.size(), d.get()) ||
+      !BN_bin2bn(p_bytes.data(), p_bytes.size(), p.get()) ||
+      !BN_bin2bn(q_bytes.data(), q_bytes.size(), q.get()) ||
+      !BN_bin2bn(dmp1_bytes.data(), dmp1_bytes.size(), dmp1.get()) ||
+      !BN_bin2bn(dmq1_bytes.data(), dmq1_bytes.size(), dmq1.get()) ||
+      !BN_bin2bn(iqmp_bytes.data(), iqmp_bytes.size(), iqmp.get())) {
     return false;
   }
-  bssl::UniquePtr<RSA> key(
-      RSA_new_private_key_large_e(n, e, d, p, q, dmp1, dmq1, iqmp));
+  bssl::UniquePtr<RSA> key(RSA_new_private_key_large_e(
+      n.get(), e.get(), d.get(), p.get(), q.get(), dmp1.get(), dmq1.get(),
+      iqmp.get()));
 
   if (key == NULL) {
     return write_reply(


### PR DESCRIPTION
### Description of changes:
The `RSADecryptionPrimitiveCRT` function in the ACVP modulewrapper leaks 8 BIGNUMs on every call. `RSA_new_private_key_large_e` takes `const BIGNUM*` parameters and copies them internally, but the originals were never freed. `RSASignaturePrimitive` and `RSADecryptionPrimitive` had the same issue on their error paths (before `RSA_set0_key` takes ownership).

Under ASAN, LeakSanitizer reports these leaks to stderr when the modulewrapper exits. Since `check_expected.go` captures combined stdout+stderr, the leak output gets mixed into the ACVP test result, causing a mismatch against the expected output.

All three functions now use `bssl::UniquePtr<BIGNUM>` for automatic cleanup.

### Testing:
Existing ACVP tests in the FIPS ASAN CI job should now pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
