### PR TITLE
Scope _STL_EXTRA_DISABLED_WARNINGS to C++ to fix Ninja + clang-cl builds

### DIFF
--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -206,64 +206,38 @@ jobs:
   cross-clang-cl-ninja:
     # Cross-compile from Linux to x86_64-pc-windows-msvc with Ninja + clang-cl,
     # mirroring the default aws-lc-rs setup. This catches command-line quoting
-    # regressions that the Windows-native clang-cl-ninja job misses because
-    # cmd.exe and /bin/sh tokenize arguments differently (see aws/aws-lc-rs#981).
+    # regressions the Windows-native clang-cl-ninja job misses because cmd.exe
+    # and /bin/sh tokenize arguments differently (see aws/aws-lc-rs#981).
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install dependencies
+      - uses: actions/checkout@v4
+      - name: Setup toolchain
         run: |
           set -ex
           sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
           sudo apt-get install --assume-yes --no-install-recommends \
             cmake ninja-build nasm \
             wget lsb-release software-properties-common gnupg
-          # Install Clang 19 from LLVM apt repository
-          # (xwin's MSVC STL headers require Clang 19+; Ubuntu 24.04 ships Clang 18)
+          # Clang 19 (xwin's MSVC STL headers require Clang >= 19; 24.04 ships 18).
           wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19
-          sudo ln -sf /usr/bin/clang-19 /usr/local/bin/clang-cl
-          sudo ln -sf /usr/bin/lld-19 /usr/local/bin/lld-link
-          sudo ln -sf /usr/bin/llvm-ar-19 /usr/local/bin/llvm-lib
-          # CMake's vs_link_exe helper invokes `rc` (resource compiler) and
-          # `mt` (manifest tool) when linking on a Windows target. Provide the
-          # LLVM equivalents so manifest generation succeeds.
-          sudo ln -sf /usr/bin/llvm-rc-19 /usr/local/bin/llvm-rc
-          sudo ln -sf /usr/bin/llvm-mt-19 /usr/local/bin/llvm-mt
-      - name: Fetch MSVC SDK via xwin
-        run: |
-          set -ex
+          sudo ln -sf /usr/bin/clang-19    /usr/local/bin/clang-cl
+          sudo ln -sf /usr/bin/lld-19      /usr/local/bin/lld-link
+          sudo ln -sf /usr/bin/llvm-ar-19  /usr/local/bin/llvm-lib
+          sudo ln -sf /usr/bin/llvm-rc-19  /usr/local/bin/llvm-rc
+          sudo ln -sf /usr/bin/llvm-mt-19  /usr/local/bin/llvm-mt
+          # xwin provides the MSVC SDK headers/libs for cross-compiling.
           XWIN_VERSION=0.6.5
-          wget -q https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VERSION}/xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          tar xzf xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl.tar.gz
+          wget -qO- https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VERSION}/xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl.tar.gz | tar xz
           sudo mv xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl/xwin /usr/local/bin/
           xwin --accept-license --arch x86_64 splat --output /tmp/xwin
-          echo '--- /tmp/xwin/crt/lib/x86_64 ---'
-          ls /tmp/xwin/crt/lib/x86_64 | head -40 || true
-      - name: Configure
+      - name: Build
         run: |
           set -ex
