### PR TITLE
Upgrade CI sanitizer jobs from Clang 15 to Clang 19

### DIFF
--- a/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
+++ b/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
@@ -41,6 +41,7 @@ dnf install -y \
     unzip \
     wget \
     which \
+    xz \
     valgrind \
     valgrind-devel
 # valgrind is just the application and core resources.

--- a/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
+++ b/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
@@ -54,12 +54,33 @@ EOF
 
 FROM base AS tools
 
-# Create compiler environment setup scripts
+# Install LLVM/Clang 19 from pre-built release
+RUN <<EOF
+set -ex
+LLVM_VERSION=19.1.7
+arch="$(uname -m)"
+if [[ "${arch}" == "x86_64" ]]; then
+    LLVM_ARCHIVE="clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-22.04.tar.xz"
+elif [[ "${arch}" == "aarch64" ]]; then
+    LLVM_ARCHIVE="clang+llvm-${LLVM_VERSION}-aarch64-linux-gnu.tar.xz"
+else
+    echo "Unsupported architecture: ${arch}"
+    exit 1
+fi
+cd /tmp
+wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVM_ARCHIVE}"
+mkdir -p /opt/clang-19
+tar -xf "${LLVM_ARCHIVE}" --strip-components=1 -C /opt/clang-19/
+ln -sf /opt/clang-19/bin/clang /usr/bin/clang-19
+ln -sf /opt/clang-19/bin/clang++ /usr/bin/clang++-19
+rm -f "${LLVM_ARCHIVE}"
+EOF
+
+# Create compiler environment setup scripts (after all compilers are installed)
 COPY --from=scripts create-compiler-env.sh /tmp
 RUN <<EOF
 set -ex
-setup_script="/tmp/create-compiler-env.sh"
-${setup_script}
+/tmp/create-compiler-env.sh
 EOF
 
 # Install SSM Agent Config

--- a/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
+++ b/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
@@ -60,7 +60,7 @@ set -ex
 LLVM_VERSION=19.1.7
 arch="$(uname -m)"
 if [[ "${arch}" == "x86_64" ]]; then
-    LLVM_ARCHIVE="clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-22.04.tar.xz"
+    LLVM_ARCHIVE="LLVM-${LLVM_VERSION}-Linux-X64.tar.xz"
 elif [[ "${arch}" == "aarch64" ]]; then
     LLVM_ARCHIVE="clang+llvm-${LLVM_VERSION}-aarch64-linux-gnu.tar.xz"
 else

--- a/.github/workflows/image-build-al2023.yml
+++ b/.github/workflows/image-build-al2023.yml
@@ -82,10 +82,14 @@ jobs:
             source /opt/compiler-env/setup-clang.sh
             ./.github/docker_images/scripts/verify-compiler-version.sh $CC clang 15.0
             ./.github/docker_images/scripts/verify-compiler-version.sh $CXX clang 15.0
-            # Check Clang 11 Compilers
+            # Check Clang 15 Compilers
             source /opt/compiler-env/setup-clang-15.sh
             ./.github/docker_images/scripts/verify-compiler-version.sh $CC clang 15.0
             ./.github/docker_images/scripts/verify-compiler-version.sh $CXX clang 15.0
+            # Check Clang 19 Compilers
+            source /opt/compiler-env/setup-clang-19.sh
+            ./.github/docker_images/scripts/verify-compiler-version.sh $CC clang 19.1
+            ./.github/docker_images/scripts/verify-compiler-version.sh $CXX clang 19.1
       - uses: docker/build-push-action@v6
         with:
           file: ./.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
@@ -161,6 +165,10 @@ jobs:
             source /opt/compiler-env/setup-clang-15.sh
             ./.github/docker_images/scripts/verify-compiler-version.sh $CC clang 15.0
             ./.github/docker_images/scripts/verify-compiler-version.sh $CXX clang 15.0
+            # Check Clang 19 Compilers
+            source /opt/compiler-env/setup-clang-19.sh
+            ./.github/docker_images/scripts/verify-compiler-version.sh $CC clang 19.1
+            ./.github/docker_images/scripts/verify-compiler-version.sh $CXX clang 19.1
 
   x86_64_push:
     if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/linux-multi-arch-omnibus.yml
+++ b/.github/workflows/linux-multi-arch-omnibus.yml
@@ -512,7 +512,7 @@ jobs:
           env: |
             AWS_LC_GO_TEST_TIMEOUT
           run: |
