### PR TITLE
Fix entropy source selection for Apple cross-compilation targets

### DIFF
--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -171,6 +171,9 @@ jobs:
           target: aarch64-apple-ios
       - name: Build for aarch64-apple-ios
         working-directory: ./aws-lc-rs
+        env:
+          CC: /opt/homebrew/opt/llvm/bin/clang
+          CXX: /opt/homebrew/opt/llvm/bin/clang++
         run: cargo build -p aws-lc-rs --target aarch64-apple-ios --features bindgen
 
   # Full bindings pre-generation test on Windows (x86_64-pc-windows-msvc)

--- a/crypto/rand_extra/internal.h
+++ b/crypto/rand_extra/internal.h
@@ -15,6 +15,8 @@
     defined(OPENSSL_SOLARIS) || defined(OPENSSL_WASM) || \
     (defined(OPENSSL_LINUX) && !defined(HAVE_LINUX_RANDOM_H))
 #define OPENSSL_RAND_GETENTROPY
+// OPENSSL_APPLE is always defined when OPENSSL_MACOS is defined, so this
+// branch must come after the OPENSSL_MACOS branch above.
 #elif defined(OPENSSL_APPLE)
 #define OPENSSL_RAND_CCRANDOMGENERATEBYTES
 #else


### PR DESCRIPTION
### Issues:
Related: aws/aws-lc-rs#1068
Related: #3111

### Context:

When cross-compiling for iOS on certain toolchains, `TARGET_OS_IPHONE` from `TargetConditionals.h` can evaluate to 0 (e.g., due to compiler/SDK version mismatches). This causes `OPENSSL_IOS` to not be defined, and the entropy source selection in `crypto/rand_extra/internal.h` falls through to `OPENSSL_RAND_URANDOM`, which is inherently Linux-specific. The build then fails in `urandom.c` due to its use of `ioctl()` and `RNDGETENTCNT`.

### Description of changes:

The fix widens the `CCRandomGenerateBytes` branch from `OPENSSL_IOS` to `OPENSSL_APPLE`. `OPENSSL_APPLE` is derived from `__APPLE__` (a compiler intrinsic) so it has no dependency on `TargetConditionals.h`. `CCRandomGenerateBytes` is available on all Apple platforms, so this is safe regardless of the specific Apple target.

### Call-outs:

We considered instead redefining `OPENSSL_IOS` using a `TargetConditionals.h`-independent condition (e.g., `OPENSSL_APPLE && !OPENSSL_MACOS`), but `OPENSSL_MACOS` depends on the same `TargetConditionals.h` mechanism and fails in the same way. It would also incorrectly label non-iOS Apple platforms (tvOS, watchOS, etc.) as iOS.

### Testing:

Added an iOS aarch64 cross-compilation job to the `aws-lc-rs.yml` workflow.
This job installs Homebrew LLVM (which reproduces the `TargetConditionals.h`
detection failure) and builds aws-lc-rs for `aarch64-apple-ios`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
