### PR TITLE
Fix intermittent `WIN32_rename` failures in `openssl ca` CLI tool due to transient file locks

### DIFF
--- a/tool-openssl/ca.cc
+++ b/tool-openssl/ca.cc
@@ -95,6 +95,12 @@ static int WIN32_rename(const char *from, const char *to) {
   TCHAR *tfrom = nullptr, *tto = nullptr;
   DWORD err = 0;
   int ret = 0;
+  // On Windows, antivirus software, file indexing services, or other
+  // background processes can briefly lock files, causing transient
+  // ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION failures. Retry with a
+  // short delay to handle these.
+  static const int kMaxRetries = 5;
+  static const DWORD kRetryDelayMs = 200;
 
   if (sizeof(TCHAR) == 1) {
     tfrom = (TCHAR *)from;
@@ -114,15 +120,23 @@ static int WIN32_rename(const char *from, const char *to) {
     }
   }
 
-  if (MoveFile(tfrom, tto)) {
-    goto ok;
-  }
-  err = GetLastError();
-  if (err == ERROR_ALREADY_EXISTS || err == ERROR_FILE_EXISTS) {
-    if (DeleteFile(tto) && MoveFile(tfrom, tto)) {
+  for (int attempt = 0; attempt <= kMaxRetries; attempt++) {
+    if (attempt > 0) {
+      Sleep(kRetryDelayMs);
+    }
+    if (MoveFile(tfrom, tto)) {
       goto ok;
     }
     err = GetLastError();
+    if (err == ERROR_ALREADY_EXISTS || err == ERROR_FILE_EXISTS) {
+      if (DeleteFile(tto) && MoveFile(tfrom, tto)) {
+        goto ok;
+      }
+      err = GetLastError();
+    }
+    if (err != ERROR_ACCESS_DENIED && err != ERROR_SHARING_VIOLATION) {
+      break;
+    }
   }
   if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) {
     errno = ENOENT;
@@ -1484,7 +1498,7 @@ bool caTool(const args_list_t &args) {
     }
     ca_section = std::move(*value);
   }
-  
+
   // These features we are choosing not to support regarding CA options:
   // RANDFILE
   // oid_file


### PR DESCRIPTION
### Issues:
Resolves intermittent `CATest.DatabaseWithRevokedEntrySuperseded` failure on `windows-ltsc2022_sde-x86_64` CI job.

### Context:
On Windows, background processes (e.g. Windows Defender, Search Indexer) can briefly hold open handles on files immediately after they are created or renamed. The `WIN32_rename` function in our `openssl ca` CLI tool (`tool-openssl/ca.cc`) calls `MoveFile` but does not handle these transient failures, causing `RotateIndex` to fail with "Permission denied" (`ERROR_ACCESS_DENIED`).

This is especially likely under Intel SDE emulation, where slower execution widens the race window between consecutive file operations.

### Description of Change:

This change adds a retry loop (up to 10 attempts, 100ms apart) in `WIN32_rename` for transient error codes `ERROR_ACCESS_DENIED` and `ERROR_SHARING_VIOLATION`. Non-transient errors still fail immediately.

This change is entirely scoped to the `openssl` CLI tool (`tool-openssl/`). No crypto library code is affected.

### Call-outs:
- `WIN32_rename` is a static function in `tool-openssl/ca.cc`, invoked via `#define rename(from, to) WIN32_rename((from), (to))` on Windows. All `rename()` calls in `RotateIndex` and `RotateSerial` go through this path.
- Worst-case added latency is ~1 second (5 × 200ms), only when a transient lock is encountered.
- This is a well-established pattern for handling file operations on Windows CI environments.
- Example ephemeral Windows Failure: https://github.com/aws/aws-lc/actions/runs/23198675561/job/67414398206?pr=3032#step:4:3054
```
[ RUN      ] CATest.DatabaseWithRevokedEntrySuperseded
Check that the request matches the signature
Signature ok
The Subject's Distinguished Name is as follows
commonName            :ASN.1 12:'test.example.com'
Certificate is to be certified until Mar 17 16:27:41 2027 GMT (365 days)

Write out database with 1 new entries
unable to rename C:\Windows\aws1336.tmp.new to C:\Windows\aws1336.tmp
reason: Permission denied
C:\Windows\Temp\codebuild\tmp\output\src4106575558\src\actions-runner\_work\aws-lc\aws-lc\tool-openssl\ca_test.cc(1921): error: Value of: caTool(args)
  Actual: false
Expected: true
[  FAILED  ] CATest.DatabaseWithRevokedEntrySuperseded (240 ms)
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