-            source /opt/compiler-env/setup-clang.sh
+            source /opt/compiler-env/setup-clang-19.sh
             ./tests/ci/run_posix_sanitizers.sh
 
   benchmark:
@@ -535,7 +535,7 @@ jobs:
         with:
           image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/amazonlinux:2023
           run: |
-            source /opt/compiler-env/setup-clang-15.sh
+            source /opt/compiler-env/setup-clang-19.sh
             ./tests/ci/run_benchmark_build_tests.sh
 
   fips_callback:

--- a/.github/workflows/linux_arm_omnibus.yml
+++ b/.github/workflows/linux_arm_omnibus.yml
@@ -41,7 +41,7 @@ jobs:
           env: |
             AWS_LC_GO_TEST_TIMEOUT=60m
           run: |
-            source /opt/compiler-env/setup-clang-15.sh
+            source /opt/compiler-env/setup-clang-19.sh
             ${{ matrix.run }}
 
   graviton4:
@@ -72,7 +72,7 @@ jobs:
           env: |
             AWS_LC_GO_TEST_TIMEOUT=60m
           run: |
-            source /opt/compiler-env/setup-clang-15.sh
+            source /opt/compiler-env/setup-clang-19.sh
             ${{ matrix.run }}
 
 
@@ -101,7 +101,7 @@ jobs:
             AWS_LC_GO_TEST_TIMEOUT
             AWS_LC_SSL_RUNNER_END_INDEX
           run: |
-            source /opt/compiler-env/setup-clang-15.sh
+            source /opt/compiler-env/setup-clang-19.sh
             ./tests/ci/run_ssl_asan_tests.sh
 
   asan-ssl-part2:
@@ -127,7 +127,7 @@ jobs:
             AWS_LC_SSL_RUNNER_START_INDEX
             AWS_LC_SSL_RUNNER_END_INDEX
           run: |
-            source /opt/compiler-env/setup-clang-15.sh
+            source /opt/compiler-env/setup-clang-19.sh
             ./tests/ci/run_ssl_asan_tests.sh
 
   asan-ssl-part3:
@@ -153,7 +153,7 @@ jobs:
             AWS_LC_SSL_RUNNER_START_INDEX
             AWS_LC_SSL_RUNNER_END_INDEX
           run: |
-            source /opt/compiler-env/setup-clang-15.sh
+            source /opt/compiler-env/setup-clang-19.sh
             ./tests/ci/run_ssl_asan_tests.sh
 
   asan-ssl-part4:
@@ -177,7 +177,7 @@ jobs:
             AWS_LC_GO_TEST_TIMEOUT
             AWS_LC_SSL_RUNNER_START_INDEX
           run: |
-            source /opt/compiler-env/setup-clang-15.sh
+            source /opt/compiler-env/setup-clang-19.sh
             ./tests/ci/run_ssl_asan_tests.sh
 
   # Build and test aws-lc without Perl/Go.


### PR DESCRIPTION
### Description of changes:
The libc++ sources in the AL2023 Docker image (`llvm-project`) were updated to a version that requires Clang 17+, which broke all MSAN and TSAN builds that use `-DUSE_CUSTOM_LIBCXX=1`. Those builds compile libc++ from source, and the newer libc++ headers emit a hard `#warning` that becomes fatal under `-Werror`.

This upgrades the AL2023 Docker image and associated workflows from Clang 15 to Clang 19:

- Install pre-built LLVM/Clang 19.1.7 from GitHub releases into the AL2023 image alongside the existing dnf-provided Clang 15
- Update the `llvm-project` clone (used for libc++/libc++abi sources) from `llvmorg-15.0.6` to `llvmorg-19.1.7` so the compiler and standard library stay in sync
- Switch `linux_arm_omnibus.yml` and `linux-multi-arch-omnibus.yml` sanitizer/benchmark jobs to `setup-clang-19.sh`
- Add Clang 19 verification to the AL2023 image build workflow

### Call-outs:
The x86_64 pre-built binary is the `ubuntu-22.04` build from LLVM's GitHub releases. AL2023 ships glibc 2.34 while that binary targets glibc 2.35, so there's a small risk of compatibility issues on x86_64. The aarch64 binary is a generic `aarch64-linux-gnu` build and should be fine.

### Testing:
Image build verification (`image-build-al2023.yml`) will confirm that `setup-clang-19.sh` is generated and reports the expected version. The sanitizer and benchmark jobs themselves serve as the integration test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
