### PR TITLE
ci: pin cryptography to source builds in pyopenssl integration

### DIFF
--- a/tests/ci/integration/run_pyopenssl_integration.sh
+++ b/tests/ci/integration/run_pyopenssl_integration.sh
@@ -63,7 +63,14 @@ function pyopenssl_run_tests() {
     # Build cryptography from source so it links against AWS-LC via OPENSSL_DIR.
     # Prebuilt wheels bundle their own libcrypto and would ignore OPENSSL_DIR.
     # Version >= 46 is required for AWS-LC source build support.
-    python -m pip install --no-binary cryptography cryptography
+    #
+    # Export PIP_NO_BINARY so subsequent `pip install` invocations (e.g. the
+    # PyOpenSSL install below) cannot transitively downgrade cryptography to a
+    # prebuilt wheel that bundles its own libcrypto. PyOpenSSL pins an upper
+    # bound on cryptography, and without this pip will silently replace our
+    # AWS-LC-linked build with a manylinux wheel when resolving dependencies.
+    export PIP_NO_BINARY=cryptography
+    python -m pip install cryptography
 
     # Install PyOpenSSL from the patched source along with test dependencies.
     python -m pip install -e '.[test]'


### PR DESCRIPTION
### Description of changes:
The `pyopenssl` integration job started failing once `cryptography 47.0.0` landed on PyPI. The script installs `cryptography` from source against AWS-LC (via `OPENSSL_DIR`), which picks up 47.0.0. The subsequent `pip install -e '.[test]'` for pyOpenSSL 25.3.0 then sees pyOpenSSL's `cryptography<47` upper bound, quietly uninstalls our source build, and replaces it with a prebuilt manylinux wheel for 46.x that bundles its own libcrypto. The linkage assertion then fails with `OpenSSL 3.5.6` instead of `AWS-LC`.

This switches to `export PIP_NO_BINARY=cryptography` before the first install so the setting persists across all subsequent `pip install` invocations in the venv. Any transitive resolution of `cryptography` is forced to build from source against `OPENSSL_DIR`, so pyOpenSSL's dependency resolver can still downgrade within the `<47` range but will rebuild against AWS-LC rather than swapping in a vendored-libcrypto wheel.

### Call-outs:
`--no-binary` on a single `pip install` line is **not** sticky across invocations — the env var form is. That's the whole point of the change; worth noting because the one-liner looks equivalent but isn't.

### Testing:
CI — the `pyopenssl-x86-64` job going green is the signal.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
