### PR TITLE
Update PyOpenSSL patch w/ PR #2897

### DIFF
--- a/tests/ci/integration/pyopenssl_patch/25.3.0/aws-lc-pyopenssl.patch
+++ b/tests/ci/integration/pyopenssl_patch/25.3.0/aws-lc-pyopenssl.patch
@@ -1,5 +1,5 @@
 diff --git a/src/OpenSSL/SSL.py b/src/OpenSSL/SSL.py
-index 3819b49..f26b250 100644
+index 51c60d5..3d6e6d6 100644
 --- a/src/OpenSSL/SSL.py
 +++ b/src/OpenSSL/SSL.py
 @@ -64,7 +64,6 @@ __all__ = [
@@ -23,8 +23,8 @@ index 3819b49..f26b250 100644
  OP_NO_TICKET: int = _lib.SSL_OP_NO_TICKET
  
  try:
-@@ -820,6 +823,11 @@ _requires_ssl_get0_group_name = _make_requires(
-     "Getting group name is not supported by the linked OpenSSL version",
+@@ -815,6 +818,11 @@ _requires_keylog = _make_requires(
+     getattr(_lib, "Cryptography_HAS_KEYLOG", 0), "Key logging not available"
  )
  
 +_requires_ssl_cookie = _make_requires(
@@ -35,7 +35,7 @@ index 3819b49..f26b250 100644
  
  class Session:
      """
-@@ -1910,6 +1918,7 @@ class Context:
+@@ -1905,6 +1913,7 @@ class Context:
          self._set_ocsp_callback(helper, data)
  
      @_require_not_used
@@ -43,7 +43,7 @@ index 3819b49..f26b250 100644
      def set_cookie_generate_callback(
          self, callback: _CookieGenerateCallback
      ) -> None:
-@@ -1920,6 +1929,7 @@ class Context:
+@@ -1915,6 +1924,7 @@ class Context:
          )
  
      @_require_not_used
@@ -67,7 +67,7 @@ index 26711da..b8a263c 100644
  def pytest_report_header(config: pytest.Config) -> str:
      import cryptography
 diff --git a/tests/test_crypto.py b/tests/test_crypto.py
-index a05640d..9edbbdc 100644
+index 7b07b44..cc5165c 100644
 --- a/tests/test_crypto.py
 +++ b/tests/test_crypto.py
 @@ -58,6 +58,7 @@ from OpenSSL.crypto import (
@@ -87,20 +87,11 @@ index a05640d..9edbbdc 100644
  BAD_CIPHER = "zippers"
  
  GOOD_DIGEST = "SHA256"
-@@ -1023,8 +1024,22 @@ class TestPKey:
-         [
+@@ -1078,7 +1079,14 @@ class TestPKey:
              (dsa_private_key_pem, dsa.DSAPrivateKey),
              (ec_private_key_pem, ec.EllipticCurvePrivateKey),
--            (ed25519_private_key_pem, ed25519.Ed25519PrivateKey),
+             (ed25519_private_key_pem, ed25519.Ed25519PrivateKey),
 -            (ed448_private_key_pem, ed448.Ed448PrivateKey),
-+            pytest.param(
-+                ed25519_private_key_pem,
-+                ed25519.Ed25519PrivateKey,
-+                marks=pytest.mark.skipif(
-+                    conftest.is_awslc,
-+                    reason="aws-lc doesn't support Ed25519 via PEM",
-+                ),
-+            ),
 +            pytest.param(
 +                ed448_private_key_pem,
 +                ed448.Ed448PrivateKey,
@@ -112,20 +103,11 @@ index a05640d..9edbbdc 100644
              (rsa_private_key_pem, rsa.RSAPrivateKey),
          ],
      )
-@@ -1077,8 +1092,22 @@ class TestPKey:
-         [
+@@ -1132,7 +1140,14 @@ class TestPKey:
              (dsa_public_key_pem, dsa.DSAPublicKey),
              (ec_public_key_pem, ec.EllipticCurvePublicKey),
--            (ed25519_public_key_pem, ed25519.Ed25519PublicKey),
+             (ed25519_public_key_pem, ed25519.Ed25519PublicKey),
 -            (ed448_public_key_pem, ed448.Ed448PublicKey),
-+            pytest.param(
-+                ed25519_public_key_pem,
-+                ed25519.Ed25519PublicKey,
-+                marks=pytest.mark.skipif(
-+                    conftest.is_awslc,
-+                    reason="aws-lc doesn't support Ed25519 via PEM",
-+                ),
-+            ),
 +            pytest.param(
 +                ed448_public_key_pem,
 +                ed448.Ed448PublicKey,
@@ -137,7 +119,7 @@ index a05640d..9edbbdc 100644
              (rsa_public_key_pem, rsa.RSAPublicKey),
          ],
      )
-@@ -1822,6 +1851,8 @@ class TestX509:
+@@ -1876,6 +1891,8 @@ class TestX509:
          key = PKey()
          key.generate_key(TYPE_RSA, 2048)
          cert.set_pubkey(key)
@@ -146,7 +128,7 @@ index a05640d..9edbbdc 100644
          cert.sign(key, GOOD_DIGEST)
  
      def test_construction(self) -> None:
-@@ -1890,20 +1921,21 @@ class TestX509:
+@@ -1944,20 +1961,21 @@ class TestX509:
          set(certificate, when)
          assert get(certificate) == when
  
@@ -182,10 +164,10 @@ index a05640d..9edbbdc 100644
          # An invalid string results in a ValueError
          with pytest.raises(ValueError):
 diff --git a/tests/test_ssl.py b/tests/test_ssl.py
-index 0dd2532..cf7b62f 100644
+index 080de2e..e0df44e 100644
 --- a/tests/test_ssl.py
 +++ b/tests/test_ssl.py
-@@ -67,7 +67,6 @@ from OpenSSL.crypto import (
+@@ -66,7 +66,6 @@ from OpenSSL.crypto import (
  )
  from OpenSSL.SSL import (
      DTLS_METHOD,
@@ -193,7 +175,7 @@ index 0dd2532..cf7b62f 100644
      NO_OVERLAPPING_PROTOCOLS,
      OP_COOKIE_EXCHANGE,
      OP_NO_COMPRESSION,
-@@ -132,6 +131,7 @@ from OpenSSL.SSL import (
+@@ -131,6 +130,7 @@ from OpenSSL.SSL import (
      _NoOverlappingProtocols,
  )
  
@@ -201,7 +183,7 @@ index 0dd2532..cf7b62f 100644
  from .test_crypto import (
      client_cert_pem,
      client_key_pem,
-@@ -643,6 +643,12 @@ class TestContext:
+@@ -642,6 +642,12 @@ class TestContext:
                  "",
                  "no cipher match",
              ),
@@ -214,7 +196,7 @@ index 0dd2532..cf7b62f 100644
          ]
  
      def test_load_client_ca(self, context: Context, ca_file: bytes) -> None:
-@@ -700,6 +706,12 @@ class TestContext:
+@@ -698,6 +704,12 @@ class TestContext:
                  "",
                  "ssl session id context too long",
              ),
@@ -227,7 +209,7 @@ index 0dd2532..cf7b62f 100644
          ]
  
      def test_set_session_id_unicode(self, context: Context) -> None:
-@@ -922,7 +934,8 @@ class TestContext:
+@@ -919,7 +931,8 @@ class TestContext:
          newly set mode.
          """
          context = Context(SSLv23_METHOD)
@@ -237,7 +219,7 @@ index 0dd2532..cf7b62f 100644
  
      def test_set_timeout_wrong_args(self) -> None:
          """
-@@ -969,7 +982,7 @@ class TestContext:
+@@ -966,7 +979,7 @@ class TestContext:
          """
          key = PKey()
          key.generate_key(TYPE_RSA, 1024)
@@ -246,7 +228,7 @@ index 0dd2532..cf7b62f 100644
          with open(tmpfile, "w") as fObj:
              fObj.write(pem.decode("ascii"))
          return tmpfile
-@@ -1163,7 +1176,7 @@ class TestContext:
+@@ -1160,7 +1173,7 @@ class TestContext:
          client_context = Context(TLS_METHOD)
          client_context.set_max_proto_version(low_version)
  
@@ -255,7 +237,7 @@ index 0dd2532..cf7b62f 100644
              self._handshake_test(server_context, client_context)
  
          client_context = Context(TLS_METHOD)
-@@ -1632,7 +1645,9 @@ class TestContext:
+@@ -1629,7 +1642,9 @@ class TestContext:
          if mode == SSL.VERIFY_PEER:
              with pytest.raises(Exception) as exc:
                  self._handshake_test(serverContext, clientContext)
@@ -266,7 +248,7 @@ index 0dd2532..cf7b62f 100644
          else:
              self._handshake_test(serverContext, clientContext)
  
-@@ -1861,9 +1876,27 @@ class TestContext:
+@@ -1858,9 +1873,27 @@ class TestContext:
              with pytest.deprecated_call():
                  context.set_tmp_ecdh(curve)
  
@@ -294,7 +276,7 @@ index 0dd2532..cf7b62f 100644
              oid = getattr(ec.EllipticCurveOID, name)
              cryptography_curve = ec.get_curve_for_oid(oid)
              context.set_tmp_ecdh(cryptography_curve())
-@@ -2699,10 +2732,12 @@ class TestConnection:
+@@ -2696,10 +2729,12 @@ class TestConnection:
          assert tls_server.get_state_string() in [
              b"before/accept initialization",
              b"before SSL initialization",
@@ -307,7 +289,7 @@ index 0dd2532..cf7b62f 100644
          ]
  
      def test_app_data(self) -> None:
-@@ -3179,9 +3214,10 @@ class TestConnection:
+@@ -3169,9 +3204,10 @@ class TestConnection:
              return False  # Retry succeeded
          except SSL.Error as e:
              reason = get_ssl_error_reason(e)
@@ -321,7 +303,7 @@ index 0dd2532..cf7b62f 100644
              return True  # Bad write retry
  
      def _shutdown_connections(
-@@ -3895,6 +3931,10 @@ class TestConnectionRenegotiate:
+@@ -3837,6 +3873,10 @@ class TestConnectionRenegotiate:
          connection = Connection(Context(SSLv23_METHOD), None)
          assert connection.total_renegotiations() == 0
  
@@ -332,7 +314,7 @@ index 0dd2532..cf7b62f 100644
      def test_renegotiate(self) -> None:
          """
          Go through a complete renegotiation cycle.
-@@ -3988,6 +4028,10 @@ class TestConstants:
+@@ -3930,6 +3970,10 @@ class TestConstants:
              "OP_NO_COMPRESSION unavailable - OpenSSL version may be too old"
          ),
      )
@@ -343,7 +325,7 @@ index 0dd2532..cf7b62f 100644
      def test_op_no_compression(self) -> None:
          """
          The value of `OpenSSL.SSL.OP_NO_COMPRESSION` is 0x20000, the
-@@ -5050,9 +5097,17 @@ class TestDTLS:
+@@ -4992,9 +5036,17 @@ class TestDTLS:
          c.set_ciphertext_mtu(500)
          assert 0 < c.get_cleartext_mtu() < 500
  


### PR DESCRIPTION
### Issues:

t/V2108049398

### Description of changes: 

We can now de/serialize Ed25519 keys properly.


### Testing:

- CI

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
