### PR TITLE
ci: add gh-pages workflow for API documentation

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,5 +1,6 @@
 name: API Documentation
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -10,11 +11,20 @@ on:
       - '.github/workflows/api-docs.yml'
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   publish-api-docs:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
@@ -24,10 +34,11 @@ jobs:
         run: |
           mkdir -p api-output
           cd util
-          go run doc.go --config doc.config --out ../api-output
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+          go run doc.go --config doc.config --out ../pages-output
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./api-output
-          destination_dir: api
+          path: ./pages-output
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,33 @@
+name: API Documentation
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'include/openssl/**'
+      - 'util/doc.go'
+      - 'util/doc.config'
+      - 'util/doc.css'
+      - '.github/workflows/api-docs.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  publish-api-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ">=1.22"
+      - name: Generate API documentation
+        run: |
+          mkdir -p api-output
+          cd util
+          go run doc.go --config doc.config --out ../api-output
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./api-output
+          destination_dir: api

--- a/include/openssl/base64.h
+++ b/include/openssl/base64.h
@@ -10,6 +10,10 @@
 extern "C" {
 #endif
 
+
+// Base64 encoding and decoding.
+
+
 /**
  * @file
  * @brief base64 encoding and decoding functions.

--- a/include/openssl/base64.h
+++ b/include/openssl/base64.h
@@ -11,286 +11,129 @@ extern "C" {
 #endif
 
 
-// Base64 encoding and decoding.
+// base64 functions.
+//
+// For historical reasons, these functions have the EVP_ prefix but just do
+// base64 encoding and decoding. Note that BoringSSL is a cryptography library,
+// so these functions are implemented with side channel protections, at a
+// performance cost. For other base64 uses, use a general-purpose base64
+// implementation.
 
 
-/**
- * @file
- * @brief base64 encoding and decoding functions.
- *
- * @details
- * For historical reasons, these functions have the `EVP_` prefix but just do
- * base64 encoding and decoding. Note that BoringSSL is a cryptography library,
- * so these functions are implemented with side channel protections, at a
- * performance cost. For other base64 uses, use a general-purpose base64
- * implementation.
- */
+// Encoding
 
-
-/**
- * @name Encoding Functions
- *
- * @{
- */
-
-/**
- * @brief Base64 encodes bytes from `src` into `dst`.
- *
- * @details
- * Base64 encodes `src_len` bytes from `src` and writes the
- * result to `dst` with a trailing `NULL`.
- *
- * @param [out] dst    Base64 encoded value
- * @param [in] src     Bytes to encode
- * @param [in] src_len Number of bytes to encode
- *
- * @return The number of bytes written, not including the trailing `NULL`
- */
+// EVP_EncodeBlock encodes |src_len| bytes from |src| and writes the
+// result to |dst| with a trailing NUL. It returns the number of bytes
+// written, not including this trailing NUL.
 OPENSSL_EXPORT size_t EVP_EncodeBlock(uint8_t *dst, const uint8_t *src,
                                       size_t src_len);
 
-/**
- * @brief Calculates the number of bytes needed to encode an input using Base64.
- *
- * @details
- * Sets `*out_len` to the number of bytes that will be needed to call
- * #EVP_EncodeBlock on an input of length `len`. `*out_len` includes the final
- * `NULL` that #EVP_EncodeBlock writes.
- *
- * @param [out] out_len Number of bytes needed to Base64 encode a source
- * @param [in] len      Source length
- *
- * @retval 1 Success
- * @retval 0 Error
- */
+// EVP_EncodedLength sets |*out_len| to the number of bytes that will be needed
+// to call |EVP_EncodeBlock| on an input of length |len|. This includes the
+// final NUL that |EVP_EncodeBlock| writes. It returns one on success or zero
+// on error.
 OPENSSL_EXPORT int EVP_EncodedLength(size_t *out_len, size_t len);
 
-/** @} Encoding Functions */
 
+// Decoding
 
-/**
- * @name Decoding Functions
- *
- * @{
- */
-
-/**
- * @brief Sets the maximum number of bytes need to store a decoded Base64 input.
- *
- * @param [out] out_len Maximum number of bytes to store decoded input
- * @param [in] len      Base64 formatted input length
- *
- * @retval 1 Success
- * @retval 0 `len` is not a valid length for a base64-encoded string
- */
+// EVP_DecodedLength sets |*out_len| to the maximum number of bytes that will
+// be needed to call |EVP_DecodeBase64| on an input of length |len|. It returns
+// one on success or zero if |len| is not a valid length for a base64-encoded
+// string.
 OPENSSL_EXPORT int EVP_DecodedLength(size_t *out_len, size_t len);
 
-/**
- * @brief Decodes specified number of Base64 formatted bytes to output buffer.
- *
- * @details
- * Decodes `in_len` bytes from base64 and writes `*out_len` bytes to `out`. If
- * `*out_len` doesn't have enough bytes for the maximum output size, the
- * operation fails.
- *
- * @param [out] out     Decoded output
- * @param [out] out_len Number of bytes written to `out`
- * @param [in] max_out  Length of `out`
- * @param [in] in       Base64 input buffer
- * @param [in] in_len   Number of bytes to decode from `in`
- *
- * @retval 1 Success
- * @retval 0 Error
- */
+// EVP_DecodeBase64 decodes |in_len| bytes from base64 and writes
+// |*out_len| bytes to |out|. |max_out| is the size of the output
+// buffer. If it is not enough for the maximum output size, the
+// operation fails. It returns one on success or zero on error.
 OPENSSL_EXPORT int EVP_DecodeBase64(uint8_t *out, size_t *out_len,
                                     size_t max_out, const uint8_t *in,
                                     size_t in_len);
 
-/** @} Decoding Functions */
 
-/**
- * @name Deprecated Functions
- *
- * OpenSSL provides a streaming base64 implementation, however its behavior is
- * very specific to PEM. It is also very lenient of invalid input. Use of any of
- * these functions is thus deprecated.
- *
- * @{
- */
+// Deprecated functions.
+//
+// OpenSSL provides a streaming base64 implementation, however its behavior is
+// very specific to PEM. It is also very lenient of invalid input. Use of any of
+// these functions is thus deprecated.
 
-/**
- * @brief Returns a newly-allocated EVP_ENCODE_CTX.
- *
- * @details
- * The caller must release the result with #EVP_ENCODE_CTX_free when
- * done.
- *
- * @returns Pointer to newly allocated EVP_ENCODE_CTX or `NULL` on error
- *
- * @deprecated OpenSSL provides a streaming base64 implementation, however its behavior is very specific to PEM. It is also very lenient of invalid input. Use of any of these functions is thus deprecated.
- */
+// EVP_ENCODE_CTX_new returns a newly-allocated |EVP_ENCODE_CTX| or NULL on
+// error. The caller must release the result with |EVP_ENCODE_CTX_free|  when
+// done.
 OPENSSL_EXPORT EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void);
 
