### PR TITLE
Prevent possible use after free in add_string and possible memory leak

### DIFF
--- a/crypto/conf/conf.c
+++ b/crypto/conf/conf.c
@@ -331,6 +331,9 @@ static int add_string(const CONF *conf, CONF_VALUE *section,
   }
 
   if (!lh_CONF_VALUE_insert(conf->data, &old_value, value)) {
+    (void)sk_CONF_VALUE_delete_ptr(section_stack, value);
+    OPENSSL_free(value->section);
+    value->section = NULL;
     return 0;
   }
   if (old_value != NULL) {


### PR DESCRIPTION
### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
In the rare case `lh_CONF_VALUE_insert` fails its possible to both leak memory by not freeing the duplicated section string name on `CONF_VALUE`, and then cause a potential for a use after free by retaining the `CONF_VALUE` in the section stack of values.

This failure scenario is only possible if memory allocation fails during `OPENSSL_lh_insert`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
