### PR TITLE
Fix Clang 19 GCC runtime detection on AL2023 aarch64

### DIFF
--- a/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
+++ b/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
@@ -75,6 +75,10 @@ tar -xf "${LLVM_ARCHIVE}" --strip-components=1 -C /opt/clang-19/
 ln -sf /opt/clang-19/bin/clang /usr/bin/clang-19
 ln -sf /opt/clang-19/bin/clang++ /usr/bin/clang++-19
 rm -f "${LLVM_ARCHIVE}"
+# The pre-built Clang 19 searches for GCC runtime files (crtbeginS.o, libgcc, etc.)
+# using standard triples like aarch64-linux-gnu or x86_64-linux-gnu, but Amazon Linux
+# uses its own triple (e.g. aarch64-amazon-linux). Create a symlink so Clang can find them.
+ln -sf /usr/lib/gcc/${arch}-amazon-linux /usr/lib/gcc/${arch}-linux-gnu
 EOF
 
 # Create compiler environment setup scripts (after all compilers are installed)


### PR DESCRIPTION
### Issues:
Follow-up to #3148

### Description of changes:
The pre-built Clang 19 for aarch64 can't find GCC runtime files (`crtbeginS.o`, `libgcc`, `libgcc_s`) on Amazon Linux 2023 because it searches under the standard `aarch64-linux-gnu` triple, but AL2023 installs GCC under `aarch64-amazon-linux`. This causes all Clang 19 builds to fail at link time on Graviton instances. The fix adds a symlink from the standard triple to the Amazon Linux one.

The x86_64 build is not affected (verified locally), but the symlink is created for both architectures as a safeguard since `${arch}` is already available in the same block.

### Testing:
Reproduced the linker failure locally in the aarch64 Docker image and confirmed the symlink resolves it. The sanitizer and SSL ASAN jobs in `linux_arm_omnibus.yml` and `linux-multi-arch-omnibus.yml` will exercise the fix end-to-end.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
