### PR TITLE
tool/s_client: fix -verify depth and missing CA store

### DIFF
--- a/tool-openssl/s_client_test.cc
+++ b/tool-openssl/s_client_test.cc
@@ -28,7 +28,7 @@ TEST(SClientTest, Help) {
 
 // Test -connect, -verify, -showcerts
 TEST(SClientTest, ConnectVerifyShowcerts) {
-  args_list_t args = {"-connect", "amazon.com:443", "-verify", "99"};
+  args_list_t args = {"-connect", "amazon.com:443", "-verify", "99", "-showcerts"};
   bool result = SClientTool(args);
   ASSERT_TRUE(result);
 }

--- a/tool/client.cc
+++ b/tool/client.cc
@@ -847,7 +847,17 @@ bool DoClient(std::map<std::string, std::string> args_map, bool is_openssl_s_cli
       return false;
     }
     fprintf(stdout, "verify depth is %d\n", (int)depth);
+    SSL_CTX_set_verify_depth(ctx.get(), (int)depth);
     verify = SSL_VERIFY_PEER;
+    // If no explicit CA source was provided, fall back to the platform default
+    // CA store. This mirrors the behaviour of OpenSSL's s_client -verify, which
+    // enables peer verification against whatever trust store the system provides
+    // when no -CAfile / -CApath is given.
+    if (args_map.count("-CAfile") == 0 && args_map.count("-CApath") == 0 &&
+        args_map.count("-root-certs") == 0 &&
+        args_map.count("-root-cert-dir") == 0) {
+      SSL_CTX_set_default_verify_paths(ctx.get());
+    }
   }
 
   if (is_openssl_s_client) { // openssl tool

--- a/tool/client.cc
+++ b/tool/client.cc
@@ -804,6 +804,7 @@ bool DoClient(std::map<std::string, std::string> args_map, bool is_openssl_s_cli
 
   std::string certPathFlag;
   int verify = SSL_VERIFY_NONE;
+  bool loaded_verify_locations = false;
   if (args_map.count("-root-certs") != 0) {
     certPathFlag = "-root-certs";
     verify = SSL_VERIFY_PEER;
@@ -819,6 +820,7 @@ bool DoClient(std::map<std::string, std::string> args_map, bool is_openssl_s_cli
       ERR_print_errors_fp(stderr);
       return false;
     }
+    loaded_verify_locations = true;
   }
 
   certPathFlag = "";
@@ -838,6 +840,7 @@ bool DoClient(std::map<std::string, std::string> args_map, bool is_openssl_s_cli
       ERR_print_errors_fp(stderr);
       return false;
     }
+    loaded_verify_locations = true;
   }
 
   if (args_map.count("-verify") != 0) {
@@ -849,14 +852,16 @@ bool DoClient(std::map<std::string, std::string> args_map, bool is_openssl_s_cli
     fprintf(stdout, "verify depth is %d\n", (int)depth);
     SSL_CTX_set_verify_depth(ctx.get(), (int)depth);
     verify = SSL_VERIFY_PEER;
-    // If no explicit CA source was provided, fall back to the platform default
-    // CA store. This mirrors the behaviour of OpenSSL's s_client -verify, which
-    // enables peer verification against whatever trust store the system provides
-    // when no -CAfile / -CApath is given.
-    if (args_map.count("-CAfile") == 0 && args_map.count("-CApath") == 0 &&
-        args_map.count("-root-certs") == 0 &&
-        args_map.count("-root-cert-dir") == 0) {
-      SSL_CTX_set_default_verify_paths(ctx.get());
+    // If no explicit CA source was provided (via -CAfile, -CApath, -root-certs,
+    // or -root-cert-dir), fall back to the platform default CA store. This
+    // mirrors the behaviour of OpenSSL's s_client -verify, which enables peer
+    // verification against whatever trust store the system provides when no
+    // explicit CA source is given.
+    if (!loaded_verify_locations) {
+      if (!SSL_CTX_set_default_verify_paths(ctx.get())) {
+        fprintf(stderr, "Warning: failed to load default verify paths.\n");
+        ERR_print_errors_fp(stderr);
+      }
     }
   }
 


### PR DESCRIPTION
### Description of changes:
`DoClient` had two bugs in its `-verify` handling. 
- First, the parsed depth value was being printed but `SSL_CTX_set_verify_depth` was never called, so the configured depth had no effect on the SSL context. 
- Second, `-verify` enables `SSL_VERIFY_PEER` but no CA certificates were loaded — unlike OpenSSL's `s_client`, which falls back to the platform trust store when no explicit `-CAfile`/`-CApath` is given. In practice the connection still succeeds because `verify_cb` unconditionally returns `ok = 1` for all errors (by design -- the `-verify` flag is documented to never fail the connection due to cert verification), but loading the system CAs means verification succeeds properly rather than purely through error suppression, which better matches OpenSSL behavior.

The `ConnectVerifyShowcerts` test is also fixed to actually pass `-showcerts`, which the test name and comment claimed it was testing but the argument was missing from the args list.

### Call-outs:
The `SSL_CTX_set_default_verify_paths` call is guarded so it only fires when none of the explicit CA-providing flags (`-CAfile`, `-CApath`, `-root-certs`, `-root-cert-dir`) are present, matching the OpenSSL fallback semantics.

### Testing:
The existing `SClientTest.ConnectVerifyShowcerts` test covers the changed code path. Note that this test suite makes live connections to `amazon.com`, so individual test failures can be caused by transient network issues in CI rather than code defects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
