### PR TITLE
Rename __AWS_LC_ENSURE to AWS_LC_ENSURE to avoid reserved identifier

### DIFF
--- a/crypto/internal.h
+++ b/crypto/internal.h
@@ -1325,7 +1325,7 @@ OPENSSL_EXPORT int OPENSSL_vasprintf_internal(char **str, const char *format,
 // Experimental safety macros inspired by s2n-tls.
 
 // If |cond| is false |action| is invoked, otherwise nothing happens.
-#define __AWS_LC_ENSURE(cond, action) \
+#define AWS_LC_ENSURE(cond, action) \
     do {                           \
         if (!(cond)) {             \
             action;                \
@@ -1340,20 +1340,20 @@ OPENSSL_EXPORT int OPENSSL_vasprintf_internal(char **str, const char *format,
 //
 // NOTE: this macro should only be used with functions that return 0 (for error)
 // and 1 (for success).
-#define GUARD_PTR(ptr) __AWS_LC_ENSURE((ptr) != NULL, OPENSSL_PUT_ERROR(CRYPTO, ERR_R_PASSED_NULL_PARAMETER); \
-                                       return AWS_LC_ERROR)
+#define GUARD_PTR(ptr) AWS_LC_ENSURE((ptr) != NULL, OPENSSL_PUT_ERROR(CRYPTO, ERR_R_PASSED_NULL_PARAMETER); \
+                                      return AWS_LC_ERROR)
 
 // GUARD_PTR_ABORT checks |ptr|: if it is NULL it calls abort() and does nothing
 // otherwise.
-#define GUARD_PTR_ABORT(ptr) __AWS_LC_ENSURE((ptr) != NULL, abort())
+#define GUARD_PTR_ABORT(ptr) AWS_LC_ENSURE((ptr) != NULL, abort())
 
 #if defined(NDEBUG)
 #define AWSLC_ASSERT(x) (void) (x)
 #else
-#define AWSLC_ASSERT(x) __AWS_LC_ENSURE(x, abort())
+#define AWSLC_ASSERT(x) AWS_LC_ENSURE(x, abort())
 #endif
 
-#define AWSLC_ABORT_IF_NOT_ONE(x) __AWS_LC_ENSURE(1 == (x), abort())
+#define AWSLC_ABORT_IF_NOT_ONE(x) AWS_LC_ENSURE(1 == (x), abort())
 
 // Windows doesn't really support weak symbols as of May 2019, and Clang on
 // Windows will emit strong symbols instead. See


### PR DESCRIPTION
### Description of changes: 

The `__AWS_LC_ENSURE` macro uses a double-underscore prefix, which is reserved by the C and C++ standards: Identifiers starting with double underscores are reserved by the C and C++ standards (C11 §7.1.3, C++17 §5.10) for the implementation. Using reserved identifiers is technically undefined behavior.

No functional change. The macro is internal-only and not exposed in any public header.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
