### PR TITLE
Add WaitForFileAccessible to fix intermittent Windows test failures

### DIFF
--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -279,7 +279,8 @@ testing::AssertionResult WaitForFileAccessible(const char *path) {
       return testing::AssertionSuccess();
     }
     DWORD err = GetLastError();
-    if (err != ERROR_SHARING_VIOLATION && err != ERROR_LOCK_VIOLATION) {
+    if (err != ERROR_ACCESS_DENIED && err != ERROR_SHARING_VIOLATION &&
+        err != ERROR_LOCK_VIOLATION) {
       break;
     }
   }

--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -307,11 +307,17 @@ FILE* createRawTempFILE() {
 }
 
 testing::AssertionResult WaitForFileAccessible(const char *path) {
-  // On Windows, antivirus software, file indexing services, or other background
-  // processes can briefly lock files after creation or modification, causing
-  // transient ERROR_SHARING_VIOLATION failures. Retry with a short delay to
-  // wait out the lock. These values mirror the retry strategy used by
-  // WIN32_rename in tool-openssl/ca.cc.
+  // On Windows, antivirus software, file indexing services, or other
+  // background processes can briefly lock files after they are written,
+  // causing transient ERROR_SHARING_VIOLATION failures when callers
+  // immediately try to reopen the file for reading. Retry fopen() with a short
+  // delay to wait out the lock. These values mirror the retry strategy used
+  // by WIN32_rename in tool-openssl/ca.cc.
+  //
+  // We deliberately probe with "rb" rather than "wb": a write-mode probe
+  // would truncate the file the caller just populated, and every failing call
+  // site we are hardening opens the file for reading, so a successful "rb"
+  // probe is exactly the signal the caller needs.
   static const int kMaxRetries = 10;
   static const DWORD kRetryDelayMs = 200;
   for (int attempt = 0; attempt <= kMaxRetries; attempt++) {

--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -310,23 +310,27 @@ testing::AssertionResult WaitForFileAccessible(const char *path) {
   // On Windows, antivirus software, file indexing services, or other
   // background processes can briefly lock files after they are written,
   // causing transient ERROR_SHARING_VIOLATION failures when callers
-  // immediately try to reopen the file for reading. Retry fopen() with a short
-  // delay to wait out the lock. These values mirror the retry strategy used
-  // by WIN32_rename in tool-openssl/ca.cc.
+  // immediately try to reopen the file for reading. Retry opening the file
+  // with a short delay to wait out the lock. These values mirror the retry
+  // strategy used by WIN32_rename in tool-openssl/ca.cc.
   //
-  // We deliberately probe with "rb" rather than "wb": a write-mode probe
-  // would truncate the file the caller just populated, and every failing call
-  // site we are hardening opens the file for reading, so a successful "rb"
-  // probe is exactly the signal the caller needs.
+  // We use CreateFileA with GENERIC_READ rather than fopen(): GetLastError()
+  // is only contractually reliable after a direct Win32 API call, and the
+  // MSVC CRT may clobber it during fopen()'s internal cleanup path. The
+  // FILE_SHARE flags ensure the probe does not itself introduce a lock that
+  // would interfere with the caller's subsequent open.
   static const int kMaxRetries = 10;
   static const DWORD kRetryDelayMs = 200;
   for (int attempt = 0; attempt <= kMaxRetries; attempt++) {
     if (attempt > 0) {
       Sleep(kRetryDelayMs);
     }
-    FILE *f = fopen(path, "rb");
-    if (f != nullptr) {
-      fclose(f);
+    HANDLE h = CreateFileA(path, GENERIC_READ,
+                           FILE_SHARE_READ | FILE_SHARE_WRITE |
+                               FILE_SHARE_DELETE,
+                           NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (h != INVALID_HANDLE_VALUE) {
+      CloseHandle(h);
       return testing::AssertionSuccess();
     }
     DWORD err = GetLastError();

--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -330,6 +330,11 @@ testing::AssertionResult WaitForFileAccessible(const char *path) {
       return testing::AssertionSuccess();
     }
     DWORD err = GetLastError();
+    // ERROR_ACCESS_DENIED is deliberately retried alongside the obvious
+    // sharing/lock violations: on Windows it can manifest transiently from
+    // pending-deletion state, AV scans, or the Search Indexer briefly holding
+    // the file. If the permission failure is genuine, the retries will all
+    // fail identically and the test fails correctly after the retry budget.
     if (err != ERROR_ACCESS_DENIED && err != ERROR_SHARING_VIOLATION &&
         err != ERROR_LOCK_VIOLATION) {
       break;

--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -261,6 +261,32 @@ FILE* createRawTempFILE() {
   return fopen(filename, "w+b");
 }
 
+testing::AssertionResult WaitForFileAccessible(const char *path) {
+  // On Windows, antivirus software, file indexing services, or other background
+  // processes can briefly lock files after creation or modification, causing
+  // transient ERROR_SHARING_VIOLATION failures. Retry with a short delay to
+  // wait out the lock. These values mirror the retry strategy used by
+  // WIN32_rename in tool-openssl/ca.cc.
+  static const int kMaxRetries = 10;
+  static const DWORD kRetryDelayMs = 200;
+  for (int attempt = 0; attempt <= kMaxRetries; attempt++) {
+    if (attempt > 0) {
+      Sleep(kRetryDelayMs);
+    }
+    FILE *f = fopen(path, "rb");
+    if (f != nullptr) {
+      fclose(f);
+      return testing::AssertionSuccess();
+    }
+    DWORD err = GetLastError();
+    if (err != ERROR_SHARING_VIOLATION && err != ERROR_LOCK_VIOLATION) {
+      break;
+    }
+  }
+  return testing::AssertionFailure()
+         << "File not accessible after retries: " << path;
+}
+
 #else
 #include <cstdlib>
 #include <unistd.h>

--- a/crypto/test/test_util.cc
+++ b/crypto/test/test_util.cc
@@ -214,13 +214,58 @@ static DWORD GetSafeTempPathA(DWORD nBufferLength, LPSTR lpBuffer) {
 }
 
 size_t createTempFILEpath(char buffer[PATH_MAX]) {
-  // On Windows, tmpfile() may attempt to create temp files in the root directory
-  // of the drive, which requires Admin privileges, resulting in test failure.
-  char pathname[PATH_MAX];
-  if(0 == GetSafeTempPathA(PATH_MAX, pathname)) {
+  // On Windows, tmpfile() may attempt to create temp files in the root
+  // directory of the drive, which requires Admin privileges, resulting in test
+  // failure.
+  //
+  // We deliberately avoid GetTempFileNameA for unique-name generation: it
+  // silently truncates the name prefix to 3 characters and, when uUnique is 0,
+  // combines that prefix with a 16-bit time-derived value. That gives only
+  // 65,536 possible filenames, and the empty stub file it creates on disk
+  // persists. In long CI runs (e.g. the Windows SDE job, which executes the
+  // full gtest binary multiple times) many tests accumulate "aws????.tmp"
+  // files in the shared temp directory. Once the namespace is crowded, the
+  // internal collision-retry loop inside GetTempFileNameA can fail to find a
+  // free name and return 0, producing intermittent test failures.
+  //
+  // Instead, mirror createTempDirPath: generate a 64-bit random suffix with
+  // RAND_bytes and create the file atomically with CREATE_NEW so that any
+  // collision with a concurrent caller is detected and retried.
+  char temp_path[PATH_MAX];
+  if (0 == GetSafeTempPathA(PATH_MAX, temp_path)) {
     return 0;
   }
-  return GetTempFileNameA(pathname, "awslctest", 0, buffer);
+
+  static const int kMaxAttempts = 10;
+  for (int attempt = 0; attempt < kMaxAttempts; attempt++) {
+    union {
+      uint8_t bytes[8];
+      uint64_t value;
+    } random_bytes;
+    if (!RAND_bytes(random_bytes.bytes, sizeof(random_bytes.bytes))) {
+      return 0;
+    }
+
+    int written = snprintf(buffer, PATH_MAX, "%sawslctest_%" PRIX64 ".tmp",
+                           temp_path, random_bytes.value);
+    // Check for truncation of the path.
+    if (written < 0 || written >= PATH_MAX) {
+      return 0;
+    }
+
+    // CREATE_NEW atomically fails with ERROR_FILE_EXISTS if the file already
+    // exists, so we never race with another caller that picked the same name.
+    HANDLE h = CreateFileA(buffer, GENERIC_WRITE, 0, NULL, CREATE_NEW,
+                           FILE_ATTRIBUTE_NORMAL, NULL);
+    if (h != INVALID_HANDLE_VALUE) {
+      CloseHandle(h);
+      return (size_t)written;
+    }
+    if (GetLastError() != ERROR_FILE_EXISTS) {
+      return 0;
+    }
+  }
+  return 0;
 }
 
 size_t createTempDirPath(char buffer[PATH_MAX]) {

--- a/crypto/test/test_util.h
+++ b/crypto/test/test_util.h
@@ -113,6 +113,15 @@ FILE* createRawTempFILE();
 TempFILE createTempFILE();
 size_t createTempDirPath(char buffer[PATH_MAX]);
 
+#if defined(OPENSSL_WINDOWS)
+// On Windows, antivirus software (e.g. Windows Defender), file indexing
+// services, or other background processes can briefly lock files after they are
+// created or modified. This causes transient ERROR_SHARING_VIOLATION failures
+// when a test immediately tries to reopen the file. This helper retries
+// fopen(path, "rb") in a loop to wait out the lock.
+testing::AssertionResult WaitForFileAccessible(const char *path);
+#endif
+
 // Returns true if operating system is Amazon Linux and false otherwise.
 // Determined at run-time and requires read-permissions to /etc.
 bool osIsAmazonLinux(void);

--- a/crypto/test/test_util.h
+++ b/crypto/test/test_util.h
@@ -118,7 +118,7 @@ size_t createTempDirPath(char buffer[PATH_MAX]);
 // services, or other background processes can briefly lock files after they are
 // created or modified. This causes transient ERROR_SHARING_VIOLATION failures
 // when a test immediately tries to reopen the file. This helper retries
-// fopen(path, "rb") in a loop to wait out the lock.
+// opening the file for reading in a loop to wait out the lock.
 testing::AssertionResult WaitForFileAccessible(const char *path);
 #endif
 

--- a/tool-openssl/pass_util_test.cc
+++ b/tool-openssl/pass_util_test.cc
@@ -35,8 +35,14 @@ void WriteTestFile(const char *path, const char *content,
           << "Failed to write to file: " << path;
     }
   }
-  // If content is NULL or empty, we just create an empty file (no assertion
-  // needed)
+  // Close the file before calling WaitForFileAccessible.
+  file.reset();
+#if defined(OPENSSL_WINDOWS)
+  // On Windows, antivirus or indexing services can briefly lock a file after it
+  // is written. Wait for the lock to be released before returning so that
+  // callers can immediately reopen the file.
+  ASSERT_TRUE(WaitForFileAccessible(path));
+#endif
 }
 
 void SetTestEnvVar(const char *name, const char *value) {


### PR DESCRIPTION
Two related fixes for intermittent Windows test-infrastructure failures, both in `crypto/test/test_util.{h,cc}`:

**1. `WaitForFileAccessible`** — a new Windows-only helper that retries `fopen(path, "rb")` in a loop (10 attempts, 200ms apart) when it fails with `ERROR_SHARING_VIOLATION`, `ERROR_LOCK_VIOLATION`, or `ERROR_ACCESS_DENIED`. These are the Windows error codes that Windows Defender, the Search Indexer, or similar background processes produce when they briefly latch onto a file immediately after it is written. `WriteTestFile` in `pass_util_test.cc` now calls this after closing the file handle, fixing the `PassUtilTest.ExtractPasswordsSameFileEdgeCases` flake on the mingw CI job. The retry cadence mirrors the existing `WIN32_rename` workaround in `tool-openssl/ca.cc`.

**2. `createTempFILEpath` rewrite on Windows** — replaces the `GetTempFileNameA`-based implementation with one that generates a 64-bit `RAND_bytes` suffix and creates the file atomically via `CreateFileA(..., CREATE_NEW, ...)` with a short retry loop for collisions. `GetTempFileNameA` silently truncates its name prefix to 3 characters and, with `uUnique=0`, combines that prefix with a 16-bit time-derived value — only 65,536 possible filenames — and leaves the stub `.tmp` file on disk. In long CI runs the shared temp directory crowds up and the internal collision-retry loop inside `GetTempFileNameA` fails to find a free name and returns 0. This was recently observed on the `windows-itcs_sde-x86_64` job as `CATest.CopyExtensionsCopyAll` failing at `ASSERT_GT(createTempFILEpath(db_path), 0u)`. The new implementation mirrors the existing `createTempDirPath` pattern directly below it in the same file.

### Call-outs:

A few choices that may look counter-intuitive without context:

* `WaitForFileAccessible` intentionally retries on `ERROR_ACCESS_DENIED` in addition to the obvious sharing/lock violations. On Windows this error code can appear transiently from pending-deletion state, AV scan windows, or the Search Indexer — and if the failure is a genuine permission problem the retries will all fail identically and the test will still fail correctly after the budget expires.
* `WaitForFileAccessible` deliberately probes with `"rb"` rather than `"wb"`: a write-mode probe would truncate the file the caller just populated, and every failing call site we are hardening opens the file for reading anyway, so `"rb"` is the exact signal the caller needs.
* The original mingw failure surfaces in the OpenSSL error log as `"Broken pipe"` — misleading, but expected, because `ERROR_SHARING_VIOLATION` and `EPIPE` share the numeric value 32 and `crypto/bio/file.c` maps `errno` through `OPENSSL_PUT_SYSTEM_ERROR`.

### Testing:

Test-infrastructure-only changes. Previously-flaky `PassUtilTest.ExtractPasswordsSameFileEdgeCases` (mingw) and `CATest.CopyExtensionsCopyAll` (`windows-itcs_sde-x86_64`) should no longer flake. Example of the latter failure:

* Example failure for [windows-ltsc2022_sde-x86_64](https://github.com/aws/aws-lc/actions/runs/25074127211/job/73462130832#step:4:2938):
```
[ RUN      ] CATest.CopyExtensionsCopyAll
C:\Windows\Temp\codebuild\tmp\output\src3278884808\src\actions-runner\_work\aws-lc\aws-lc\tool-openssl\ca_test.cc(37): error: Expected: (createTempFILEpath(db_path)) > (0u), actual: 0 vs 0
[  FAILED  ] CATest.CopyExtensionsCopyAll (132 ms)
```

* Example Failure in the [mingw job](https://github.com/aws/aws-lc/actions/runs/24510110298/job/71638659743?pr=3170#step:7:1747):

```
[ RUN      ] PassUtilTest.ExtractPasswordsSameFileEdgeCases
Cannot read password file
Cannot open password file
D:/a/aws-lc/aws-lc/path has spaces/aws-lc/tool-openssl/pass_util_test.cc:418: Failure
Value of: pass_util::ExtractPasswords(passin, passout)
  Actual: false
Expected: true
D:/a/aws-lc/aws-lc/path has spaces/aws-lc/tool-openssl/pass_util_test.cc:419: Failure
Expected equality of these values:
  passin.get()
    Which is: "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\awsD7AE.tmp"
  "line1"
D:/a/aws-lc/aws-lc/path has spaces/aws-lc/tool-openssl/pass_util_test.cc:420: Failure
Expected equality of these values:
  passout.get()
    Which is: "file:C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\awsD7AE.tmp"
  "line2"
933178576:error:02000020:system library:OPENSSL_internal:Broken pipe:D:/a/aws-lc/aws-lc/path has spaces/aws-lc/crypto/bio/file.c:57:fopen('C:\Users\RUNNER~1\AppData\Local\Temp\awsD7AE.tmp','r')
933178576:error:11000070:BIO routines:OPENSSL_internal:SYS_LIB:D:/a/aws-lc/aws-lc/path has spaces/aws-lc/crypto/bio/file.c:63:
[  FAILED  ] PassUtilTest.ExtractPasswordsSameFileEdgeCases (6 ms)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
