### PR TITLE
openssl-tool CLI: CA cleanup

### DIFF
--- a/tool-openssl/ca.cc
+++ b/tool-openssl/ca.cc
@@ -156,8 +156,8 @@ ok:
 #endif
 
 static std::unique_ptr<std::string> GetSectionValue(bssl::UniquePtr<CONF> &conf,
-                                                    std::string section,
-                                                    std::string key) {
+                                                    const std::string &section,
+                                                    const std::string &key) {
   auto *value = NCONF_get_string(conf.get(), section.c_str(), key.c_str());
   if (value == NULL) {
     return std::unique_ptr<std::string>(nullptr);
@@ -166,7 +166,8 @@ static std::unique_ptr<std::string> GetSectionValue(bssl::UniquePtr<CONF> &conf,
 }
 
 static bool ParseBoolSectionValue(bssl::UniquePtr<CONF> &conf,
-                                  std::string section, std::string key,
+                                  const std::string &section,
+                                  const std::string &key,
                                   bool default_value) {
   auto value = GetSectionValue(conf, section, key);
   if (!value) {
@@ -176,7 +177,8 @@ static bool ParseBoolSectionValue(bssl::UniquePtr<CONF> &conf,
 }
 
 static long ParseNumberSectionValue(bssl::UniquePtr<CONF> &conf,
-                                    std::string section, std::string key,
+                                    const std::string &section,
+                                    const std::string &key,
                                     long default_value) {
   auto value = GetSectionValue(conf, section, key);
   if (!value) {
@@ -185,7 +187,7 @@ static long ParseNumberSectionValue(bssl::UniquePtr<CONF> &conf,
   return std::atol(value->c_str());
 }
 
-static EXT_COPY_TYPE ParseCopyExtensionValue(std::string value) {
+static EXT_COPY_TYPE ParseCopyExtensionValue(const std::string &value) {
   if (strcasecmp(value.c_str(), "none") == 0) {
     return EXT_COPY_NONE;
   } else if (strcasecmp(value.c_str(), "copy") == 0) {
@@ -212,7 +214,7 @@ static EXT_COPY_TYPE ParseCopyExtensionValue(std::string value) {
 #define DB_TYPE_VAL 'V'   // Valid; inserted with: ca ... -valid
 #define DB_TYPE_SUSP 'S'  // Suspended
 
-static bssl::UniquePtr<CA_DB> LoadIndex(const std::string dbfile,
+static bssl::UniquePtr<CA_DB> LoadIndex(const std::string &dbfile,
                                         DB_ATTR *db_attr) {
   bssl::UniquePtr<CONF> dbattr_conf(NCONF_new(nullptr));
   bssl::UniquePtr<CA_DB> retdb;
@@ -283,7 +285,7 @@ static const char *crl_reasons[] = {
 static int UnpackRevinfo(bssl::UniquePtr<ASN1_TIME> &prevtm, int *preason,
                          bssl::UniquePtr<ASN1_OBJECT> &phold,
                          bssl::UniquePtr<ASN1_GENERALIZEDTIME> &pinvtm,
-                         std::string str) {
+                         const std::string &str) {
   ossl_char_ptr tmp = ossl_char_ptr(nullptr, OPENSSL_free);
   char *rtime_str = NULL, *reason_str = NULL, *arg_str = NULL, *p = NULL;
   int reason_code = -1;
@@ -390,7 +392,7 @@ static int UnpackRevinfo(bssl::UniquePtr<ASN1_TIME> &prevtm, int *preason,
 // 0 error
 // 1 OK
 // 2 OK and some extensions added (i.e. V2 CRL)
-static int MakeRevoked(X509_REVOKED *rev, std::string str) {
+static int MakeRevoked(X509_REVOKED *rev, const std::string &str) {
   int reason_code = -1;
   int i = 0, ret = 0;
   bssl::UniquePtr<ASN1_OBJECT> hold;
@@ -493,7 +495,7 @@ static int IndexIndex(bssl::UniquePtr<CA_DB> &db) {
   return 1;
 }
 
-static int SaveIndex(std::string dbfile, std::string suffix,
+static int SaveIndex(const std::string &dbfile, const std::string &suffix,
                      bssl::UniquePtr<CA_DB> &db) {
   char buf[3][BSIZE];
   bssl::UniquePtr<BIO> out;
@@ -533,8 +535,8 @@ static int SaveIndex(std::string dbfile, std::string suffix,
   return 1;
 }
 
-static int RotateIndex(std::string dbfile, std::string new_suffix,
-                       std::string old_suffix) {
+static int RotateIndex(const std::string &dbfile, const std::string &new_suffix,
+                       const std::string &old_suffix) {
   char buf[5][BSIZE];
   int i = 0, j = 0;
 
@@ -566,22 +568,34 @@ static int RotateIndex(std::string dbfile, std::string new_suffix,
   if (rename(buf[0], dbfile.c_str()) < 0) {
     fprintf(stderr, "unable to rename %s to %s\n", buf[0], dbfile.c_str());
     perror("reason");
-    rename(buf[1], dbfile.c_str());
+    if (rename(buf[1], dbfile.c_str()) < 0) {
+      perror("unable to restore original database file");
+    }
     return 0;
   }
   if (rename(buf[4], buf[3]) < 0 && errno != ENOENT && errno != ENOTDIR) {
     fprintf(stderr, "unable to rename %s to %s\n", buf[4], buf[3]);
     perror("reason");
-    rename(dbfile.c_str(), buf[0]);
-    rename(buf[1], dbfile.c_str());
+    if (rename(dbfile.c_str(), buf[0]) < 0) {
+      perror("unable to restore new database file");
+    }
+    if (rename(buf[1], dbfile.c_str()) < 0) {
+      perror("unable to restore original database file");
+    }
     return 0;
   }
   if (rename(buf[2], buf[4]) < 0) {
     fprintf(stderr, "unable to rename %s to %s\n", buf[2], buf[4]);
     perror("reason");
-    rename(buf[3], buf[4]);
-    rename(dbfile.c_str(), buf[0]);
-    rename(buf[1], dbfile.c_str());
+    if (rename(buf[3], buf[4]) < 0) {
+      perror("unable to restore attribute file");
+    }
+    if (rename(dbfile.c_str(), buf[0]) < 0) {
+      perror("unable to restore new database file");
+    }
+    if (rename(buf[1], dbfile.c_str()) < 0) {
+      perror("unable to restore original database file");
+    }
     return 0;
   }
   return 1;
@@ -656,8 +670,8 @@ static int RandSerial(bssl::UniquePtr<BIGNUM> &b, ASN1_INTEGER *ai) {
   return 1;
 }
 
-static bssl::UniquePtr<BIGNUM> LoadSerial(std::string serialfile, int *exists,
-                                          int create) {
+static bssl::UniquePtr<BIGNUM> LoadSerial(const std::string &serialfile,
+                                          int *exists, int create) {
   bssl::UniquePtr<BIO> in;
   bssl::UniquePtr<BIGNUM> ret;
   bssl::UniquePtr<ASN1_INTEGER> ai;
@@ -701,8 +715,8 @@ static bssl::UniquePtr<BIGNUM> LoadSerial(std::string serialfile, int *exists,
   return ret;
 }
 
-static int SetCertTimes(X509 *x, std::string startdate, std::string enddate,
-                        int days) {
+static int SetCertTimes(X509 *x, const std::string &startdate,
+                        const std::string &enddate, int days) {
   if (startdate.empty() || strcmp(startdate.c_str(), "today") == 0) {
     if (X509_gmtime_adj(X509_getm_notBefore(x), 0) == NULL) {
       return 0;
@@ -830,11 +844,11 @@ static int DoBody(bssl::UniquePtr<BIO> &bio_err, X509 **xret,
                   bssl::UniquePtr<EVP_PKEY> &pkey, X509 *x509,
                   const EVP_MD *dgst, const STACK_OF(CONF_VALUE) *policy,
                   bssl::UniquePtr<CA_DB> &db, bssl::UniquePtr<BIGNUM> &serial,
-                  std::string subj, unsigned long chtype, std::string startdate,
-                  std::string enddate, long days, int verbose,
-                  bssl::UniquePtr<X509_REQ> &req, std::string ext_sect,
-                  bssl::UniquePtr<CONF> &lconf, EXT_COPY_TYPE ext_copy,
-                  int selfsign, int preserve) {
+                  const std::string &subj, unsigned long chtype,
+                  const std::string &startdate, const std::string &enddate,
+                  long days, int verbose, bssl::UniquePtr<X509_REQ> &req,
+                  const std::string &ext_sect, bssl::UniquePtr<CONF> &lconf,
+                  EXT_COPY_TYPE ext_copy, int selfsign, int preserve) {
   X509_NAME *name = nullptr;
   bssl::UniquePtr<X509_NAME> CAname, subject;
   const ASN1_TIME *tm = nullptr;
@@ -1257,7 +1271,7 @@ static int DoBody(bssl::UniquePtr<BIO> &bio_err, X509 **xret,
     goto end;
   }
 
-  irow.reset((OPENSSL_STRING *)OPENSSL_malloc(sizeof(OPENSSL_STRING *) *
+  irow.reset((OPENSSL_STRING *)OPENSSL_malloc(sizeof(OPENSSL_STRING) *
                                               (DB_NUMBER + 1)));
   if (!irow) {
     BIO_printf(bio_err.get(), "Memory allocation failure\n");
@@ -1290,15 +1304,15 @@ end:
   return ok;
 }
 
-static int Certify(X509 **ret, std::string infile,
+static int Certify(X509 **ret, const std::string &infile,
                    bssl::UniquePtr<EVP_PKEY> &pkey, X509 *x509,
                    const EVP_MD *dgst, const STACK_OF(CONF_VALUE) *policy,
                    bssl::UniquePtr<CA_DB> &db, bssl::UniquePtr<BIGNUM> &serial,
-                   std::string subj, unsigned long chtype,
-                   std::string startdate, std::string enddate, long days,
-                   std::string ext_sect, bssl::UniquePtr<CONF> &lconf,
-                   int verbose, EXT_COPY_TYPE ext_copy, int selfsign,
-                   int preserve) {
+                   const std::string &subj, unsigned long chtype,
+                   const std::string &startdate, const std::string &enddate,
+                   long days, const std::string &ext_sect,
+                   bssl::UniquePtr<CONF> &lconf, int verbose,
+                   EXT_COPY_TYPE ext_copy, int selfsign, int preserve) {
   bssl::UniquePtr<X509_REQ> req;
   bssl::UniquePtr<BIO> in;
   EVP_PKEY *pktmp = NULL;
@@ -1352,7 +1366,8 @@ static int Certify(X509 **ret, std::string infile,
                 ext_copy, selfsign, preserve);
 }
 
-static int SaveSerial(std::string serialfile, std::string suffix,
+static int SaveSerial(const std::string &serialfile,
+                      const std::string &suffix,
                       bssl::UniquePtr<BIGNUM> &serial) {
   char buf[1][BSIZE];
   bssl::UniquePtr<BIO> out;
@@ -1391,8 +1406,9 @@ static int SaveSerial(std::string serialfile, std::string suffix,
   return 1;
 }
 
-static int RotateSerial(std::string serialfile, std::string new_suffix,
-                        std::string old_suffix) {
+static int RotateSerial(const std::string &serialfile,
+                        const std::string &new_suffix,
+                        const std::string &old_suffix) {
   char buf[2][BSIZE];
   int i = 0, j = 0;
 
@@ -1419,7 +1435,9 @@ static int RotateSerial(std::string serialfile, std::string new_suffix,
   if (rename(buf[0], serialfile.c_str()) < 0) {
     fprintf(stderr, "unable to rename %s to %s\n", buf[0], serialfile.c_str());
     perror("reason");
-    rename(buf[1], serialfile.c_str());
+    if (rename(buf[1], serialfile.c_str()) < 0) {
+      perror("unable to restore original serial file");
+    }
     return 0;
   }
   return 1;

--- a/tool-openssl/ca_req_common.cc
+++ b/tool-openssl/ca_req_common.cc
@@ -134,7 +134,7 @@ bool LoadPrivateKey(const std::string &key_file_path,
 }
 
 // Parse the subject string provided by a user with the -subj option.
-bssl::UniquePtr<X509_NAME> ParseSubjectName(std::string &subject_string) {
+bssl::UniquePtr<X509_NAME> ParseSubjectName(const std::string &subject_string) {
   const char *subject_name_ptr = subject_string.c_str();
 
   if (*subject_name_ptr++ != '/') {

--- a/tool-openssl/ca_req_common.h
+++ b/tool-openssl/ca_req_common.h
@@ -61,6 +61,6 @@ bool LoadPrivateKey(const std::string &key_file_path,
                     Password &passin,
                     bssl::UniquePtr<EVP_PKEY> &pkey);
 
-bssl::UniquePtr<X509_NAME> ParseSubjectName(std::string &subject_string);
+bssl::UniquePtr<X509_NAME> ParseSubjectName(const std::string &subject_string);
 
 #endif

--- a/tool-openssl/internal.h
+++ b/tool-openssl/internal.h
@@ -181,7 +181,7 @@ bool VersionTool(const args_list_t &args);
 bool X509Tool(const args_list_t &args);
 
 // Req Tool Utilities
-bssl::UniquePtr<X509_NAME> ParseSubjectName(std::string &subject_string);
+bssl::UniquePtr<X509_NAME> ParseSubjectName(const std::string &subject_string);
 
 
 // Rehash tool Utils

--- a/tool-openssl/req.cc
+++ b/tool-openssl/req.cc
@@ -632,6 +632,11 @@ bool reqTool(const args_list_t &args) {
   }
 
   digest = EVP_get_digestbyname(digest_name.c_str());
+  if (digest == nullptr) {
+    fprintf(stderr, "Error: unsupported digest algorithm: %s\n",
+            digest_name.c_str());
+    return false;
+  }
 
   bool encrypt_key = true;
   const char *encrypt_key_str = NULL;

--- a/tool-openssl/txt_db/txt_db.cc
+++ b/tool-openssl/txt_db/txt_db.cc
@@ -163,6 +163,9 @@ int TXT_DB_create_index(bssl::UniquePtr<TXT_DB> &db, int field, int (*qual)(OPEN
   n = sk_OPENSSL_PSTRING_num(db->data);
   for (i = 0; i < n; i++) {
     r = sk_OPENSSL_PSTRING_value(db->data, i);
+    if (r == nullptr) {
+      continue;
+    }
     if ((qual != NULL) && (qual(r) == 0)) {
       continue;
     }
@@ -195,6 +198,9 @@ long TXT_DB_write(bssl::UniquePtr<BIO> &out, bssl::UniquePtr<TXT_DB> &db) {
   nn = db->num_fields;
   for (long i = 0; i < n; i++) {
     pp = sk_OPENSSL_PSTRING_value(db->data, i);
+    if (pp == nullptr) {
+      continue;
+    }
 
     long j = 0;
     l = 0;
@@ -303,6 +309,9 @@ void TXT_DB_free(TXT_DB *db) {
       // check if any 'fields' have been allocated from outside of the
       // initial block
       p = sk_OPENSSL_PSTRING_value(db->data, i);
+      if (p == nullptr) {
+        continue;
+      }
       max = p[db->num_fields]; // last address
       if (max == NULL) {       // new row
         for (n = 0; n < db->num_fields; n++) {


### PR DESCRIPTION
### Issues:
Resolves AWS-LC-1036

### Description of changes:
- Fix unchecked `EVP_get_digestbyname()` return in `req.cc` — an unrecognized digest name from a config file would pass NULL into `X509_sign`.
- Change `std::string` pass-by-value parameters to `const std::string &` across 15 static functions in `ca.cc` that only read the string.
- Add defensive NULL checks after `sk_OPENSSL_PSTRING_value()` in `txt_db.cc`.
- Check `rename()` return values in error-recovery paths and log secondary failures.
- Fix `sizeof(OPENSSL_STRING *)` → `sizeof(OPENSSL_STRING)` in the `irow` allocation (same size in practice, but matches intent).

### Call-outs:
- `ParseSubjectName` signature changed from `std::string &` to `const std::string &` in both `ca_req_common.h` and `internal.h`. The function only called `.c_str()` on the parameter.
- All changes are scoped to `tool-openssl/`. No crypto library code is affected.

### Testing:
Existing `CA*`, `Req*`, and `SubjectName*` tests pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