-          XWIN=/tmp/xwin
-          INCLUDES="/imsvc ${XWIN}/crt/include /imsvc ${XWIN}/sdk/include/ucrt /imsvc ${XWIN}/sdk/include/um /imsvc ${XWIN}/sdk/include/shared"
-          LIBPATHS="/LIBPATH:${XWIN}/crt/lib/x86_64 /LIBPATH:${XWIN}/sdk/lib/um/x86_64 /LIBPATH:${XWIN}/sdk/lib/ucrt/x86_64"
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_SYSTEM_NAME=Windows \
-            -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
-            -DCMAKE_C_COMPILER=clang-cl \
-            -DCMAKE_CXX_COMPILER=clang-cl \
-            -DCMAKE_C_COMPILER_TARGET=x86_64-pc-windows-msvc \
-            -DCMAKE_CXX_COMPILER_TARGET=x86_64-pc-windows-msvc \
-            -DCMAKE_RC_COMPILER=llvm-rc \
-            -DCMAKE_MT=llvm-mt \
-            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL \
-            -DCMAKE_C_FLAGS="${INCLUDES}" \
-            -DCMAKE_CXX_FLAGS="${INCLUDES}" \
-            -DCMAKE_EXE_LINKER_FLAGS="${LIBPATHS}" \
-            -DCMAKE_SHARED_LINKER_FLAGS="${LIBPATHS}"
-      - name: Build
-        run: cmake --build build --target all
+            -DCMAKE_TOOLCHAIN_FILE=util/x86_64-windows-clang-cl-toolchain.cmake
+          cmake --build build --target all
   msys2:
     name: msys2 ${{ matrix.sys }} - ${{ matrix.generator }}
     if: github.repository_owner == 'aws'

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -203,6 +203,57 @@ jobs:
       - name: x86_64-w64-mingw32 Build/Test
         run:
           ./tests/ci/run_cross_mingw_tests.sh x86_64 w64-mingw32 "-DCMAKE_BUILD_TYPE=Release"
+  cross-clang-cl-ninja:
+    # Cross-compile from Linux to x86_64-pc-windows-msvc with Ninja + clang-cl,
+    # mirroring the default aws-lc-rs setup. This catches command-line quoting
+    # regressions that the Windows-native clang-cl-ninja job misses because
+    # cmd.exe and /bin/sh tokenize arguments differently (see aws/aws-lc-rs#981).
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          set -ex
+          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
+          sudo apt-get install --assume-yes --no-install-recommends \
+            cmake ninja-build nasm \
+            wget lsb-release software-properties-common gnupg
+          # Install Clang 19 from LLVM apt repository
+          # (xwin's MSVC STL headers require Clang 19+; Ubuntu 24.04 ships Clang 18)
+          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19
+          sudo ln -sf /usr/bin/clang-19 /usr/local/bin/clang-cl
+          sudo ln -sf /usr/bin/lld-19 /usr/local/bin/lld-link
+          sudo ln -sf /usr/bin/llvm-ar-19 /usr/local/bin/llvm-lib
+      - name: Fetch MSVC SDK via xwin
+        run: |
+          set -ex
+          XWIN_VERSION=0.6.5
+          wget -q https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VERSION}/xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl.tar.gz
+          tar xzf xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl.tar.gz
+          sudo mv xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl/xwin /usr/local/bin/
+          xwin --accept-license splat --output /tmp/xwin --arch x86_64
+      - name: Configure
+        run: |
+          set -ex
+          XWIN=/tmp/xwin
+          INCLUDES="/imsvc ${XWIN}/crt/include /imsvc ${XWIN}/sdk/include/ucrt /imsvc ${XWIN}/sdk/include/um /imsvc ${XWIN}/sdk/include/shared"
+          LIBPATHS="/LIBPATH:${XWIN}/crt/lib/x86_64 /LIBPATH:${XWIN}/sdk/lib/um/x86_64 /LIBPATH:${XWIN}/sdk/lib/ucrt/x86_64"
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_SYSTEM_NAME=Windows \
+            -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
+            -DCMAKE_C_COMPILER=clang-cl \
+            -DCMAKE_CXX_COMPILER=clang-cl \
+            -DCMAKE_C_COMPILER_TARGET=x86_64-pc-windows-msvc \
+            -DCMAKE_CXX_COMPILER_TARGET=x86_64-pc-windows-msvc \
+            -DCMAKE_C_FLAGS="${INCLUDES}" \
+            -DCMAKE_CXX_FLAGS="${INCLUDES}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${LIBPATHS}" \
+            -DCMAKE_SHARED_LINKER_FLAGS="${LIBPATHS}"
+      - name: Build
+        run: cmake --build build --target all
   msys2:
     name: msys2 ${{ matrix.sys }} - ${{ matrix.generator }}
     if: github.repository_owner == 'aws'

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -239,6 +239,8 @@ jobs:
           tar xzf xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl.tar.gz
           sudo mv xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl/xwin /usr/local/bin/
           xwin --accept-license --arch x86_64 splat --output /tmp/xwin
+          echo '--- /tmp/xwin/crt/lib/x86_64 ---'
+          ls /tmp/xwin/crt/lib/x86_64 | head -40 || true
       - name: Configure
         run: |
           set -ex