-/**
- * @brief Releases memory associated with `ctx`.
- *
- * @param [in] ctx Pointer to deallocate
- *
- * @deprecated OpenSSL provides a streaming base64 implementation, however its behavior is very specific to PEM. It is also very lenient of invalid input. Use of any of these functions is thus deprecated.
- */
+// EVP_ENCODE_CTX_free releases memory associated with |ctx|.
 OPENSSL_EXPORT void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx);
 
-/**
- * @brief Initialises `*ctx`.
- *
- * @details
- * This is typically stack allocated, for an encoding operation.
- *
- * @param [in,out] ctx Context to initialize
- *
- * @warning The encoding operation breaks its output with newlines every 64 characters of output (48 characters of input). Use #EVP_EncodeBlock to encode raw base64.
- *
- * @deprecated OpenSSL provides a streaming base64 implementation, however its behavior is very specific to PEM. It is also very lenient of invalid input. Use of any of these functions is thus deprecated.
- */
+// EVP_EncodeInit initialises |*ctx|, which is typically stack
+// allocated, for an encoding operation.
+//
+// NOTE: The encoding operation breaks its output with newlines every
+// 64 characters of output (48 characters of input). Use
+// EVP_EncodeBlock to encode raw base64.
 OPENSSL_EXPORT void EVP_EncodeInit(EVP_ENCODE_CTX *ctx);
 
-/**
- * @brief Encodes bytes from `in` to Base64 and writes the value to `out`.
- *
- * @details
- * Some state may be contained in `ctx` so #EVP_EncodeFinal must be used to
- * flush it before using the encoded data.
- *
- * @param [in,out] ctx     Encoding context
- * @param [out]    out     Base64 encoded value
- * @param [out]    out_len Number of bytes written
- * @param [in]     in      Input buffer
- * @param [in]     in_len  Number of bytes to encode
- *
- * @retval 1 Success
- * @retval 0 Failure or `in_len` was 0
- *
- * @deprecated OpenSSL provides a streaming base64 implementation, however its behavior is very specific to PEM. It is also very lenient of invalid input. Use of any of these functions is thus deprecated.
- */
+// EVP_EncodeUpdate encodes |in_len| bytes from |in| and writes an encoded
+// version of them to |out| and sets |*out_len| to the number of bytes written.
+// Some state may be contained in |ctx| so |EVP_EncodeFinal| must be used to
+// flush it before using the encoded data.
 OPENSSL_EXPORT int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, uint8_t *out,
                                     int *out_len, const uint8_t *in,
                                     size_t in_len);
 
