### PR TITLE
Bound ReadConsoleW by stack buffer size

### DIFF
--- a/crypto/console/console.c
+++ b/crypto/console/console.c
@@ -279,8 +279,14 @@ int openssl_console_read(char *buf, int minsize, int maxsize, int echo) {
         WCHAR wresult[BUFSIZ];
         OPENSSL_cleanse(wresult, sizeof(wresult));
 
+        // Cap the read count to the wresult buffer size to prevent overflow.
+        DWORD read_count = (DWORD)maxsize;
+        if (read_count >= (sizeof(wresult) / sizeof(wresult[0]))) {
+          read_count = (sizeof(wresult) / sizeof(wresult[0])) - 1;
+        }
+
         if (ReadConsoleW(GetStdHandle(STD_INPUT_HANDLE),
-                     wresult, maxsize, &numread, NULL)) {
+                     wresult, read_count, &numread, NULL)) {
             if (numread >= 2 && wresult[numread-2] == L'\r' &&
                 wresult[numread-1] == L'\n') {
                 wresult[numread-2] = L'\n';


### PR DESCRIPTION

## Issue

V2168717713 (Finding 4)

## Description

In the Windows password-reading path, `ReadConsoleW` is called with the caller-supplied `maxsize` (up to `PEM_BUFSIZE` 1024) as the character count, but writes into a fixed-size stack buffer `WCHAR wresult[BUFSIZ]` where `BUFSIZ` is typically 512 on Windows. Since each `WCHAR` is 2 bytes, reading 1024 wide characters into a 512-element array overflows the stack buffer by up to 1024 bytes.

## Changes

- Cap the `ReadConsoleW` character count to `BUFSIZ - 1` (reserving one element for the null terminator) instead of using the caller-supplied `maxsize`

## Testing

This is Windows-only code behind `#if defined(OPENSSL_WINDOWS)` and the `is_a_tty` branch, so it cannot be exercised by the existing non-TTY test harness. The crypto library builds cleanly and all existing console tests pass.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.