### PR TITLE
Dilently drop handshake fragments at the far edge of the seq window

### DIFF
--- a/ssl/d1_both.cc
+++ b/ssl/d1_both.cc
@@ -155,7 +155,7 @@ static hm_fragment *dtls1_get_incoming_message(
     SSL *ssl, uint8_t *out_alert, const struct hm_header_st *msg_hdr) {
   if (msg_hdr->seq < ssl->d1->handshake_read_seq ||
       msg_hdr->seq - ssl->d1->handshake_read_seq >= SSL_MAX_HANDSHAKE_FLIGHT) {
-    *out_alert = SSL_AD_INTERNAL_ERROR;
+    *out_alert = SSL_AD_ILLEGAL_PARAMETER;
     return NULL;
   }
 
@@ -267,8 +267,7 @@ ssl_open_record_t dtls1_open_handshake(SSL *ssl, size_t *out_consumed,
     }
 
     if (msg_hdr.seq < ssl->d1->handshake_read_seq ||
-        msg_hdr.seq >
-            (unsigned)ssl->d1->handshake_read_seq + SSL_MAX_HANDSHAKE_FLIGHT) {
+        msg_hdr.seq - ssl->d1->handshake_read_seq >= SSL_MAX_HANDSHAKE_FLIGHT) {
       // Ignore fragments from the past, or ones too far in the future.
       continue;
     }

--- a/ssl/test/runner/common.go
+++ b/ssl/test/runner/common.go
@@ -1304,6 +1304,12 @@ type ProtocolBugs struct {
 	// fragments in DTLS.
 	SendEmptyFragments bool
 
+	// SendExtraFutureHandshakeFragment, if non-zero, causes each outgoing
+	// DTLS handshake message to be preceded by an extra fragment carrying
+	// message_seq equal to the current sequence number plus this value.
+	// The peer is expected to silently ignore the extra fragment.
+	SendExtraFutureHandshakeFragment int
+
 	// SendSplitAlert, if true, causes an alert to be sent with the header
 	// and record body split across multiple packets. The peer should
 	// discard these packets rather than process it.

--- a/ssl/test/runner/dtls.go
+++ b/ssl/test/runner/dtls.go
@@ -211,6 +211,17 @@ func (c *Conn) dtlsWriteRecord(typ recordType, data []byte) (n int, err error) {
 		c.pendingFragments = append(c.pendingFragments, c.makeFragment(header, data, len(data), 0))
 	}
 
+	// Only inject the extra future-seq fragment during the plaintext
+	// handshake. The encrypted epoch uses a separate code path on the
+	// peer that enforces an exact-seq match (d1_both.cc: r_epoch == 1
+	// branch), which is not what this knob is meant to exercise.
+	if offset := c.config.Bugs.SendExtraFutureHandshakeFragment; offset != 0 && c.out.cipher == nil {
+		origSeq := c.sendHandshakeSeq
+		c.sendHandshakeSeq = origSeq + uint16(offset)
+		c.pendingFragments = append(c.pendingFragments, c.makeFragment(header, data, 0, len(data)))
+		c.sendHandshakeSeq = origSeq
+	}
+
 	firstRun := true
 	fragOffset := 0
 	for firstRun || fragOffset < len(data) {

--- a/ssl/test/runner/runner.go
+++ b/ssl/test/runner/runner.go
@@ -2646,6 +2646,27 @@ read alert 1 0
 			},
 		},
 		{
+			protocol: dtls,
+			name:     "SendExtraFutureHandshakeFragment-AtWindowEdge-DTLS",
+			config: Config{
+				Bugs: ProtocolBugs{
+					// 7 == SSL_MAX_HANDSHAKE_FLIGHT. With the off-by-one
+					// in the outer filter, this fragment would hit the
+					// inner bounds check and abort the connection.
+					SendExtraFutureHandshakeFragment: 7,
+				},
+			},
+		},
+		{
+			protocol: dtls,
+			name:     "SendExtraFutureHandshakeFragment-FarFuture-DTLS",
+			config: Config{
+				Bugs: ProtocolBugs{
+					SendExtraFutureHandshakeFragment: 100,
+				},
+			},
+		},
+		{
 			name: "SendInvalidRecordType",
 			config: Config{
 				Bugs: ProtocolBugs{


### PR DESCRIPTION
### Issues:

P424976664

### Description of changes: 

The outer filter in dtls1_open_handshake rejected handshake fragments whose message_seq was strictly greater than handshake_read_seq + SSL_MAX_HANDSHAKE_FLIGHT, but the inner bounds check in dtls1_get_incoming_message rejected anything with seq - R >= SSL_MAX_HANDSHAKE_FLIGHT. This is a tiny one-value gap: a fragment with seq == handshake_read_seq + SSL_MAX_HANDSHAKE_FLIGHT is not caught in the outer "ignore" filter, reached the inner check, and caused the connection to be torn down with a fatal internal error alert.

RFC 6347 section 4.2.2 and RFC 9147 section 5.2 specify that a handshake message with message_seq greater than next_receive_seq SHOULD be queued and MAY be discarded. Neither RFC permits a fatal alert in this case. Our buffer holds SSL_MAX_HANDSHAKE_FLIGHT messages, so any seq beyond that window probably match best the the "MAY discard" clause since it's not a malformed message per-se, just one we cannot store.

Align the outer filter with the inner window so seq == handshake_read_seq + SSL_MAX_HANDSHAKE_FLIGHT is silently dropped as "too far in the future", consistent with the comment on the same branch. Keep the bounds check inside dtls1_get_incoming_message as defense in depth, but change its alert from SSL_AD_INTERNAL_ERROR to SSL_AD_ILLEGAL_PARAMETER. SSL_AD_INTERNAL_ERROR is inappropriate since the condition is driven by the peer's header, not internal state.

At the same time, avoid any chance of wrapping under the if-condition.

### Testing:

Without patched inequality
```
$ ninja-build run_tests
[0/2] cd /home/ec2-user/humble/aws-lc && /usr/bin/cmake -E echo Runni...2-user/humble/aws-lc/ssl/test/runner/ssl_transfer/test_case_names.txt
Running SSL tests
FAILED (SendExtraFutureHandshakeFragment-AtWindowEdge-DTLS)
unexpected failure: local error 'remote error: illegal parameter', child error 'exit status 1', stdout:

stderr:
SSL error: SYSCALL
Error occurred: errno = 0, description = Success
Connection 1 failed.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
