### PR TITLE
fix: include TargetConditionals.h in target.h for iOS cross-compilation

### DIFF
--- a/crypto/rand_extra/urandom.c
+++ b/crypto/rand_extra/urandom.c
@@ -352,8 +352,10 @@ static void ensure_getrandom_is_initialized(void) {
 
 static void ensure_dev_urandom_is_initialized(void) {
 
-  // On platforms where urandom doesn't block at startup, we ensure that the
-  // kernel has sufficient entropy before continuing.
+#if defined(OPENSSL_LINUX)
+  // On Linux, where urandom doesn't block at startup, we ensure that the
+  // kernel has sufficient entropy before continuing. RNDGETENTCNT and ioctl
+  // are Linux-specific (from <linux/random.h> and <sys/ioctl.h>).
   for (;;) {
     int entropy_bits = 0;
     if (ioctl(urandom_fd, RNDGETENTCNT, &entropy_bits)) {
@@ -377,6 +379,7 @@ static void ensure_dev_urandom_is_initialized(void) {
     nanosleep(&sleep_time, &sleep_time);
   }
 
+#endif  // OPENSSL_LINUX
   random_flavor_state = STATE_READY;
 }
 

--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -87,6 +87,14 @@
 #endif
 
 #if defined(__APPLE__)
+// TargetConditionals.h defines TARGET_OS_OSX, TARGET_OS_IPHONE, etc.
+// base.h includes it for C/C++, but target.h must be self-contained
+// because it can be included before base.h. In assembly contexts the
+// header is unavailable, but the TARGET_OS_* checks below will simply
+// evaluate to false, which is fine -- assembly never inspects them.
+#if !defined(__ASSEMBLER__)
+#include <TargetConditionals.h>
+#endif
 #define OPENSSL_APPLE
 // Note |TARGET_OS_MAC| is set for all Apple OS variants. |TARGET_OS_OSX|
 // targets macOS specifically.


### PR DESCRIPTION

### Issues:
None filed yet — discovered in the wild cross-compiling for iOS via `aws-lc-sys` 0.38.0.

### Description of changes:

`target.h` checks `TARGET_OS_IPHONE` and `TARGET_OS_OSX` to define `OPENSSL_IOS` and `OPENSSL_MACOS`, but never includes `<TargetConditionals.h>` itself. It relies on `base.h` having done the include first. On toolchains where `TARGET_OS_*` are not compiler builtins (observed with Xcode 16.2 / iPhoneOS 18.2 SDK, compiled through the cc-rs build system), the macros are absent when `target.h` is processed. `OPENSSL_IOS` is never defined.

That causes the entropy source selection in `crypto/rand_extra/internal.h` to skip `OPENSSL_RAND_CCRANDOMGENERATEBYTES` and fall through to `OPENSSL_RAND_URANDOM`. `urandom.c` then fails to compile because `ensure_dev_urandom_is_initialized()` references `ioctl()` and `RNDGETENTCNT`, whose headers (`<linux/random.h>`, `<sys/ioctl.h>`) are only included behind `#if defined(OPENSSL_LINUX)`:

    urandom.c:370:9: error: call to undeclared function 'ioctl'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
    urandom.c:370:27: error: use of undeclared identifier 'RNDGETENTCNT'

Fix: include `<TargetConditionals.h>` directly in `target.h` so it is self-contained on Apple platforms. Guarded by `!__ASSEMBLER__` since `target.h` is also pulled into `.S` files.

### Call-outs:

The `target.h` header is documented as safe for C, C++, and assembly. The `!__ASSEMBLER__` guard keeps `<TargetConditionals.h>` out of assembly contexts where system headers aren't available. In assembly, the `TARGET_OS_*` checks simply evaluate to false, which matches current behavior (assembly files don't inspect `OPENSSL_IOS`).

### Testing:

We verified this end-to-end. Our project ([worldcoin/walletkit](https://github.com/worldcoin/walletkit)) cross-compiles `aws-lc-sys` 0.38.0 for `aarch64-apple-ios`, `aarch64-apple-ios-sim`, and `x86_64-apple-ios` in CI on a macOS 14 / Xcode 16.2 runner.

**Before (no fix):** CI fails compiling `urandom.c` — [failing run](https://github.com/worldcoin/walletkit/actions/runs/23310002470)

**After (this fix):** We forked `aws-lc-rs`, pointed the `aws-lc-sys/aws-lc` submodule at this branch (`lukejmann/aws-lc@fix/ios-cross-compilation`), then patched our `Cargo.toml` to use the fork:

```toml
[patch.crates-io]
aws-lc-sys = { git = "https://github.com/lukejmann/aws-lc-rs.git", branch = "fix/ios-cross-compilation" }
```

CI passes with no workarounds — [passing run](https://github.com/worldcoin/walletkit/actions/runs/23321826517)

The fix and test wiring can be seen in this walletkit PR, which is structured as a single commit on top of the original failing commit: [worldcoin/walletkit#314](https://github.com/worldcoin/walletkit/pull/314) (base `bump-aws-lc-broken` = the commit that bumps to aws-lc-sys 0.38.0 and fails, head `fix/aws-lc-ios` = same + the `[patch.crates-io]` line).

Existing CI for Linux / macOS / Windows targets should be unaffected since the change only adds an include that's already present in `base.h` for those paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
