### PR TITLE
Remove redundant definitions

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -41,17 +41,6 @@ extern "C" {
 #define AWSLC_FIPS
 #endif
 
-#if defined(__APPLE__)
-// Note |TARGET_OS_MAC| is set for all Apple OS variants. |TARGET_OS_OSX|
-// targets macOS specifically.
-#if defined(TARGET_OS_OSX) && TARGET_OS_OSX
-#define OPENSSL_MACOS
-#endif
-#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-#define OPENSSL_IOS
-#endif
-#endif
-
 #define AWSLC_VERSION_NAME "AWS-LC"
 #define OPENSSL_IS_AWSLC
 // |OPENSSL_VERSION_NUMBER| should match the version number in opensslv.h.

--- a/include/openssl/base.h.in
+++ b/include/openssl/base.h.in
@@ -41,17 +41,6 @@ extern "C" {
 #define AWSLC_FIPS
 #endif
 
-#if defined(__APPLE__)
-// Note |TARGET_OS_MAC| is set for all Apple OS variants. |TARGET_OS_OSX|
-// targets macOS specifically.
-#if defined(TARGET_OS_OSX) && TARGET_OS_OSX
-#define OPENSSL_MACOS
-#endif
-#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-#define OPENSSL_IOS
-#endif
-#endif
-
 #define AWSLC_VERSION_NAME "AWS-LC"
 #define OPENSSL_IS_AWSLC
 // |OPENSSL_VERSION_NUMBER| should match the version number in opensslv.h.


### PR DESCRIPTION
### Description of changes: 

Defined in `target.h`: https://github.com/aws/aws-lc/blob/main/include/openssl/target.h#L89-L99 which base.h imports.
Keep in former.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
