### PR TITLE
Reject invalid email name constraints per RFC 5280

### DIFF
--- a/crypto/x509/v3_ncons.c
+++ b/crypto/x509/v3_ncons.c
@@ -619,14 +619,24 @@ static int nc_email(const ASN1_IA5STRING *eml, const ASN1_IA5STRING *base) {
   CBS_init(&eml_cbs, eml->data, eml->length);
   CBS_init(&base_cbs, base->data, base->length);
 
-  // TODO(davidben): In OpenSSL 1.1.1, this switched from the first '@' to the
-  // last one. Match them here, or perhaps do an actual parse. Looks like
-  // multiple '@'s may be allowed in quoted strings.
   CBS eml_local, base_local;
   if (!CBS_get_until_first(&eml_cbs, &eml_local, '@')) {
     return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
   }
   int base_has_at = CBS_get_until_first(&base_cbs, &base_local, '@');
+  if (base_has_at && CBS_len(&base_local) == 0) {
+    // "@example.com" is not a valid constraint per RFC 5280.
+    return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
+  }
+  if (base_has_at) {
+    // Reject constraints with multiple '@' signs.
+    CBS base_rest = base_cbs;
+    CBS_skip(&base_rest, 1);  // skip past the first '@'
+    CBS unused;
+    if (CBS_get_until_first(&base_rest, &unused, '@')) {
+      return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
+    }
+  }
 
   // Special case: initial '.' is RHS match
   if (!base_has_at && starts_with(&base_cbs, '.')) {
@@ -638,8 +648,6 @@ static int nc_email(const ASN1_IA5STRING *eml, const ASN1_IA5STRING *base) {
 
   // If we have anything before '@' match local part
   if (base_has_at) {
-    // TODO(davidben): This interprets a constraint of "@example.com" as
-    // "example.com", which is not part of RFC5280.
     if (CBS_len(&base_local) > 0) {
       // Case sensitive match of local part
       if (!CBS_mem_equal(&base_local, CBS_data(&eml_local),

--- a/crypto/x509/x509_test.cc
+++ b/crypto/x509/x509_test.cc
@@ -2508,13 +2508,20 @@ TEST(X509Test, NameConstraints) {
        X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
       {GEN_EMAIL, "foo@example.com", "bar@example.com",
        X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
-      // OpenSSL ignores a stray leading @.
-      {GEN_EMAIL, "foo@example.com", "@example.com", X509_V_OK,
-       X509_V_ERR_EXCLUDED_VIOLATION},
-      {GEN_EMAIL, "foo@example.com", "@EXAMPLE.COM", X509_V_OK,
-       X509_V_ERR_EXCLUDED_VIOLATION},
+      // OpenSSL ignores a stray leading @. AWS-LC and BoringSSL do not.
+      {GEN_EMAIL, "foo@example.com", "@example.com",
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+      {GEN_EMAIL, "foo@example.com", "@EXAMPLE.COM",
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
       {GEN_EMAIL, "foo@bar.example.com", "@example.com",
-       X509_V_ERR_PERMITTED_VIOLATION, X509_V_OK},
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
+      // Multiple '@' in a constraint is invalid.
+      {GEN_EMAIL, "foo@example.com", "a@b@example.com",
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
+       X509_V_ERR_UNSUPPORTED_NAME_SYNTAX},
 
       // Basic syntax check.
       {GEN_URI, "not-a-url", "not-a-url", X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,


### PR DESCRIPTION
Upstream BoringSSL conformance fixes for email name constraints:
- https://boringssl-review.googlesource.com/c/boringssl/+/92067
- https://boringssl-review.googlesource.com/c/boringssl/+/90907

`nc_email` previously accepted `@example.com` as a name constraint, interpreting it as `example.com` (matching all emails at that domain). This is OpenSSL legacy behavior not permitted by RFC 5280. Additionally, constraints with multiple `@` signs (e.g. `a@b@example.com`) were not rejected and could produce incorrect matching results.

This change:
- Rejects `@example.com` (empty local part) as unsupported name syntax
- Rejects constraints containing multiple `@` as unsupported name syntax
- Removes stale TODO comments about these issues
- Updates test expectations to match the new behavior

`crypto_test --gtest_filter=X509Test.NameConstraint*` passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.