### PR TITLE
Bump minimum Go version to 1.20 and update Go dependencies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,11 +14,11 @@ permissions:
   contents: read
 
 jobs:
-  go-version-1_17_13:
+  go-version-1_20:
     if: github.repository_owner == 'aws'
     env:
       GOROOT: "/usr/local/go"
-      GO_ARCHIVE: "go1.17.13.linux-amd64.tar.gz"
+      GO_ARCHIVE: "go1.20.linux-amd64.tar.gz"
     runs-on: ubuntu-latest
     steps:
       - name: Install OS Dependencies

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ If in doubt, use the most recent stable version of each build tool.
     `PERL_EXECUTABLE`.
     * To build without Perl (not recommended) see [this section.](#using-pre-generated-build-files)
 
-  * [Go](https://golang.org/dl/) 1.17.13 or later is required. If not found by
+  * [Go](https://golang.org/dl/) 1.20 or later is required. If not found by
     CMake, the go executable may be configured explicitly by setting
     `GO_EXECUTABLE`.
     * To build without Go (not recommended) see [this section.](#using-pre-generated-build-files)

--- a/cmake/go.cmake
+++ b/cmake/go.cmake
@@ -14,7 +14,7 @@ elseif(NOT DISABLE_GO)
   string(REGEX MATCH "([0-9]+\\.)*[0-9]+" go_version ${go_version_output})
 
   # This should track /go.mod and /BUILDING.md
-  set(minimum_go_version "1.17.13")
+  set(minimum_go_version "1.20")
   if(go_version VERSION_LESS minimum_go_version)
     message(FATAL_ERROR "Go compiler version must be at least ${minimum_go_version}. Found version ${go_version}")
   else()

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module github.com/aws/aws-lc
 
 // When this changes update /cmake/go.cmake minimum_go_version and /BUILDING.md
-go 1.17
+go 1.20
 
-// v0.14.0 was the last version that support 1.17
-require golang.org/x/crypto v0.14.0
+require golang.org/x/crypto v0.31.0
 
 require (
-	golang.org/x/sys v0.13.0 // indirect
-	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/term v0.27.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
-golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
-golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
+golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=


### PR DESCRIPTION
### Issues:
Addresses 
* #2856

### Description of changes:
The minimum Go version was pinned at 1.17, which forced `golang.org/x/crypto` to stay at v0.14.0 (the last version supporting Go 1.17). This bumps the minimum to Go 1.20 and updates the Go dependencies to current versions:

- `golang.org/x/crypto` v0.14.0 → v0.31.0
- `golang.org/x/sys` v0.13.0 → v0.28.0
- `golang.org/x/term` v0.13.0 → v0.27.0

The minimum version is updated consistently across `go.mod`, `BUILDING.md`, and `cmake/go.cmake`. The Go compatibility CI job is also updated to test against 1.20 instead of 1.17.13.

### Call-outs:
Dependabot opened #2856 which bumps `golang.org/x/crypto` to v0.45.0, requiring Go 1.24. This is a more conservative alternative that raises the floor to 1.20 — enough to unpin the `golang.org/x` dependencies without requiring a very recent Go toolchain.

### Testing:
Existing CI covers this. The `go.yml` workflow has been updated to test against the new minimum version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
