### PR TITLE
Silence two stringop-overflow false-positives

### DIFF
--- a/crypto/cipher_extra/aead_test.cc
+++ b/crypto/cipher_extra/aead_test.cc
@@ -1302,7 +1302,17 @@ TEST(AEADTest, TestGCMSIV128Change16Alignment) {
   GTEST_LOG_(INFO) << "Orig. Ctx.State Location: " << &encrypt_ctx_128->state;
   EVP_AEAD_CTX *moved_encrypt_ctx_128 =
       (EVP_AEAD_CTX *)(((uint8_t *)encrypt_ctx_128) + 8);
+  // The destination pointer is offset into the allocation so that it aliases
+  // the |state| subobject; GCC / fortify-headers infer the subobject size and
+  // report a `stringop-overflow` false positive (see aws-lc#3083).
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
   memmove(moved_encrypt_ctx_128, encrypt_ctx_128, sizeof(EVP_AEAD_CTX));
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
   GTEST_LOG_(INFO) << "Moved Ctx.State Location: "
                    << &moved_encrypt_ctx_128->state;
 
@@ -1343,7 +1353,15 @@ TEST(AEADTest, TestGCMSIV256Change16Alignment) {
   GTEST_LOG_(INFO) << "Orig. Ctx.State Location: " << &encrypt_ctx_256->state;
   EVP_AEAD_CTX *moved_encrypt_ctx_256 =
       (EVP_AEAD_CTX *)(((uint8_t *)encrypt_ctx_256) + 8);
+  // See TestGCMSIV128Change16Alignment for why this pragma is needed.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
   memmove(moved_encrypt_ctx_256, encrypt_ctx_256, sizeof(EVP_AEAD_CTX));
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
   GTEST_LOG_(INFO) << "Moved Ctx.State Location: "
                    << &moved_encrypt_ctx_256->state;
 

--- a/crypto/cipher_extra/aead_test.cc
+++ b/crypto/cipher_extra/aead_test.cc
@@ -1305,12 +1305,14 @@ TEST(AEADTest, TestGCMSIV128Change16Alignment) {
   // The destination pointer is offset into the allocation so that it aliases
   // the |state| subobject; GCC / fortify-headers infer the subobject size and
   // report a `stringop-overflow` false positive (see aws-lc#3083).
-#if defined(__GNUC__) && !defined(__clang__)
+  // -Wstringop-overflow was introduced in GCC 7; older GCC versions reject
+  // the pragma with -Werror=pragmas.
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 7)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
   memmove(moved_encrypt_ctx_128, encrypt_ctx_128, sizeof(EVP_AEAD_CTX));
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 7)
 #pragma GCC diagnostic pop
 #endif
   GTEST_LOG_(INFO) << "Moved Ctx.State Location: "
@@ -1354,12 +1356,12 @@ TEST(AEADTest, TestGCMSIV256Change16Alignment) {
   EVP_AEAD_CTX *moved_encrypt_ctx_256 =
       (EVP_AEAD_CTX *)(((uint8_t *)encrypt_ctx_256) + 8);
   // See TestGCMSIV128Change16Alignment for why this pragma is needed.
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 7)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
   memmove(moved_encrypt_ctx_256, encrypt_ctx_256, sizeof(EVP_AEAD_CTX));
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 7)
 #pragma GCC diagnostic pop
 #endif
   GTEST_LOG_(INFO) << "Moved Ctx.State Location: "

--- a/crypto/fipsmodule/bn/bytes.c
+++ b/crypto/fipsmodule/bn/bytes.c
@@ -199,14 +199,16 @@ void bn_words_to_big_endian(uint8_t *out, size_t out_len, const BN_ULONG *in,
     num_bytes = out_len;
   }
 
+  // The redundant `i < out_len` guard below silences a GCC 14+
+  // `-Wstringop-overflow` false positive under LTO (see aws-lc#3166).
 #ifdef OPENSSL_BIG_ENDIAN
-  for (size_t i = 0; i < num_bytes; i++) {
+  for (size_t i = 0; i < num_bytes && i < out_len; i++) {
     BN_ULONG l = in[i / BN_BYTES];
     out[out_len - i - 1] = (uint8_t)(l >> (8 * (i % BN_BYTES))) & 0xff;
   }
 #else
   const uint8_t *bytes = (const uint8_t *)in;
-  for (size_t i = 0; i < num_bytes; i++) {
+  for (size_t i = 0; i < num_bytes && i < out_len; i++) {
     out[out_len - i - 1] = bytes[i];
   }
 #endif


### PR DESCRIPTION
### Issues:

https://github.com/aws/aws-lc/issues/3083
https://github.com/aws/aws-lc/issues/3166

### Description of changes: 

Silence two stringop-overflow false-positives. Routine thing due to compilers getting "smarter".

#3083 `-Wstringop-overflow` false positive in `TestGCMSIV{128,256}Change16Alignment`. The tests intentionally offset the destination pointer into an `EVP_AEAD_CTX` allocation so it aliases the state subobject; GCC (notably under Alpine's fortify-headers) then infers the  smaller subobject size and flags the `memmove` as an overflow. Wrap just the two `memmove` calls in a GCC-only diagnostic push/ignored/pop. No runtime change.

#3166 `-Wstringop-overflow` false positive in `bn_words_to_big_endian` under LTO. Add a redundant `i < out_len` guard to both loops so the compiler can see the in-bounds invariant the caller already enforces. Semantically a no-op (`num_bytes` is already clamped to `out_len`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
