### PR TITLE
Bump Go version in gcc-4.8 Docker image from 1.18.10 to 1.22.12

### DIFF
--- a/.github/docker_images/gcc-4.8/Dockerfile
+++ b/.github/docker_images/gcc-4.8/Dockerfile
@@ -27,10 +27,10 @@ COPY entry.sh /
 
 WORKDIR /
 
-RUN curl -LOk "https://go.dev/dl/go1.18.10.linux-amd64.tar.gz"
-RUN sha256sum go1.18.10.linux-amd64.tar.gz | grep -q "5e05400e4c79ef5394424c0eff5b9141cb782da25f64f79d54c98af0a37f8d49"
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.10.linux-amd64.tar.gz
-RUN rm go1.18.10.linux-amd64.tar.gz
+RUN curl -LOk "https://go.dev/dl/go1.22.12.linux-amd64.tar.gz"
+RUN sha256sum go1.22.12.linux-amd64.tar.gz | grep -q "4fa4f869b0f7fc6bb1eb2660e74657fbf04cdd290b5aef905585c86051b34d43"
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.12.linux-amd64.tar.gz
+RUN rm go1.22.12.linux-amd64.tar.gz
 
 ENV PATH="${PATH}:/usr/local/go/bin"
 


### PR DESCRIPTION
### Description of changes:
The `gcc-4_8` CI job is failing because the Docker image pins Go 1.18.10, but `cmake/go.cmake` (and `go.mod`) require Go >= 1.20. This bumps the Go version in the gcc-4.8 Docker image to 1.22.12.

### Testing:
The gcc-4.8 CI job should pass again with this change. No other jobs are affected since they use `actions/setup-go` which resolves to a recent Go version independently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
