### PR TITLE
Handle id-pkix-ocsp-nocheck in OCSP responder verification

### DIFF
--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -2054,3 +2054,149 @@ TEST(OCSPTest, OCSP_SINGLERESP) {
                                   X509_EXTENSION_get_data(ext.get())),
             0);
 }
+
+// Helper to create an OCSP responder cert issued by |ca_cert|/|ca_key|, with
+// EKU=OCSP Signing. If |add_nocheck| is true, the id-pkix-ocsp-nocheck
+// extension is added.
+static bssl::UniquePtr<X509> MakeOCSPResponderCert(EVP_PKEY *responder_key,
+                                                   X509 *ca_cert,
+                                                   EVP_PKEY *ca_key,
+                                                   bool add_nocheck) {
+  bssl::UniquePtr<X509> cert(X509_new());
+  if (!cert ||
+      !X509_set_version(cert.get(), X509_VERSION_3) ||
+      !ASN1_INTEGER_set(X509_get_serialNumber(cert.get()), 1) ||
+      !X509_set_issuer_name(cert.get(), X509_get_subject_name(ca_cert)) ||
+      !X509_NAME_add_entry_by_txt(
+          X509_get_subject_name(cert.get()), "CN", MBSTRING_UTF8,
+          reinterpret_cast<const uint8_t *>("OCSP Responder"), -1, -1, 0) ||
+      !X509_set_pubkey(cert.get(), responder_key) ||
+      !ASN1_TIME_adj(X509_getm_notBefore(cert.get()), kReferenceTime, -1, 0) ||
+      !ASN1_TIME_adj(X509_getm_notAfter(cert.get()), kReferenceTime, 1, 0)) {
+    return nullptr;
+  }
+
+  // Add EKU: OCSP Signing (required for delegated responder).
+  bssl::UniquePtr<STACK_OF(ASN1_OBJECT)> eku(sk_ASN1_OBJECT_new_null());
+  if (!eku || !sk_ASN1_OBJECT_push(eku.get(), OBJ_nid2obj(NID_OCSP_sign)) ||
+      !X509_add1_ext_i2d(cert.get(), NID_ext_key_usage, eku.get(),
+                         /*crit=*/1, /*flags=*/0)) {
+    return nullptr;
+  }
+
+  if (add_nocheck) {
+    ASN1_NULL *null_val = ASN1_NULL_new();
+    if (null_val == NULL ||
+        !X509_add1_ext_i2d(cert.get(), NID_id_pkix_OCSP_noCheck, null_val,
+                           /*crit=*/0, /*flags=*/0)) {
+      ASN1_NULL_free(null_val);
+      return nullptr;
+    }
+    ASN1_NULL_free(null_val);
+  }
+
+  if (!X509_sign(cert.get(), ca_key, EVP_sha256())) {
+    return nullptr;
+  }
+  return cert;
+}
+
+// Test that the id-pkix-ocsp-nocheck extension on a delegated OCSP responder
+// certificate causes CRL checking to be skipped during verification. Without
+// the extension, verification should fail when CRL checking is enabled because
+// no CRL is available.
+TEST(OCSPTest, OCSPNoCheckExtension) {
+  // Generate CA key and self-signed CA cert.
+  bssl::UniquePtr<EVP_PKEY> ca_key(EVP_PKEY_new());
+  ASSERT_TRUE(ca_key);
+  bssl::UniquePtr<RSA> ca_rsa(RSA_new());
+  bssl::UniquePtr<BIGNUM> e(BN_new());
+  ASSERT_TRUE(BN_set_word(e.get(), RSA_F4));
+  ASSERT_TRUE(RSA_generate_key_ex(ca_rsa.get(), 2048, e.get(), nullptr));
+  ASSERT_TRUE(EVP_PKEY_set1_RSA(ca_key.get(), ca_rsa.get()));
+
+  bssl::UniquePtr<X509> ca_cert =
+      MakeTestCert("Test CA", "Test CA", ca_key.get(), /*is_ca=*/true);
+  ASSERT_TRUE(ca_cert);
+  ASSERT_TRUE(X509_sign(ca_cert.get(), ca_key.get(), EVP_sha256()));
+
+  // Generate responder key.
+  bssl::UniquePtr<EVP_PKEY> resp_key(EVP_PKEY_new());
+  ASSERT_TRUE(resp_key);
+  bssl::UniquePtr<RSA> resp_rsa(RSA_new());
+  ASSERT_TRUE(RSA_generate_key_ex(resp_rsa.get(), 2048, e.get(), nullptr));
+  ASSERT_TRUE(EVP_PKEY_set1_RSA(resp_key.get(), resp_rsa.get()));
+
+  // Create trust store with CRL checking enabled and verification time set
+  // to kReferenceTime (certs from MakeTestCert are only valid around that time).
+  bssl::UniquePtr<X509_STORE> trust_store(X509_STORE_new());
+  ASSERT_TRUE(trust_store);
+  ASSERT_TRUE(X509_STORE_add_cert(trust_store.get(), ca_cert.get()));
+  X509_STORE_set_flags(trust_store.get(), X509_V_FLAG_CRL_CHECK);
+  X509_VERIFY_PARAM *store_param = X509_STORE_get0_param(trust_store.get());
+  ASSERT_TRUE(store_param);
+  X509_VERIFY_PARAM_set_time_posix(store_param, kReferenceTime);
+
+  // Create an OCSP_CERTID for use in the OCSP response.
+  bssl::UniquePtr<OCSP_CERTID> cert_id(
+      OCSP_cert_to_id(EVP_sha1(), ca_cert.get(), ca_cert.get()));
+  ASSERT_TRUE(cert_id);
+
+  // Test with nocheck extension: verification should succeed despite CRL
+  // checking being enabled, because the extension causes the flag to be
+  // cleared for the responder cert.
+  {
+    bssl::UniquePtr<X509> responder_cert = MakeOCSPResponderCert(
+        resp_key.get(), ca_cert.get(), ca_key.get(), /*add_nocheck=*/true);
+    ASSERT_TRUE(responder_cert);
+
+    bssl::UniquePtr<OCSP_BASICRESP> bs(OCSP_BASICRESP_new());
+    ASSERT_TRUE(bs);
+
+    bssl::UniquePtr<ASN1_TIME> this_update(ASN1_TIME_adj(nullptr, kReferenceTime, -1, 0));
+    bssl::UniquePtr<ASN1_TIME> next_update(ASN1_TIME_adj(nullptr, kReferenceTime, 1, 0));
+    ASSERT_TRUE(OCSP_basic_add1_status(bs.get(), cert_id.get(),
+                                       V_OCSP_CERTSTATUS_GOOD, 0, nullptr,
+                                       this_update.get(), next_update.get()));
+
+    ASSERT_TRUE(OCSP_basic_sign(bs.get(), responder_cert.get(), resp_key.get(),
+                                EVP_sha256(),
+                                CertsToStack({ca_cert.get()}).get(), 0));
+
+    int ret = OCSP_basic_verify(
+        bs.get(), CertsToStack({responder_cert.get()}).get(), trust_store.get(),
+        0);
+    EXPECT_EQ(ret, OCSP_VERIFYSTATUS_SUCCESS)
+        << "Verification should succeed with nocheck extension";
+  }
+
+  ERR_clear_error();
+
+  // Test without nocheck extension: verification should fail because CRL
+  // checking is enabled but no CRL is available.
+  {
+    bssl::UniquePtr<X509> responder_cert = MakeOCSPResponderCert(
+        resp_key.get(), ca_cert.get(), ca_key.get(), /*add_nocheck=*/false);
+    ASSERT_TRUE(responder_cert);
+
+    bssl::UniquePtr<OCSP_BASICRESP> bs(OCSP_BASICRESP_new());
+    ASSERT_TRUE(bs);
+
+    bssl::UniquePtr<ASN1_TIME> this_update(ASN1_TIME_adj(nullptr, kReferenceTime, -1, 0));
+    bssl::UniquePtr<ASN1_TIME> next_update(ASN1_TIME_adj(nullptr, kReferenceTime, 1, 0));
+    ASSERT_TRUE(OCSP_basic_add1_status(bs.get(), cert_id.get(),
+                                       V_OCSP_CERTSTATUS_GOOD, 0, nullptr,
+                                       this_update.get(), next_update.get()));
+
+    ASSERT_TRUE(OCSP_basic_sign(bs.get(), responder_cert.get(), resp_key.get(),
+                                EVP_sha256(),
+                                CertsToStack({ca_cert.get()}).get(), 0));
+
+    int ret = OCSP_basic_verify(
+        bs.get(), CertsToStack({responder_cert.get()}).get(), trust_store.get(),
+        0);
+    EXPECT_NE(ret, OCSP_VERIFYSTATUS_SUCCESS)
+        << "Verification should fail without nocheck extension when CRL "
+           "checking is enabled";
+  }
+}