-/**
- * @brief Flushes any remaining output bytes from `ctx` to `out`.
- *
- * @param [in,out] ctx     Encoding context
- * @param [out]    out     Output buffer
- * @param [out]    out_len Number of bytes written to buffer
- *
- * @deprecated OpenSSL provides a streaming base64 implementation, however its behavior is very specific to PEM. It is also very lenient of invalid input. Use of any of these functions is thus deprecated.
- */
+// EVP_EncodeFinal flushes any remaining output bytes from |ctx| to |out| and
+// sets |*out_len| to the number of bytes written.
 OPENSSL_EXPORT void EVP_EncodeFinal(EVP_ENCODE_CTX *ctx, uint8_t *out,
                                     int *out_len);
 
-/**
- * @brief Initialises `*ctx` for a decoding operation.
- *
- * @details
- * This is typically stack allocated.
- *
- * @param [in,out] ctx Context to initialize
- *
- * @todo davidben: This isn't a straight-up base64 decode either. Document and/or fix exactly what's going on here; maximum line length and such.
- *
- * @deprecated OpenSSL provides a streaming base64 implementation, however its behavior is very specific to PEM. It is also very lenient of invalid input. Use of any of these functions is thus deprecated.
- */
+// EVP_DecodeInit initialises |*ctx|, which is typically stack allocated, for
+// a decoding operation.
+//
+// TODO(davidben): This isn't a straight-up base64 decode either. Document
+// and/or fix exactly what's going on here; maximum line length and such.
 OPENSSL_EXPORT void EVP_DecodeInit(EVP_ENCODE_CTX *ctx);
 
-/**
- * @brief Decodes bytes from `in` and writes the decoded data to `out`.
- *
- * @details
- * Some state may be contained in `ctx` so #EVP_DecodeFinal must be used to
- * flush it before using the decoded data.
- *
- * @param [in,out] ctx     Decoding context
- * @param [out]    out     Decoded bytes
- * @param [out]    out_len Number of bytes written
- * @param [in]     in      Input buffer
- * @param [in]     in_len  Number of bytes to decode
- *
- * @retval -1 Error
- * @retval 0 The line was short (i.e., it was the last line)
- * @retval 1 A full line of input was processed
- *
- * @deprecated OpenSSL provides a streaming base64 implementation, however its behavior is very specific to PEM. It is also very lenient of invalid input. Use of any of these functions is thus deprecated.
- */
+// EVP_DecodeUpdate decodes |in_len| bytes from |in| and writes the decoded
+// data to |out| and sets |*out_len| to the number of bytes written. Some state
+// may be contained in |ctx| so |EVP_DecodeFinal| must be used to flush it
+// before using the encoded data.
+//
+// It returns -1 on error, one if a full line of input was processed and zero
+// if the line was short (i.e. it was the last line).
 OPENSSL_EXPORT int EVP_DecodeUpdate(EVP_ENCODE_CTX *ctx, uint8_t *out,
                                     int *out_len, const uint8_t *in,
                                     size_t in_len);
 
-/**
- * @brief Flushes any remaining output bytes from `ctx` to `out`.
- *
- * @param [in,out] ctx Decoding context
- * @param [out]    out Output buffer
- * @param [out]    out_len Number of bytes written to buffer
- *
- * @retval 1 Success
- * @retval -1 Error
- *
- * @deprecated OpenSSL provides a streaming base64 implementation, however its behavior is very specific to PEM. It is also very lenient of invalid input. Use of any of these functions is thus deprecated.
- */
+// EVP_DecodeFinal flushes any remaining output bytes from |ctx| to |out| and
+// sets |*out_len| to the number of bytes written. It returns one on success
+// and minus one on error.
 OPENSSL_EXPORT int EVP_DecodeFinal(EVP_ENCODE_CTX *ctx, uint8_t *out,
                                    int *out_len);
 
-/**
- * @brief Decodes Base64 bytes from `src` and writes value to `dst`.
- *
- * @param [out] dst Decoded bytes
- * @param [in] src  Base64 encoded bytes
- * @param [in] src_len Number of bytes to decode
- *
- * @returns Number of bytes written or -1 on error
- *
- * @warning `EVP_DecodeBlock`'s return value does not take padding into account. It also strips leading whitespace and trailing whitespace and minuses.
- *
- * @deprecated OpenSSL provides a streaming base64 implementation, however its behavior is very specific to PEM. It is also very lenient of invalid input. Use of any of these functions is thus deprecated.
- */
+// EVP_DecodeBlock encodes |src_len| bytes from |src| and writes the result to
+// |dst|. It returns the number of bytes written or -1 on error.
+//
+// WARNING: EVP_DecodeBlock's return value does not take padding into
+// account. It also strips leading whitespace and trailing
+// whitespace and minuses.
 OPENSSL_EXPORT int EVP_DecodeBlock(uint8_t *dst, const uint8_t *src,
                                    size_t src_len);
 
