### PR TITLE
Fix bind9 integration test for upstream build system changes

### DIFF
--- a/tests/ci/integration/run_bind9_integration.sh
+++ b/tests/ci/integration/run_bind9_integration.sh
@@ -8,6 +8,12 @@ source tests/ci/common_posix_setup.sh
 
 # Set up environment.
 
+# Dependencies: Ubuntu
+if [ -f /etc/debian_version ] && [ "$(id -u)" -eq 0 ]; then
+  apt-get update
+  apt-get install -y --no-install-recommends liblmdb-dev
+fi
+
 # SYS_ROOT
 #  - SRC_ROOT(aws-lc)
 #  - SCRATCH_FOLDER
@@ -30,8 +36,6 @@ function bind9_patch() {
 }
 
 function bind9_build() {
-  BIND9_VERSION=$(meson introspect meson.build --projectinfo | jq -r '.version')
-
   #dnsrps was removed since bind9 9.21.2
   meson setup "$BIND9_BUILD_FOLDER" \
     --pkg-config-path="${AWS_LC_INSTALL_FOLDER}/lib/pkgconfig" \
@@ -42,6 +46,8 @@ function bind9_build() {
     -Dleak-detection=enabled \
     -Djemalloc=disabled \
     -Dtracing=disabled
+
+  BIND9_VERSION=$(meson introspect "$BIND9_BUILD_FOLDER" --projectinfo | jq -r '.version')
 
   meson compile -C "$BIND9_BUILD_FOLDER"
   "$BIND9_BUILD_FOLDER"/named -V


### PR DESCRIPTION

### Description of changes:

The bind9 `main` branch has introduced two changes that break our integration test:

1. Their `meson.build` now uses multiline f-strings, which causes `meson introspect meson.build --projectinfo` to crash in the AST interpreter on older meson versions. We now introspect the configured build directory instead of the raw source file, which avoids the AST interpreter entirely.

2. `lmdb` is now a hard build dependency (no meson option to disable it). We conditionally install `liblmdb-dev` on Debian-based systems at the top of the script, matching the pattern used by other integration tests.

### Testing:

Ran `run_bind9_integration.sh` locally and confirmed bind9 builds and links against AWS-LC successfully.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
