### PR TITLE
Validate PBKDF2 iteration count before writing output

### DIFF
--- a/crypto/fipsmodule/pbkdf/pbkdf.c
+++ b/crypto/fipsmodule/pbkdf/pbkdf.c
@@ -26,6 +26,13 @@ int PKCS5_PBKDF2_HMAC(const char *password, size_t password_len,
   // state, so we lock the state here.
   FIPS_service_indicator_lock_state();
 
+  // RFC 8018 describes iterations (c) as being a "positive integer", so a
+  // value of 0 is an error. Validate before writing any output to avoid
+  // leaving insufficiently-derived key material in the caller's buffer.
+  if (iterations == 0) {
+    goto err;
+  }
+
   if (!HMAC_Init_ex(&hctx, password, password_len, digest, NULL)) {
     goto err;
   }
@@ -67,21 +74,6 @@ int PKCS5_PBKDF2_HMAC(const char *password, size_t password_len,
     key_len -= todo;
     out_key += todo;
     i++;
-  }
-
-  // RFC 8018 describes iterations (c) as being a "positive integer", so a
-  // value of 0 is an error.
-  //
-  // Unfortunately not all consumers of PKCS5_PBKDF2_HMAC() check their return
-  // value, expecting it to succeed and unconditionally using |out_key|.  As a
-  // precaution for such callsites in external code, the old behavior of
-  // iterations < 1 being treated as iterations == 1 is preserved, but
-  // additionally an error result is returned.
-  //
-  // TODO(eroman): Figure out how to remove this compatibility hack, or change
-  // the default to something more sensible like 2048.
-  if (iterations == 0) {
-    goto err;
   }
 
   ret = 1;

--- a/crypto/fipsmodule/pbkdf/pbkdf_test.cc
+++ b/crypto/fipsmodule/pbkdf/pbkdf_test.cc
@@ -136,15 +136,16 @@ TEST(PBKDFTest, ZeroIterations) {
   ASSERT_TRUE(PKCS5_PBKDF2_HMAC(kPassword, password_len, kSalt, salt_len,
                                 1 /* iterations */, digest, key_len, key));
 
-  // Flip the first key byte (so can later test if it got set).
-  const uint8_t expected_first_byte = key[0];
-  key[0] = ~key[0];
+  // Fill the buffer with a sentinel pattern before calling with iterations=0.
+  uint8_t sentinel[sizeof(key)];
+  OPENSSL_memset(sentinel, 0xAB, sizeof(sentinel));
+  OPENSSL_memcpy(key, sentinel, key_len);
 
-  // However calling it with iterations=0 fails.
+  // Calling with iterations=0 must fail.
   ASSERT_FALSE(PKCS5_PBKDF2_HMAC(kPassword, password_len, kSalt, salt_len,
                                  0 /* iterations */, digest, key_len, key));
 
-  // For backwards compatibility, the iterations == 0 case still fills in
-  // the out key.
-  EXPECT_EQ(expected_first_byte, key[0]);
+  // The output buffer must not be modified when iterations is 0, since the
+  // error is detected before any HMAC output is written.
+  EXPECT_EQ(0, OPENSSL_memcmp(key, sentinel, key_len));
 }


### PR DESCRIPTION
## Description

`PKCS5_PBKDF2_HMAC` writes HMAC output blocks to the caller's buffer before checking if the iteration count is zero. When `iterations==0`, the function writes a single HMAC block (`HMAC(password, salt||block_counter)`) to the output, then checks iterations and returns an error. If the caller neglects to check the return value, it may use this insufficiently-derived key material — effectively a key produced by a single HMAC operation rather than thousands of iterations.

## Changes

- Move the `iterations == 0` check before the HMAC loop so no output is written to the caller's buffer on error
- Remove the old compatibility hack comment and post-loop check
- Update the `ZeroIterations` test to verify the output buffer is untouched when `iterations` is 0 (uses a sentinel pattern)

## Testing

All 5 PBKDF2 tests pass with no regressions.

## Issue

V2168717713 (Finding #3)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.