### PR TITLE
Fix intermittent `ImplDispatchTest.AEAD_AES_GCM` failure in gcc-4.8 CI

### DIFF
--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -181,10 +181,12 @@ TEST_F(ImplDispatchTest, AEAD_AES_GCM) {
           {kFlag_vpaes_set_encrypt_key, aes_vpaes_ && !aes_hw_},
 #if defined(OPENSSL_X86) || defined(OPENSSL_X86_64)
           {kFlag_aes_hw_ctr32_encrypt_blocks, aes_hw_ &&
-           (!is_x86_64_ || is_assembler_too_old || !vaes_vpclmulqdq_)},
+           (!is_x86_64_ || is_assembler_too_old ||
+            !(vaes_vpclmulqdq_ && !is_assembler_too_old_avx512))},
           {kFlag_aesni_gcm_encrypt,
            is_x86_64_ && aes_hw_ && avx_movbe_ &&
-           !is_assembler_too_old && !vaes_vpclmulqdq_},
+           !is_assembler_too_old &&
+           !(vaes_vpclmulqdq_ && !is_assembler_too_old_avx512)},
           {kFlag_aes_gcm_encrypt_avx512,
            is_x86_64_ && aes_hw_ &&
            !is_assembler_too_old_avx512 &&


### PR DESCRIPTION
### TL;DR
The test assumes that if the host is capable of AVX512, then the implementation will use AVX512 -- but that's not true with `is_assembler_too_old_avx512`.

### Description of changes:

The `AEAD_AES_GCM` dispatch test intermittently fails in the `gcc-4_8` CI job. That build sets `-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=1`, which excludes AVX-512 GCM assembly at compile time. The test's expected values for `aes_hw_ctr32_encrypt_blocks` and `aesni_gcm_encrypt` used `vaes_vpclmulqdq_` (a runtime CPU capability check) to predict the AVX-512 path would be taken, without considering that the AVX-512 assembly was compiled out. When the runner happens to have a VAES/VPCLMULQDQ-capable CPU, the runtime falls back to `aesni_gcm_encrypt`, but the test expected none of the GCM paths to be hit.

The fix replaces `!vaes_vpclmulqdq_` with `!(vaes_vpclmulqdq_ && !is_assembler_too_old_avx512)` in the fallback path conditions, matching the actual runtime dispatch behavior in `gcm.c`.

### Testing:

This is a test-only change. The fix makes the test pass regardless of runner CPU capabilities when building with `-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
