### PR TITLE
Zeroize sensitive stack buffers in DRBG, X25519, Ed25519, ECDSA, ECDH…

### DIFF
--- a/crypto/fipsmodule/curve25519/curve25519_nohw.c
+++ b/crypto/fipsmodule/curve25519/curve25519_nohw.c
@@ -1934,6 +1934,20 @@ void x25519_scalar_mult_generic_nohw(
   fe_invert(&z2, &z2);
   fe_mul_ttt(&x2, &x2, &z2);
   fe_tobytes(out_shared_key, &x2);
+
+  OPENSSL_cleanse(e, sizeof(e));
+  OPENSSL_cleanse(&x1, sizeof(x1));
+  OPENSSL_cleanse(&x2, sizeof(x2));
+  OPENSSL_cleanse(&z2, sizeof(z2));
+  OPENSSL_cleanse(&x3, sizeof(x3));
+  OPENSSL_cleanse(&z3, sizeof(z3));
+  OPENSSL_cleanse(&tmp0, sizeof(tmp0));
+  OPENSSL_cleanse(&tmp1, sizeof(tmp1));
+  OPENSSL_cleanse(&x2l, sizeof(x2l));
+  OPENSSL_cleanse(&z2l, sizeof(z2l));
+  OPENSSL_cleanse(&x3l, sizeof(x3l));
+  OPENSSL_cleanse(&tmp0l, sizeof(tmp0l));
+  OPENSSL_cleanse(&tmp1l, sizeof(tmp1l));
 }
 
 void x25519_public_from_private_nohw(
@@ -1959,6 +1973,12 @@ void x25519_public_from_private_nohw(
   fe_mul_tlt(&zminusy_inv, &zplusy, &zminusy_inv);
   fe_tobytes(out_public_value, &zminusy_inv);
   CONSTTIME_DECLASSIFY(out_public_value, X25519_PUBLIC_VALUE_LEN);
+
+  OPENSSL_cleanse(e, sizeof(e));
+  OPENSSL_cleanse(&A, sizeof(A));
+  OPENSSL_cleanse(&zplusy, sizeof(zplusy));
+  OPENSSL_cleanse(&zminusy, sizeof(zminusy));
+  OPENSSL_cleanse(&zminusy_inv, sizeof(zminusy_inv));
 }
 
 void ed25519_public_key_from_hashed_seed_nohw(
@@ -1968,6 +1988,8 @@ void ed25519_public_key_from_hashed_seed_nohw(
   ge_p3 A;
   x25519_ge_scalarmult_base(&A, az);
   ge_p3_tobytes(out_public_key, &A);
+
+  OPENSSL_cleanse(&A, sizeof(A));
 }
 
 void ed25519_sign_nohw(uint8_t out_sig[ED25519_SIGNATURE_LEN],
@@ -1998,6 +2020,9 @@ void ed25519_sign_nohw(uint8_t out_sig[ED25519_SIGNATURE_LEN],
   // Compute S = r + k * s modulo the order of the base-point B.
   // out_sig = R || S
   sc_muladd(out_sig + 32, k, s, r);
+
+  OPENSSL_cleanse(k, sizeof(k));
+  OPENSSL_cleanse(&R, sizeof(R));
 }
 
 int ed25519_verify_nohw(uint8_t R_computed_encoded[32],

--- a/crypto/fipsmodule/curve25519/curve25519_s2n_bignum_asm.c
+++ b/crypto/fipsmodule/curve25519/curve25519_s2n_bignum_asm.c
@@ -21,6 +21,8 @@ void x25519_scalar_mult_generic_s2n_bignum(
   curve25519_x25519_byte_selector(out_shared_key,
                                   private_key_internal_demask,
                                   peer_public_value);
+
+  OPENSSL_cleanse(private_key_internal_demask, sizeof(private_key_internal_demask));
 }
 
 void x25519_public_from_private_s2n_bignum(
@@ -34,6 +36,8 @@ void x25519_public_from_private_s2n_bignum(
   private_key_internal_demask[31] |= 64;
 
   curve25519_x25519base_byte_selector(out_public_value, private_key_internal_demask);
+
+  OPENSSL_cleanse(private_key_internal_demask, sizeof(private_key_internal_demask));
 }
 
 void ed25519_public_key_from_hashed_seed_s2n_bignum(
@@ -47,6 +51,8 @@ void ed25519_public_key_from_hashed_seed_s2n_bignum(
   edwards25519_scalarmulbase_selector(uint64_point, uint64_hashed_seed);
 
   edwards25519_encode(out_public_key, uint64_point);
+
+  OPENSSL_cleanse(uint64_hashed_seed, sizeof(uint64_hashed_seed));
 }
 
 void ed25519_sign_s2n_bignum(uint8_t out_sig[ED25519_SIGNATURE_LEN],
@@ -86,6 +92,11 @@ void ed25519_sign_s2n_bignum(uint8_t out_sig[ED25519_SIGNATURE_LEN],
   // out_sig = R || S
   bignum_madd_n25519_selector(S, uint64_k, uint64_s, uint64_r);
   OPENSSL_memcpy(out_sig + 32, S, 32);
+
+  OPENSSL_cleanse(k, sizeof(k));
+  OPENSSL_cleanse(uint64_r, sizeof(uint64_r));
+  OPENSSL_cleanse(uint64_k, sizeof(uint64_k));
+  OPENSSL_cleanse(uint64_s, sizeof(uint64_s));
 }
 
 int ed25519_verify_s2n_bignum(uint8_t R_computed_encoded[32],

--- a/crypto/fipsmodule/ecdh/ecdh.c
+++ b/crypto/fipsmodule/ecdh/ecdh.c
@@ -112,6 +112,7 @@ int ECDH_compute_key_fips(uint8_t *out, size_t out_len, const EC_POINT *pub_key,
   ret = 1;
 
 end:
+  OPENSSL_cleanse(buf, sizeof(buf));
   FIPS_service_indicator_unlock_state();
   if(ret) {
     ECDH_verify_service_indicator(priv_key);

--- a/crypto/fipsmodule/ecdsa/ecdsa.c
+++ b/crypto/fipsmodule/ecdsa/ecdsa.c
@@ -202,6 +202,7 @@ static ECDSA_SIG *ecdsa_sign_impl(const EC_GROUP *group, int *out_retry,
   ec_scalar_inv0_montgomery(group, &tmp, k);     // tmp = k^-1 R^2
   ec_scalar_from_montgomery(group, &tmp, &tmp);  // tmp = k^-1 R
   ec_scalar_mul_montgomery(group, &s, &s, &tmp);
+  OPENSSL_cleanse(&tmp, sizeof(tmp));
   if (constant_time_declassify_int(ec_scalar_is_zero(group, &s))) {
     *out_retry = 1;
     return NULL;

--- a/crypto/fipsmodule/modes/gcm.c
+++ b/crypto/fipsmodule/modes/gcm.c
@@ -218,7 +218,7 @@ void CRYPTO_ghash_init(gmult_func *out_mult, ghash_func *out_hash,
     *out_mult = gcm_gmult_avx512;
     *out_hash = gcm_ghash_avx512;
     *out_is_avx = 1;
-    return;
+    goto out;
   }
 #endif
   if (crypto_gcm_clmul_enabled()) {
@@ -227,58 +227,63 @@ void CRYPTO_ghash_init(gmult_func *out_mult, ghash_func *out_hash,
       *out_mult = gcm_gmult_avx;
       *out_hash = gcm_ghash_avx;
       *out_is_avx = 1;
-      return;
+      goto out;
     }
     gcm_init_clmul(out_table, H);
     *out_mult = gcm_gmult_clmul;
     *out_hash = gcm_ghash_clmul;
-    return;
+    goto out;
   }
   if (CRYPTO_is_SSSE3_capable()) {
     gcm_init_ssse3(out_table, H);
     *out_mult = gcm_gmult_ssse3;
     *out_hash = gcm_ghash_ssse3;
-    return;
+    goto out;
   }
 #elif defined(GHASH_ASM_X86)
   if (crypto_gcm_clmul_enabled()) {
     gcm_init_clmul(out_table, H);
     *out_mult = gcm_gmult_clmul;
     *out_hash = gcm_ghash_clmul;
-    return;
+    goto out;
   }
   if (CRYPTO_is_SSSE3_capable()) {
     gcm_init_ssse3(out_table, H);
     *out_mult = gcm_gmult_ssse3;
     *out_hash = gcm_ghash_ssse3;
-    return;
+    goto out;
   }
 #elif defined(GHASH_ASM_ARM)
   if (gcm_pmull_capable()) {
     gcm_init_v8(out_table, H);
     *out_mult = gcm_gmult_v8_wrapper;
     *out_hash = gcm_ghash_v8_wrapper;
-    return;
+    goto out;
   }
 
   if (gcm_neon_capable()) {
     gcm_init_neon(out_table, H);
     *out_mult = gcm_gmult_neon_wrapper;
     *out_hash = gcm_ghash_neon_wrapper;
-    return;
+    goto out;
   }
 #elif defined(GHASH_ASM_PPC64LE)
   if (CRYPTO_is_PPC64LE_vcrypto_capable()) {
     gcm_init_p8(out_table, H);
     *out_mult = gcm_gmult_p8;
     *out_hash = gcm_ghash_p8;
-    return;
+    goto out;
   }
 #endif
 
   gcm_init_nohw(out_table, H);
   *out_mult = gcm_gmult_nohw;
   *out_hash = gcm_ghash_nohw;
+
+#if defined(GHASH_ASM_X86_64) || defined(GHASH_ASM_X86) || defined(GHASH_ASM_ARM) || defined(GHASH_ASM_PPC64LE)
+out:
+#endif
+  OPENSSL_cleanse(H, sizeof(H));
 }
 
 void CRYPTO_gcm128_init_key(GCM128_KEY *gcm_key, const AES_KEY *aes_key,
@@ -293,6 +298,7 @@ void CRYPTO_gcm128_init_key(GCM128_KEY *gcm_key, const AES_KEY *aes_key,
   int is_avx;
   CRYPTO_ghash_init(&gcm_key->gmult, &gcm_key->ghash, gcm_key->Htable, &is_avx,
                     ghash_key);
+  OPENSSL_cleanse(ghash_key, sizeof(ghash_key));
 
 #if defined(OPENSSL_AARCH64) && defined(GHASH_ASM_ARM)
   gcm_key->use_hw_gcm_crypt = (gcm_pmull_capable() && block_is_hwaes) ? 1 : 0;

--- a/crypto/fipsmodule/rand/ctrdrbg.c
+++ b/crypto/fipsmodule/rand/ctrdrbg.c
@@ -76,6 +76,7 @@ int CTR_DRBG_init(CTR_DRBG_STATE *drbg,
   OPENSSL_memcpy(drbg->counter, seed_material + 32, 16);
   drbg->reseed_counter = 1;
 
+  OPENSSL_cleanse(seed_material, sizeof(seed_material));
   return 1;
 }
 
@@ -111,6 +112,7 @@ static int ctr_drbg_update(CTR_DRBG_STATE *drbg, const uint8_t *data,
   drbg->ctr = aes_ctr_set_key(&drbg->ks, NULL, &drbg->block, temp, 32);
   OPENSSL_memcpy(drbg->counter, temp + 32, 16);
 
+  OPENSSL_cleanse(temp, sizeof(temp));
   return 1;
 }
 
@@ -142,11 +144,13 @@ int CTR_DRBG_reseed(CTR_DRBG_STATE *drbg,
   }
 
   if (!ctr_drbg_update(drbg, entropy, CTR_DRBG_ENTROPY_LEN)) {
+    OPENSSL_cleanse(entropy_copy, sizeof(entropy_copy));
     return 0;
   }
 
   drbg->reseed_counter = 1;
 
+  OPENSSL_cleanse(entropy_copy, sizeof(entropy_copy));
   return 1;
 }
 
@@ -208,6 +212,7 @@ int CTR_DRBG_generate(CTR_DRBG_STATE *drbg, uint8_t *out, size_t out_len,
     drbg->block(drbg->counter, block, &drbg->ks);
 
     OPENSSL_memcpy(out, block, out_len);
+    OPENSSL_cleanse(block, sizeof(block));
   }
 
   // Right-padding |additional_data| in step 2.2 is handled implicitly by


### PR DESCRIPTION
### Issues
Addresses: AWS-LC-1073

### Related
* awslabs/aws-lc-verification#186

### Description of changes:

Several functions were leaving sensitive intermediate values on the stack after returning. This change adds `OPENSSL_cleanse` calls to zeroize those buffers before they go out of scope:

- **CTR-DRBG** (`ctrdrbg.c`): Zeroize `seed_material`, `temp`, `entropy_copy`, and partial keystream `block`.
- **ECDH** (`ecdh.c`): Zeroize the raw shared secret `buf` in `ECDH_compute_key_fips`.
- **ECDSA** (`ecdsa.c`): Zeroize `tmp` after it holds k⁻¹ in `ecdsa_sign_impl`.
- **X25519 / Ed25519 nohw** (`curve25519_nohw.c`): Zeroize clamped private scalars, Montgomery ladder intermediates, and nonce-derived values.
- **X25519 / Ed25519 s2n-bignum** (`curve25519_s2n_bignum_asm.c`): Same treatment for the s2n-bignum code paths.
- **GCM** (`gcm.c`): Zeroize the GHASH hash key `H` (derived from `AES_K(0^128)`) and `ghash_key`. The early `return` statements in `CRYPTO_ghash_init` are refactored to `goto out` so all paths go through a single cleanup site.

### Call-outs:

The GCM change is the only one with a structural refactor — the `return` → `goto out` conversion in `CRYPTO_ghash_init`. All other changes are purely additive `OPENSSL_cleanse` calls at function exit points.

### Testing:

Existing tests cover the functional behavior of all affected code paths. These changes should be transparent since they only zero memory that is no longer used.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
