### PR TITLE
Harden OCSP response printing and fix integer overflow in `x509v3_bytes_to_hex`

### DIFF
--- a/crypto/ocsp/ocsp_print.c
+++ b/crypto/ocsp/ocsp_print.c
@@ -178,11 +178,21 @@ int OCSP_RESPONSE_print(BIO *bp, OCSP_RESPONSE *resp, unsigned long flags) {
   rid = rd->responderId;
   switch (rid->type) {
     case V_OCSP_RESPID_NAME:
-      X509_NAME_print_ex(bp, rid->value.byName, 0, XN_FLAG_ONELINE);
+      if (rid->value.byName == NULL) {
+        goto err;
+      }
+      if (X509_NAME_print_ex(bp, rid->value.byName, 0, XN_FLAG_ONELINE) < 0) {
+        goto err;
+      }
       break;
     case V_OCSP_RESPID_KEY:
+      if (rid->value.byKey == NULL) {
+        goto err;
+      }
       i2a_ASN1_STRING(bp, rid->value.byKey, 0);
       break;
+    default:
+      goto err;
   }
 
   if (BIO_printf(bp, "\n    Produced At: ") <= 0) {

--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -1933,6 +1933,51 @@ TEST(OCSPTest, OCSPResponsePrint) {
   }
 }
 
+// Verify that malformed OCSP responder IDs cannot be encoded into an
+// |OCSP_RESPONSE|.
+TEST(OCSPTest, OCSPResponsePrintMalformedResponderId) {
+  // A default-initialized |OCSP_RESPID| (ASN1_CHOICE) has type -1, indicating
+  // no alternative has been selected.
+  bssl::UniquePtr<OCSP_BASICRESP> br(OCSP_BASICRESP_new());
+  ASSERT_TRUE(br);
+  OCSP_RESPID *rid = br->tbsResponseData->responderId;
+  EXPECT_EQ(rid->type, -1);
+  EXPECT_EQ(rid->value.byName, nullptr);
+
+  // The ASN.1 encoder rejects an |OCSP_BASICRESP| with an uninitialized
+  // responderId choice.
+  EXPECT_FALSE(
+      OCSP_response_create(OCSP_RESPONSE_STATUS_SUCCESSFUL, br.get()));
+
+  // Set type to |V_OCSP_RESPID_KEY| without providing a key. The encoder
+  // rejects this.
+  br.reset(OCSP_BASICRESP_new());
+  ASSERT_TRUE(br);
+  rid = br->tbsResponseData->responderId;
+  rid->type = V_OCSP_RESPID_KEY;
+  EXPECT_EQ(rid->value.byKey, nullptr);
+  EXPECT_FALSE(
+      OCSP_response_create(OCSP_RESPONSE_STATUS_SUCCESSFUL, br.get()));
+
+  // Set type to |V_OCSP_RESPID_NAME| without providing a name. The encoder
+  // rejects this.
+  br.reset(OCSP_BASICRESP_new());
+  ASSERT_TRUE(br);
+  rid = br->tbsResponseData->responderId;
+  rid->type = V_OCSP_RESPID_NAME;
+  EXPECT_EQ(rid->value.byName, nullptr);
+  EXPECT_FALSE(
+      OCSP_response_create(OCSP_RESPONSE_STATUS_SUCCESSFUL, br.get()));
+
+  // Set an unrecognized type. The encoder rejects this.
+  br.reset(OCSP_BASICRESP_new());
+  ASSERT_TRUE(br);
+  rid = br->tbsResponseData->responderId;
+  rid->type = 42;
+  EXPECT_FALSE(
+      OCSP_response_create(OCSP_RESPONSE_STATUS_SUCCESSFUL, br.get()));
+}
+
 TEST(OCSPTest, OCSPRequestPrint) {
   static const std::array<std::string, 11> kExpected{
       {"OCSP Request Data:", "    Version: 1 (0x0)", "    Requestor List:",

--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -418,7 +418,13 @@ static char *strip_spaces(char *name) {
 
 char *x509v3_bytes_to_hex(const uint8_t *in, size_t len) {
   CBB cbb;
-  if (!CBB_init(&cbb, len * 3 + 1)) {
+  // Each byte expands to "XX:" (3 chars), plus a NUL terminator. Guard against
+  // size_t overflow in the initial capacity hint on 32-bit platforms.
+  size_t initial_capacity = 0;
+  if (len <= (SIZE_MAX - 1) / 3) {
+    initial_capacity = len * 3 + 1;
+  }
+  if (!CBB_init(&cbb, initial_capacity)) {
     goto err;
   }
   for (size_t i = 0; i < len; i++) {


### PR DESCRIPTION
### Description of changes: 
Add NULL checks and a default case to the `OCSP_RESPID` switch in `OCSP_RESPONSE_print` to prevent NULL pointer dereferences when the responder ID is malformed. The ASN.1 encoder already rejects these cases, so this is defense-in-depth. Also checks the return value of `X509_NAME_print_ex` for consistency with the rest of the function.

In `x509v3_bytes_to_hex`, guard against `size_t` overflow when computing the initial CBB capacity on 32-bit platforms. Falls back to 0 (dynamic growth) if the multiplication would wrap.

### Testing:

New test `OCSPResponsePrintMalformedResponderId` verifies that `OCSP_response_create` rejects `OCSP_BASICRESP` objects with uninitialized, NULL-valued, or unrecognized responder ID types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