@@ -255,6 +257,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_TARGET=x86_64-pc-windows-msvc \
             -DCMAKE_RC_COMPILER=llvm-rc \
             -DCMAKE_MT=llvm-mt \
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL \
             -DCMAKE_C_FLAGS="${INCLUDES}" \
             -DCMAKE_CXX_FLAGS="${INCLUDES}" \
             -DCMAKE_EXE_LINKER_FLAGS="${LIBPATHS}" \

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -226,6 +226,11 @@ jobs:
           sudo ln -sf /usr/bin/clang-19 /usr/local/bin/clang-cl
           sudo ln -sf /usr/bin/lld-19 /usr/local/bin/lld-link
           sudo ln -sf /usr/bin/llvm-ar-19 /usr/local/bin/llvm-lib
+          # CMake's vs_link_exe helper invokes `rc` (resource compiler) and
+          # `mt` (manifest tool) when linking on a Windows target. Provide the
+          # LLVM equivalents so manifest generation succeeds.
+          sudo ln -sf /usr/bin/llvm-rc-19 /usr/local/bin/llvm-rc
+          sudo ln -sf /usr/bin/llvm-mt-19 /usr/local/bin/llvm-mt
       - name: Fetch MSVC SDK via xwin
         run: |
           set -ex
@@ -248,6 +253,8 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang-cl \
             -DCMAKE_C_COMPILER_TARGET=x86_64-pc-windows-msvc \
             -DCMAKE_CXX_COMPILER_TARGET=x86_64-pc-windows-msvc \
+            -DCMAKE_RC_COMPILER=llvm-rc \
+            -DCMAKE_MT=llvm-mt \
             -DCMAKE_C_FLAGS="${INCLUDES}" \
             -DCMAKE_CXX_FLAGS="${INCLUDES}" \
             -DCMAKE_EXE_LINKER_FLAGS="${LIBPATHS}" \

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -233,7 +233,7 @@ jobs:
           wget -q https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VERSION}/xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl.tar.gz
           tar xzf xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl.tar.gz
           sudo mv xwin-${XWIN_VERSION}-x86_64-unknown-linux-musl/xwin /usr/local/bin/
-          xwin --accept-license splat --output /tmp/xwin --arch x86_64
+          xwin --accept-license --arch x86_64 splat --output /tmp/xwin
       - name: Configure
         run: |
           set -ex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -849,9 +849,12 @@ if(WIN32)
   # Allow use of fopen.
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
   # VS 2017 and higher supports STL-only warning suppressions.
-  # A bug in CMake < 3.13.0 may cause the space in this value to
-  # cause issues when building with NASM. In that case, update CMake.
-  add_definitions("-D_STL_EXTRA_DISABLED_WARNINGS=4774 4987")
+  # _STL_EXTRA_DISABLED_WARNINGS is only consumed by MSVC STL headers,
+  # so scope the definition to C++. Using add_compile_options with a
+  # CMake-escaped space keeps the value as a single argument under
+  # Ninja + clang-cl, where add_definitions with a space-containing
+  # value is not quoted robustly (see aws/aws-lc-rs#981).
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-D_STL_EXTRA_DISABLED_WARNINGS=4774\ 4987>)
 endif()
 
 add_flag_if_supported(C_CXX_FLAGS "-Wshadow")