-/** @} Deprecated Functions */
 
-/**
- * @struct evp_encode_ctx_st
- * Encoding Context
- */
 struct evp_encode_ctx_st {
-  /**
-   * @brief Number of valid bytes
-   *
-   * @details
-   * When encoding, `data` will be filled and encoded as a lump. When decoding,
-   * only the first four bytes of `data` will be used.
-   */
+  // data_used indicates the number of bytes of |data| that are valid. When
+  // encoding, |data| will be filled and encoded as a lump. When decoding, only
+  // the first four bytes of |data| will be used.
   unsigned data_used;
-
-  /**
-   * @brief Encoded or decoded data.
-   */
   uint8_t data[48];
 
-  /**
-   * @brief Indicates that the end of the base64 data has been seen.
-   *
-   * @details
-   * Only used when decoding. Only whitespace can follow.
-   */
+  // eof_seen indicates that the end of the base64 data has been seen when
+  // decoding. Only whitespace can follow.
   char eof_seen;
 
-  /**
-   * @brief indicates that invalid base64 data was found.
-   *
-   * @details
-   * This will gitcause all future calls to fail.
-   */
+  // error_encountered indicates that invalid base64 data was found. This will
+  // cause all future calls to fail.
   char error_encountered;
 };
 

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -15,6 +15,10 @@
 extern "C" {
 #endif
 
+
+// Digital Signature Algorithm (deprecated).
+
+
 #define OPENSSL_DSA_MAX_MODULUS_BITS 10000
 
 

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -10,6 +10,10 @@
 extern "C" {
 #endif
 
+
+// Key derivation functions.
+
+
 // CRYPTO_tls1_prf calculates |out_len| bytes of the TLS PRF, using |digest|,
 // and writes them to |out|. It returns one on success and zero on error.
 // TLS 1.2: https://datatracker.ietf.org/doc/html/rfc5246#section-5

--- a/include/openssl/lhash.h
+++ b/include/openssl/lhash.h
@@ -10,6 +10,10 @@
 extern "C" {
 #endif
 
+
+// Hash table implementation for internal use.
+
+
 typedef struct lhash_st _LHASH;
 
 // lhash is an internal library and not exported for use outside BoringSSL. This

--- a/include/openssl/opensslconf.h
+++ b/include/openssl/opensslconf.h
@@ -13,6 +13,9 @@ extern "C" {
 #endif
 
 
+// OpenSSL compatibility configuration flags.
+
+
 #define OPENSSL_NO_ASYNC
 #define OPENSSL_NO_BLAKE2
 #define OPENSSL_NO_BUF_FREELISTS

--- a/include/openssl/pkcs8.h
+++ b/include/openssl/pkcs8.h
@@ -15,6 +15,9 @@ extern "C" {
 #endif
 
 
+// PKCS#8 private key encryption and decryption.
+
+
 // PKCS8_encrypt serializes and encrypts a PKCS8_PRIV_KEY_INFO with PBES1 or
 // PBES2 as defined in PKCS #5. Only pbeWithSHAAnd128BitRC4,
 // pbeWithSHAAnd3-KeyTripleDES-CBC and pbeWithSHA1And40BitRC2, defined in PKCS


### PR DESCRIPTION
### Description of changes: 
Generate HTML API docs from header comments using the existing
doc.go tool (inherited from BoringSSL) and publish to gh-pages, on pushes to `main` where specific files have been touched, or a user with write manually kicks off the workflow.

There were some missing annotations that kiro filled in for me. 

### Call-outs:
I've pushed a sample to gh-pages to show how this would look at https://dougch.github.io/aws-lc/headers.html

The doxygen annotations weren't playing nice with the go doc tool, so the changes to [base64.h](https://github.com/aws/aws-lc/pull/2908) were reverted.

The repo settings will need updating post merge to allow an `app` vs. a `branch` to write to gh-pages; see the [docs](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site).

The first party action for publishing allows for fine grained publish controls, but does a complete replacement of the content (it's sending a tarball to an API vs. committing to a branch); this is a 2 way door...

### Testing:
Because of the `workflow_dispatch`, you can run these actions in a fork.... the new actions are working fine, example at https://dougch.github.io/aws-lc/headers.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
