### PR TITLE
Fix Clang 19 C++ header detection on AL2023 aarch64

### DIFF
--- a/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
+++ b/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
@@ -76,9 +76,12 @@ ln -sf /opt/clang-19/bin/clang /usr/bin/clang-19
 ln -sf /opt/clang-19/bin/clang++ /usr/bin/clang++-19
 rm -f "${LLVM_ARCHIVE}"
 # The pre-built Clang 19 searches for GCC runtime files (crtbeginS.o, libgcc, etc.)
-# using standard triples like aarch64-linux-gnu or x86_64-linux-gnu, but Amazon Linux
-# uses its own triple (e.g. aarch64-amazon-linux). Create a symlink so Clang can find them.
+# and C++ platform headers using standard triples like aarch64-linux-gnu or
+# x86_64-linux-gnu, but Amazon Linux uses its own triple (e.g. aarch64-amazon-linux).
+# Create symlinks so Clang can find them.
 ln -sf /usr/lib/gcc/${arch}-amazon-linux /usr/lib/gcc/${arch}-linux-gnu
+gcc_version=$(ls /usr/lib/gcc/${arch}-amazon-linux/)
+ln -sf /usr/include/c++/${gcc_version}/${arch}-amazon-linux /usr/include/c++/${gcc_version}/${arch}-linux-gnu
 EOF
 
 # Create compiler environment setup scripts (after all compilers are installed)


### PR DESCRIPTION
### Issues:
Follow-up to #3150

### Description of changes:
The GCC runtime symlink from #3150 fixed linking, but the same triple mismatch also affects C++ platform headers. Clang 19 looks for `bits/c++config.h` under `/usr/include/c++/<version>/aarch64-linux-gnu/`, but on AL2023 it lives under `aarch64-amazon-linux`. This adds a second symlink for the C++ include directory, with the GCC version detected dynamically.

### Call-outs:
N/A

### Testing:
Reproduced the `bits/c++config.h` failure locally in the aarch64 Docker image and confirmed both symlinks together allow Clang 19 to compile and link successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
