### PR TITLE
Fix FIPS build under MSAN by broadening integrity-test guards

### DIFF
--- a/.github/workflows/linux-multi-arch-omnibus.yml
+++ b/.github/workflows/linux-multi-arch-omnibus.yml
@@ -194,7 +194,7 @@ jobs:
             ./tests/ci/run_posix_tests.sh
 
   fips_tests:
-    name: ${{ matrix.enableASAN && 'asan-' || '' }}fips-tests-${{ matrix.image }}-${{ matrix.compiler }}-${{ matrix.arch }}
+    name: ${{ matrix.enableASAN && 'asan-' || '' }}${{ matrix.enableMSAN && 'msan-' || '' }}fips-tests-${{ matrix.image }}-${{ matrix.compiler }}-${{ matrix.arch }}
     runs-on:
       - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
         image:${{ matrix.arch == 'x86_64' && 'linux-5.0' || matrix.arch == 'aarch64' && 'arm-3.0' }}
@@ -315,6 +315,10 @@ jobs:
           - image: ubuntu:22.04
             arch: x86_64
             compiler: clang-14
+          - image: amazonlinux:2023
+            arch: x86_64
+            compiler: clang-19
+            enableMSAN: 1
           - image: ubuntu:22.04
             arch: x86_64
             compiler: gcc-10
@@ -349,6 +353,7 @@ jobs:
             compiler: gcc-12
     env:
       AWSLC_ENABLE_FIPS_ASAN: ${{ matrix.enableASAN }}
+      AWSLC_ENABLE_FIPS_MSAN: ${{ matrix.enableMSAN }}
     steps:
       - uses: actions/checkout@v5
       - name: Login to Amazon ECR
@@ -360,6 +365,7 @@ jobs:
           image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/${{ matrix.image }}
           env: |
             AWSLC_ENABLE_FIPS_ASAN
+            AWSLC_ENABLE_FIPS_MSAN
           run: |
             source /opt/compiler-env/setup-${{ matrix.compiler }}.sh
             if [[ "${{ matrix.goTestTimeout }}z" != "z" ]]; then

--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -106,7 +106,7 @@ TEST(CryptoTest, FIPSdownstreamPrecompilationFlag) {
 }
 #endif // defined(BORINGSSL_FIPS)
 
-#if defined(BORINGSSL_FIPS) && !defined(OPENSSL_ASAN)
+#if defined(BORINGSSL_FIPS) && !defined(OPENSSL_ASAN) && !defined(OPENSSL_MSAN)
 TEST(Crypto, OnDemandIntegrityTest) {
   BORINGSSL_integrity_test();
 }

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -156,7 +156,7 @@
 
 #if defined(BORINGSSL_FIPS)
 
