### PR TITLE
Decouple the FIPS version number from the AWS-LC version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 
 set(SOFTWARE_NAME "awslc")
 set(SOFTWARE_VERSION "5.0.0")
+set(AWSLC_FIPS_VERSION 4)
 set(ABI_VERSION 0)
 set(CRYPTO_LIB_NAME "crypto")
 set(SSL_LIB_NAME "ssl")

--- a/crypto/crypto_test.cc
+++ b/crypto/crypto_test.cc
@@ -69,6 +69,15 @@ TEST(CryptoTest, aws_lc_assert_entropy_cpu_jitter) {
   }
 }
 
+// FIPS_version returns the FIPS version number in FIPS builds and 0 otherwise.
+TEST(CryptoTest, FIPSVersion) {
+  if (FIPS_mode() == 1) {
+    EXPECT_EQ(FIPS_version(), (uint32_t)AWSLC_FIPS_VERSION_NUMBER);
+  } else {
+    EXPECT_EQ(FIPS_version(), 0u);
+  }
+}
+
 TEST(CryptoTest, OPENSSL_hexstr2buf) {
   const char *test_cases[][2] = {{"a2", "\xa2"},
                                  {"a213", "\xa2\x13"},

--- a/crypto/fipsmodule/FIPS.md
+++ b/crypto/fipsmodule/FIPS.md
@@ -14,6 +14,16 @@ NIST has also awarded SP 800-90B validation certificate for our CPU Jitter Entro
 
 1. 2023-09-14: entropy certificate [#E77](https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/77), [public use document](https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/entropy/E77_PublicUse.pdf)
 
+## FIPS version number
+
+The `FIPS_version` API, declared in `openssl/crypto.h`, returns the FIPS version number of the current build:
+
+```c
+OPENSSL_EXPORT uint32_t FIPS_version(void);
+```
+
+It returns 0 when AWS-LC is not built in FIPS mode. The FIPS version number is independent of the AWS-LC version number and is incremented each time a new FIPS branch is cut from mainline.
+
 ## Platform Limitations
 
 When building AWS-LC in FIPS mode, please be aware of the following platform limitations:

--- a/crypto/fipsmodule/self_check/fips.c
+++ b/crypto/fipsmodule/self_check/fips.c
@@ -26,4 +26,12 @@ int FIPS_is_entropy_cpu_jitter(void) {
   return 1;
 }
 
+uint32_t FIPS_version(void) {
+#if defined(BORINGSSL_FIPS) && !defined(OPENSSL_ASAN) && !defined(OPENSSL_MSAN)
+  return AWSLC_FIPS_VERSION_NUMBER;
+#else
+  return 0;
+#endif
+}
+
 int FIPS_mode_set(int on) { return on == FIPS_mode(); }

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -67,6 +67,11 @@ extern "C" {
 // depending on FIPS mode.
 #define AWSLC_VERSION_NUMBER_STRING "5.0.0"
 
+// AWSLC_FIPS_VERSION_NUMBER is the FIPS version number of mainline AWS-LC,
+// independent of |AWSLC_VERSION_NUMBER_STRING|. It is incremented each time a
+// new FIPS branch is cut from mainline.
+#define AWSLC_FIPS_VERSION_NUMBER 4
+
 #if defined(BORINGSSL_SHARED_LIBRARY)
 
 #if defined(OPENSSL_WINDOWS)

--- a/include/openssl/base.h.in
+++ b/include/openssl/base.h.in
@@ -67,6 +67,11 @@ extern "C" {
 // depending on FIPS mode.
 #define AWSLC_VERSION_NUMBER_STRING "@SOFTWARE_VERSION@"
 
+// AWSLC_FIPS_VERSION_NUMBER is the FIPS version number of mainline AWS-LC,
+// independent of |AWSLC_VERSION_NUMBER_STRING|. It is incremented each time a
+// new FIPS branch is cut from mainline.
+#define AWSLC_FIPS_VERSION_NUMBER @AWSLC_FIPS_VERSION@
+
 #if defined(BORINGSSL_SHARED_LIBRARY)
 
 #if defined(OPENSSL_WINDOWS)

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -110,6 +110,11 @@ OPENSSL_EXPORT int FIPS_mode(void);
 // for AWS-LC. Otherwise, returns 0;
 OPENSSL_EXPORT int FIPS_is_entropy_cpu_jitter(void);
 
+// FIPS_version returns the FIPS version number of the current build,
+// independent of the AWS-LC version number. It returns 0 when AWS-LC is not
+// built in FIPS mode.
+OPENSSL_EXPORT uint32_t FIPS_version(void);
+
 // Deprecated functions.
 
 // OPENSSL_VERSION_TEXT contains a string the identifies the version of


### PR DESCRIPTION
### Description of changes:
Historically, the FIPS version number has been tied to AWS-LC's own
version number — consumers inferred which FIPS submission a build
corresponded to from the AWS-LC version. This change decouples the two
so the FIPS version number can evolve independently on a separate
cadence from AWS-LC releases.

Adds `FIPS_version`, a new public API declared in `openssl/crypto.h`,
that returns the FIPS version number of the current build. Returns 0
when AWS-LC is not built in FIPS mode. `AWSLC_FIPS_VERSION_NUMBER` in
`openssl/base.h` is the single source of truth — bump it there when
cutting a new FIPS branch. `FIPS_version` mirrors `FIPS_mode`'s gating
so the two agree on what counts as a FIPS build, including under
Address and Memory sanitizers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
