### PR TITLE
Bump MySQL version to 9.7.0

### DIFF
--- a/tests/ci/integration/run_mysql_integration.sh
+++ b/tests/ci/integration/run_mysql_integration.sh
@@ -6,7 +6,7 @@ set -exu
 
 source tests/ci/common_posix_setup.sh
 
-MYSQL_VERSION_TAG="mysql-cluster-9.6.0"
+MYSQL_VERSION_TAG="mysql-cluster-9.7.0"
 # This directory is specific to the docker image used. Use -DDOWNLOAD_BOOST=1 -DWITH_BOOST=<directory>
 # with mySQL to download a compatible boost version locally.
 BOOST_INSTALL_FOLDER=/home/dependencies/boost


### PR DESCRIPTION
### Issues:
Resolves P418596610

### Description of changes: 
Bump the CI to use MySQL v9.7.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
