### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,136 @@
+# Dependabot configuration for aws-lc.
+#
+# Notes for maintainers:
+# - The root go.mod and tests/ci/x509/limbo-report/go.mod are intentionally
+#   pinned to Go 1.20 for platform compatibility (see BUILDING.md and
+#   cmake/go.cmake). To keep Dependabot noise down for those modules we:
+#     * ignore major version bumps (where Go-version floors are most often
+#       raised),
+#     * use monthly scheduling,
+#     * apply a cooldown so newly-released versions have time to settle,
+#     * group updates into a single PR per module.
+# - util/vecgen is on Go 1.24 and can track modern versions freely.
+# - When a Dependabot PR is incompatible with our Go floor, close it with
+#   `@dependabot ignore this major version` (or `ignore this dependency`)
+#   so it is not re-proposed.
+version: 2
+updates:
+  # ---------------------------------------------------------------------------
+  # GitHub Actions used by workflows under .github/workflows and the composite
+  # actions under .github/actions.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # ---------------------------------------------------------------------------
+  # Root Go module — pinned to Go 1.20 for platform compatibility.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    ignore:
+      # Suppress major bumps: new majors are the most common place for
+      # dependencies to raise their minimum Go version.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      gomod-root:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "go"
+
+  # ---------------------------------------------------------------------------
+  # util/vecgen — Go 1.24, can track modern versions.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "gomod"
+    directory: "/util/vecgen"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      gomod-vecgen:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "go"
+
+  # ---------------------------------------------------------------------------
+  # tests/ci/x509/limbo-report — pinned to Go 1.20 for consistency with root.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "gomod"
+    directory: "/tests/ci/x509/limbo-report"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    groups:
+      gomod-limbo-report:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "go"
+
+  # ---------------------------------------------------------------------------
+  # CI Lambda helper (Rust).
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "cargo"
+    directory: "/tests/ci/lambda"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      cargo-ci-lambda:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "rust"
+
+  # ---------------------------------------------------------------------------
+  # CI Python requirements.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "pip"
+    directory: "/tests/ci"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      pip-ci:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "python"

--- a/tests/ci/x509/limbo-report/go.mod
+++ b/tests/ci/x509/limbo-report/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/aws-lc/tests/ci/x509/limbo-report
 
-go 1.17
+go 1.20
 
 require github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
### Description of changes:
Adds `.github/dependabot.yml`. AWS-LC currently has no Dependabot configuration, which means we receive no notifications (or PRs) when the GitHub Actions referenced by our ~40 workflows go out of date, and similarly for the Go/Rust/Python dependencies we vendor under `tests/ci` and `util/`.

The new config covers five ecosystems:
- `github-actions` at `/` — weekly, grouped.
- `gomod` at `/`, `/util/vecgen`, and `/tests/ci/x509/limbo-report` — monthly, grouped per module.
- `cargo` at `/tests/ci/lambda` — monthly, grouped.
- `pip` at `/tests/ci` — monthly, grouped.

Also bumps `tests/ci/x509/limbo-report/go.mod` from Go 1.17 to Go 1.20 so it matches the floor declared in the root `go.mod`. The only dependency (`github.com/google/go-cmp v0.6.0`) is already compatible.

### Call-outs:
The root `go.mod` is deliberately pinned to Go 1.20 for platform compatibility (called out in `BUILDING.md` and `cmake/go.cmake`). A naive Dependabot config would generate a lot of noise from modules that drop support for older Go versions in new major releases. To mitigate:

- Major version bumps are ignored (`version-update:semver-major`) for the two Go 1.20–pinned modules. Patch and minor updates — where security-relevant churn for `golang.org/x/crypto` and friends actually lives — still come through.
- `util/vecgen` is on Go 1.24 and is configured without the major-version ignore, so it can track modern versions freely.
- A `cooldown` block delays PRs for newly-released versions so the ecosystem has time to settle. Combined with monthly scheduling, this should produce a small, consolidated batch per month.
- An `open-pull-requests-limit: 3` backstop is set on each ecosystem.
- When a Dependabot PR does land that's incompatible with our Go floor, closing it with `@dependabot ignore this major version` will permanently suppress that specific bump without needing to maintain a hand-written ignore list.

One thing worth deciding during review: the `cooldown` key is a relatively new Dependabot feature. It's supported on github.com today but may not be understood by older GHES instances if anyone is mirroring this config there.

### Testing:
No runtime behavior is changed. Once merged, Dependabot will run against the config and its first batch of PRs will serve as the functional test; any schema issues would surface as a Dependabot alert on the repository settings page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
