### PR TITLE
Rework order for initialisation of digest object. If memory allocation fails, object is now not in a corrupted state.

### DIFF
--- a/crypto/fipsmodule/digest/digest.c
+++ b/crypto/fipsmodule/digest/digest.c
@@ -195,17 +195,24 @@ int EVP_MD_CTX_reset(EVP_MD_CTX *ctx) {
 
 int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *engine) {
   if (ctx->digest != type) {
-    ctx->digest = type;
     if (!used_for_hmac(ctx)) {
+      // Drop any existing digest state first. On allocation failure below
+      // |ctx| is left in an empty-but-valid state equivalent to a freshly
+      // |EVP_MD_CTX_init|'d context.
+      OPENSSL_free(ctx->md_data);
+      ctx->md_data = NULL;
+      ctx->update = NULL;
+      ctx->digest = NULL;
+
       assert(type->ctx_size != 0);
-      ctx->update = type->update;
       uint8_t *md_data = OPENSSL_malloc(type->ctx_size);
       if (md_data == NULL) {
         return 0;
       }
-      OPENSSL_free(ctx->md_data);
       ctx->md_data = md_data;
+      ctx->update = type->update;
     }
+    ctx->digest = type;
   }
 
   assert(ctx->pctx == NULL || ctx->pctx_ops != NULL);

--- a/include/openssl/digest.h
+++ b/include/openssl/digest.h
@@ -101,6 +101,8 @@ OPENSSL_EXPORT int EVP_MD_CTX_reset(EVP_MD_CTX *ctx);
 // EVP_DigestInit_ex configures |ctx|, which must already have been
 // initialised, for a fresh hashing operation using |type|. It returns one on
 // success and zero on allocation failure.
+//
+// On failure, |ctx| must be released with |EVP_MD_CTX_[cleanup,free]|.
 OPENSSL_EXPORT int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type,
                                      ENGINE *engine);
 


### PR DESCRIPTION
### Issues:

V2186717843

### Description of changes: 

Small hardening change in the EVP digest layer.                                  
                                                                                                 
`EVP_DigestInit_ex` switches an already-initialised `EVP_MD_CTX` to a new                      
`EVP_MD` by replacing the backing `md_data` buffer, the digest pointer, and                    
the update callback. Prior to this change, `ctx->digest` and `ctx->update`                     
were assigned before the new `md_data` buffer was allocated. On                                
`OPENSSL_malloc` failure the function returned 0 but left the context in a                     
state where `ctx->digest`'s expected `ctx_size` no longer matched the                          
`md_data` buffer actually held by the context.                                                 
                                                                                                 
This change aligns `EVP_DigestInit_ex` with the existing ordering in                           
`EVP_CipherInit_ex` (`crypto/fipsmodule/cipher/cipher.c`) and                                  
`EVP_AEAD_CTX_init_with_direction` (`crypto/fipsmodule/cipher/aead.c`): any                    
previous digest state is released first, then the new backing buffer is                        
allocated, then the new digest pointer and update callback are committed.                      
On allocation failure the context is left in an empty-but-valid state                          
equivalent to a freshly `EVP_MD_CTX_init`'d context — the caller can                           
re-initialise it with another `EVP_DigestInit*` call or release it with                        
`EVP_MD_CTX_cleanup` / `EVP_MD_CTX_free`. 

This behaviour is not documented in the function description on purpose.
Users should act on error-return by freeing the object, not continue using it.
Although, make this change to follow behaviour for similar APIs.

### Testing:

Automatic testing requires injecting malloc error, not worth it IMO. But tested it manually through code-changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
