### PR TITLE
Fix intermittent CA test failure on Windows CI when TEMP is unset

### DIFF
--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -182,11 +182,42 @@ bool PEM_to_DER(const char *pem_str, uint8_t **out_der, long *out_der_len) {
 }
 
 #if defined(OPENSSL_WINDOWS)
+// GetTempPathA falls back to the Windows directory (e.g. C:\Windows\) when the
+// TMP, TEMP, and USERPROFILE environment variables are all unset. This commonly
+// happens when running as SYSTEM in Docker containers or CI agents. The Windows
+// directory has special protections that cause file rename operations to fail
+// intermittently. Detect this case and redirect to C:\Windows\Temp\ instead.
+static DWORD GetSafeTempPathA(DWORD nBufferLength, LPSTR lpBuffer) {
+  DWORD ret = GetTempPathA(nBufferLength, lpBuffer);
+  if (ret == 0 || ret >= nBufferLength) {
+    return ret;
+  }
+  char win_dir[PATH_MAX];
+  UINT win_len = GetWindowsDirectoryA(win_dir, sizeof(win_dir));
+  if (win_len == 0 || win_len >= sizeof(win_dir)) {
+    return ret;
+  }
+  // Append trailing backslash to match GetTempPathA's format for comparison.
+  if (win_len + 1 >= sizeof(win_dir)) {
+    return ret;
+  }
+  win_dir[win_len] = '\\';
+  win_dir[win_len + 1] = '\0';
+  if (_stricmp(lpBuffer, win_dir) == 0) {
+    int written = snprintf(lpBuffer, nBufferLength, "%sTemp\\", win_dir);
+    if (written < 0 || (DWORD)written >= nBufferLength) {
+      return 0;
+    }
+    ret = (DWORD)written;
+  }
+  return ret;
+}
+
 size_t createTempFILEpath(char buffer[PATH_MAX]) {
   // On Windows, tmpfile() may attempt to create temp files in the root directory
   // of the drive, which requires Admin privileges, resulting in test failure.
   char pathname[PATH_MAX];
-  if(0 == GetTempPathA(PATH_MAX, pathname)) {
+  if(0 == GetSafeTempPathA(PATH_MAX, pathname)) {
     return 0;
   }
   return GetTempFileNameA(pathname, "awslctest", 0, buffer);
@@ -200,7 +231,7 @@ size_t createTempDirPath(char buffer[PATH_MAX]) {
   } random_bytes;
 
   // Get the temporary path
-  if (0 == GetTempPathA(PATH_MAX, temp_path)) {
+  if (0 == GetSafeTempPathA(PATH_MAX, temp_path)) {
     return 0;
   }
 

--- a/tool-openssl/ca.cc
+++ b/tool-openssl/ca.cc
@@ -126,16 +126,15 @@ static int WIN32_rename(const char *from, const char *to) {
     if (attempt > 0) {
       Sleep(kRetryDelayMs);
     }
-    if (MoveFile(tfrom, tto)) {
+    // Use MoveFileEx with MOVEFILE_REPLACE_EXISTING to match POSIX rename()
+    // semantics: atomically replace the target if it already exists. Plain
+    // MoveFile fails with ERROR_ALREADY_EXISTS when the target exists, and the
+    // previous DeleteFile+MoveFile workaround was racy because NTFS defers
+    // file removal until all handles are closed ("pending delete" state).
+    if (MoveFileEx(tfrom, tto, MOVEFILE_REPLACE_EXISTING)) {
       goto ok;
     }
     err = GetLastError();
-    if (err == ERROR_ALREADY_EXISTS || err == ERROR_FILE_EXISTS) {
-      if (DeleteFile(tto) && MoveFile(tfrom, tto)) {
-        goto ok;
-      }
-      err = GetLastError();
-    }
     if (err != ERROR_ACCESS_DENIED && err != ERROR_SHARING_VIOLATION &&
         err != ERROR_LOCK_VIOLATION) {
       break;
@@ -149,7 +148,7 @@ static int WIN32_rename(const char *from, const char *to) {
     errno = EACCES;
   } else {
     errno = EINVAL;
-    fprintf(stderr, "WIN32_rename: MoveFile('%s', '%s') failed with Windows "
+    fprintf(stderr, "WIN32_rename: MoveFileEx('%s', '%s') failed with Windows "
             "error code %lu\n", from, to, (unsigned long)err);
   }
 err:

--- a/tool-openssl/ca_test.cc
+++ b/tool-openssl/ca_test.cc
@@ -84,8 +84,14 @@ class CATest : public ::testing::Test {
     RemoveFile(db_old_path.c_str());
     std::string db_attr_old_path = std::string(db_path) + ".attr.old";
     RemoveFile(db_attr_old_path.c_str());
+    std::string db_new_path = std::string(db_path) + ".new";
+    RemoveFile(db_new_path.c_str());
+    std::string db_attr_new_path = std::string(db_path) + ".attr.new";
+    RemoveFile(db_attr_new_path.c_str());
     std::string serial_old_path = std::string(serial_path) + ".old";
     RemoveFile(serial_old_path.c_str());
+    std::string serial_new_path = std::string(serial_path) + ".new";
+    RemoveFile(serial_new_path.c_str());
 
     // Clean up temp directory and its contents
     CleanupTempDir(new_certs_dir);


### PR DESCRIPTION
### Description of changes:

CA tests (`CATest.DatabaseWithRevokedEntryBasicTimestamp`, `CATest.CustomEndDate`, etc.) fail intermittently on the `windows-ltsc2022_sde-x86_64` CI job due to two issues with `WIN32_rename`:

1. **Temp files landing in `C:\Windows\`**: `GetTempPathA` falls back to the Windows directory when `TMP`, `TEMP`, and `USERPROFILE` are all unset — which is the case when running as SYSTEM in our Docker-based CI. This introduces a `GetSafeTempPathA` wrapper that detects the fallback and redirects to `C:\Windows\Temp\` instead.

2. **NTFS pending-delete race in `WIN32_rename`**: The `DeleteFile` + `MoveFile` workaround for `ERROR_ALREADY_EXISTS` is racy. NTFS defers file removal until all handles are closed, so `DeleteFile` can return success while the file is still visible. The subsequent `MoveFile` fails with `ERROR_ALREADY_EXISTS` (183), which wasn't in the retryable error set, so the retry budget was never used. Replaced with `MoveFileEx` using `MOVEFILE_REPLACE_EXISTING`, which atomically replaces the target — matching POSIX `rename()` semantics.

### Call-outs:

`CATest::TearDown` was missing cleanup of `.new` and `.attr.new` files. These get left behind when a test fails between `SaveIndex` and `RotateIndex`. Added while in here.

See failure [here](https://github.com/aws/aws-lc/actions/runs/24354082397/job/71116230692?pr=2934#step:4:3018).

### Testing:

Existing CA tests cover this path. The fix should be verified by the `windows-ltsc2022_sde-x86_64` job no longer failing intermittently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
