### PR TITLE
`WIN32_rename`: fix errno mapping and increase retry budget for transient failures

### DIFF
--- a/tool-openssl/ca.cc
+++ b/tool-openssl/ca.cc
@@ -97,9 +97,11 @@ static int WIN32_rename(const char *from, const char *to) {
   int ret = 0;
   // On Windows, antivirus software, file indexing services, or other
   // background processes can briefly lock files, causing transient
-  // ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION failures. Retry with a
-  // short delay to handle these.
-  static const int kMaxRetries = 5;
+  // ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION, or ERROR_LOCK_VIOLATION
+  // failures. Retry with a short delay to handle these. Under heavy load
+  // (e.g. running under SDE with parallel tests), locks can persist for
+  // multiple seconds, so we use a generous retry budget.
+  static const int kMaxRetries = 10;
   static const DWORD kRetryDelayMs = 200;
 
   if (sizeof(TCHAR) == 1) {
@@ -134,7 +136,8 @@ static int WIN32_rename(const char *from, const char *to) {
       }
       err = GetLastError();
     }
-    if (err != ERROR_ACCESS_DENIED && err != ERROR_SHARING_VIOLATION) {
+    if (err != ERROR_ACCESS_DENIED && err != ERROR_SHARING_VIOLATION &&
+        err != ERROR_LOCK_VIOLATION) {
       break;
     }
   }
@@ -142,8 +145,12 @@ static int WIN32_rename(const char *from, const char *to) {
     errno = ENOENT;
   } else if (err == ERROR_ACCESS_DENIED) {
     errno = EACCES;
+  } else if (err == ERROR_SHARING_VIOLATION || err == ERROR_LOCK_VIOLATION) {
+    errno = EACCES;
   } else {
-    errno = EINVAL; // we could map more codes...
+    errno = EINVAL;
+    fprintf(stderr, "WIN32_rename: MoveFile('%s', '%s') failed with Windows "
+            "error code %lu\n", from, to, (unsigned long)err);
   }
 err:
   ret = -1;


### PR DESCRIPTION
### Issues:
Follow-up to #3100. Resolves intermittent `CATest.CopyExtensionsNone` failure on `windows-ltsc2022_sde-x86_64` CI job.

### Context:
PR #3100 added a retry loop in `WIN32_rename` for transient file lock errors, but the CI is still producing intermittent rename failures under SDE. The root cause is that `ERROR_SHARING_VIOLATION` is correctly retried but, if retries are exhausted, is misreported as `EINVAL` ("Invalid argument") due to a gap in the post-loop errno mapping. The 1-second retry window (5 × 200ms) is also too short for the SDE environment under parallel load.

### Description of Changes:
- Increase `kMaxRetries` from 5 to 10 (~2s total retry window)
- Add `ERROR_LOCK_VIOLATION` to the set of retried error codes
- Fix errno mapping so `ERROR_SHARING_VIOLATION` / `ERROR_LOCK_VIOLATION` map to `EACCES` instead of falling through to `EINVAL`
- Log the actual Windows error code on unexpected failures for future diagnostics

Scoped entirely to `tool-openssl/ca.cc`. No crypto library code is affected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
