### PR TITLE
Check RSA-PSS digest algorithms for X509

### DIFF
--- a/crypto/x509/algorithm.c
+++ b/crypto/x509/algorithm.c
@@ -14,7 +14,7 @@
 #include "internal.h"
 
 // Restrict the digests that are allowed in X509 certificates
-static int x509_digest_nid_ok(const int digest_nid) {
+int x509_digest_nid_ok(const int digest_nid) {
   switch (digest_nid) {
     case NID_md4:
     case NID_md5:

--- a/crypto/x509/internal.h
+++ b/crypto/x509/internal.h
@@ -533,6 +533,8 @@ OPENSSL_EXPORT int validate_cidr_mask(CBS *cidr_mask);
 
 OPENSSL_EXPORT int cn2dnsid(ASN1_STRING *cn, unsigned char **dnsid, size_t *idlen);
 
+int x509_digest_nid_ok(const int digest_nid);
+
 // Match reference identifiers starting with "." to any sub-domain.
 // This is a non-public flag, turned on implicitly when the subject
 // reference identity is a DNS name.

--- a/crypto/x509/rsa_pss.c
+++ b/crypto/x509/rsa_pss.c
@@ -230,6 +230,12 @@ int x509_rsa_pss_to_ctx(EVP_MD_CTX *ctx, const X509_ALGOR *sigalg,
     goto err;
   }
 
+  // Check that both signature algorithms are not weak
+  if(!x509_digest_nid_ok(EVP_MD_type(md)) || !x509_digest_nid_ok(EVP_MD_type(mgf1md))) {
+    OPENSSL_PUT_ERROR(X509, ASN1_R_DIGEST_AND_KEY_TYPE_NOT_SUPPORTED);
+    goto err;
+  }
+
   int saltlen = 20;
   if (pss->saltLength != NULL) {
     saltlen = ASN1_INTEGER_get(pss->saltLength);

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -333,6 +333,56 @@ lC9+9hPHIoc9UMmAQNo1vGIW3NWVoeGbaJ8=
 -----END CERTIFICATE-----
 )";
 
+// kPSSWithMD5CertPEM is a self-signed RSA-PSS certificate where both the
+// signature hash and MGF1 hash are MD5. Verification should be rejected because
+// MD5 is not an allowed digest for X509.
+static const char kPSSWithMD5CertPEM[] = R"(
+-----BEGIN CERTIFICATE-----
+MIIDCzCCAcGgAwIBAgIBATA/BgkqhkiG9w0BAQowMqAOMAwGCCqGSIb3DQIFBQCh
+GzAZBgkqhkiG9w0BAQgwDAYIKoZIhvcNAgUFAKIDAgEUMBcxFTATBgNVBAMMDFRl
+c3QgUFNTIE1ENTAeFw0yNDAxMDEwMDAwMDBaFw0yNTEyMzEwMDAwMDBaMBcxFTAT
+BgNVBAMMDFRlc3QgUFNTIE1ENTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAKaM2+beVXSa6Zo2hxtzZGAszBtfK8oKFys82u1ozs4n8XeJDMuD89HCKdSk
+AboB0rTDEPEU9zKH/TmMykDlRramVKOiMnMYRBHa50YaKEUSLFrBmRJ9yq3P/7Un
+TyMcbjuu1/MPLeVkePmOW2aKdyWzl8HYkKqNo3a9qOj/BiV3JxNiL/G6tBXCt7hW
+qWYe+xskSS2Nne1iVEDXjpSFwqDE+gOcNCc/b/mQ3v54Cg1l76H0I3trKLpUqBWT
+NBXYXynUu2LhHGKY37dzkF93nWrN5X9qZksV8U2Wayg6mIL1ZU3ABv/uwhUrLOo5
+s2YLRtGzIOyRiDwZhufOYHA/Q3cCAwEAATA/BgkqhkiG9w0BAQowMqAOMAwGCCqG
+SIb3DQIFBQChGzAZBgkqhkiG9w0BAQgwDAYIKoZIhvcNAgUFAKIDAgEUA4IBAQAM
+1KSnQ7aV8fsGyw4NaOUvgRvuCaE6dkuB0L1oT52oAvTpUpMfqNb6bneeWylQq3NO
+/z8Z8xGqZboC6+qgF9rNkfnhW8UTUUstkMpdZ4yqNChoRTwmMe3XzcX0U1g2iQ20
+KHM4NoKRhnvl4aBJwdmeEo3LOM+2yKL75u6aZpgmOHtgVVAYvaLIRQqELTu+m2zi
+QApYwFBknrF3AkMEXRPjxqv43gNZwBFZaVGMtU9XTaJovyMi2EkkGivU4CPWmvp/
+g+qv2Ixx8/Hhoj5LDoUykRD4K6nFb+XR8XnqRMBmgWlEGvikeNiW9WWH18TSO6I1
+QZEvmEIIefTImQHkOYd+
+-----END CERTIFICATE-----
+)";
+
+// kPSSWithMD5MGF1CertPEM is a self-signed RSA-PSS certificate where the
+// signature hash is SHA-256 but the MGF1 hash is MD5. Verification should be
+// rejected because MD5 is not an allowed digest for X509.
+static const char kPSSWithMD5MGF1CertPEM[] = R"(
+-----BEGIN CERTIFICATE-----
+MIIDFzCCAcygAwIBAgIBATBABgkqhkiG9w0BAQowM6APMA0GCWCGSAFlAwQCAQUA
+oRswGQYJKoZIhvcNAQEIMAwGCCqGSIb3DQIFBQCiAwIBFDAcMRowGAYDVQQDDBFU
+ZXN0IFBTUyBNR0YxIE1ENTAeFw0yNDAxMDEwMDAwMDBaFw0yNTEyMzEwMDAwMDBa
+MBwxGjAYBgNVBAMMEVRlc3QgUFNTIE1HRjEgTUQ1MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAwwZBPVm8slRMuKriAosz1Ic7fmo54JwOD3ObYZva09Ns
+M4idmQKxwZt3H/XbQOIGhfEIjbcuJ55VXnq/gp9Zkf7mnVuAWYlhIDz0DBs+Px/w
+zRHXd9acwjGozA98/2iJLQ+SPgeMb28hKpspNGJtAGY6fOMUlIu5fd6bBlVv5pTm
+/k10Eo/dhsTvXQsbpmRRihH19jGNU+mpNGCZoceJ5wKwTNSm5cJcZc5FawAVMtUN
++VGEznmGiw8/9P2PO+O9wcF6OfIbjYuWrigqMwg8YLC9rTegg6XNy3T0vTPkUzmn
+nbdoEc4NbWL88BiJHpYFEzzBmzmeoSokaeMu0MK8sQIDAQABMEAGCSqGSIb3DQEB
+CjAzoA8wDQYJYIZIAWUDBAIBBQChGzAZBgkqhkiG9w0BAQgwDAYIKoZIhvcNAgUF
+AKIDAgEUA4IBAQC2+FvViIlmoNaPPAIUPICD7m25BVjCRKrtoogUt/uEGhybjqna
+LaSmMJ6CJzQBsyH48H6ul1q8axtRzhWmUdjN1e1FxEeZCrcxANMXzf+W8oukyNaA
+7Lu8Fg68Un2/gx7aheSvBMkyO56bVVcNO4Q4LMcgJ6Gdh1U9Kf1FKagAoRPSaeOv
+TvadDSwLhcsF58UlK/KVwdfo/rkMd/yJHcLEj99gRiQ075CIaTsf6i70f2jqIAlX
+RwSCqCMOzNx/ZbZXpAE6IZPNBtfZHWMTzIkyRrrtBgsguTP4rBk7TAk+AUj/6O6D
+hbhL/QKQNSyw/Z71mUUOvgmUqtsGWWJPL8Js
+-----END CERTIFICATE-----
+)";
+
 static const char kRSAKey[] = R"(
 -----BEGIN RSA PRIVATE KEY-----
 MIICXgIBAAKBgQDYK8imMuRi/03z0K1Zi0WnvfFHvwlYeyK9Na6XJYaUoIDAtB92
@@ -2806,6 +2856,34 @@ TEST(X509Test, TestPSSBadParameters) {
   ASSERT_TRUE(pkey);
 
   ASSERT_FALSE(X509_verify(cert.get(), pkey.get()));
+  ERR_clear_error();
+}
+
+TEST(X509Test, TestPSSMD5Digest) {
+  bssl::UniquePtr<X509> cert(CertFromPEM(kPSSWithMD5CertPEM));
+  ASSERT_TRUE(cert);
+
+  bssl::UniquePtr<EVP_PKEY> pkey(X509_get_pubkey(cert.get()));
+  ASSERT_TRUE(pkey);
+
+  ASSERT_FALSE(X509_verify(cert.get(), pkey.get()));
+  uint32_t err = ERR_get_error();
+  ASSERT_EQ(ERR_LIB_X509, ERR_GET_LIB(err));
+  ASSERT_EQ(ASN1_R_DIGEST_AND_KEY_TYPE_NOT_SUPPORTED, ERR_GET_REASON(err));
+  ERR_clear_error();
+}
+
+TEST(X509Test, TestPSSMD5MGF1Digest) {
+  bssl::UniquePtr<X509> cert(CertFromPEM(kPSSWithMD5MGF1CertPEM));
+  ASSERT_TRUE(cert);
+
+  bssl::UniquePtr<EVP_PKEY> pkey(X509_get_pubkey(cert.get()));
+  ASSERT_TRUE(pkey);
+
+  ASSERT_FALSE(X509_verify(cert.get(), pkey.get()));
+  uint32_t err = ERR_get_error();
+  ASSERT_EQ(ERR_LIB_X509, ERR_GET_LIB(err));
+  ASSERT_EQ(ASN1_R_DIGEST_AND_KEY_TYPE_NOT_SUPPORTED, ERR_GET_REASON(err));
   ERR_clear_error();
 }
 


### PR DESCRIPTION
### Description of changes: 
MD4 and MD5 digest algorithms are not allowed for signature algorithms for signing X.509 certificates with RSA keys. This check however is not enforced for RSA-PSS signature algorithm. This pull request modifies this behavior to also enforce the constraint for the RSA-PSS signature algorithm when verifying X.509 certificates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
