### PR TITLE
Handle allocation failures in add_string's section strdup and stack push

### DIFF
--- a/crypto/conf/conf.c
+++ b/crypto/conf/conf.c
@@ -331,6 +331,9 @@ static int add_string(const CONF *conf, CONF_VALUE *section,
   }
 
   if (!lh_CONF_VALUE_insert(conf->data, &old_value, value)) {
+    (void)sk_CONF_VALUE_delete_ptr(section_stack, value);
+    OPENSSL_free(value->section);
+    value->section = NULL;
     return 0;
   }
   if (old_value != NULL) {

--- a/crypto/conf/conf.c
+++ b/crypto/conf/conf.c
@@ -326,7 +326,13 @@ static int add_string(const CONF *conf, CONF_VALUE *section,
   CONF_VALUE *old_value;
 
   value->section = OPENSSL_strdup(section->section);
+  if (value->section == NULL) {
+    return 0;
+  }
+
   if (!sk_CONF_VALUE_push(section_stack, value)) {
+    OPENSSL_free(value->section);
+    value->section = NULL;
     return 0;
   }
 


### PR DESCRIPTION
### Description of changes:
Follow-up to #3139. That PR hardened the `lh_CONF_VALUE_insert` failure path in `add_string` (`crypto/conf/conf.c`) against a use-after-free and a leak of the strdup'd `value->section`. Two sibling allocation-failure paths in the same function had the same class of issue and are addressed here:

1. `OPENSSL_strdup(section->section)` was unchecked. On failure `value->section` is left NULL; we'd then proceed into `sk_CONF_VALUE_push` and `lh_CONF_VALUE_insert`, and `conf_value_cmp` would NULL-deref on any hash collision (it calls `strcmp(a->section, b->section)` unconditionally when the pointers differ). Now we bail out immediately.
2. If `sk_CONF_VALUE_push` fails after `OPENSSL_strdup` succeeded, `value->section` was leaked — the caller in `NCONF_load_bio` only frees `v->name`, `v->value`, and `v`. We now free it on this path, matching the cleanup introduced in #3139 on the `lh_CONF_VALUE_insert` path.

Both paths are only reachable under allocation failure.


### Testing:
Existing `ConfTest.*` suite continues to pass. The failure paths themselves are OOM-only and not exercised by the current test suite; no new test is included.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
