### PR TITLE
Ensure correct bio memory buffer type is assigned

### DIFF
--- a/crypto/bio/bio_mem.c
+++ b/crypto/bio/bio_mem.c
@@ -261,11 +261,25 @@ static long mem_ctrl(BIO *bio, int cmd, long num, void *ptr) {
         *pptr = (b->data != NULL) ? &b->data[bbm->read_off] : NULL;
       }
       break;
-    case BIO_C_SET_BUF_MEM:
+    case BIO_C_SET_BUF_MEM: {
+      // |bio->ptr| stores a |BIO_BUF_MEM| wrapper, not a raw |BUF_MEM*|.
+      // Allocate the wrapper before releasing the old state so a failure here
+      // leaves |bio| usable and does not take ownership of |ptr|.
+      BIO_BUF_MEM *new_bbm = OPENSSL_zalloc(sizeof(*new_bbm));
+      if (new_bbm == NULL) {
+        ret = 0;
+        break;
+      }
+      new_bbm->buf = ptr;
+      new_bbm->read_off = 0;
       mem_free(bio);
       bio->shutdown = (int)num;
-      bio->ptr = ptr;
+      bio->init = 1;
+      bio->ptr = new_bbm;
+      bio->num = -1;
+      bio->flags &= ~BIO_FLAGS_MEM_RDONLY;
       break;
+    }
     case BIO_C_GET_BUF_MEM_PTR:
       if (ptr != NULL) {
         mem_buf_sync(bio);

--- a/crypto/bio/bio_test.cc
+++ b/crypto/bio/bio_test.cc
@@ -447,6 +447,63 @@ TEST(BIOTest, BioGetMemLeak) {
   ASSERT_EQ(Bytes(buf_mem->data, buf_mem->length), Bytes("Hello World\n"));
 }
 
+// SetMemBufNoClose, SetMemBufClose, and SetMemBufReplacesState exercise
+// a number of code-paths to ensure |BIO_set_mem_buf| functions correctly.
+TEST(BIOTest, SetMemBufNoClose) {
+  bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
+  ASSERT_TRUE(bio);
+
+  BUF_MEM *m = BUF_MEM_new();
+  ASSERT_TRUE(m);
+  ASSERT_TRUE(BUF_MEM_grow(m, 5));
+  OPENSSL_memcpy(m->data, "hello", 5);
+
+  ASSERT_TRUE(BIO_set_mem_buf(bio.get(), m, BIO_NOCLOSE));
+
+  char out[8] = {0};
+  EXPECT_EQ(5, BIO_read(bio.get(), out, sizeof(out)));
+  EXPECT_EQ(Bytes(out, 5), Bytes("hello", 5));
+
+  // Exercise to surface memory violations. 
+  bio.reset();
+  BUF_MEM_free(m);
+}
+
+TEST(BIOTest, SetMemBufClose) {
+  bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
+  ASSERT_TRUE(bio);
+
+  BUF_MEM *m = BUF_MEM_new();
+  ASSERT_TRUE(m);
+  ASSERT_TRUE(BUF_MEM_grow(m, 5));
+  OPENSSL_memcpy(m->data, "world", 5);
+
+  ASSERT_TRUE(BIO_set_mem_buf(bio.get(), m, BIO_CLOSE));
+
+  char out[8] = {0};
+  EXPECT_EQ(5, BIO_read(bio.get(), out, sizeof(out)));
+  EXPECT_EQ(Bytes(out, 5), Bytes("world", 5));
+
+  // Exercise to surface memory violations. 
+  bio.reset();
+}
+
+TEST(BIOTest, SetMemBufReplacesState) {
+  // After BIO_set_mem_buf, reads must see the new buffer, not the
+  // zero-initialized BUF_MEM allocated by mem_new().
+  bssl::UniquePtr<BIO> bio(BIO_new(BIO_s_mem()));
+  ASSERT_EQ(BIO_puts(bio.get(), "initial"), 7);
+
+  bssl::UniquePtr<BUF_MEM> m(BUF_MEM_new());
+  ASSERT_TRUE(BUF_MEM_grow(m.get(), 3));
+  OPENSSL_memcpy(m->data, "abc", 3);
+  ASSERT_TRUE(BIO_set_mem_buf(bio.get(), m.get(), BIO_NOCLOSE));
+
+  char out[8] = {0};
+  EXPECT_EQ(3, BIO_read(bio.get(), out, sizeof(out)));
+  EXPECT_EQ(Bytes(out, 3), Bytes("abc", 3));
+}
+
 TEST(BIOTest, Gets) {
   const struct {
     std::string bio;


### PR DESCRIPTION
### Issues:

V2186717843

### Description of changes: 

Stash correct type in `mem_ctrl()`. A `BUF_MEM` needs to be wrapped by `BIO_BUF_MEM`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
