### PR TITLE
Lower default SSL peek test rounds and remove CI workarounds

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -23,6 +23,8 @@ jobs:
   # MacOS and Windows GHA runners are more expensive, so we do a sanity test run before proceeding.
   sanity-test-run:
     runs-on: ubuntu-latest
+    env:
+      AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS: 100
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v3
@@ -92,8 +94,6 @@ jobs:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     runs-on: ${{ matrix.os }}
-    env:
-      AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS: 5
     strategy:
       fail-fast: false
       matrix:
@@ -576,10 +576,9 @@ jobs:
       - name: OpenBSD
         uses: cross-platform-actions/action@2d97d42e1972a17b045fd709a422f7e55a86230d
         env:
-          AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS: 5
           AWS_LC_GO_TEST_TIMEOUT: 120m
         with:
-          environment_variables: AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS AWS_LC_GO_TEST_TIMEOUT
+          environment_variables: AWS_LC_GO_TEST_TIMEOUT
           operating_system: openbsd
           cpu_count: 3
           memory: 12G
@@ -612,7 +611,6 @@ jobs:
             sudo usermod -L unlimited runner
             sudo su -c unlimited -s /usr/local/bin/bash -l runner <<EOF
             set -x
-            export AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS=${AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS}
             export AWS_LC_GO_TEST_TIMEOUT=${AWS_LC_GO_TEST_TIMEOUT}
             cd $(pwd)
             export PATH="${HOME}/bin:${PATH}"
@@ -712,12 +710,10 @@ jobs:
       - name: Prepare VM
         uses: cross-platform-actions/action@v0.32.0
         env:
-          AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS: 5
           AWS_LC_GO_TEST_TIMEOUT: 90m
-          AWS_LC_SSL_RUNNER_IDLE_TIMEOUT: 60s
           GOFLAGS: "-buildvcs=false"
         with:
-          environment_variables: "AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS AWS_LC_GO_TEST_TIMEOUT AWS_LC_SSL_RUNNER_IDLE_TIMEOUT GOFLAGS"
+          environment_variables: "AWS_LC_GO_TEST_TIMEOUT GOFLAGS"
           operating_system: freebsd
           architecture: ${{ matrix.arch }}
           version: ${{ matrix.version }}
@@ -747,11 +743,10 @@ jobs:
       - name: Prepare VM
         uses: cross-platform-actions/action@2d97d42e1972a17b045fd709a422f7e55a86230d
         env:
-          AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS: 5
           AWS_LC_GO_TEST_TIMEOUT: 90m
           GOFLAGS: "-buildvcs=false"
         with:
-          environment_variables: "AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS AWS_LC_GO_TEST_TIMEOUT GOFLAGS"
+          environment_variables: "AWS_LC_GO_TEST_TIMEOUT GOFLAGS"
           operating_system: netbsd
           architecture: ${{ matrix.arch }}
           version: ${{ matrix.version }}

--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -87,8 +87,6 @@ jobs:
   path-has-spaces:
     if: github.repository_owner == 'aws'
     runs-on: ${{ matrix.os }}
-    env:
-      AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS: 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -7,8 +7,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
-env:
-  AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS: 5
 permissions:
   contents: read
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1339,7 +1339,7 @@ else()
   set(GO_TEST_TIMEOUT "10m")
 endif()
 
-# Allow overriding the SSL test runner's idle timeout (default in runner.go is 15s).
+# Allow overriding the SSL test runner's idle timeout (default in runner.go is 30s).
 # Useful for resource-constrained environments (e.g. FreeBSD VMs) where the shim
 # may be slow to respond.
 if(DEFINED ENV{AWS_LC_SSL_RUNNER_IDLE_TIMEOUT})

