### PR TITLE
Generalize SSL test runner idle-timeout retry to all tests

### DIFF
--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -1660,9 +1660,26 @@ func runTest(dispatcher *shimDispatcher, statusChan chan statusMsg, test *testCa
 	localErr := doExchanges(test, shim, resumeCount, &transcripts)
 	childErr := shim.wait()
 
-	// shim is marked as idled only when |idleTimeout| is reached.
-	// This retry fix is scoped with "InvalidChannelIDSignature-TLS13-TLS-Sync-SplitHandshakeRecords".
-	if shim.idled && test.name == "InvalidChannelIDSignature-TLS13-TLS-Sync-SplitHandshakeRecords" {
+	// Determine if the test should be retried. shim.idled is set when the
+	// idle timeout kills the process. A child killed by a transient signal
+	// (SIGABRT, SIGKILL, SIGTERM, SIGPIPE) on resource-constrained CI is
+	// also typically caused by timing or resource contention. Retry once in
+	// either case; a real bug will fail again on the retry.
+	//
+	// Signals like SIGSEGV, SIGBUS, SIGFPE, and SIGILL indicate real bugs
+	// (memory safety, illegal instructions, etc.) and must not be retried.
+	shouldRetry := shim.idled
+	if !shouldRetry {
+		if exitErr, ok := childErr.(*exec.ExitError); ok {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+				switch status.Signal() {
+				case syscall.SIGABRT, syscall.SIGKILL, syscall.SIGTERM, syscall.SIGPIPE:
+					shouldRetry = true
+				}
+			}
+		}
+	}
+	if shouldRetry {
 		shim, err := newShimProcess(dispatcher, shimPath, flags, env)
 		if err != nil {
 			return err

--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -1668,18 +1668,19 @@ func runTest(dispatcher *shimDispatcher, statusChan chan statusMsg, test *testCa
 	//
 	// Signals like SIGSEGV, SIGBUS, SIGFPE, and SIGILL indicate real bugs
 	// (memory safety, illegal instructions, etc.) and must not be retried.
-	shouldRetry := shim.idled
-	if !shouldRetry {
-		if exitErr, ok := childErr.(*exec.ExitError); ok {
-			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
-				switch status.Signal() {
-				case syscall.SIGABRT, syscall.SIGKILL, syscall.SIGTERM, syscall.SIGPIPE:
-					shouldRetry = true
-				}
+	var retryReason string
+	if shim.idled {
+		retryReason = "idle timeout"
+	} else if exitErr, ok := childErr.(*exec.ExitError); ok {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			switch status.Signal() {
+			case syscall.SIGABRT, syscall.SIGKILL, syscall.SIGTERM, syscall.SIGPIPE:
+				retryReason = fmt.Sprintf("signal: %s", status.Signal())
 			}
 		}
 	}
-	if shouldRetry {
+	if retryReason != "" {
+		fmt.Fprintf(os.Stderr, "Retrying %s (%s)\n", test.name, retryReason)
 		shim, err := newShimProcess(dispatcher, shimPath, flags, env)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Description of changes:
Several SSL runner tests sporadically fail on CI when the shim process doesn't respond in time or crashes under resource contention. The existing retry logic only handled a single hard-coded test name (`InvalidChannelIDSignature-TLS13-TLS-Sync-SplitHandshakeRecords`). This broadens the retry to cover two cases:

1. **Idle timeout** (`shim.idled`): the process didn't exit within the 30-second idle timeout and was killed (SIGKILL).
2. **Transient signal death**: the child was killed by SIGABRT, SIGKILL, SIGTERM, or SIGPIPE — signals typically caused by resource contention or timing issues rather than bugs.

Signals like SIGSEGV, SIGBUS, SIGFPE, and SIGILL are explicitly *not* retried, as these indicate real bugs (memory safety issues, illegal instructions, etc.).

Examples of sporadic failures this addresses:
- [`ChannelID-ECDHE-TLS12-TLS-Async-ImplicitHandshake-Hints`](https://github.com/aws/aws-lc/actions/runs/24160287048/job/70509700653#step:4:4430)
- [`Server-VerifyDefault-ECDSA_P224_SHA256-TLS12-Split`](https://github.com/aws/aws-lc/actions/runs/24207954652/job/70668735540#step:4:2782)
- [`SendV2ClientHello-33-TLS-Sync-SplitHandshakeRecords`](https://github.com/aws/aws-lc/actions/runs/24352380967/job/71110278282#step:4:1110)
- [`ALPS-WrongServerCodepoint-Client-New-QUIC-TLS13`](https://github.com/aws/aws-lc/actions/runs/23861472160/job/69569031111#step:4:4409)
- [`CertificateVerificationPassesOnResume-Client-TLS13-CustomCallback-TLS-Async-SplitHandshakeRecords`](https://github.com/aws/aws-lc/actions/runs/24363908657/job/71150491984?pr=3163#step:4:1112)

### Call-outs:
The retry is limited to a single attempt. If the failure is caused by a real bug rather than transient CI issues, the retry will also fail and the test is still reported as failed.

### Testing:
Relying on existing CI coverage. The change only affects the retry path in the test runner, not any test logic or cryptographic code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
