### PR TITLE
Align X.509 Limbo local patch with upstream changes

### DIFF
--- a/tests/ci/x509/x509-limbo.patch
+++ b/tests/ci/x509/x509-limbo.patch
@@ -1,22 +1,17 @@
 diff --git a/Makefile b/Makefile
-index ff0e109..53b4611 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -110,8 +110,13 @@ test-certvalidator: $(NEEDS_VENV)
- test-gnutls:
- 	$(MAKE) run ARGS="harness --output ./results/gnutls.json -- ./$(VENV_BIN)/python ./harness/gnutls/test-gnutls"
+@@ -104,8 +104,8 @@ test-boringssl:
  
-+.PHONY: test-aws-lc
-+test-aws-lc:
+ .PHONY: test-aws-lc
+ test-aws-lc:
+-	$(MAKE) -C harness/openssl aws-lc
+-	$(MAKE) run ARGS="harness --output ./results/aws-lc.json -- docker run --rm -i x509-limbo-aws-lc"
 +	$(MAKE) -C harness/aws-lc build-image
 +	$(MAKE) run ARGS="harness --output ./results/aws-lc.json -- docker run --platform linux/amd64 --rm -i x509-limbo-aws-lc"
-+
- .PHONY: test
--test: test-go test-openssl test-rust-webpki test-rustls-webpki test-pyca-cryptography test-certvalidator test-gnutls
-+test: test-go test-openssl test-rust-webpki test-rustls-webpki test-pyca-cryptography test-certvalidator test-gnutls test-aws-lc
  
- .PHONY: site
- site: $(NEEDS_VENV)
+ .PHONY: test-rust-webpki
+ test-rust-webpki:
 diff --git a/harness/aws-lc/.gitignore b/harness/aws-lc/.gitignore
 new file mode 100644
 index 0000000..9bc5102


### PR DESCRIPTION
### Description of changes: 

`aws-lc-ci-x509` has been failing on every PR with:

```
patching file Makefile
Hunk #1 FAILED at 110.
1 out of 1 hunks failed -- saving rejects to file Makefile.rej
```

Our x509-limbo docker image clones C2SP/x509-limbo from `main` without
pinning a commit, so whenever upstream touches the Makefile the context
for our patch drifts and the hunk stops applying.

Upstream has since:
  * added `test-libressl` and `test-boringssl` targets,
  * added their own `test-aws-lc` target (which builds from the
    `ghcr.io/woodruffw/openssl-dockerfiles/aws-lc:latest` prebuilt
    image via `harness/openssl`), and
  * added `test-aws-lc` to the top-level `test:` aggregate.

Our patch assumed none of that existed: it added a brand new
`test-aws-lc` target anchored on `test-gnutls:` and rewrote the `test:`
line to append `test-aws-lc`. Both anchors are gone from upstream now,
so the whole hunk rejects.

We can't use upstream's `test-aws-lc` verbatim because it pulls a
prebuilt AWS-LC image from ghcr.io. The whole point of this job is to
build AWS-LC from the source under test and diff the results against
the base ref, so we still need the harness in `harness/aws-lc/` that
builds from a local source tree.

This rewrites the Makefile hunk to replace the body of upstream's
`test-aws-lc` recipe (two lines) with the source-build version, and
drops the `test:` change since upstream already lists `test-aws-lc`
there. The `test-aws-lc` target itself isn't exercised by
`run_x509_limbo.sh` — the script drives `harness/aws-lc/Makefile`
directly and runs the resulting binary — but the hunk still has to
apply for the rest of the patch (the `harness/aws-lc/` file additions)
to land.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
