### PR TITLE
[FIPS 2024]  Disable SLP vectorizer for FIPS shared library builds on GCC 14+ (#2977 CHERRY-PICK)

### DIFF
--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -476,6 +476,18 @@ elseif(FIPS_SHARED)
   add_dependencies(bcm_library boringssl_prefix_symbols)
   target_include_directories(bcm_library BEFORE PRIVATE ${PROJECT_BINARY_DIR}/symbol_prefix_include)
   target_include_directories(bcm_library PRIVATE ${PROJECT_SOURCE_DIR}/include)
+
+  # On GCC 14+ the Superword Level Parallelism (SLP) vectorizer causes the
+  # compiler to aggressively store static function pointer addresses in the
+  # .data.rel.ro.local section which is discarded by our linker script and
+  # results in undefined references when linking libcrypto.
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND
+     CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "14" AND
+     CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+     ARCH STREQUAL "x86_64")
+    target_compile_options(bcm_library PRIVATE -fno-tree-slp-vectorize)
+  endif()
+
   if (APPLE)
     set(BCM_NAME bcm.o)
     # The linker on macOS doesn't have the ability to process linker scripts,


### PR DESCRIPTION
### Description of changes:

Cherry-pick of #2977 onto `fips-2024-09-27`. On GCC 14+, the SLP vectorizer causes the compiler to emit static function pointer addresses into `.data.rel.ro.local`, which is discarded by our FIPS linker script, resulting in undefined references when linking `libcrypto` as a shared library. This change adds `-fno-tree-slp-vectorize` for `bcm_library` on GCC 14+ / Linux / x86_64 only. This is a no-op for any compiler or platform combination that currently builds successfully — it only fixes configurations that were previously broken.

The cherry-pick had merge conflicts in two files due to divergence between `main` and `fips-2024-09-27`.

**`crypto/fipsmodule/CMakeLists.txt`**: The `fips-2024-09-27` branch uses the older `bcm_library` target setup. Resolution keeps the existing target configuration and applies the new `-fno-tree-slp-vectorize` workaround on top of it.

**`.github/workflows/actions-ci.yml`**: The `fips-2024-09-27` branch has the older per-distro sanity job structure rather than `main`'s consolidated `compiler-tests` job. Resolution keeps the existing CI structure. The `shared`/`BUILD_SHARED_LIBS` matrix dimension that was part of #2977's CI changes on `main` is not carried over here.

### Testing:

Existing CI on the `fips-2024-09-27` branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
