### PR TITLE
Add missing error return for short metadata keys

### DIFF
--- a/crypto/trust_token/trust_token.c
+++ b/crypto/trust_token/trust_token.c
@@ -486,6 +486,7 @@ int TRUST_TOKEN_ISSUER_set_metadata_key(TRUST_TOKEN_ISSUER *ctx,
                                         const uint8_t *key, size_t len) {
   if (len < 32) {
     OPENSSL_PUT_ERROR(TRUST_TOKEN, TRUST_TOKEN_R_INVALID_METADATA_KEY);
+    return 0;
   }
   OPENSSL_free(ctx->metadata_key);
   ctx->metadata_key_len = 0;

--- a/crypto/trust_token/trust_token_test.cc
+++ b/crypto/trust_token/trust_token_test.cc
@@ -1245,4 +1245,23 @@ INSTANTIATE_TEST_SUITE_P(TrustTokenAllBadKeyTest, TrustTokenBadKeyTest,
                                           testing::Values(0, 1, 2, 3, 4, 5)));
 
 }  // namespace
+
+TEST(TrustTokenTest, ShortMetadataKeyRejected) {
+  bssl::UniquePtr<TRUST_TOKEN_ISSUER> issuer(
+      TRUST_TOKEN_ISSUER_new(TRUST_TOKEN_experiment_v1(), 10));
+  ASSERT_TRUE(issuer);
+
+  // A 31-byte key must be rejected.
+  uint8_t short_key[31];
+  RAND_bytes(short_key, sizeof(short_key));
+  ASSERT_FALSE(TRUST_TOKEN_ISSUER_set_metadata_key(issuer.get(), short_key,
+                                                    sizeof(short_key)));
+
+  // A 32-byte key must be accepted.
+  uint8_t good_key[32];
+  RAND_bytes(good_key, sizeof(good_key));
+  ASSERT_TRUE(TRUST_TOKEN_ISSUER_set_metadata_key(issuer.get(), good_key,
+                                                   sizeof(good_key)));
+}
+
 BSSL_NAMESPACE_END


### PR DESCRIPTION
## Issue

t/V2168717713

## Description

`TRUST_TOKEN_ISSUER_set_metadata_key` sets an error via `OPENSSL_PUT_ERROR` when the key length is less than 32 bytes, but does not return 0. Execution falls through to accept and store the short key, returning success. This contradicts the documented API contract in `trust_token.h` which states the key must be at least 32 bytes.

## Changes

- Add the missing `return 0` after `OPENSSL_PUT_ERROR` in `TRUST_TOKEN_ISSUER_set_metadata_key` so short keys are properly rejected
- Add `ShortMetadataKeyRejected` test verifying that 31-byte keys are rejected and 32-byte keys are accepted

## Testing

- CI



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.