### PR TITLE
Fix Clang 19 C++ headers and LLVM tool version mismatches on AL2023

### DIFF
--- a/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
+++ b/.github/docker_images/aws-lc/amazonlinux/Dockerfile.al2023
@@ -89,6 +89,10 @@ COPY --from=scripts create-compiler-env.sh /tmp
 RUN <<EOF
 set -ex
 /tmp/create-compiler-env.sh
+# Ensure setup-clang-19.sh also prepends /opt/clang-19/bin to PATH so that
+# matching versions of llvm-ar, llvm-ranlib, llvm-symbolizer, etc. are used
+# instead of the system LLVM 15 versions.
+echo 'export PATH=/opt/clang-19/bin:$PATH' >> /opt/compiler-env/setup-clang-19.sh
 EOF
 
 # Install SSM Agent Config


### PR DESCRIPTION
### Issues:
Follow-up to #3152

### Description of changes:
The `setup-clang-19.sh` script sets `CC` and `CXX` but doesn't update `PATH`, so CMake still picks up `/usr/bin/llvm-ar` and `/usr/bin/llvm-ranlib` from the dnf-installed LLVM 15. These can't read object files produced by Clang 19 (`Unknown attribute kind (86) — Producer: 'LLVM19.1.7' Reader: 'LLVM 15.0.7'`). This appends `export PATH=/opt/clang-19/bin:$PATH` to the generated setup script so the matching LLVM 19 tools are found first.

### Testing:
Verified locally in the aarch64 Docker image that `which llvm-ar` resolves to `/opt/clang-19/bin/llvm-ar` after sourcing the updated script, and the ASAN build compiles and links successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