--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -15760,10 +15760,12 @@ func addPeekTests() {
 //  3. Let Golang TLS client sends messages(len: |maxPlaintext * peek_rounds + 1|) to repeatedly test |SSL_peek|
 //     and |SSL_read|.
 //     Here, the peek_rounds is just a magic number used to test SSL_peek with more rounds.
-//     100 was used but it caused some tcp io timeout on macOS and OpenBSD. See below reference
+//     100 was used but it caused tcp i/o timeouts on macOS and OpenBSD, so it was reduced to 50.
+//     50 still caused timeouts on FreeBSD, Windows, NetBSD, and OpenBSD (see github.com/aws/aws-lc/issues/3141),
+//     so the default was lowered to 10. The env var override remains for stress testing.
 //     CryptoAlg-850?selectedConversation=8749cd07-dcec-44f1-8405-c22aad9fb306.
 func addServerPeekTests() {
-	const DEFAULT_PEEK_ROUNDS int = 50
+	const DEFAULT_PEEK_ROUNDS int = 10
 
 	peek_rounds := DEFAULT_PEEK_ROUNDS
 	if v := os.Getenv("AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS"); len(v) != 0 {

--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -61,7 +61,7 @@ var (
 	handshakerPath     = flag.String("handshaker-path", "../../../build/ssl/test/handshaker", "The location of the handshaker binary.")
 	fuzzer             = flag.Bool("fuzzer", false, "If true, tests against a BoringSSL built in fuzzer mode.")
 	transcriptDir      = flag.String("transcript-dir", "", "The directory in which to write transcripts.")
-	idleTimeout        = flag.Duration("idle-timeout", 15*time.Second, "The number of seconds to wait for a read or write to bssl_shim.")
+	idleTimeout        = flag.Duration("idle-timeout", 30*time.Second, "The number of seconds to wait for a read or write to bssl_shim.")
 	deterministic      = flag.Bool("deterministic", false, "If true, uses a deterministic PRNG in the runner.")
 	allowUnimplemented = flag.Bool("allow-unimplemented", false, "If true, report pass even if some tests are unimplemented.")
 	looseErrors        = flag.Bool("loose-errors", false, "If true, allow shims to report an untranslated error code.")

--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -15762,10 +15762,10 @@ func addPeekTests() {
 //     Here, the peek_rounds is just a magic number used to test SSL_peek with more rounds.
 //     100 was used but it caused tcp i/o timeouts on macOS and OpenBSD, so it was reduced to 50.
 //     50 still caused timeouts on FreeBSD, Windows, NetBSD, and OpenBSD (see github.com/aws/aws-lc/issues/3141),
-//     so the default was lowered to 10. The env var override remains for stress testing.
+//     so the default was lowered to 10, then further to 5. The env var override remains for stress testing.
 //     CryptoAlg-850?selectedConversation=8749cd07-dcec-44f1-8405-c22aad9fb306.
 func addServerPeekTests() {
-	const DEFAULT_PEEK_ROUNDS int = 10
+	const DEFAULT_PEEK_ROUNDS int = 5
 
 	peek_rounds := DEFAULT_PEEK_ROUNDS
 	if v := os.Getenv("AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS"); len(v) != 0 {


### PR DESCRIPTION
### Issues:
Resolves #3141

### Description of changes:

The SSL runner's `DEFAULT_PEEK_ROUNDS` of 50 has been causing i/o timeouts on non-Linux platforms for a while now. We've been working around this by setting `AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS=5` in CI for Windows, OpenBSD, FreeBSD, and NetBSD — but that leaves anyone building locally on those platforms hitting the same failures (#3141).

This lowers the default from 50 to 5 and removes all the per-job CI overrides. The `sanity-test-run` job (Linux, `ubuntu-latest`) now runs with `AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS=100` to provide stress-test coverage of the peek buffer drain/refill cycle on a platform that can comfortably handle it.

### Call-outs:

The peek test verifies the `SSL_peek → SSL_peek → SSL_read` state transition per TLS record. Each round exercises the same code path — the internal buffer fill/drain cycle through `ssl->s3->pending_app_data`. 5 rounds is sufficient for correctness; higher round counts only repeat the same transition and don't exercise additional code paths. The env var override remains available for targeted stress testing.

The `AWS_LC_SSL_TEST_RUNNER_PEEK_ROUNDS` env var support in `runner.go` and the `AWS_LC_SSL_RUNNER_IDLE_TIMEOUT` CMake plumbing are intentionally preserved as general-purpose knobs for slow environments or stress testing.

### Testing:

CI should pass without the per-platform peek rounds overrides. The FreeBSD, OpenBSD, NetBSD, and Windows jobs are the ones to watch. The `sanity-test-run` job validates the stress-test configuration at 100 rounds on Linux.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
