### PR TITLE
fix: include TargetConditionals.h in target.h for iOS cross-compilation

### DIFF
--- a/crypto/rand_extra/urandom.c
+++ b/crypto/rand_extra/urandom.c
@@ -352,8 +352,10 @@ static void ensure_getrandom_is_initialized(void) {
 
 static void ensure_dev_urandom_is_initialized(void) {
 
-  // On platforms where urandom doesn't block at startup, we ensure that the
-  // kernel has sufficient entropy before continuing.
+#if defined(OPENSSL_LINUX)
+  // On Linux, where urandom doesn't block at startup, we ensure that the
+  // kernel has sufficient entropy before continuing. RNDGETENTCNT and ioctl
+  // are Linux-specific (from <linux/random.h> and <sys/ioctl.h>).
   for (;;) {
     int entropy_bits = 0;
     if (ioctl(urandom_fd, RNDGETENTCNT, &entropy_bits)) {
@@ -376,6 +378,7 @@ static void ensure_dev_urandom_is_initialized(void) {
     struct timespec sleep_time = {.tv_sec = 0, .tv_nsec = MILLISECONDS_250 };
     nanosleep(&sleep_time, &sleep_time);
   }
+#endif  // OPENSSL_LINUX
 
   random_flavor_state = STATE_READY;
 }

--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -87,6 +87,14 @@
 #endif
 
 #if defined(__APPLE__)
+// TargetConditionals.h defines TARGET_OS_OSX, TARGET_OS_IPHONE, etc.
+// base.h includes it for C/C++, but target.h must be self-contained
+// because it can be included before base.h. In assembly contexts the
+// header is unavailable, but the TARGET_OS_* checks below will simply
+// evaluate to false, which is fine -- assembly never inspects them.
+#if !defined(__ASSEMBLER__)
+#include <TargetConditionals.h>
+#endif
 #define OPENSSL_APPLE
 // Note |TARGET_OS_MAC| is set for all Apple OS variants. |TARGET_OS_OSX|
 // targets macOS specifically.


### PR DESCRIPTION
### Issues:
None filed yet — discovered in the wild cross-compiling for iOS via `aws-lc-sys` 0.38.0.
### Description of changes:
aws-lc-sys 0.38.0 fails to compile `urandom.c` for `aarch64-apple-ios` on Xcode 16.2 (iPhoneOS 18.2 SDK) when built through the Rust `cc-rs` build system. Two compiler errors:
    `urandom.c:370:9: error: call to undeclared function 'ioctl' [-Werror,-Wimplicit-function-declaration]`
    `urandom.c:370:27: error: use of undeclared identifier 'RNDGETENTCNT'`


Root cause: `target.h` checks `TARGET_OS_IPHONE` to define `OPENSSL_IOS`, but never includes `<TargetConditionals.h>` itself — it relies on `base.h` having done so. On this toolchain, `TARGET_OS_IPHONE` is not available as a compiler builtin when `target.h` is processed, so `OPENSSL_IOS` is never defined. The entropy source selection in `internal.h` falls through to `OPENSSL_RAND_URANDOM` (the Linux `/dev/urandom` path) instead of `OPENSSL_RAND_CCRANDOMGENERATEBYTES`. `urandom.c` then tries to call `ioctl(RNDGETENTCNT)`, but the headers for those (`<linux/random.h>`, `<sys/ioctl.h>`) are only included behind `#if defined(OPENSSL_LINUX)`.
Two changes:
1. **`include/openssl/target.h`**: Include `<TargetConditionals.h>` directly, guarded by `!__ASSEMBLER__` since `target.h` is also used from `.S` files.
2. **`crypto/rand_extra/urandom.c`**: Guard the `RNDGETENTCNT` / `ioctl()` entropy-check loop in `ensure_dev_urandom_is_initialized()` behind `#if defined(OPENSSL_LINUX)`, matching the guards already on the corresponding `#include` directives. Both fixes are required — CI testing showed that fix 1 alone is not sufficient on Xcode 16.2.
### Call-outs:
- The `target.h` `!__ASSEMBLER__` guard keeps `<TargetConditionals.h>` out of assembly contexts. In assembly, the `TARGET_OS_*` checks evaluate to false, matching current behavior.
- The `urandom.c` change doesn't alter any behavior on Linux, where `OPENSSL_LINUX` is always defined alongside `OPENSSL_RAND_URANDOM`. On non-Linux platforms that reach this path, it skips the entropy-count check and goes straight to `STATE_READY`.
### Testing:
We verified this end-to-end in CI on a macOS 14 / Xcode 16.2 runner. Our project ([worldcoin/walletkit](https://github.com/worldcoin/walletkit)) cross-compiles `aws-lc-sys` 0.38.0 for `aarch64-apple-ios`, `aarch64-apple-ios-sim`, and `x86_64-apple-ios`.
**Before (no fix):** [CI run — urandom.c fails](https://github.com/worldcoin/walletkit/actions/runs/23310002470)
**After (both fixes applied as a build-time source patch):** [CI run — Swift build passes](https://github.com/worldcoin/walletkit/actions/runs/23321826517)
**Fix 1 alone (target.h only, no urandom.c guard):** [CI run — still fails](https://github.com/worldcoin/walletkit/actions/runs/23324550452) — confirmed that `TARGET_OS_IPHONE` remains unavailable on Xcode 16.2 even with the explicit include, so the urandom.c guard is also needed.
The test wiring is visible in [worldcoin/walletkit#314](https://github.com/worldcoin/walletkit/pull/314), which applies both patches at build time against the crates.io source.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
