### PR TITLE
Add OPENSSL_INIT_ATFORK compatibility stub

### DIFF
--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -179,6 +179,7 @@ OPENSSL_EXPORT void OPENSSL_load_builtin_modules(void);
 #define OPENSSL_INIT_LOAD_CONFIG 0
 #define OPENSSL_INIT_NO_LOAD_CONFIG 0
 #define OPENSSL_INIT_ENGINE_ALL_BUILTIN 0
+#define OPENSSL_INIT_ATFORK 0
 
 // OPENSSL_init_crypto calls |CRYPTO_library_init| and returns one.
 OPENSSL_EXPORT int OPENSSL_init_crypto(uint64_t opts,


### PR DESCRIPTION
### Description of changes: 
OPENSSL_INIT_ATFORK is an OpenSSL 1.1.x flag that registers
pthread_atfork() handlers for PRNG fork safety. AWS-LC handles fork
detection automatically via kernel-level mechanisms, so this flag is a
safe no-op. Define it as 0 alongside the other stubbed OPENSSL_INIT_*
flags to unblock consumers that reference it (e.g. Valkey).

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