--- a/crypto/ocsp/ocsp_verify.c
+++ b/crypto/ocsp/ocsp_verify.c
@@ -133,7 +133,6 @@ static int ocsp_verify_signer(X509 *signer, X509_STORE *st,
 
   // Set up |X509_STORE_CTX| with |*signer|, |*st|, and |*untrusted|.
   X509_STORE_CTX *ctx = X509_STORE_CTX_new();
-  X509_VERIFY_PARAM *vp;
   int ret = -1;
 
   if (ctx == NULL) {
@@ -143,15 +142,16 @@ static int ocsp_verify_signer(X509 *signer, X509_STORE *st,
     OPENSSL_PUT_ERROR(OCSP, ERR_R_X509_LIB);
     goto end;
   }
-  if ((vp = X509_STORE_CTX_get0_param(ctx)) == NULL) {
-    OPENSSL_PUT_ERROR(OCSP, ERR_R_X509_LIB);
-    goto end;
-  }
   // RFC 6960 section 4.2.2.2.1: if the responder certificate has the
   // id-pkix-ocsp-nocheck extension, the CA has indicated that the client
   // should trust the responder for its lifetime without revocation checking.
   // Locally disable CRL-based revocation checking in this case.
   if (X509_get_ext_by_NID(signer, NID_id_pkix_OCSP_noCheck, -1) >= 0) {
+    X509_VERIFY_PARAM *vp = X509_STORE_CTX_get0_param(ctx);
+    if (vp == NULL) {
+      OPENSSL_PUT_ERROR(OCSP, ERR_R_X509_LIB);
+      goto end;
+    }
     X509_VERIFY_PARAM_clear_flags(vp, X509_V_FLAG_CRL_CHECK);
   }
   if (!X509_STORE_CTX_set_purpose(ctx, X509_PURPOSE_OCSP_HELPER)) {

--- a/crypto/ocsp/ocsp_verify.c
+++ b/crypto/ocsp/ocsp_verify.c
@@ -123,7 +123,7 @@ static int ocsp_setup_untrusted(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
 }
 
 
-static int ocsp_verify_signer(X509 *signer, X509_STORE *st,
+static int ocsp_verify_signer(X509 *signer, int response, X509_STORE *st,
                               STACK_OF(X509) *untrusted,
                               STACK_OF(X509) **chain) {
   if (signer == NULL) {
@@ -133,6 +133,7 @@ static int ocsp_verify_signer(X509 *signer, X509_STORE *st,
 
   // Set up |X509_STORE_CTX| with |*signer|, |*st|, and |*untrusted|.
   X509_STORE_CTX *ctx = X509_STORE_CTX_new();
+  X509_VERIFY_PARAM *vp;
   int ret = -1;
 
   if (ctx == NULL) {
@@ -141,6 +142,17 @@ static int ocsp_verify_signer(X509 *signer, X509_STORE *st,
   if (!X509_STORE_CTX_init(ctx, st, signer, untrusted)) {
     OPENSSL_PUT_ERROR(OCSP, ERR_R_X509_LIB);
     goto end;
+  }
+  if ((vp = X509_STORE_CTX_get0_param(ctx)) == NULL) {
+    goto end;
+  }
+  // RFC 6960 section 4.2.2.2.1: if the responder certificate has the
+  // id-pkix-ocsp-nocheck extension, the CA has indicated that the client
+  // should trust the responder for its lifetime without revocation checking.
+  // Locally disable CRL-based revocation checking in this case.
+  if (response &&
+      X509_get_ext_by_NID(signer, NID_id_pkix_OCSP_noCheck, -1) >= 0) {
+    X509_VERIFY_PARAM_clear_flags(vp, X509_V_FLAG_CRL_CHECK);
   }
   if (!X509_STORE_CTX_set_purpose(ctx, X509_PURPOSE_OCSP_HELPER)) {
     OPENSSL_PUT_ERROR(OCSP, ERR_R_X509_LIB);
@@ -362,7 +374,7 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs, X509_STORE *st,
     if (ret <= 0) {
       goto end;
     }
-    ret = ocsp_verify_signer(signer, st, untrusted, &chain);
+    ret = ocsp_verify_signer(signer, 1, st, untrusted, &chain);
     if (ret <= 0) {
       goto end;
     }

--- a/crypto/ocsp/ocsp_verify.c
+++ b/crypto/ocsp/ocsp_verify.c
@@ -123,7 +123,7 @@ static int ocsp_setup_untrusted(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
 }
 
 
-static int ocsp_verify_signer(X509 *signer, int response, X509_STORE *st,
+static int ocsp_verify_signer(X509 *signer, X509_STORE *st,
                               STACK_OF(X509) *untrusted,
                               STACK_OF(X509) **chain) {
   if (signer == NULL) {
@@ -144,14 +144,14 @@ static int ocsp_verify_signer(X509 *signer, int response, X509_STORE *st,
     goto end;
   }
   if ((vp = X509_STORE_CTX_get0_param(ctx)) == NULL) {
+    OPENSSL_PUT_ERROR(OCSP, ERR_R_X509_LIB);
     goto end;
   }
   // RFC 6960 section 4.2.2.2.1: if the responder certificate has the
   // id-pkix-ocsp-nocheck extension, the CA has indicated that the client
   // should trust the responder for its lifetime without revocation checking.
   // Locally disable CRL-based revocation checking in this case.
-  if (response &&
-      X509_get_ext_by_NID(signer, NID_id_pkix_OCSP_noCheck, -1) >= 0) {
+  if (X509_get_ext_by_NID(signer, NID_id_pkix_OCSP_noCheck, -1) >= 0) {
     X509_VERIFY_PARAM_clear_flags(vp, X509_V_FLAG_CRL_CHECK);
   }
   if (!X509_STORE_CTX_set_purpose(ctx, X509_PURPOSE_OCSP_HELPER)) {
@@ -374,7 +374,7 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs, X509_STORE *st,
     if (ret <= 0) {
       goto end;
     }
-    ret = ocsp_verify_signer(signer, 1, st, untrusted, &chain);
+    ret = ocsp_verify_signer(signer, st, untrusted, &chain);
     if (ret <= 0) {
       goto end;
     }


### PR DESCRIPTION
### Issues:
D431426583

### Description of changes: 
When verifying a delegated OCSP responder certificate, check for the id-pkix-ocsp-nocheck extension (RFC 6960 section 4.2.2.2.1). If present, clear X509_V_FLAG_CRL_CHECK from the verification parameters so that CRL checking is not required for the responder certificate.

This brings AWS-LC to parity with OpenSSL's handling of this extension.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
