### PR TITLE
Shard valgrind CI job to avoid GitHub Actions timeout

### DIFF
--- a/.github/workflows/linux-multi-arch-omnibus.yml
+++ b/.github/workflows/linux-multi-arch-omnibus.yml
@@ -396,17 +396,20 @@ jobs:
             ./tests/ci/run_prefix_tests.sh
 
   valgrind:
-    name: valgrind-${{ matrix.arch }}
+    name: valgrind-${{ matrix.arch }}-${{ matrix.shard }}
     runs-on:
       - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
         image:${{ matrix.arch == 'x86_64' && 'linux-5.0' || matrix.arch == 'aarch64' && 'arm-3.0' }}
         instance-size:large
     env:
       AWS_LC_GO_TEST_TIMEOUT: 60m
+      AWS_LC_VALGRIND_SHARD_INDEX: ${{ matrix.shard }}
+      AWS_LC_VALGRIND_TOTAL_SHARDS: 6
     strategy:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
+        shard: [0, 1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v5
       - name: Login to Amazon ECR
@@ -418,6 +421,8 @@ jobs:
           image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/amazonlinux:2023
           env: |
             AWS_LC_GO_TEST_TIMEOUT
+            AWS_LC_VALGRIND_SHARD_INDEX
+            AWS_LC_VALGRIND_TOTAL_SHARDS
           run: |
             source /opt/compiler-env/setup-gcc-11.sh
             ./tests/ci/run_valgrind_tests.sh

--- a/.github/workflows/linux-multi-arch-omnibus.yml
+++ b/.github/workflows/linux-multi-arch-omnibus.yml
@@ -404,6 +404,8 @@ jobs:
     env:
       AWS_LC_GO_TEST_TIMEOUT: 60m
       AWS_LC_VALGRIND_SHARD_INDEX: ${{ matrix.shard }}
+      # NOTE: TOTAL_SHARDS must equal the number of values in matrix.shard below.
+      # If they drift, some tests will silently never run.
       AWS_LC_VALGRIND_TOTAL_SHARDS: 6
     strategy:
       fail-fast: false

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -92,9 +92,10 @@ type test struct {
 }
 
 type result struct {
-	Test   test
-	Passed bool
-	Error  error
+	Test     test
+	Passed   bool
+	Error    error
+	Duration time.Duration
 }
 
 // Default list of CPU codes that are compatible with MSVC
@@ -233,6 +234,10 @@ func runTestOnce(test test, mallocNumToFail int64) (passed bool, err error) {
 	prog := filepath.Join(*buildDir, test.Cmd[0])
 	args := append([]string{}, test.Cmd[1:]...)
 
+	if *useValgrind && test.ValgrindFilter != "" {
+		args = append(args, "--gtest_filter="+test.ValgrindFilter)
+	}
+
 	var cmd *exec.Cmd
 	var cancel context.CancelFunc
 
@@ -365,8 +370,9 @@ func setWorkingDirectory() {
 func worker(tests <-chan test, results chan<- result, done *sync.WaitGroup) {
 	defer done.Done()
 	for test := range tests {
+		start := time.Now()
 		passed, err := runTest(test)
-		results <- result{test, passed, err}
+		results <- result{test, passed, err, time.Since(start)}
 	}
 }
 
@@ -530,34 +536,35 @@ func main() {
 		test := testResult.Test
 		args := test.Cmd
 
+		dur := testResult.Duration.Round(time.Second)
 		if testResult.Error == errTestSkipped {
-			fmt.Printf("%s\n", test.longName())
+			fmt.Printf("[%v] %s\n", dur, test.longName())
 			fmt.Printf("%s was skipped\n", args[0])
 			skipped = append(skipped, test)
 			testOutput.AddSkip(test.longName())
 		} else if testResult.Error == errTestHanging {
 			if !testResult.Passed {
-				fmt.Printf("%s\n", test.longName())
+				fmt.Printf("[%v] %s\n", dur, test.longName())
 				fmt.Printf("%s did not finish. Try increasing timeout.\n", args[0])
 				failed = append(failed, test)
 				testOutput.AddResult(test.longName(), "FAIL")
 			} else {
-				fmt.Printf("%s\n", test.shortName())
+				fmt.Printf("[%v] %s\n", dur, test.shortName())
 				fmt.Printf("%s was left hanging, but actually passed\n", args[0])
 				testOutput.AddResult(test.longName(), "PASS")
 			}
 		} else if testResult.Error != nil {
-			fmt.Printf("%s\n", test.longName())
+			fmt.Printf("[%v] %s\n", dur, test.longName())
 			fmt.Printf("%s failed to complete: %s\n", args[0], testResult.Error)
 			failed = append(failed, test)
 			testOutput.AddResult(test.longName(), "CRASH")
 		} else if !testResult.Passed {
-			fmt.Printf("%s\n", test.longName())
+			fmt.Printf("[%v] %s\n", dur, test.longName())
 			fmt.Printf("%s failed to print PASS on the last line.\n", args[0])
 			failed = append(failed, test)
 			testOutput.AddResult(test.longName(), "FAIL")
 		} else {
-			fmt.Printf("%s\n", test.shortName())
+			fmt.Printf("[%v] %s\n", dur, test.shortName())
 			testOutput.AddResult(test.longName(), "PASS")
 		}
 	}

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -43,16 +43,20 @@ var (
 	mallocTestDebug = flag.Bool("malloc-test-debug", false, "If true, ask each test to abort rather than fail a malloc. This can be used with a specific value for --malloc-test to identity the malloc failing that is causing problems.")
 )
 
-// Job-level sharding support. When AWS_LC_VALGRIND_TOTAL_SHARDS > 1 and
+// CI job-level sharding support. When AWS_LC_VALGRIND_TOTAL_SHARDS > 1 and
 // AWS_LC_VALGRIND_SHARD_INDEX is set, the expanded test list is partitioned
 // across multiple CI jobs so that each job completes in a fraction of the
 // original wall-clock time. For GTest-sharded tests (shard: true in
 // all_tests.json), the total number of GTest shards is multiplied by
-// jobTotalShards, and each job runs a contiguous block of numWorkers shards.
+// ciJobCount, and each job runs a contiguous block of numWorkers shards.
 // Non-sharded tests are distributed round-robin across jobs.
+//
+// This is distinct from numWorkers, which controls per-machine parallelism
+// (goroutines within a single job). ciJobCount controls how many separate
+// CI machines share the overall test workload.
 var (
-	jobShardIndex  int
-	jobTotalShards int
+	ciJobIndex int
+	ciJobCount int
 )
 
 func getEnvInt(name string, defaultVal int) int {
@@ -68,16 +72,16 @@ func getEnvInt(name string, defaultVal int) int {
 }
 
 func initJobSharding() {
-	jobShardIndex = getEnvInt("AWS_LC_VALGRIND_SHARD_INDEX", 0)
-	jobTotalShards = getEnvInt("AWS_LC_VALGRIND_TOTAL_SHARDS", 0)
+	ciJobIndex = getEnvInt("AWS_LC_VALGRIND_SHARD_INDEX", 0)
+	ciJobCount = getEnvInt("AWS_LC_VALGRIND_TOTAL_SHARDS", 0)
 
-	if jobTotalShards > 1 {
-		if jobShardIndex < 0 || jobShardIndex >= jobTotalShards {
+	if ciJobCount > 1 {
+		if ciJobIndex < 0 || ciJobIndex >= ciJobCount {
 			fmt.Printf("Invalid job shard config: AWS_LC_VALGRIND_SHARD_INDEX=%d, AWS_LC_VALGRIND_TOTAL_SHARDS=%d\n",
-				jobShardIndex, jobTotalShards)
+				ciJobIndex, ciJobCount)
 			os.Exit(1)
 		}
-		fmt.Printf("Job-level sharding enabled: shard %d of %d\n", jobShardIndex, jobTotalShards)
+		fmt.Printf("Job-level sharding enabled: job %d of %d\n", ciJobIndex, ciJobCount)
 	}
 }
 
@@ -421,8 +425,8 @@ func (t test) getGTestShards() ([]test, error) {
 	}
 
 	totalShards := *numWorkers
-	if jobTotalShards > 1 {
-		totalShards = *numWorkers * jobTotalShards
+	if ciJobCount > 1 {
+		totalShards = *numWorkers * ciJobCount
 	}
 
 	shards := make([]test, totalShards)
@@ -436,21 +440,21 @@ func (t test) getGTestShards() ([]test, error) {
 }
 
 // shouldRunInThisJob determines whether a test should be executed by the
-// current job shard. For GTest-sharded tests, each job gets a contiguous block
+// current CI job. For GTest-sharded tests, each job gets a contiguous block
 // of numWorkers shards. For non-sharded tests, they are distributed
 // round-robin across jobs.
 func shouldRunInThisJob(t test, nonShardedIdx *int) bool {
-	if jobTotalShards <= 1 {
+	if ciJobCount <= 1 {
 		return true
 	}
 	if t.numShards > 0 {
-		// Sharded test: each job gets shards [jobShardIndex*numWorkers, (jobShardIndex+1)*numWorkers)
-		return t.shard / *numWorkers == jobShardIndex
+		// Sharded test: each job gets shards [ciJobIndex*numWorkers, (ciJobIndex+1)*numWorkers)
+		return t.shard / *numWorkers == ciJobIndex
 	}
 	// Non-sharded test: distribute round-robin across jobs
 	idx := *nonShardedIdx
 	*nonShardedIdx++
-	return idx%jobTotalShards == jobShardIndex
+	return idx%ciJobCount == ciJobIndex
 }
 
 func main() {

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -43,6 +43,44 @@ var (
 	mallocTestDebug = flag.Bool("malloc-test-debug", false, "If true, ask each test to abort rather than fail a malloc. This can be used with a specific value for --malloc-test to identity the malloc failing that is causing problems.")
 )
 
+// Job-level sharding support. When AWS_LC_VALGRIND_TOTAL_SHARDS > 1 and
+// AWS_LC_VALGRIND_SHARD_INDEX is set, the expanded test list is partitioned
+// across multiple CI jobs so that each job completes in a fraction of the
+// original wall-clock time. For GTest-sharded tests (shard: true in
+// all_tests.json), the total number of GTest shards is multiplied by
+// jobTotalShards, and each job runs a contiguous block of numWorkers shards.
+// Non-sharded tests are distributed round-robin across jobs.
+var (
+	jobShardIndex  int
+	jobTotalShards int
+)
+
+func getEnvInt(name string, defaultVal int) int {
+	s := os.Getenv(name)
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return defaultVal
+	}
+	return v
+}
+
+func initJobSharding() {
+	jobShardIndex = getEnvInt("AWS_LC_VALGRIND_SHARD_INDEX", 0)
+	jobTotalShards = getEnvInt("AWS_LC_VALGRIND_TOTAL_SHARDS", 0)
+
+	if jobTotalShards > 1 {
+		if jobShardIndex < 0 || jobShardIndex >= jobTotalShards {
+			fmt.Printf("Invalid job shard config: AWS_LC_VALGRIND_SHARD_INDEX=%d, AWS_LC_VALGRIND_TOTAL_SHARDS=%d\n",
+				jobShardIndex, jobTotalShards)
+			os.Exit(1)
+		}
+		fmt.Printf("Job-level sharding enabled: shard %d of %d\n", jobShardIndex, jobTotalShards)
+	}
+}
+
 type test struct {
 	testconfig.Test
 
@@ -376,14 +414,37 @@ func (t test) getGTestShards() ([]test, error) {
 		return []test{t}, nil
 	}
 
-	shards := make([]test, *numWorkers)
+	totalShards := *numWorkers
+	if jobTotalShards > 1 {
+		totalShards = *numWorkers * jobTotalShards
+	}
+
+	shards := make([]test, totalShards)
 	for i := range shards {
 		shards[i] = t
 		shards[i].shard = i
-		shards[i].numShards = *numWorkers
+		shards[i].numShards = totalShards
 	}
 
 	return shards, nil
+}
+
+// shouldRunInThisJob determines whether a test should be executed by the
+// current job shard. For GTest-sharded tests, each job gets a contiguous block
+// of numWorkers shards. For non-sharded tests, they are distributed
+// round-robin across jobs.
+func shouldRunInThisJob(t test, nonShardedIdx *int) bool {
+	if jobTotalShards <= 1 {
+		return true
+	}
+	if t.numShards > 0 {
+		// Sharded test: each job gets shards [jobShardIndex*numWorkers, (jobShardIndex+1)*numWorkers)
+		return t.shard / *numWorkers == jobShardIndex
+	}
+	// Non-sharded test: distribute round-robin across jobs
+	idx := *nonShardedIdx
+	*nonShardedIdx++
+	return idx%jobTotalShards == jobShardIndex
 }
 
 func main() {
@@ -392,6 +453,9 @@ func main() {
 
 	// Initialize sdeCPUs now that flags are parsed
 	initSDECPUs()
+
+	// Initialize job-level sharding from environment variables
+	initJobSharding()
 
 	testCases, err := testconfig.ParseTestConfig("util/all_tests.json")
 	if err != nil {
@@ -409,6 +473,7 @@ func main() {
 	}
 
 	go func() {
+		nonShardedTestIdx := 0
 		for _, baseTest := range testCases {
 			test := test{Test: baseTest}
 
@@ -446,6 +511,9 @@ func main() {
 					os.Exit(1)
 				}
 				for _, shard := range shards {
+					if !shouldRunInThisJob(shard, &nonShardedTestIdx) {
+						continue
+					}
 					tests <- shard
 				}
 			}

--- a/util/all_tests.go
+++ b/util/all_tests.go
@@ -37,7 +37,7 @@ var (
 	sslTests        = flag.Bool("ssl-tests", true, "If true, run BoringSSL tests against libssl")
 	sdePath         = flag.String("sde-path", "sde", "The path to find the sde binary.")
 	buildDir        = flag.String("build-dir", "build", "The build directory to run the tests from.")
-	numWorkers      = flag.Int("num-workers", runtime.NumCPU(), "Runs the given number of workers when testing.")
+	numWorkers      = flag.Int("num-workers", defaultNumWorkers(), "Runs the given number of workers when testing.")
 	jsonOutput      = flag.String("json-output", "", "The file to output JSON results to.")
 	mallocTest      = flag.Int64("malloc-test", -1, "If non-negative, run each test with each malloc in turn failing from the given number onwards.")
 	mallocTestDebug = flag.Bool("malloc-test-debug", false, "If true, ask each test to abort rather than fail a malloc. This can be used with a specific value for --malloc-test to identity the malloc failing that is causing problems.")
@@ -58,6 +58,13 @@ var (
 	ciJobIndex int
 	ciJobCount int
 )
+
+func defaultNumWorkers() int {
+	if n := getEnvInt("AWS_LC_NUM_TEST_WORKERS", 0); n > 0 {
+		return n
+	}
+	return runtime.NumCPU()
+}
 
 func getEnvInt(name string, defaultVal int) int {
 	s := os.Getenv(name)
@@ -590,6 +597,27 @@ func main() {
 		fmt.Printf("\n%d of %d tests failed:\n", len(failed), len(testCases))
 		for _, test := range failed {
 			fmt.Printf("\t%s\n", test.shortName())
+		}
+		fmt.Printf("\nTo reproduce this failure locally, run with:\n")
+		fmt.Printf("  AWS_LC_NUM_TEST_WORKERS=%d", *numWorkers)
+		if ciJobCount > 1 {
+			fmt.Printf(" AWS_LC_VALGRIND_SHARD_INDEX=%d AWS_LC_VALGRIND_TOTAL_SHARDS=%d", ciJobIndex, ciJobCount)
+		}
+		fmt.Printf(" go run util/all_tests.go -build-dir <build-dir>")
+		if *useValgrind {
+			fmt.Printf(" -valgrind")
+		}
+		fmt.Printf("\n")
+		for _, test := range failed {
+			if test.numShards > 0 {
+				fmt.Printf("\nTo run the failing shard directly:\n")
+				fmt.Printf("  GTEST_TOTAL_SHARDS=%d GTEST_SHARD_INDEX=%d", test.numShards, test.shard)
+				if *useValgrind {
+					fmt.Printf(" valgrind")
+				}
+				fmt.Printf(" ./<build-dir>/%s\n", test.Cmd[0])
+				break
+			}
 		}
 		os.Exit(1)
 	}

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -2,6 +2,7 @@
   {
     "cmd": ["crypto/crypto_test"],
     "valgrind_supp": ["valgrind_suppressions_crypto_test.supp"],
+    "valgrind_filter": "-DigestTest.InitAndGetState*Large",
     "shard": true
   },
   {

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -2,7 +2,6 @@
   {
     "cmd": ["crypto/crypto_test"],
     "valgrind_supp": ["valgrind_suppressions_crypto_test.supp"],
-    "valgrind_filter": "-DigestTest.InitAndGetState*Large",
     "shard": true
   },
   {

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -149,8 +149,10 @@
     ]
   },
   {
+    "comment": "tool_openssl_test generates 100+ RSA keys across its test suite (ca_test, req_test, genrsa_test, etc.). Sharding is required to keep Valgrind runtime manageable.",
     "cmd": [
       "tool-openssl/tool_openssl_test"
-    ]
+    ],
+    "shard": true
   }
 ]

--- a/util/testconfig/testconfig.go
+++ b/util/testconfig/testconfig.go
@@ -9,13 +9,14 @@ import (
 )
 
 type Test struct {
-	Cmd          []string `json:"cmd"`
-	Env          []string `json:"env"`
-	SkipSDE      bool     `json:"skip_sde"`
-	SkipValgrind bool     `json:"skip_valgrind"`
-	ValgrindSupp []string `json:"valgrind_supp"`
-	TargetArch   string   `json:"target_arch"`
-	Shard        bool     `json:"shard"`
+	Cmd            []string `json:"cmd"`
+	Env            []string `json:"env"`
+	SkipSDE        bool     `json:"skip_sde"`
+	SkipValgrind   bool     `json:"skip_valgrind"`
+	ValgrindSupp   []string `json:"valgrind_supp"`
+	ValgrindFilter string   `json:"valgrind_filter"`
+	TargetArch     string   `json:"target_arch"`
+	Shard          bool     `json:"shard"`
 }
 
 func ParseTestConfig(filename string) ([]Test, error) {


### PR DESCRIPTION
### Description of changes:

The `valgrind-x86_64` job in `linux-multi-arch-omnibus` is frequently timing out. When successful it barely squeaks by at [2:53:48](https://github.com/aws/aws-lc/actions/runs/24212207410/job/70683671713), and it recently [timed out at 3:09:21](https://github.com/aws/aws-lc/actions/runs/24211552799/job/70681415264) (GitHub's default job timeout is 6 hours, but CodeBuild has a 3-hour limit).

This PR adds job-level sharding to `util/all_tests.go` so the valgrind work can be split across multiple parallel CI jobs. Two new environment variables control this: `AWS_LC_VALGRIND_SHARD_INDEX` and `AWS_LC_VALGRIND_TOTAL_SHARDS`. The workflow now runs 6 shards per architecture instead of 1.

### Call-outs:

The sharding works by multiplying the GTest shard count by the number of job shards. With 8 cores and 6 job shards, `crypto/crypto_test` gets 48 GTest shards total instead of 8. Each CI job runs a contiguous block of 8 shards on its local cores, so each shard covers 1/48th of the test cases instead of 1/8th. This brings individual job runtime from ~3 hours down to ~30 minutes.

When the env vars are unset, `all_tests.go` behaves identically to before — no existing usage is affected.

The shard count is easy to tune: just change the `shard` matrix list and `AWS_LC_VALGRIND_TOTAL_SHARDS` value in the workflow.

### Testing:

The `all_tests.go` change is exercised by the valgrind CI jobs themselves. The sharding logic can also be verified locally by setting the environment variables and confirming that `all_tests.go` partitions the test list correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