--- a/util/x86_64-windows-clang-cl-toolchain.cmake
+++ b/util/x86_64-windows-clang-cl-toolchain.cmake
@@ -1,0 +1,59 @@
+# AWS-LC Cross-compile Toolchain: Linux → x86_64-pc-windows-msvc
+#
+# This toolchain configures clang-cl + lld-link + LLVM tools to cross-compile
+# AWS-LC from a Linux host to a Windows MSVC target, using MSVC SDK headers
+# and libraries supplied by xwin (https://github.com/Jake-Shadle/xwin).
+#
+# Usage:
+#   cmake -DCMAKE_TOOLCHAIN_FILE=util/x86_64-windows-clang-cl-toolchain.cmake \
+#         -G Ninja -DCMAKE_BUILD_TYPE=Release ...
+#
+# Prerequisites:
+#   - clang-cl, lld-link, llvm-lib, llvm-rc, llvm-mt on PATH (Clang >= 19)
+#   - An xwin-splatted MSVC SDK. The layout is expected to be:
+#       ${XWIN_SDK_ROOT}/crt/{include,lib/x86_64}
+#       ${XWIN_SDK_ROOT}/sdk/include/{ucrt,um,shared}
+#       ${XWIN_SDK_ROOT}/sdk/lib/{ucrt,um}/x86_64
+#     Override the root via the XWIN_SDK_ROOT cache variable or environment
+#     variable; defaults to /tmp/xwin.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(CMAKE_C_COMPILER clang-cl)
+set(CMAKE_CXX_COMPILER clang-cl)
+set(CMAKE_C_COMPILER_TARGET x86_64-pc-windows-msvc)
+set(CMAKE_CXX_COMPILER_TARGET x86_64-pc-windows-msvc)
+set(CMAKE_RC_COMPILER llvm-rc)
+set(CMAKE_MT llvm-mt)
+
+# Force the MSVC release dynamic runtime (/MD) everywhere, including inside
+# CMake's initial try_compile probe. xwin does not splat the debug CRT import
+# libraries by default, so without this CMake's probe fails to link against
+# msvcrtd.lib. Requires CMP0091 NEW, which AWS-LC's top-level CMakeLists sets.
+set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+
+# Locate the xwin SDK. Prefer an explicit cache variable, then the environment,
+# then fall back to the conventional /tmp/xwin used by the CI job.
+if(NOT DEFINED XWIN_SDK_ROOT)
+  if(DEFINED ENV{XWIN_SDK_ROOT})
+    set(XWIN_SDK_ROOT "$ENV{XWIN_SDK_ROOT}" CACHE PATH "xwin MSVC SDK root")
+  else()
+    set(XWIN_SDK_ROOT "/tmp/xwin" CACHE PATH "xwin MSVC SDK root")
+  endif()
+endif()
+
+# Include paths use /imsvc so clang-cl treats them as system headers and does
+# not emit warnings from within them.
+string(APPEND CMAKE_C_FLAGS_INIT
+  " /imsvc ${XWIN_SDK_ROOT}/crt/include"
+  " /imsvc ${XWIN_SDK_ROOT}/sdk/include/ucrt"
+  " /imsvc ${XWIN_SDK_ROOT}/sdk/include/um"
+  " /imsvc ${XWIN_SDK_ROOT}/sdk/include/shared")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_C_FLAGS_INIT}")
+
+string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT
+  " /LIBPATH:${XWIN_SDK_ROOT}/crt/lib/x86_64"
+  " /LIBPATH:${XWIN_SDK_ROOT}/sdk/lib/um/x86_64"
+  " /LIBPATH:${XWIN_SDK_ROOT}/sdk/lib/ucrt/x86_64")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS_INIT}")


### PR DESCRIPTION
### Issues:
Addresses aws/aws-lc-rs#981

### Description of changes:
The value `4774 4987` in `add_definitions("-D_STL_EXTRA_DISABLED_WARNINGS=4774 4987")` contains a space, which is not quoted robustly by the Ninja generator when the compiler is clang-cl. clang-cl ends up parsing `4987` as a second positional argument, which breaks cross-compiling to `x86_64-pc-windows-msvc` from Linux (the default aws-lc-rs setup).

This change scopes the definition to C++ (where `_STL_EXTRA_DISABLED_WARNINGS` is actually consumed, by MSVC STL headers) and switches to `add_compile_options` with a CMake-escaped space so the value survives as a single argument.

### Call-outs:
This is effectively restoring the form BoringSSL used [before it was reverted](https://github.com/google/boringssl/commit/f7b830d8df) for an old CMake < 3.13 NASM bug that is no longer relevant to us. Upstream BoringSSL has since [dropped the suppression entirely](https://github.com/google/boringssl/blob/main/CMakeLists.txt); this PR is the more conservative fix that keeps the warning suppression for our C++ code under `-WX`.

### Testing:
Existing CI covers the MSVC `cl.exe` and Windows-native clang-cl paths. The new `cross-clang-cl-ninja` job in this PR exercises the specific scenario from the report and will continue to guard against it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
