### PR TITLE
Add CI for Zig compiler support

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -67,11 +67,31 @@ jobs:
           set(CMAKE_VERBOSE_MAKEFILE ON)
           set(CMAKE_MESSAGE_LOG_LEVEL DEBUG)
           EOF
+          # Workaround: zig's self-hosted MachO linker segfaults on macOS.
+          # Override CMake's link rules to use the system compiler for linking.
+          # Zig is still used for all compilation steps.
+          # Tracked upstream:
+          #   https://github.com/ziglang/zig/issues/25451
+          #   https://github.com/ziglang/zig/issues/23704
+          if [[ "${{ matrix.config.target_system }}" == "Darwin" ]]; then
+            cat <<EOF >> ./toolchain.cmake
+          set(CMAKE_C_LINK_EXECUTABLE "/usr/bin/cc <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+          set(CMAKE_CXX_LINK_EXECUTABLE "/usr/bin/c++ <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+          EOF
+          fi
       - name: Setup CMake
         shell: bash
         run: |
           cat ./toolchain.cmake
-          cmake '.' -B ./build -G Ninja -DCMAKE_TOOLCHAIN_FILE=./toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+          # Workaround: Peek-*-Server SSL runner tests hang on Windows when
+          # bssl_shim is built with zig (SSL_peek appears to block indefinitely).
+          # We use a shim config file with DisabledTests because Go 1.20+ has a
+          # built-in -skip flag that shadows the runner's custom -skip flag.
+          EXTRA_ARGS=""
+          if [[ "${{ matrix.config.target_system }}" == "Windows" ]]; then
+            EXTRA_ARGS="-DSSL_RUNNER_SHIM_CONFIG=ssl/test/runner/zig_windows_config.json"
+          fi
+          cmake '.' -B ./build -G Ninja -DCMAKE_TOOLCHAIN_FILE=./toolchain.cmake -DCMAKE_BUILD_TYPE=Release ${EXTRA_ARGS}
       - name: Build Project
         shell: bash
         run: |

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -1,0 +1,78 @@
+name: Zig compiler
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+jobs:
+  zig:
+    if: github.repository_owner == 'aws'
+    runs-on: ${{ matrix.config.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - host: windows-11-arm
+            target_arch: aarch64
+            target_system: Windows
+          - host: ubuntu-24.04-arm
+            target_arch: aarch64
+            target_system: Linux
+          - host: windows-latest
+            target_arch: x86_64
+            target_system: Windows
+          - host: ubuntu-latest
+            target_arch: x86_64
+            target_system: Linux
+          - host: macos-latest
+            target_arch: aarch64
+            target_system: Darwin
+    steps:
+      - name: Install NASM
+        if: matrix.config.target_arch == 'x86_64'
+        uses: ilammy/setup-nasm@v1.5.1
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>= 1.18'
+      - name: Install zigcc
+        uses: jiacai2050/my-works@8707121a859749b56c1a553e16cec59d1dddb24e # zigcc v1.1.0
+        with:
+          zig-version: 0.15.2
+      - name: Set compiler wrappers
+        shell: bash
+        run: |
+          if [[ "${{ matrix.config.target_system }}" == "Windows" ]]; then
+            echo "ZIGCC=$(cygpath -m "${PWD}/util/zig-cc.cmd")" >> $GITHUB_ENV
+            echo "ZIGCXX=$(cygpath -m "${PWD}/util/zig-c++.cmd")" >> $GITHUB_ENV
+          else
+            echo "ZIGCC=${PWD}/util/zig-cc" >> $GITHUB_ENV
+            echo "ZIGCXX=${PWD}/util/zig-c++" >> $GITHUB_ENV
+          fi
+      - name: Create toolchain
+        shell: bash
+        run: |
+          cat <<EOF > ./toolchain.cmake
+          set(CMAKE_C_COMPILER ${ZIGCC})
+          set(CMAKE_SYSTEM_NAME  ${{ matrix.config.target_system }})
+          set(CMAKE_SYSTEM_PROCESSOR  ${{ matrix.config.target_arch }})
+          set(CMAKE_CXX_COMPILER ${ZIGCXX})
+          set(CMAKE_ASM_COMPILER ${ZIGCC})
+          set(CMAKE_VERBOSE_MAKEFILE ON)
+          set(CMAKE_MESSAGE_LOG_LEVEL DEBUG)
+          EOF
+      - name: Setup CMake
+        shell: bash
+        run: |
+          cat ./toolchain.cmake
+          cmake '.' -B ./build -G Ninja -DCMAKE_TOOLCHAIN_FILE=./toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+      - name: Build Project
+        shell: bash
+        run: |
+          cmake --build ./build --target run_tests --verbose

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -95,4 +95,20 @@ jobs:
       - name: Build Project
         shell: bash
         run: |
-          cmake --build ./build --target run_tests --verbose
+          cmake --build ./build --target all_tests run_ssl_runner_tests --verbose
+      - name: Run Tests
+        shell: bash
+        run: |
+          # Workaround: Zig's LLD linker produces .pdata/.xdata (SEH unwind
+          # data) that is incompatible with the RtlVirtualUnwind-based unwind
+          # tester, causing STATUS_ACCESS_VIOLATION in ABITest.SanityCheck.
+          # Disable unwind tests on Windows until this is resolved upstream.
+          NO_UNWIND_TESTS=""
+          if [[ "${{ matrix.config.target_system }}" == "Windows" ]]; then
+            NO_UNWIND_TESTS="-no-unwind-tests"
+          fi
+          cmake -E echo "Running Go tests"
+          go test ./ssl/test/runner/hpke ./util/ar
+          cmake -E echo
+          cmake -E echo "Running unit tests"
+          go run util/all_tests.go -build-dir ./build ${NO_UNWIND_TESTS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,6 +879,10 @@ if(FUZZ)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,fuzzer-no-link -fsanitize-coverage=edge,indirect-calls")
 endif()
 
+if(SSL_RUNNER_SHIM_CONFIG)
+  set(RUNNER_ARGS ${RUNNER_ARGS} "-shim-config" "${AWSLC_SOURCE_DIR}/${SSL_RUNNER_SHIM_CONFIG}")
+endif()
+
 if(BUILD_SHARED_LIBS)
   add_definitions(-DBORINGSSL_SHARED_LIBRARY)
   # Enable position-independent code globally. This is needed because

--- a/ssl/test/runner/zig_windows_config.json
+++ b/ssl/test/runner/zig_windows_config.json
@@ -1,0 +1,5 @@
+{
+  "DisabledTests": {
+    "Peek-*-Server": "SSL_peek tests hang when bssl_shim is compiled with zig on Windows (i/o timeout)"
+  }
+}

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -41,6 +41,7 @@ var (
 	jsonOutput      = flag.String("json-output", "", "The file to output JSON results to.")
 	mallocTest      = flag.Int64("malloc-test", -1, "If non-negative, run each test with each malloc in turn failing from the given number onwards.")
 	mallocTestDebug = flag.Bool("malloc-test-debug", false, "If true, ask each test to abort rather than fail a malloc. This can be used with a specific value for --malloc-test to identity the malloc failing that is causing problems.")
+	noUnwindTests   = flag.Bool("no-unwind-tests", false, "If true, pass --no_unwind_tests to test binaries to disable unwind testing")
 )
 
 type test struct {
@@ -194,6 +195,9 @@ var (
 func runTestOnce(test test, mallocNumToFail int64) (passed bool, err error) {
 	prog := filepath.Join(*buildDir, test.Cmd[0])
 	args := append([]string{}, test.Cmd[1:]...)
+	if *noUnwindTests {
+		args = append(args, "--no_unwind_tests")
+	}
 
 	var cmd *exec.Cmd
 	var cancel context.CancelFunc

--- a/util/zig-c++
+++ b/util/zig-c++
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Zig C++ compiler wrapper
+#
+# Translates GCC/Clang-specific flags that Zig doesn't understand into
+# compatible equivalents. Currently handles:
+#
+#   -march=armv8.4-a+sha3  →  -mcpu=generic+v8.4a+sha3
+#       Zig doesn't accept GCC-style -march for AArch64 targets.
+#       This is the only -march variant used in the AWS-LC build today
+#       (see crypto/fipsmodule/CMakeLists.txt). If additional -march flags
+#       are added in the future, corresponding translations may be needed here.
+#
+#   -Wp,<arg>  →  <arg>
+#       Zig doesn't support the -Wp, preprocessor passthrough syntax.
+#       The underlying flags (-D, -U, etc.) are passed directly instead.
+#       Used by third_party/jitterentropy for -Wp,-U_FORTIFY_SOURCE.
+
+set -euo pipefail
+
+if ! command -v zig &> /dev/null; then
+    echo "Error: zig compiler not found in PATH" >&2
+    echo "Please install zig from https://ziglang.org/download/" >&2
+    exit 1
+fi
+
+filtered_args=()
+for arg in "$@"; do
+    case "$arg" in
+        -march=armv8.4-a+sha3)
+            filtered_args+=("-mcpu=generic+v8.4a+sha3")
+            ;;
+        -Wp,*)
+            filtered_args+=("${arg#-Wp,}")
+            ;;
+        *)
+            filtered_args+=("$arg")
+            ;;
+    esac
+done
+
+exec zig c++ -fno-sanitize=undefined -fno-sanitize=address -fno-sanitize=memory "${filtered_args[@]}"

--- a/util/zig-c++.cmd
+++ b/util/zig-c++.cmd
@@ -1,0 +1,2 @@
+@echo off
+bash "%~dp0zig-c++" %*

--- a/util/zig-cc
+++ b/util/zig-cc
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Zig C compiler wrapper
+#
+# Translates GCC/Clang-specific flags that Zig doesn't understand into
+# compatible equivalents. Currently handles:
+#
+#   -march=armv8.4-a+sha3  →  -mcpu=generic+v8.4a+sha3
+#       Zig doesn't accept GCC-style -march for AArch64 targets.
+#       This is the only -march variant used in the AWS-LC build today
+#       (see crypto/fipsmodule/CMakeLists.txt). If additional -march flags
+#       are added in the future, corresponding translations may be needed here.
+#
+#   -Wp,<arg>  →  <arg>
+#       Zig doesn't support the -Wp, preprocessor passthrough syntax.
+#       The underlying flags (-D, -U, etc.) are passed directly instead.
+#       Used by third_party/jitterentropy for -Wp,-U_FORTIFY_SOURCE.
+
+set -euo pipefail
+
+if ! command -v zig &> /dev/null; then
+    echo "Error: zig compiler not found in PATH" >&2
+    echo "Please install zig from https://ziglang.org/download/" >&2
+    exit 1
+fi
+
+filtered_args=()
+for arg in "$@"; do
+    case "$arg" in
+        -march=armv8.4-a+sha3)
+            filtered_args+=("-mcpu=generic+v8.4a+sha3")
+            ;;
+        -Wp,*)
+            filtered_args+=("${arg#-Wp,}")
+            ;;
+        *)
+            filtered_args+=("$arg")
+            ;;
+    esac
+done
+
+exec zig cc -fno-sanitize=undefined -fno-sanitize=address -fno-sanitize=memory "${filtered_args[@]}"

--- a/util/zig-cc.cmd
+++ b/util/zig-cc.cmd
@@ -1,0 +1,2 @@
+@echo off
+bash "%~dp0zig-cc" %*


### PR DESCRIPTION
### Description of changes:

Adds CI to build and test AWS-LC using the [Zig](https://ziglang.org/) compiler toolchain (`zig cc` / `zig c++`). The Zig compiler is Clang-based and is increasingly popular for cross-compilation and as an alternative C/C++ toolchain. This PR validates that AWS-LC builds and passes tests when compiled with Zig across five platform configurations:

| Runner | Arch | OS |
|---|---|---|
| `ubuntu-latest` | x86_64 | Linux |
| `ubuntu-24.04-arm` | aarch64 | Linux |
| `windows-latest` | x86_64 | Windows |
| `windows-11-arm` | aarch64 | Windows |
| `macos-latest` | aarch64 | Darwin |

Zig doesn't accept a few GCC/Clang flags that our build emits, so this PR includes thin wrapper scripts (`util/zig-cc`, `util/zig-c++`) that translate them before forwarding to `zig cc`/`zig c++`. The Windows variants (`.cmd`) are shims that call the bash scripts through Git Bash.

### Call-outs:

There are three platform-specific workarounds, all documented inline:

1. **macOS linking**: Zig's self-hosted MachO linker segfaults ([ziglang/zig#25451](https://github.com/ziglang/zig/issues/25451), [ziglang/zig#23704](https://github.com/ziglang/zig/issues/23704)), so the toolchain falls back to the system compiler (`/usr/bin/cc`) for linking only. Zig still handles all compilation.

2. **Windows `SSL_peek` tests**: The `Peek-*-Server` SSL runner tests hang when `bssl_shim` is compiled with Zig. These are disabled via a shim config file (`zig_windows_config.json`). A small CMake change plumbs the `-DSSL_RUNNER_SHIM_CONFIG` option through to the runner's `-shim-config` flag.

3. **Windows SEH unwind tests**: Zig's LLD linker produces `.pdata`/`.xdata` (SEH unwind metadata) that is incompatible with the `RtlVirtualUnwind`-based unwind tester, causing `STATUS_ACCESS_VIOLATION` in `ABITest.SanityCheck`. The non-unwind ABI register-preservation tests pass fine — only the single-step unwind verification crashes. A `-no-unwind-tests` flag was added to `all_tests.go` (following the existing SDE pattern) and is used for the Windows Zig targets.

### Testing:

CI across the five matrix configurations listed above. All tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
