### PR TITLE
Fix CN fallback handling in name constraints checking

### DIFF
--- a/crypto/x509/v3_ncons.c
+++ b/crypto/x509/v3_ncons.c
@@ -28,9 +28,11 @@ static int do_i2r_name_constraints(const X509V3_EXT_METHOD *method,
 static int print_nc_ipadd(BIO *bp, const ASN1_OCTET_STRING *ip);
 
 static int nc_match(GENERAL_NAME *gen, NAME_CONSTRAINTS *nc);
-static int nc_match_single(GENERAL_NAME *sub, GENERAL_NAME *gen);
+static int nc_match_single(GENERAL_NAME *sub, GENERAL_NAME *gen,
+                           int excluding);
 static int nc_dn(X509_NAME *sub, X509_NAME *nm);
-static int nc_dns(const ASN1_IA5STRING *sub, const ASN1_IA5STRING *dns);
+static int nc_dns(const ASN1_IA5STRING *sub, const ASN1_IA5STRING *dns,
+                  int excluding);
 static int nc_email(const ASN1_IA5STRING *sub, const ASN1_IA5STRING *eml);
 static int nc_uri(const ASN1_IA5STRING *uri, const ASN1_IA5STRING *base);
 static int nc_ip(const ASN1_OCTET_STRING *ip, const ASN1_OCTET_STRING *base);
@@ -295,15 +297,32 @@ int cn2dnsid(ASN1_STRING *cn, unsigned char **dnsid, size_t *idlen) {
   }
 
   int isdnsname = 0;
+  int has_non_dns_char = 0;
+
+  // Per RFC 6125 Section 6.4.3, a wildcard DNS-ID uses a leading "*." covering
+  // the first label. Skip past it for validation, but return the full value so
+  // |nc_dns| can match it against name constraints.
+  int check_start = 0;
+  if (utf8_length > 2 && utf8_value[0] == '*' && utf8_value[1] == '.') {
+    check_start = 2;
+  }
   
-  // XXX: Deviation from strict DNS name syntax, also check names with '_'
-  // Check DNS name syntax, any '-' or '.' must be internal,
-  // and on either side of each '.' we can't have a '-' or '.'.
+  // Check DNS name syntax. Any '-' or '.' must be internal, and on either side
+  // of each '.' we can't have a '-' or '.'. Names with '_' are also accepted
+  // as a deviation from strict DNS syntax.
   //
-  // If the name has just one label, we don't consider it a DNS name.  This
+  // If the name has just one label, we don't consider it a DNS name. This
   // means that "CN=sometld" cannot be precluded by DNS name constraints, but
-  // that is not a problem.
-  for (int i = 0; i < utf8_length; ++i) {
+  // that is not a problem. Single-label CNs may contain non-ASCII characters
+  // (e.g. "CN=Ünternehmen") and are silently skipped.
+  //
+  // Multi-label CNs that resemble DNS names must be ASCII-only. Per RFC 6125
+  // Section 6.4.2, internationalized domain names should appear in A-label
+  // (punycode) form. A multi-label CN containing non-ASCII bytes or control
+  // characters is rejected with |X509_V_ERR_UNSUPPORTED_NAME_SYNTAX| to
+  // prevent it from bypassing name constraints while still being accepted by
+  // hostname verification.
+  for (int i = check_start; i < utf8_length; ++i) {
     const unsigned char c = utf8_value[i];
 
     if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
@@ -311,8 +330,13 @@ int cn2dnsid(ASN1_STRING *cn, unsigned char **dnsid, size_t *idlen) {
       continue;
     }
 
+    if (c >= 0x80 || c <= 0x20 || c == 0x7F) {
+      has_non_dns_char = 1;
+      continue;
+    }
+
     // Dot and hyphen cannot be first or last.
-    if (i > 0 && i < utf8_length - 1) {
+    if (i > check_start && i < utf8_length - 1) {
       if (c == '-') {
         continue;
       }
@@ -328,6 +352,13 @@ int cn2dnsid(ASN1_STRING *cn, unsigned char **dnsid, size_t *idlen) {
     }
     isdnsname = 0;
     break;
+  }
+
+  if (isdnsname && has_non_dns_char) {
+    // Multi-label CN with non-ASCII bytes or control characters. This
+    // resembles a DNS name but contains characters not permitted in DNS.
+    OPENSSL_free(utf8_value);
+    return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
   }
 
   if (isdnsname) {
@@ -402,7 +433,7 @@ static int nc_match(GENERAL_NAME *gen, NAME_CONSTRAINTS *nc) {
     if (match == 0) {
       match = 1;
     }
-    r = nc_match_single(gen, sub->base);
+    r = nc_match_single(gen, sub->base, /*excluding=*/0);
     if (r == X509_V_OK) {
       match = 2;
     } else if (r != X509_V_ERR_PERMITTED_VIOLATION) {
@@ -425,7 +456,7 @@ static int nc_match(GENERAL_NAME *gen, NAME_CONSTRAINTS *nc) {
       return X509_V_ERR_SUBTREE_MINMAX;
     }
 
-    r = nc_match_single(gen, sub->base);
+    r = nc_match_single(gen, sub->base, /*excluding=*/1);
     if (r == X509_V_OK) {
       return X509_V_ERR_EXCLUDED_VIOLATION;
     } else if (r != X509_V_ERR_PERMITTED_VIOLATION) {
@@ -436,13 +467,14 @@ static int nc_match(GENERAL_NAME *gen, NAME_CONSTRAINTS *nc) {
   return X509_V_OK;
 }
 
-static int nc_match_single(GENERAL_NAME *gen, GENERAL_NAME *base) {
+static int nc_match_single(GENERAL_NAME *gen, GENERAL_NAME *base,
+                           int excluding) {
   switch (base->type) {
     case GEN_DIRNAME:
       return nc_dn(gen->d.directoryName, base->d.directoryName);
 
     case GEN_DNS:
-      return nc_dns(gen->d.dNSName, base->d.dNSName);
+      return nc_dns(gen->d.dNSName, base->d.dNSName, excluding);
 
     case GEN_EMAIL:
       return nc_email(gen->d.rfc822Name, base->d.rfc822Name);
@@ -484,6 +516,15 @@ static int starts_with(const CBS *cbs, uint8_t c) {
   return CBS_len(cbs) > 0 && CBS_data(cbs)[0] == c;
 }
 
+static int starts_with_str(const CBS *cbs, const char *str, size_t str_len) {
+  return CBS_len(cbs) >= str_len &&
+         !OPENSSL_memcmp(CBS_data(cbs), str, str_len);
+}
+
+static int ends_with_byte(const CBS *cbs, uint8_t c) {
+  return CBS_len(cbs) > 0 && CBS_data(cbs)[CBS_len(cbs) - 1] == c;
+}
+
 static int equal_case(const CBS *a, const CBS *b) {
   if (CBS_len(a) != CBS_len(b)) {
     return 0;
@@ -508,7 +549,8 @@ static int has_suffix_case(const CBS *a, const CBS *b) {
   return equal_case(&copy, b);
 }
 
-static int nc_dns(const ASN1_IA5STRING *dns, const ASN1_IA5STRING *base) {
+static int nc_dns(const ASN1_IA5STRING *dns, const ASN1_IA5STRING *base,
+                  int excluding) {
   CBS dns_cbs, base_cbs;
   CBS_init(&dns_cbs, dns->data, dns->length);
   CBS_init(&base_cbs, base->data, base->length);
@@ -516,6 +558,34 @@ static int nc_dns(const ASN1_IA5STRING *dns, const ASN1_IA5STRING *base) {
   // Empty matches everything
   if (CBS_len(&base_cbs) == 0) {
     return X509_V_OK;
+  }
+
+  // Normalize absolute DNS names by removing the trailing dot, if any.
+  if (ends_with_byte(&dns_cbs, '.')) {
+    uint8_t unused;
+    CBS_get_last_u8(&dns_cbs, &unused);
+  }
+  if (ends_with_byte(&base_cbs, '.')) {
+    uint8_t unused;
+    CBS_get_last_u8(&base_cbs, &unused);
+  }
+
+  // Wildcard partial-match handling ("*.bar.com" matching name constraint
+  // "foo.bar.com"). This only handles the case where the dnsname and the
+  // constraint match after removing the leftmost label, otherwise it is handled
+  // by falling through to the check of whether the dnsname is fully within or
+  // fully outside of the constraint.
+  if (excluding && starts_with_str(&dns_cbs, "*.", 2)) {
+    CBS unused;
+    CBS base_parent_cbs = base_cbs;
+    CBS dns_parent_cbs = dns_cbs;
+    CBS_skip(&dns_parent_cbs, 2);
+    if (CBS_get_until_first(&base_parent_cbs, &unused, '.') &&
+        CBS_skip(&base_parent_cbs, 1)) {
+      if (equal_case(&dns_parent_cbs, &base_parent_cbs)) {
+        return X509_V_OK;
+      }
+    }
   }
 
   // If |base_cbs| begins with a '.', do a simple suffix comparison. This is

--- a/crypto/x509/x509_compat_test.cc
+++ b/crypto/x509/x509_compat_test.cc
@@ -2496,6 +2496,39 @@ TEST(X509CompatTest, CommonNameToDNS) {
       {"eXaMpLe", false, ""},
       {"cn with spaces", false, ""},
       {"1 and 2 and 3", false, ""},
+      // Wildcard CN test cases: wildcard CNs must be recognized as DNS-IDs
+      // so that name constraints are enforced on them.
+      {"*.example.com", true, "*.example.com"},
+      {"*.sub.example.com", true, "*.sub.example.com"},
+      {"*.exa_mple.com", true, "*.exa_mple.com"},
+      {"*.foo-bar.example.com", true, "*.foo-bar.example.com"},
+      // Wildcard with single remaining label is not a DNS name.
+      {"*.com", false, ""},
+      // Bare wildcard or incomplete wildcard prefix.
+      {"*", false, ""},
+      {"*.", false, ""},
+      {"*..", false, ""},
+      // Star without dot is not a valid wildcard prefix.
+      {"*example.com", false, ""},
+      // Double star is not valid.
+      {"**.example.com", false, ""},
+      // Invalid DNS syntax after wildcard prefix.
+      {"*.-example.com", false, ""},
+      {"*.example-.com", false, ""},
+      {"*.example..com", false, ""},
+      {"*.example.com.", false, ""},
+      {".*.example.com", false, ""},
+      // Single-label CNs with non-ASCII are accepted (not DNS names).
+      {"r\xc3\xa4ger", false, ""},
+      {"\xc3\x9cnternehmen", false, ""},
+      // Single-label CNs with control characters are accepted (not DNS names).
+      {"foo\x01" "bar", false, ""},
+      {std::string("\x7f") + "tld", false, ""},
+      // Single-label CN with space is accepted (not a DNS name).
+      {"foo bar", false, ""},
+      // Punycode equivalents are valid ASCII DNS names.
+      {"xn--rger-koa.evil.com", true, "xn--rger-koa.evil.com"},
+      {"xn--caf-dma.example.com", true, "xn--caf-dma.example.com"},
   };
 
   for (CommonNameToDNSTestParam &param : params) {
@@ -2520,6 +2553,38 @@ TEST(X509CompatTest, CommonNameToDNS) {
       ASSERT_EQ((size_t)0, idlen);
     }
   }
+
+  // Multi-label CNs with non-ASCII bytes should return
+  // X509_V_ERR_UNSUPPORTED_NAME_SYNTAX. Per RFC 6125 Section 6.4.2,
+  // internationalized domain names should use A-label (punycode) form.
+  const std::string non_ascii_dns[] = {
+      "r\xc3\xa4ger.evil.com",
+      "caf\xc3\xa9.example.com",
+      "*.r\xc3\xa4ger.evil.com",
+      // Control characters in multi-label CNs.
+      "foo\x01.evil.com",
+      std::string("bar\x7f") + ".evil.com",
+      "baz\x1f.example.com",
+      // Space in multi-label CN.
+      "foo .evil.com",
+  };
+  for (const std::string &name : non_ascii_dns) {
+    SCOPED_TRACE(name);
+    ASN1_STRING *asn1_str_ptr = NULL;
+    std::vector<uint8_t> cn(name.begin(), name.end());
+    ASSERT_GE(ASN1_mbstring_copy(&asn1_str_ptr, cn.data(), cn.size(),
+                                 MBSTRING_UTF8, V_ASN1_IA5STRING),
+              0);
+    bssl::UniquePtr<ASN1_STRING> asn1_cn(asn1_str_ptr);
+    ASSERT_TRUE(asn1_cn);
+    unsigned char *dnsid_ptr = NULL;
+    size_t idlen = 0;
+    ASSERT_EQ(X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
+              cn2dnsid(asn1_cn.get(), &dnsid_ptr, &idlen));
+    ASSERT_FALSE(dnsid_ptr);
+    ASSERT_EQ((size_t)0, idlen);
+  }
+
 }
 
 

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -2162,6 +2162,34 @@ static bool AddKeyUsage(X509 *x509, const std::vector<KeyUsage> usages) {
                            /*flags=*/0);
 }
 
+// Creates a NAME_CONSTRAINTS with a single permitted or excluded subtree.
+static bssl::UniquePtr<NAME_CONSTRAINTS> MakeNameConstraint(
+    int type, const std::string &name, bool excluded) {
+  bssl::UniquePtr<NAME_CONSTRAINTS> nc(NAME_CONSTRAINTS_new());
+  if (!nc) {
+    return nullptr;
+  }
+  STACK_OF(GENERAL_SUBTREE) **rule =
+      excluded ? &nc->excludedSubtrees : &nc->permittedSubtrees;
+  *rule = sk_GENERAL_SUBTREE_new_null();
+  if (!*rule) {
+    return nullptr;
+  }
+  bssl::UniquePtr<GENERAL_SUBTREE> subtree(GENERAL_SUBTREE_new());
+  if (!subtree) {
+    return nullptr;
+  }
+  GENERAL_NAME_free(subtree->base);
+  subtree->base = MakeGeneralName(type, name).release();
+  if (!subtree->base) {
+    return nullptr;
+  }
+  if (!bssl::PushToStack(*rule, std::move(subtree))) {
+    return nullptr;
+  }
+  return nc;
+}
+
 TEST(X509Test, NameConstraints) {
   bssl::UniquePtr<EVP_PKEY> key = PrivateKeyFromPEM(kP256Key);
   ASSERT_TRUE(key);
@@ -2170,112 +2198,155 @@ TEST(X509Test, NameConstraints) {
     int type;
     std::string name;
     std::string constraint;
-    int result;
+    int permit_result;
+    int exclude_result;
   } kTests[] = {
       // Empty string matches everything.
-      {GEN_DNS, "foo.example.com", "", X509_V_OK},
+      {GEN_DNS, "foo.example.com", "", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       // Name constraints match the entire subtree.
-      {GEN_DNS, "foo.example.com", "example.com", X509_V_OK},
-      {GEN_DNS, "foo.example.com", "EXAMPLE.COM", X509_V_OK},
+      {GEN_DNS, "foo.example.com", "example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_DNS, "foo.example.com", "EXAMPLE.COM", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       {GEN_DNS, "foo.example.com", "xample.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_DNS, "foo.example.com", "unrelated.much.longer.name.example",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       // A leading dot means at least one component must be added.
-      {GEN_DNS, "foo.example.com", ".example.com", X509_V_OK},
-      {GEN_DNS, "foo.example.com", "foo.example.com", X509_V_OK},
+      {GEN_DNS, "foo.example.com", ".example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_DNS, "foo.example.com", "foo.example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       {GEN_DNS, "foo.example.com", ".foo.example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_DNS, "foo.example.com", ".xample.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_DNS, "foo.example.com", ".unrelated.much.longer.name.example",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
+      // Trailing dot is ignored.
+      {GEN_DNS, "foo.example.com.", "example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_DNS, "foo.example.com", "example.com.", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       // NUL bytes, if not rejected, should not confuse the matching logic.
       {GEN_DNS, std::string({'a', '\0', 'a'}), std::string({'a', '\0', 'b'}),
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
+
+      // Wildcard DNS names against name constraints.
+      {GEN_DNS, "*.com", "foo.example.com", X509_V_ERR_PERMITTED_VIOLATION,
+       X509_V_OK},
+      {GEN_DNS, "*.example.com", "foo.example.com",
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_DNS, "*.foo.example.com", "foo.example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_DNS, "*.sub.foo.example.com", "foo.example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_DNS, "*.bar.example.com", "foo.example.com",
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
+      {GEN_DNS, "*.example.com", "net", X509_V_ERR_PERMITTED_VIOLATION,
+       X509_V_OK},
+      {GEN_DNS, "*.example.com", "com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
 
       // Names must be emails.
       {GEN_EMAIL, "not-an-email.example", "not-an-email.example",
-       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX, X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
       // A leading dot matches all local names and all subdomains
-      {GEN_EMAIL, "foo@bar.example.com", ".example.com", X509_V_OK},
-      {GEN_EMAIL, "foo@bar.example.com", ".EXAMPLE.COM", X509_V_OK},
+      {GEN_EMAIL, "foo@bar.example.com", ".example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_EMAIL, "foo@bar.example.com", ".EXAMPLE.COM", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       {GEN_EMAIL, "foo@bar.example.com", ".bar.example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       // Without a leading dot, the host must match exactly.
-      {GEN_EMAIL, "foo@example.com", "example.com", X509_V_OK},
-      {GEN_EMAIL, "foo@example.com", "EXAMPLE.COM", X509_V_OK},
+      {GEN_EMAIL, "foo@example.com", "example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_EMAIL, "foo@example.com", "EXAMPLE.COM", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       {GEN_EMAIL, "foo@bar.example.com", "example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       // If the constraint specifies a mailbox, it specifies the whole thing.
       // The halves are compared insensitively.
-      {GEN_EMAIL, "foo@example.com", "foo@example.com", X509_V_OK},
-      {GEN_EMAIL, "foo@example.com", "foo@EXAMPLE.COM", X509_V_OK},
+      {GEN_EMAIL, "foo@example.com", "foo@example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_EMAIL, "foo@example.com", "foo@EXAMPLE.COM", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       {GEN_EMAIL, "foo@example.com", "FOO@example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_EMAIL, "foo@example.com", "bar@example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       // OpenSSL ignores a stray leading @.
-      {GEN_EMAIL, "foo@example.com", "@example.com", X509_V_OK},
-      {GEN_EMAIL, "foo@example.com", "@EXAMPLE.COM", X509_V_OK},
+      {GEN_EMAIL, "foo@example.com", "@example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_EMAIL, "foo@example.com", "@EXAMPLE.COM", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       {GEN_EMAIL, "foo@bar.example.com", "@example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
 
       // Basic syntax check.
-      {GEN_URI, "not-a-url", "not-a-url", X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+      {GEN_URI, "not-a-url", "not-a-url", X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
       {GEN_URI, "foo:not-a-url", "not-a-url",
-       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX, X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
       {GEN_URI, "foo:/not-a-url", "not-a-url",
-       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX, X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
       {GEN_URI, "foo:///not-a-url", "not-a-url",
-       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX, X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
       {GEN_URI, "foo://:not-a-url", "not-a-url",
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX, X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+      {GEN_URI, "foo://", "not-a-url", X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
        X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
-      {GEN_URI, "foo://", "not-a-url", X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
       // Hosts are an exact match.
-      {GEN_URI, "foo://example.com", "example.com", X509_V_OK},
-      {GEN_URI, "foo://example.com:443", "example.com", X509_V_OK},
-      {GEN_URI, "foo://example.com/whatever", "example.com", X509_V_OK},
+      {GEN_URI, "foo://example.com", "example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_URI, "foo://example.com:443", "example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_URI, "foo://example.com/whatever", "example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       {GEN_URI, "foo://bar.example.com", "example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://bar.example.com:443", "example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://bar.example.com/whatever", "example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://bar.example.com", "xample.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://bar.example.com:443", "xample.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://bar.example.com/whatever", "xample.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com", "some-other-name.example",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com:443", "some-other-name.example",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com/whatever", "some-other-name.example",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       // A leading dot allows components to be added.
       {GEN_URI, "foo://example.com", ".example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com:443", ".example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com/whatever", ".example.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
-      {GEN_URI, "foo://bar.example.com", ".example.com", X509_V_OK},
-      {GEN_URI, "foo://bar.example.com:443", ".example.com", X509_V_OK},
-      {GEN_URI, "foo://bar.example.com/whatever", ".example.com", X509_V_OK},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
+      {GEN_URI, "foo://bar.example.com", ".example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_URI, "foo://bar.example.com:443", ".example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
+      {GEN_URI, "foo://bar.example.com/whatever", ".example.com", X509_V_OK,
+       X509_V_ERR_EXCLUDED_VIOLATION},
       {GEN_URI, "foo://example.com", ".some-other-name.example",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com:443", ".some-other-name.example",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com/whatever", ".some-other-name.example",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com", ".xample.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com:443", ".xample.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_URI, "foo://example.com/whatever", ".xample.com",
-       X509_V_ERR_PERMITTED_VIOLATION},
+       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
 
       // RFC 5280 §4.2.1.10 specifies URI name constraints "MUST be specified
       // as a fully qualified domain name". IPv6 literal URIs are not domain
@@ -2283,50 +2354,183 @@ TEST(X509Test, NameConstraints) {
       // multiple equivalent textual representations. They are rejected as
       // unsupported syntax (fail-closed).
       {GEN_URI, "foo://[2001:db8::1]", "[2001:db8::1]",
-       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX, X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
       // An incomplete IPv6 literal is also rejected.
       {GEN_URI, "foo://[2001:db8::1", "[2001:db8::1]",
-       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX, X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
   };
   for (const auto &t : kTests) {
     SCOPED_TRACE(t.type);
     SCOPED_TRACE(t.name);
     SCOPED_TRACE(t.constraint);
 
-    bssl::UniquePtr<GENERAL_NAME> name = MakeGeneralName(t.type, t.name);
-    ASSERT_TRUE(name);
-    bssl::UniquePtr<GENERAL_NAMES> names(GENERAL_NAMES_new());
-    ASSERT_TRUE(names);
-    ASSERT_TRUE(bssl::PushToStack(names.get(), std::move(name)));
+    for (bool exclude : {false, true}) {
+      SCOPED_TRACE(exclude);
 
-    bssl::UniquePtr<NAME_CONSTRAINTS> nc(NAME_CONSTRAINTS_new());
-    ASSERT_TRUE(nc);
-    nc->permittedSubtrees = sk_GENERAL_SUBTREE_new_null();
-    ASSERT_TRUE(nc->permittedSubtrees);
-    bssl::UniquePtr<GENERAL_SUBTREE> subtree(GENERAL_SUBTREE_new());
-    ASSERT_TRUE(subtree);
-    GENERAL_NAME_free(subtree->base);
-    subtree->base = MakeGeneralName(t.type, t.constraint).release();
-    ASSERT_TRUE(subtree->base);
-    ASSERT_TRUE(bssl::PushToStack(nc->permittedSubtrees, std::move(subtree)));
+      bssl::UniquePtr<GENERAL_NAME> name = MakeGeneralName(t.type, t.name);
+      ASSERT_TRUE(name);
+      bssl::UniquePtr<GENERAL_NAMES> names(GENERAL_NAMES_new());
+      ASSERT_TRUE(names);
+      ASSERT_TRUE(bssl::PushToStack(names.get(), std::move(name)));
 
-    bssl::UniquePtr<X509> root =
-        MakeTestCert("Root", "Root", key.get(), /*is_ca=*/true);
-    ASSERT_TRUE(root);
-    ASSERT_TRUE(X509_add1_ext_i2d(root.get(), NID_name_constraints, nc.get(),
-                                  /*crit=*/1, /*flags=*/0));
-    ASSERT_TRUE(X509_sign(root.get(), key.get(), EVP_sha256()));
+      bssl::UniquePtr<NAME_CONSTRAINTS> nc =
+          MakeNameConstraint(t.type, t.constraint, /*excluded=*/exclude);
+      ASSERT_TRUE(nc);
 
-    bssl::UniquePtr<X509> leaf =
-        MakeTestCert("Root", "Leaf", key.get(), /*is_ca=*/false);
-    ASSERT_TRUE(leaf);
-    ASSERT_TRUE(X509_add1_ext_i2d(leaf.get(), NID_subject_alt_name, names.get(),
-                                  /*crit=*/0, /*flags=*/0));
-    ASSERT_TRUE(X509_sign(leaf.get(), key.get(), EVP_sha256()));
+      bssl::UniquePtr<X509> root =
+          MakeTestCert("Root", "Root", key.get(), /*is_ca=*/true);
+      ASSERT_TRUE(root);
+      ASSERT_TRUE(X509_add1_ext_i2d(root.get(), NID_name_constraints, nc.get(),
+                                    /*crit=*/1, /*flags=*/0));
+      ASSERT_TRUE(X509_sign(root.get(), key.get(), EVP_sha256()));
 
-    int ret = Verify(leaf.get(), {root.get()}, {}, {}, 0);
-    EXPECT_EQ(t.result, ret) << X509_verify_cert_error_string(ret);
+      bssl::UniquePtr<X509> leaf =
+          MakeTestCert("Root", "Leaf", key.get(), /*is_ca=*/false);
+      ASSERT_TRUE(leaf);
+      ASSERT_TRUE(X509_add1_ext_i2d(leaf.get(), NID_subject_alt_name,
+                                    names.get(),
+                                    /*crit=*/0, /*flags=*/0));
+      ASSERT_TRUE(X509_sign(leaf.get(), key.get(), EVP_sha256()));
+
+      int got_result = Verify(leaf.get(), {root.get()}, {}, {}, 0);
+      int want_result = exclude ? t.exclude_result : t.permit_result;
+      EXPECT_EQ(want_result, got_result)
+          << "got \"" << X509_verify_cert_error_string(got_result)
+          << "\", want \"" << X509_verify_cert_error_string(want_result)
+          << "\"";
+    }
   }
+}
+
+// Test that wildcard CNs are checked against name constraints when no
+// dNSName SAN is present.
+TEST(X509Test, NameConstraintsWildcardCN) {
+  bssl::UniquePtr<EVP_PKEY> key = PrivateKeyFromPEM(kP256Key);
+  ASSERT_TRUE(key);
+
+  // Permitted subtree: only .example.com
+  bssl::UniquePtr<NAME_CONSTRAINTS> nc =
+      MakeNameConstraint(GEN_DNS, ".example.com", /*excluded=*/false);
+  ASSERT_TRUE(nc);
+
+  bssl::UniquePtr<X509> root =
+      MakeTestCert("Root", "Root", key.get(), /*is_ca=*/true);
+  ASSERT_TRUE(root);
+  ASSERT_TRUE(X509_add1_ext_i2d(root.get(), NID_name_constraints, nc.get(),
+                                /*crit=*/1, /*flags=*/0));
+  ASSERT_TRUE(X509_sign(root.get(), key.get(), EVP_sha256()));
+
+  // Wildcard CN outside permitted subtree, no SAN. Should be rejected.
+  bssl::UniquePtr<X509> leaf =
+      MakeTestCert("Root", "*.evil.com", key.get(), /*is_ca=*/false);
+  ASSERT_TRUE(leaf);
+  ASSERT_TRUE(X509_sign(leaf.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_ERR_PERMITTED_VIOLATION,
+            Verify(leaf.get(), {root.get()}, {}, {}, 0));
+
+  // Wildcard CN inside permitted subtree, no SAN. Should be permitted.
+  bssl::UniquePtr<X509> leaf_ok =
+      MakeTestCert("Root", "*.example.com", key.get(), /*is_ca=*/false);
+  ASSERT_TRUE(leaf_ok);
+  ASSERT_TRUE(X509_sign(leaf_ok.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_OK, Verify(leaf_ok.get(), {root.get()}, {}, {}, 0));
+
+  // Non-wildcard CN outside permitted subtree, no SAN. Sanity check.
+  bssl::UniquePtr<X509> leaf_bad =
+      MakeTestCert("Root", "foo.evil.com", key.get(), /*is_ca=*/false);
+  ASSERT_TRUE(leaf_bad);
+  ASSERT_TRUE(X509_sign(leaf_bad.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_ERR_PERMITTED_VIOLATION,
+            Verify(leaf_bad.get(), {root.get()}, {}, {}, 0));
+
+  // Excluded subtree: wildcard CN inside excluded namespace should be rejected.
+  bssl::UniquePtr<NAME_CONSTRAINTS> nc_excl =
+      MakeNameConstraint(GEN_DNS, ".evil.com", /*excluded=*/true);
+  ASSERT_TRUE(nc_excl);
+
+  bssl::UniquePtr<X509> root_excl =
+      MakeTestCert("Root2", "Root2", key.get(), /*is_ca=*/true);
+  ASSERT_TRUE(root_excl);
+  ASSERT_TRUE(X509_add1_ext_i2d(root_excl.get(), NID_name_constraints,
+                                nc_excl.get(), /*crit=*/1, /*flags=*/0));
+  ASSERT_TRUE(X509_sign(root_excl.get(), key.get(), EVP_sha256()));
+
+  bssl::UniquePtr<X509> leaf_excl =
+      MakeTestCert("Root2", "*.evil.com", key.get(), /*is_ca=*/false);
+  ASSERT_TRUE(leaf_excl);
+  ASSERT_TRUE(X509_sign(leaf_excl.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_ERR_EXCLUDED_VIOLATION,
+            Verify(leaf_excl.get(), {root_excl.get()}, {}, {}, 0));
+
+  // Wildcard CN outside excluded namespace should not be rejected.
+  bssl::UniquePtr<X509> leaf_excl_ok =
+      MakeTestCert("Root2", "*.good.com", key.get(), /*is_ca=*/false);
+  ASSERT_TRUE(leaf_excl_ok);
+  ASSERT_TRUE(X509_sign(leaf_excl_ok.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_OK, Verify(leaf_excl_ok.get(), {root_excl.get()}, {}, {}, 0));
+
+  // Excluded subtree "com": wildcard CN *.example.com is under "com".
+  bssl::UniquePtr<NAME_CONSTRAINTS> nc_excl_com =
+      MakeNameConstraint(GEN_DNS, "com", /*excluded=*/true);
+  ASSERT_TRUE(nc_excl_com);
+
+  bssl::UniquePtr<X509> root_excl_com =
+      MakeTestCert("Root3", "Root3", key.get(), /*is_ca=*/true);
+  ASSERT_TRUE(root_excl_com);
+  ASSERT_TRUE(X509_add1_ext_i2d(root_excl_com.get(), NID_name_constraints,
+                                nc_excl_com.get(), /*crit=*/1, /*flags=*/0));
+  ASSERT_TRUE(X509_sign(root_excl_com.get(), key.get(), EVP_sha256()));
+
+  bssl::UniquePtr<X509> leaf_excl_com =
+      MakeTestCert("Root3", "*.example.com", key.get(), /*is_ca=*/false);
+  ASSERT_TRUE(leaf_excl_com);
+  ASSERT_TRUE(X509_sign(leaf_excl_com.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_ERR_EXCLUDED_VIOLATION,
+            Verify(leaf_excl_com.get(), {root_excl_com.get()}, {}, {}, 0));
+
+  // Non-ASCII multi-label CN under a constrained CA should be rejected.
+  // Per RFC 6125, internationalized names should use punycode (A-label) form.
+  bssl::UniquePtr<X509> leaf_utf8 =
+      MakeTestCert("Root", "r\xc3\xa4ger.evil.com", key.get(),
+                   /*is_ca=*/false);
+  ASSERT_TRUE(leaf_utf8);
+  ASSERT_TRUE(X509_sign(leaf_utf8.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
+            Verify(leaf_utf8.get(), {root.get()}, {}, {}, 0));
+
+  // Control character in multi-label CN should also be rejected.
+  bssl::UniquePtr<X509> leaf_ctrl =
+      MakeTestCert("Root", "foo\x01.evil.com", key.get(), /*is_ca=*/false);
+  ASSERT_TRUE(leaf_ctrl);
+  ASSERT_TRUE(X509_sign(leaf_ctrl.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
+            Verify(leaf_ctrl.get(), {root.get()}, {}, {}, 0));
+
+  // Space in multi-label CN should also be rejected.
+  bssl::UniquePtr<X509> leaf_space =
+      MakeTestCert("Root", "foo .evil.com", key.get(), /*is_ca=*/false);
+  ASSERT_TRUE(leaf_space);
+  ASSERT_TRUE(X509_sign(leaf_space.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
+            Verify(leaf_space.get(), {root.get()}, {}, {}, 0));
+
+  // The punycode equivalent should be checked normally against constraints.
+  bssl::UniquePtr<X509> leaf_punycode =
+      MakeTestCert("Root", "xn--rger-koa.evil.com", key.get(),
+                   /*is_ca=*/false);
+  ASSERT_TRUE(leaf_punycode);
+  ASSERT_TRUE(X509_sign(leaf_punycode.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_ERR_PERMITTED_VIOLATION,
+            Verify(leaf_punycode.get(), {root.get()}, {}, {}, 0));
+
+  // Punycode CN inside the permitted subtree should pass.
+  bssl::UniquePtr<X509> leaf_punycode_ok =
+      MakeTestCert("Root", "xn--rger-koa.example.com", key.get(),
+                   /*is_ca=*/false);
+  ASSERT_TRUE(leaf_punycode_ok);
+  ASSERT_TRUE(X509_sign(leaf_punycode_ok.get(), key.get(), EVP_sha256()));
+  EXPECT_EQ(X509_V_OK,
+            Verify(leaf_punycode_ok.get(), {root.get()}, {}, {}, 0));
 }
 
 TEST(X509Test, PrintGeneralName) {


### PR DESCRIPTION
### Description of changes:
This change fixes two issues in name constraints enforcement:
1. `cn2dnsid` now recognizes wildcard CNs (leading `*.`) as DNS identifiers by skipping the prefix during DNS syntax validation. The full wildcard string is returned so `nc_dns` can perform suffix matching against permitted/excluded subtrees.

2. `nc_dns` now handles wildcard DNS names against excluded subtrees. An exclusion of `foo.example.com` correctly matches `*.example.com` by comparing parent domains when the DNS name starts with `*`. This is based on upstream commit: https://github.com/google/boringssl/commit/5774eca6004ed7c7467bd644c057797ca96b65f2

### Call-outs:
This change makes name constraints enforcement stricter. Certificates that were previously accepted (due to wildcard CNs being skipped) will now be checked against their CA's name constraints. Only certificates that were already in violation of their CA's constraints will be newly rejected.

### Testing:
- Expanded `NameConstraints` in `x509_test.cc` to test both permitted and excluded subtrees. Also taken from upstream commit referenced above.
- Added wildcard CN test cases to `CommonNameToDNS` in `x509_compat_test.cc`.
- Added `NameConstraintsWildcardCN` in `x509_test.cc` to test the end-to-end CN fallback path with wildcard CNs against both permitted and excluded subtrees.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