-#if !defined(OPENSSL_ASAN)
+#if !defined(OPENSSL_ASAN) && !defined(OPENSSL_MSAN)
 
 static const void* function_entry_ptr(const void* func_sym) {
 #if defined(OPENSSL_PPC64BE)
@@ -243,7 +243,7 @@ static void BORINGSSL_maybe_set_module_text_permissions(int permission) {
 static void BORINGSSL_maybe_set_module_text_permissions(int _permission) {}
 #endif  // !ANDROID
 
-#endif  // !ASAN
+#endif  // !ASAN && !MSAN
 
 #if defined(AWSLC_FIPS_FAILURE_CALLBACK)
 #if defined(__ELF__) && defined(__GNUC__)
@@ -271,20 +271,21 @@ static void BORINGSSL_bcm_power_on_self_test(void) {
     AWS_LC_FIPS_failure("CPU Jitter entropy RNG initialization failed");
   }
 
-#if !defined(OPENSSL_ASAN)
-  // Integrity tests cannot run under ASAN because it involves reading the full
-  // .text section, which triggers the global-buffer overflow detection.
+#if !defined(OPENSSL_ASAN) && !defined(OPENSSL_MSAN)
+  // Integrity tests cannot run under ASAN or MSAN because it involves reading
+  // the full .text section, which triggers the global-buffer overflow detection
+  // (ASAN) or use of uninstrumented code (MSAN).
   if (!BORINGSSL_integrity_test()) {
     AWS_LC_FIPS_failure("Integrity test failed");
   }
-#endif  // OPENSSL_ASAN
+#endif  // !ASAN && !MSAN
 
   if (!boringssl_self_test_startup()) {
     AWS_LC_FIPS_failure("Power on self test failed");
   }
 }
 
-#if !defined(OPENSSL_ASAN)
+#if !defined(OPENSSL_ASAN) && !defined(OPENSSL_MSAN)
 int BORINGSSL_integrity_test(void) {
   const uint8_t *const start = BORINGSSL_bcm_text_start;
   const uint8_t *const end = BORINGSSL_bcm_text_end;
@@ -385,7 +386,7 @@ int BORINGSSL_integrity_test(void) {
   OPENSSL_cleanse(result, sizeof(result)); // FIPS 140-3, AS05.10.
   return 1;
 }
-#endif  // OPENSSL_ASAN
+#endif  // !ASAN && !MSAN
 
 void AWS_LC_FIPS_failure(const char* message) {
 #if defined(AWSLC_FIPS_FAILURE_CALLBACK)

--- a/crypto/fipsmodule/self_check/fips.c
+++ b/crypto/fipsmodule/self_check/fips.c
@@ -12,7 +12,7 @@
 
 
 int FIPS_mode(void) {
-#if defined(BORINGSSL_FIPS) && !defined(OPENSSL_ASAN)
+#if defined(BORINGSSL_FIPS) && !defined(OPENSSL_ASAN) && !defined(OPENSSL_MSAN)
   return 1;
 #else
   return 0;

--- a/crypto/fipsmodule/service_indicator/internal.h
+++ b/crypto/fipsmodule/service_indicator/internal.h
@@ -136,7 +136,7 @@ OPENSSL_INLINE void EVP_PKEY_decapsulate_verify_service_indicator(OPENSSL_UNUSED
 #endif // AWSLC_FIPS
 
 // is_fips_build is similar to |FIPS_mode| but returns 1 including in the case
-// of #if defined(OPENSSL_ASAN)
+// of #if defined(OPENSSL_ASAN) or #if defined(OPENSSL_MSAN)
 int is_fips_build(void);
 
 #endif  // AWSLC_HEADER_SERVICE_INDICATOR_INTERNAL_H

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -140,12 +140,11 @@ function fips_build_and_test {
   run_build "$@" -DFIPS=1
   # Upon completion of the build process. The module’s status can be verified by 'tool/bssl isfips'.
   # https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3678.pdf
-  # FIPS mode is enabled when 'defined(BORINGSSL_FIPS) && !defined(OPENSSL_ASAN)'.
-  # https://github.com/aws/aws-lc/blob/220e266d4e415cf0101388b89a2bd855e0e4e203/crypto/fipsmodule/is_fips.c#L22
+  # FIPS mode is enabled when 'defined(BORINGSSL_FIPS) && !defined(OPENSSL_ASAN) && !defined(OPENSSL_MSAN)'.
   expect_fips_mode=1
   for build_flag in "$@"
   do
-    if [[ "${build_flag}" == '-DASAN=1' ]]; then
+    if [[ "${build_flag}" == '-DASAN=1' || "${build_flag}" == '-DMSAN=1' ]]; then
       expect_fips_mode=0
       break
     fi

--- a/tests/ci/run_fips_tests.sh
+++ b/tests/ci/run_fips_tests.sh
@@ -81,6 +81,16 @@ if [[ "${AWSLC_ENABLE_FIPS_ASAN:-0}" == "1" ]]; then
   fi
 fi
 
+if [[ "${AWSLC_ENABLE_FIPS_MSAN:-0}" == "1" ]]; then
+  # The ACVP modulewrapper subprocess crashes under MSAN, so we use
+  # run_build + all_tests.go instead of fips_build_and_test to skip the
+  # ACVP tests. On ARM, MSAN also gets stuck on PoolTest.Threads
+  # (https://github.com/aws/aws-lc/issues/13).
+  echo "Building with Clang and testing AWS-LC in FIPS Release mode with memory sanitizer."
+  run_build -DFIPS=1 -DMSAN=1 -DUSE_CUSTOM_LIBCXX=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
+  go run util/all_tests.go -build-dir "$BUILD_ROOT"
+fi
+
 echo "Testing shared AWS-LC in FIPS Debug mode in a different folder."
 BUILD_ROOT=$(mktemp -d)
 fips_build_and_test -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=1


### PR DESCRIPTION
### Issues:
* In `aws-lc-rs`: https://github.com/aws/aws-lc-rs/issues/1077
  * Related PR: https://github.com/aws/aws-lc-rs/pull/1100


### Description of changes:

CMake already skips the delocator (and linker script) for both ASAN and MSAN FIPS builds, but `bcm.c` and `fips.c` only guarded the integrity-test symbol references with `#if !defined(OPENSSL_ASAN)`. This means an MSAN+FIPS build still `extern`-declares `BORINGSSL_bcm_text_start/end/hash` and tries to call `BORINGSSL_integrity_test()`, even though nothing provides those symbols — resulting in link failures.

This broadens all three guards in `bcm.c` and the `FIPS_mode()` check in `fips.c` to `!defined(OPENSSL_ASAN) && !defined(OPENSSL_MSAN)`, matching the existing guard in `delocate.h`.

### Call-outs:

`FIPS_mode()` now returns 0 under MSAN, just as it does under ASAN. `is_fips_build()` is unaffected — it still returns 1 for any `BORINGSSL_FIPS` build regardless of sanitizer, which is the intended distinction between the two.

### Testing:

Added a targeted MSAN+FIPS CI job (`ubuntu:22.04` / `clang-14` / `x86_64`) in `linux-multi-arch-omnibus.yml`, gated behind `AWSLC_ENABLE_FIPS_MSAN`. The corresponding `run_fips_tests.sh` block builds with `-DFIPS=1 -DMSAN=1 -DUSE_CUSTOM_LIBCXX=1`, verifies `bssl isfips` returns 0, and runs the test suite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
