### PR TITLE
docs: update platform support tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ A more complete description of our test setup can be found in the
 | OS      | CPU                                   |
 |---------|---------------------------------------|
 | Android | aarch64                               |
-| Linux   | aarch64, ppc, ppc64, ppc64le, x86-64 |
+| iOS     | aarch64                               |
+| Linux   | aarch64, ppc, ppc64, ppc64le, x86-64  |
 | macOS   | aarch64, x86-64                       |
 | Windows | x86-64                                |
 
@@ -103,7 +104,6 @@ that improve the experience for consumers on these platforms.
 | Android    | arm32                            |
 | Emscripten | wasm32                           |
 | FreeBSD    | arm64, x86-64                    |
-| iOS        | aarch64                          |
 | Linux      | arm32, loongarch64, risc-v64, s390x, x86 |
 | NetBSD     | arm64, x86-64                    |
 | OpenBSD    | arm64, x86-64                    |

--- a/README.md
+++ b/README.md
@@ -85,18 +85,12 @@ successfully builds and tests pass for these platform.
 A more complete description of our test setup can be found in the
 [CI README](https://github.com/aws/aws-lc/blob/main/tests/ci/README.md).
 
-| OS      | CPU     |
-|---------|---------|
-| Linux   | x86     |
-| Linux   | x86-64  |
-| Linux   | aarch64 |
-| Windows | x86-64  |
-| macOS   | x86-64  |
-| macOS   | aarch64 |
-| Android | aarch64 |
-| Linux   | ppc     |
-| Linux   | ppc64   |
-| Linux   | ppc64le |
+| OS      | CPU                                   |
+|---------|---------------------------------------|
+| Android | aarch64                               |
+| Linux   | aarch64, ppc, ppc64, ppc64le, x86-64 |
+| macOS   | aarch64, x86-64                       |
+| Windows | x86-64                                |
 
 ### Other platforms
 
@@ -104,18 +98,16 @@ The platforms listed below are of interest to us or to our community. However, p
 against them might not be prioritized for immediate action by our team. We welcome contributions
 that improve the experience for consumers on these platforms.
 
-| OS         | CPU         |
-|------------|-------------|
-| Android    | arm32       |
-| Emscripten | wasm32      |
-| iOS        | aarch64     |
-| Linux      | arm32       |
-| Linux      | loongarch64 |
-| Linux      | risc-v64    |
-| Linux      | s390x       |
-| Windows    | aarch64     |
-| OpenBSD    | x86-64      |
-| FreeBSD    | x86-64      |
+| OS         | CPU                              |
+|------------|----------------------------------|
+| Android    | arm32                            |
+| Emscripten | wasm32                           |
+| FreeBSD    | arm64, x86-64                    |
+| iOS        | aarch64                          |
+| Linux      | arm32, loongarch64, risc-v64, s390x, x86 |
+| NetBSD     | arm64, x86-64                    |
+| OpenBSD    | arm64, x86-64                    |
+| Windows    | aarch64                          |
 
 ### WebAssembly (WASM) Support
 


### PR DESCRIPTION
### Description of changes: 
Add missing BSD platform to the platforms table, as well as formatting updates.

### Call-outs:
The *BSDs are in CI but are not in the supported platforms table, implying their failures are best-effort.

The Linux i386 line was moved from supported to other.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
