### PR TITLE
Change ML-KEM PKCS#8 encoding from expanded to seed form

### DIFF
--- a/crypto/evp_extra/p_kem_asn1.c
+++ b/crypto/evp_extra/p_kem_asn1.c
@@ -104,7 +104,7 @@ static int kem_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b) {
 
 
 static int kem_pub_decode(EVP_PKEY *out, CBS *oid, CBS *params, CBS *key) {
-  // See https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+  // See https://datatracker.ietf.org/doc/rfc9935/
   // section 4. There should be no parameters
   if (CBS_len(params) > 0) {
     OPENSSL_PUT_ERROR(EVP, EVP_R_DECODE_ERROR);
@@ -132,7 +132,7 @@ static int kem_pub_encode(CBB *out, const EVP_PKEY *pkey) {
     return 0;
   }
 
-  // See https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+  // See https://datatracker.ietf.org/doc/rfc9935/
   // section 4.
   CBB spki, algorithm, oid, key_bitstring;
   if (!CBB_add_asn1(out, &spki, CBS_ASN1_SEQUENCE) || // SubjectPublicKeyInfo SEQUENCE
@@ -165,7 +165,7 @@ static int kem_pub_cmp(const EVP_PKEY *a, const EVP_PKEY *b) {
 
 static int kem_priv_decode(EVP_PKEY *out, CBS *oid, CBS *params, CBS *key,
                            CBS *pubkey) {
-  // See https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+  // See https://datatracker.ietf.org/doc/rfc9935/
   // section 6. There should be no parameters.
   if (CBS_len(params) > 0) {
     OPENSSL_PUT_ERROR(EVP, EVP_R_DECODE_ERROR);
@@ -179,7 +179,7 @@ static int kem_priv_decode(EVP_PKEY *out, CBS *oid, CBS *params, CBS *key,
   }
 
   // Support multiple ML-KEM private key formats from
-  // https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+  // https://datatracker.ietf.org/doc/rfc9935/
   // Case 1: seed [0] OCTET STRING
   // Case 2: expandedKey OCTET STRING
   // Case 3: TODO: both SEQUENCE {seed, expandedKey}
@@ -226,20 +226,37 @@ static int kem_priv_encode(CBB *out, const EVP_PKEY *pkey) {
     OPENSSL_PUT_ERROR(EVP, EVP_R_NOT_A_PRIVATE_KEY);
     return 0;
   }
-  // See https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+  // See https://datatracker.ietf.org/doc/rfc9935/
   // section 6.
-  CBB pkcs8, algorithm, oid, private_key, expanded_key;
+  CBB pkcs8, algorithm, oid, private_key;
   if (!CBB_add_asn1(out, &pkcs8, CBS_ASN1_SEQUENCE) || // OneAsymmetricKey SEQUENCE
       !CBB_add_asn1_uint64(&pkcs8, PKCS8_VERSION_ONE /* version */) ||
       !CBB_add_asn1(&pkcs8, &algorithm, CBS_ASN1_SEQUENCE) || // privateKeyAlgorithm: SEQUENCE
       !CBB_add_asn1(&algorithm, &oid, CBS_ASN1_OBJECT) || // algorithm: OBJECT IDENTIFIER
       !CBB_add_bytes(&oid, kem->oid, kem->oid_len) || // OID bytes for id-alg-ml-kem-512/768/1024
-      !CBB_add_asn1(&pkcs8, &private_key, CBS_ASN1_OCTETSTRING) || // // privateKey: OCTET STRING (outer container)
-      !CBB_add_asn1(&private_key, &expanded_key, CBS_ASN1_OCTETSTRING) || // expandedKey CHOICE variant, AWS-LC uses expandedKey for the moment
-      !CBB_add_bytes(&expanded_key, key->secret_key, kem->secret_key_len) || // raw private key 
-      !CBB_flush(out)) {
+      !CBB_add_asn1(&pkcs8, &private_key, CBS_ASN1_OCTETSTRING)) { // privateKey: OCTET STRING (outer container)
     OPENSSL_PUT_ERROR(EVP, EVP_R_ENCODE_ERROR);
     return 0;
+  }
+
+  if (key->seed != NULL) {
+    // Seed format: [0] IMPLICIT OCTET STRING
+    CBB seed_choice;
+    if (!CBB_add_asn1(&private_key, &seed_choice, CBS_ASN1_CONTEXT_SPECIFIC | 0) ||
+        !CBB_add_bytes(&seed_choice, key->seed, kem->keygen_seed_len) ||
+        !CBB_flush(out)) {
+      OPENSSL_PUT_ERROR(EVP, EVP_R_ENCODE_ERROR);
+      return 0;
+    }
+  } else {
+    // Expanded format: OCTET STRING (for keys without seed, e.g. raw import)
+    CBB expanded_key;
+    if (!CBB_add_asn1(&private_key, &expanded_key, CBS_ASN1_OCTETSTRING) ||
+        !CBB_add_bytes(&expanded_key, key->secret_key, kem->secret_key_len) ||
+        !CBB_flush(out)) {
+      OPENSSL_PUT_ERROR(EVP, EVP_R_ENCODE_ERROR);
+      return 0;
+    }
   }
 
   return 1;

--- a/crypto/evp_extra/p_kem_test.cc
+++ b/crypto/evp_extra/p_kem_test.cc
@@ -18,7 +18,7 @@
 #include "../test/wycheproof_util.h"
 
 
-// https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+// https://datatracker.ietf.org/doc/rfc9935/
 // All example keys are from Appendix C in the above standard
 // Example ML-KEM-512 public key
 const char *mlkem_512_pub_pem_str =
@@ -43,7 +43,7 @@ const char *mlkem_512_pub_pem_str =
     "WhttY7Js\n"
     "-----END PUBLIC KEY-----\n";
 
-// https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+// https://datatracker.ietf.org/doc/rfc9935/
 // Example ML-KEM-768 public key
 const char *mlkem_768_pub_pem_str =
     "-----BEGIN PUBLIC KEY-----\n"
@@ -75,7 +75,7 @@ const char *mlkem_768_pub_pem_str =
     "QvpN6gV4\n"
     "-----END PUBLIC KEY-----\n";
 
-// https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+// https://datatracker.ietf.org/doc/rfc9935/
 // Example ML-KEM-1024 public key
 const char *mlkem_1024_pub_pem_str =
     "-----BEGIN PUBLIC KEY-----\n"
@@ -115,7 +115,7 @@ const char *mlkem_1024_pub_pem_str =
     "uYOILhF1\n"
     "-----END PUBLIC KEY-----\n";
 
-// https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+// https://datatracker.ietf.org/doc/rfc9935/
 // C.1.1.1. ML-KEM-512 Private Key Examples: Seed Format
 const char *mlkem_512_seed_pem_str =
     "-----BEGIN PRIVATE KEY-----\n"
@@ -484,17 +484,17 @@ struct KEMTestVector {
 
 static const KEMTestVector kemParameters[] = {
     {NID_MLKEM512, mlkem_512_pub_pem_str, mlkem_512_priv_expanded_pem_str,
-     mlkem_512_seed_pem_str, mlkem_512_pub_pem_str, mlkem_512_priv_expanded_pem_str, 800, 1632},
+     mlkem_512_seed_pem_str, mlkem_512_pub_pem_str, mlkem_512_seed_pem_str, 800, 1632},
     {NID_MLKEM768, mlkem_768_pub_pem_str, mlkem_768_priv_expanded_pem_str,
-     mlkem_768_seed_pem_str, mlkem_768_pub_pem_str, mlkem_768_priv_expanded_pem_str, 1184, 2400},
+     mlkem_768_seed_pem_str, mlkem_768_pub_pem_str, mlkem_768_seed_pem_str, 1184, 2400},
     {NID_MLKEM1024, mlkem_1024_pub_pem_str, mlkem_1024_priv_expanded_pem_str,
-     mlkem_1024_seed_pem_str, mlkem_1024_pub_pem_str, mlkem_1024_priv_expanded_pem_str, 1568, 3168},
+     mlkem_1024_seed_pem_str, mlkem_1024_pub_pem_str, mlkem_1024_seed_pem_str, 1568, 3168},
     {NID_MLKEM512, bouncy_castle_mlkem_512_pub_pem_str,
      bouncy_castle_mlkem_512_priv_expanded_pem_str, bouncy_castle_ml_kem_512_seed_pem_str,
-     mlkem_512_pub_pem_str, mlkem_512_priv_expanded_pem_str, 800, 1632},
+     mlkem_512_pub_pem_str, mlkem_512_seed_pem_str, 800, 1632},
     {NID_MLKEM768, bouncy_castle_mlkem_768_pub_pem_str,
      bouncy_castle_mlkem_768_priv_expanded_str, bouncy_castle_ml_kem_768_seed_pem_str,
-     mlkem_768_pub_pem_str, mlkem_768_priv_expanded_pem_str, 1184, 2400},
+     mlkem_768_pub_pem_str, mlkem_768_seed_pem_str, 1184, 2400},
 };
 
 
@@ -554,29 +554,31 @@ TEST_P(KEMTest, MarshalParse) {
             Bytes(pkey->pkey.kem_key->secret_key, GetParam().secret_key_len));
 }
 
-// Test that the private key is encoded in expandedKey format
-TEST_P(KEMTest, PrivateKeyExpandedFormat) {
+// Test that the private key is encoded in seed format
+TEST_P(KEMTest, PrivateKeySeedFormat) {
   const KEMTestVector &test = GetParam();
 
   // Generate a key pair
   bssl::UniquePtr<EVP_PKEY> pkey(generate_kem_key_pair(test.nid));
   ASSERT_TRUE(pkey);
 
+  // Verify the seed is present
+  ASSERT_TRUE(pkey->pkey.kem_key->seed);
+
   // Encode the private key
   bssl::ScopedCBB cbb;
   ASSERT_TRUE(CBB_init(cbb.get(), 0));
   ASSERT_TRUE(EVP_marshal_private_key(cbb.get(), pkey.get()));
 
-  uint8_t *der;
-  size_t der_len;
+  uint8_t *der = nullptr;
+  size_t der_len = 0;
   ASSERT_TRUE(CBB_finish(cbb.get(), &der, &der_len));
   bssl::UniquePtr<uint8_t> free_der(der);
 
   // Parse the PKCS#8 structure to verify the privateKey field contains
-  // the expandedKey format - AWS-LC currently only supports expandedKey
-  // encoding
+  // the seed format ([0] IMPLICIT OCTET STRING)
   CBS pkcs8, algorithm, private_key;
-  uint64_t version;
+  uint64_t version = 0;
   CBS_init(&pkcs8, der, der_len);
 
   ASSERT_TRUE(CBS_get_asn1(&pkcs8, &pkcs8, CBS_ASN1_SEQUENCE));
@@ -585,14 +587,14 @@ TEST_P(KEMTest, PrivateKeyExpandedFormat) {
   ASSERT_TRUE(CBS_get_asn1(&pkcs8, &algorithm, CBS_ASN1_SEQUENCE));
   ASSERT_TRUE(CBS_get_asn1(&pkcs8, &private_key, CBS_ASN1_OCTETSTRING));
 
-  // The privateKey field should contain the expandedKey as an OCTET STRING
-  CBS expanded_key;
-  ASSERT_TRUE(CBS_get_asn1(&private_key, &expanded_key, CBS_ASN1_OCTETSTRING));
-  ASSERT_EQ(CBS_len(&expanded_key), test.secret_key_len);
+  // The privateKey field should contain the seed as [0] context-specific tag
+  CBS seed;
+  ASSERT_TRUE(CBS_get_asn1(&private_key, &seed, CBS_ASN1_CONTEXT_SPECIFIC | 0));
+  ASSERT_EQ(CBS_len(&seed), 64u);
 
-  // Verify it matches the original secret key
-  EXPECT_EQ(Bytes(CBS_data(&expanded_key), CBS_len(&expanded_key)),
-            Bytes(pkey->pkey.kem_key->secret_key, test.secret_key_len));
+  // Verify it matches the seed stored in the key
+  EXPECT_EQ(Bytes(CBS_data(&seed), CBS_len(&seed)),
+            Bytes(pkey->pkey.kem_key->seed, 64));
 }
 
 TEST_P(KEMTest, ParsePublicKey) {
@@ -690,7 +692,7 @@ TEST(KEMTest, ParsePrivateKeyInvalidLength) {
 // Verifies that deterministic ML-KEM key generation with the fixed seed from the IETF standard produces keys that exactly
 // match the expected PEM strings from the standard. 
 // The expected PEM strings from the given seed are fields at the top (mlkem_XXX_pub/priv_pem_str)
-// See Appendix C.1 in https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/ for the seed value
+// See Appendix C.1 in https://datatracker.ietf.org/doc/rfc9935/ for the seed value
 TEST_P(KEMTest, DeterministicKeyMarshaling) {
   const KEMTestVector& test = GetParam();
   
@@ -701,7 +703,7 @@ TEST_P(KEMTest, DeterministicKeyMarshaling) {
   ASSERT_TRUE(EVP_PKEY_CTX_kem_set_params(ctx.get(), test.nid));
 
   // ---- 2. Create deterministic seed: 00 01 02 ... 3f (64 consecutive bytes) ----
-  // Seed is specified in Appendix C.1 in https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+  // Seed is specified in Appendix C.1 in https://datatracker.ietf.org/doc/rfc9935/
   std::vector<uint8_t> keygen_seed(64);
   for (size_t i = 0; i < 64; i++) {
     keygen_seed[i] = static_cast<uint8_t>(i);  // seed is a sequence - 00, 01, 02, ... 3f (from above standard)
@@ -761,8 +763,8 @@ TEST_P(KEMTest, DeterministicKeyMarshaling) {
             Bytes(expected_priv_der, expected_priv_der_len))
       << "Private key DER content mismatch";
 
-  // ---- 10. Verify private key DER is larger than public key DER ----
-  EXPECT_GT(generated_priv_der_len, generated_pub_der_len);
+  // ---- 10. Verify seed-format private key DER is smaller than public key DER ----
+  EXPECT_LT(generated_priv_der_len, generated_pub_der_len);
 }
 
 // Test KEM public key round-trip serialization using i2d_PUBKEY and d2i_PUBKEY functions.
@@ -929,6 +931,131 @@ TEST(KEMTest, InvalidSeedLength) {
   EXPECT_EQ(ERR_GET_REASON(err), EVP_R_INVALID_BUFFER_SIZE);
   
   OPENSSL_free(der_priv);
+}
+
+// Test that parsing a seed-format PKCS#8 and re-serializing produces seed
+// format (round-trip preservation).
+TEST_P(KEMTest, SeedFormatRoundTrip) {
+  const KEMTestVector &test = GetParam();
+
+  // Parse seed-format private key
+  uint8_t *der = nullptr;
+  long der_len = 0;
+  ASSERT_TRUE(PEM_to_DER(test.private_pem_seed_str, &der, &der_len));
+  bssl::UniquePtr<uint8_t> free_der(der);
+
+  CBS cbs;
+  CBS_init(&cbs, der, der_len);
+  bssl::UniquePtr<EVP_PKEY> pkey(EVP_parse_private_key(&cbs));
+  ASSERT_TRUE(pkey);
+  ASSERT_TRUE(pkey->pkey.kem_key->seed);
+
+  // Re-serialize — should produce seed format
+  bssl::ScopedCBB cbb;
+  ASSERT_TRUE(CBB_init(cbb.get(), 0));
+  ASSERT_TRUE(EVP_marshal_private_key(cbb.get(), pkey.get()));
+
+  uint8_t *der2 = nullptr;
+  size_t der2_len = 0;
+  ASSERT_TRUE(CBB_finish(cbb.get(), &der2, &der2_len));
+  bssl::UniquePtr<uint8_t> free_der2(der2);
+
+  // Round-trip: output should match input
+  EXPECT_EQ(Bytes(der, der_len), Bytes(der2, der2_len));
+
+  // Parse again and verify key material matches
+  CBS cbs2;
+  CBS_init(&cbs2, der2, der2_len);
+  bssl::UniquePtr<EVP_PKEY> pkey2(EVP_parse_private_key(&cbs2));
+  ASSERT_TRUE(pkey2);
+  EXPECT_EQ(Bytes(pkey->pkey.kem_key->secret_key, test.secret_key_len),
+            Bytes(pkey2->pkey.kem_key->secret_key, test.secret_key_len));
+}
+
+// Test that keys created via raw import (no seed) encode in expanded format.
+TEST_P(KEMTest, RawImportExpandedFormat) {
+  const KEMTestVector &test = GetParam();
+
+  // Generate a key to get valid raw key material
+  bssl::UniquePtr<EVP_PKEY> pkey(generate_kem_key_pair(test.nid));
+  ASSERT_TRUE(pkey);
+
+  // Extract raw secret key
+  size_t sk_len = 0;
+  ASSERT_TRUE(EVP_PKEY_get_raw_private_key(pkey.get(), nullptr, &sk_len));
+  std::vector<uint8_t> sk(sk_len);
+  ASSERT_TRUE(EVP_PKEY_get_raw_private_key(pkey.get(), sk.data(), &sk_len));
+
+  // Create a new key from raw secret key — no seed available
+  bssl::UniquePtr<EVP_PKEY> raw_pkey(
+      EVP_PKEY_kem_new_raw_secret_key(test.nid, sk.data(), sk_len));
+  ASSERT_TRUE(raw_pkey);
+  ASSERT_TRUE(raw_pkey->pkey.kem_key->seed == nullptr);
+
+  // Encode — should produce expanded format
+  bssl::ScopedCBB cbb;
+  ASSERT_TRUE(CBB_init(cbb.get(), 0));
+  ASSERT_TRUE(EVP_marshal_private_key(cbb.get(), raw_pkey.get()));
+
+  uint8_t *der = nullptr;
+  size_t der_len = 0;
+  ASSERT_TRUE(CBB_finish(cbb.get(), &der, &der_len));
+  bssl::UniquePtr<uint8_t> free_der(der);
+
+  // Verify expanded format: parse PKCS#8 and check for OCTET STRING tag
+  CBS pkcs8, algorithm, private_key, expanded_key;
+  uint64_t version = 0;
+  CBS_init(&pkcs8, der, der_len);
+  ASSERT_TRUE(CBS_get_asn1(&pkcs8, &pkcs8, CBS_ASN1_SEQUENCE));
+  ASSERT_TRUE(CBS_get_asn1_uint64(&pkcs8, &version));
+  ASSERT_TRUE(CBS_get_asn1(&pkcs8, &algorithm, CBS_ASN1_SEQUENCE));
+  ASSERT_TRUE(CBS_get_asn1(&pkcs8, &private_key, CBS_ASN1_OCTETSTRING));
+  ASSERT_TRUE(CBS_get_asn1(&private_key, &expanded_key, CBS_ASN1_OCTETSTRING));
+  ASSERT_EQ(CBS_len(&expanded_key), test.secret_key_len);
+}
+
+// Test that a generated key (seed format) can perform encaps/decaps correctly
+// after a serialize → parse round-trip.
+TEST_P(KEMTest, SeedFormatEncapsDecapsRoundTrip) {
+  const KEMTestVector &test = GetParam();
+
+  // Generate a key pair
+  bssl::UniquePtr<EVP_PKEY> pkey(generate_kem_key_pair(test.nid));
+  ASSERT_TRUE(pkey);
+
+  // Serialize (seed format) and parse back
+  bssl::ScopedCBB cbb;
+  ASSERT_TRUE(CBB_init(cbb.get(), 0));
+  ASSERT_TRUE(EVP_marshal_private_key(cbb.get(), pkey.get()));
+  uint8_t *der = nullptr;
+  size_t der_len = 0;
+  ASSERT_TRUE(CBB_finish(cbb.get(), &der, &der_len));
+  bssl::UniquePtr<uint8_t> free_der(der);
+
+  CBS cbs;
+  CBS_init(&cbs, der, der_len);
+  bssl::UniquePtr<EVP_PKEY> parsed_pkey(EVP_parse_private_key(&cbs));
+  ASSERT_TRUE(parsed_pkey);
+
+  // Encapsulate with the original key's public key
+  bssl::UniquePtr<EVP_PKEY_CTX> enc_ctx(EVP_PKEY_CTX_new(pkey.get(), nullptr));
+  ASSERT_TRUE(enc_ctx);
+  size_t ct_len = 0, ss_len = 0;
+  ASSERT_TRUE(EVP_PKEY_encapsulate(enc_ctx.get(), nullptr, &ct_len,
+                                   nullptr, &ss_len));
+  std::vector<uint8_t> ct(ct_len), ss_enc(ss_len);
+  ASSERT_TRUE(EVP_PKEY_encapsulate(enc_ctx.get(), ct.data(), &ct_len,
+                                   ss_enc.data(), &ss_len));
+
+  // Decapsulate with the parsed key
+  bssl::UniquePtr<EVP_PKEY_CTX> dec_ctx(
+      EVP_PKEY_CTX_new(parsed_pkey.get(), nullptr));
+  ASSERT_TRUE(dec_ctx);
+  std::vector<uint8_t> ss_dec(ss_len);
+  ASSERT_TRUE(EVP_PKEY_decapsulate(dec_ctx.get(), ss_dec.data(), &ss_len,
+                                   ct.data(), ct_len));
+
+  EXPECT_EQ(Bytes(ss_enc), Bytes(ss_dec));
 }
 
 

--- a/crypto/fipsmodule/evp/p_kem.c
+++ b/crypto/fipsmodule/evp/p_kem.c
@@ -108,6 +108,7 @@ static int pkey_kem_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey) {
   // Generate random seed, use deterministic keygen, and save the seed.
   // All ML-KEM variants use 64-byte seeds (d || z).
   uint8_t seed[64];
+  BSSL_CHECK(kem->keygen_seed_len == 64);
   RAND_bytes(seed, kem->keygen_seed_len);
 
   if (key == NULL ||

--- a/crypto/fipsmodule/evp/p_kem.c
+++ b/crypto/fipsmodule/evp/p_kem.c
@@ -5,6 +5,7 @@
 
 #include <openssl/err.h>
 #include <openssl/mem.h>
+#include <openssl/rand.h>
 
 #include "../crypto/evp_extra/internal.h"
 #include "internal.h"
@@ -72,7 +73,13 @@ static int pkey_kem_keygen_deterministic(EVP_PKEY_CTX *ctx,
   size_t secret_len = kem->secret_key_len;
   if (key == NULL ||
       !KEM_KEY_init(key, kem) ||
-      !kem->method->keygen_deterministic(key->public_key, &pubkey_len, key->secret_key, &secret_len, seed) ||
+      !kem->method->keygen_deterministic(key->public_key, &pubkey_len, key->secret_key, &secret_len, seed)) {
+    KEM_KEY_free(key);
+    return 0;
+  }
+
+  key->seed = OPENSSL_memdup(seed, kem->keygen_seed_len);
+  if (key->seed == NULL ||
       !EVP_PKEY_assign(pkey, EVP_PKEY_KEM, key)) {
     KEM_KEY_free(key);
     return 0;
@@ -97,9 +104,24 @@ static int pkey_kem_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey) {
   KEM_KEY *key = KEM_KEY_new();
   size_t pubkey_len = kem->public_key_len;
   size_t secret_len = kem->secret_key_len;
+
+  // Generate random seed, use deterministic keygen, and save the seed.
+  // All ML-KEM variants use 64-byte seeds (d || z).
+  uint8_t seed[64];
+  RAND_bytes(seed, kem->keygen_seed_len);
+
   if (key == NULL ||
       !KEM_KEY_init(key, kem) ||
-      !kem->method->keygen(key->public_key, &pubkey_len, key->secret_key, &secret_len) ||
+      !kem->method->keygen_deterministic(key->public_key, &pubkey_len,
+                                         key->secret_key, &secret_len, seed)) {
+    OPENSSL_cleanse(seed, sizeof(seed));
+    KEM_KEY_free(key);
+    return 0;
+  }
+
+  key->seed = OPENSSL_memdup(seed, kem->keygen_seed_len);
+  OPENSSL_cleanse(seed, sizeof(seed));
+  if (key->seed == NULL ||
       !EVP_PKEY_set_type(pkey, EVP_PKEY_KEM)) {
     KEM_KEY_free(key);
     return 0;

--- a/crypto/fipsmodule/kem/internal.h
+++ b/crypto/fipsmodule/kem/internal.h
@@ -19,11 +19,6 @@ typedef struct {
                               size_t *pkey_len,
                               const uint8_t *seed);
 
-  int (*keygen)(uint8_t *public_key,
-                size_t *public_key_len,
-                uint8_t *secret_key,
-                size_t *secret_key_len);
-
   int (*encaps_deterministic)(uint8_t *ciphertext,
                               size_t *ciphertext_len,
                               uint8_t *shared_secret,
@@ -63,6 +58,7 @@ struct kem_key_st {
   const KEM *kem;
   uint8_t *public_key;
   uint8_t *secret_key;
+  uint8_t *seed;
 };
 
 const KEM *KEM_find_kem_by_nid(int nid);

--- a/crypto/fipsmodule/kem/kem.c
+++ b/crypto/fipsmodule/kem/kem.c
@@ -25,13 +25,6 @@ static int ml_kem_1024_keygen_deterministic(uint8_t *public_key,
   return ml_kem_1024_keypair_deterministic(public_key, public_len, secret_key, secret_len, seed) == 0;
 }
 
-static int ml_kem_1024_keygen(uint8_t *public_key,
-                              size_t *public_len,
-                              uint8_t *secret_key,
-                              size_t *secret_len) {
-  return ml_kem_1024_keypair(public_key, public_len, secret_key, secret_len) == 0;
-}
-
 static int ml_kem_1024_encaps_deterministic(uint8_t *ciphertext,
                                             size_t *ciphertext_len,
                                             uint8_t *shared_secret,
@@ -58,7 +51,6 @@ static int ml_kem_1024_decaps(uint8_t *shared_secret,
 
 DEFINE_LOCAL_DATA(KEM_METHOD, kem_ml_kem_1024_method) {
   out->keygen_deterministic = ml_kem_1024_keygen_deterministic;
-  out->keygen = ml_kem_1024_keygen;
   out->encaps_deterministic = ml_kem_1024_encaps_deterministic;
   out->encaps = ml_kem_1024_encaps;
   out->decaps = ml_kem_1024_decaps;
@@ -70,13 +62,6 @@ static int ml_kem_768_keygen_deterministic(uint8_t *public_key,
                                            size_t *secret_len,
                                            const uint8_t *seed) {
   return ml_kem_768_keypair_deterministic(public_key, public_len, secret_key, secret_len, seed) == 0;
-}
-
-static int ml_kem_768_keygen(uint8_t *public_key,
-                             size_t *public_len,
-                             uint8_t *secret_key,
-                             size_t *secret_len) {
-  return ml_kem_768_keypair(public_key, public_len, secret_key, secret_len) == 0;
 }
 
 static int ml_kem_768_encaps_deterministic(uint8_t *ciphertext,
@@ -105,7 +90,6 @@ static int ml_kem_768_decaps(uint8_t *shared_secret,
 
 DEFINE_LOCAL_DATA(KEM_METHOD, kem_ml_kem_768_method) {
   out->keygen_deterministic = ml_kem_768_keygen_deterministic;
-  out->keygen = ml_kem_768_keygen;
   out->encaps_deterministic = ml_kem_768_encaps_deterministic;
   out->encaps = ml_kem_768_encaps;
   out->decaps = ml_kem_768_decaps;
@@ -117,13 +101,6 @@ static int ml_kem_512_keygen_deterministic(uint8_t *public_key,
                                            size_t *secret_len,
                                            const uint8_t *seed) {
   return ml_kem_512_keypair_deterministic(public_key, public_len, secret_key, secret_len, seed) == 0;
-}
-
-static int ml_kem_512_keygen(uint8_t *public_key,
-                             size_t *public_len,
-                             uint8_t *secret_key,
-                             size_t *secret_len) {
-  return ml_kem_512_keypair(public_key, public_len, secret_key, secret_len) == 0;
 }
 
 static int ml_kem_512_encaps_deterministic(uint8_t *ciphertext,
@@ -152,7 +129,6 @@ static int ml_kem_512_decaps(uint8_t *shared_secret,
 
 DEFINE_LOCAL_DATA(KEM_METHOD, kem_ml_kem_512_method) {
   out->keygen_deterministic = ml_kem_512_keygen_deterministic;
-  out->keygen = ml_kem_512_keygen;
   out->encaps_deterministic = ml_kem_512_encaps_deterministic;
   out->encaps = ml_kem_512_encaps;
   out->decaps = ml_kem_512_decaps;
@@ -226,8 +202,10 @@ static void KEM_KEY_clear(KEM_KEY *key) {
   key->kem = NULL;
   OPENSSL_free(key->public_key);
   OPENSSL_free(key->secret_key);
+  OPENSSL_free(key->seed);
   key->public_key = NULL;
   key->secret_key = NULL;
+  key->seed = NULL;
 }
 
 int KEM_KEY_init(KEM_KEY *key, const KEM *kem) {
@@ -349,6 +327,13 @@ int KEM_KEY_set_raw_keypair_from_seed(KEM_KEY *key, const CBS *seed) {
   // Set public and secret key
   key->public_key = public_key;
   key->secret_key = secret_key;
+
+  // Save a copy of the seed for seed-format encoding
+  key->seed = OPENSSL_memdup(CBS_data(seed), key->kem->keygen_seed_len);
+  if (key->seed == NULL) {
+    KEM_KEY_clear(key);
+    return 0;
+  }
 
   return 1;
 }


### PR DESCRIPTION
### Issues:
Addresses P409194150, #3140 

### Description of changes: 
Add seed field to KEM_KEY and make seed format the default PKCS#8
encoding for all ML-KEM private keys, mirroring the existing ML-DSA
pattern. This implements RFC 9935 seed format encoding.

Changes:
- Add uint8_t *seed to kem_key_st, preserved during all keygen paths
  and seed-format PKCS#8 import
- Rewrite pkey_kem_keygen to generate seed via RAND_bytes and call
  keygen_deterministic, so all generated keys retain their seed
- Save seed in pkey_kem_keygen_deterministic and
  KEM_KEY_set_raw_keypair_from_seed (decode path)
- Update kem_priv_encode to emit seed format ([0] IMPLICIT OCTET
  STRING) when seed is available, expanded format otherwise

Keys imported via raw expanded bytes (EVP_PKEY_kem_new_raw_secret_key)
continue to encode as expanded format since no seed is available.
EVP_PKEY_get_raw_private_key continues to return the expanded secret
key regardless of encoding format.

### Call-outs:
This changes the default output format of from the expanded key format to the seed format. There is a remote possibility that this is breaking for some customer that relies on the expanded format being output by AWS-LC and passing that key into some software stack that does not support seed format. Of all the major implementers (AWS-LC, BoringSSL, OpenSSL, BouncyCastle...) of RFC 9935, the consensus is to support importing from either format so we don't expect there to be any large scale regressions.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
