### PR TITLE
Fix thread-local DRBG cleanup deadlock at process exit

### DIFF
--- a/crypto/fipsmodule/rand/internal.h
+++ b/crypto/fipsmodule/rand/internal.h
@@ -28,6 +28,15 @@ OPENSSL_EXPORT uint64_t get_private_thread_reseed_calls_since_initialization(voi
 OPENSSL_EXPORT uint64_t get_public_thread_generate_calls_since_seed(void);
 OPENSSL_EXPORT uint64_t get_public_thread_reseed_calls_since_initialization(void);
 
+// rand_thread_local_state_clear_all_FOR_TESTING runs the same shutdown
+// zeroization sequence that is registered via |atexit|. It is exposed for tests
+// that need to verify shutdown behavior (e.g. that a thread exiting after
+// shutdown does not deadlock). After this is called, no further |RAND_bytes|
+// calls in the test process will return output, so the caller is responsible
+// for arranging that no other code paths in the same process require
+// randomness afterwards.
+OPENSSL_EXPORT void rand_thread_local_state_clear_all_FOR_TESTING(void);
+
 // CTR_DRBG_STATE contains the state of a CTR_DRBG based on AES-256. See SP
 // 800-90Ar1.
 struct ctr_drbg_state_st {

--- a/crypto/fipsmodule/rand/rand.c
+++ b/crypto/fipsmodule/rand/rand.c
@@ -47,6 +47,16 @@ OPENSSL_STATIC_ASSERT((sizeof((struct rand_thread_local_state*)0)->generate_call
 DEFINE_BSS_GET(struct rand_thread_local_state *, thread_states_list_head)
 DEFINE_STATIC_MUTEX(thread_local_states_list_lock)
 
+// thread_local_drbg_shutdown_started is set to a non-zero value during process
+// exit by |rand_thread_local_state_clear_all|, while the linked-list lock is
+// held. All reads and writes occur under |thread_local_states_list_lock|, so
+// no atomic accessors are needed; doing the check under the lock also avoids
+// the otherwise-racy window where a TLS destructor could observe the flag as
+// unset, then block on the lock while shutdown zeroization runs, and then
+// free a state whose |state_clear_lock| has been intentionally write-locked
+// forever.
+DEFINE_BSS_GET(int, thread_local_drbg_shutdown_started)
+
 #if defined(_MSC_VER)
 #pragma section(".CRT$XCU", read)
 static void rand_thread_local_state_clear_all(void);
@@ -67,19 +77,42 @@ static void rand_thread_local_state_clear_all(void) __attribute__ ((destructor))
 // randomness from a non-valid state. The linked application should obviously
 // arrange that all threads are gracefully exited before exiting the process.
 // Yet, in cases where such graceful exit does not happen we ensure that no
-// output can be returned by locking all thread-local states and deliberately
-// not releasing the lock. A synchronization step in the core randomness
-// generation routine |RAND_bytes_core| then ensures that no randomness
-// generation can occur after a thread-local state has been locked. It also
-// ensures |rand_thread_local_state_free| cannot free any thread state while we
-// own the lock.
+// output can be returned by locking each thread-local state's
+// |state_clear_lock| and deliberately not releasing it. A synchronization step
+// in the core randomness generation routine |RAND_bytes_core| then ensures
+// that no randomness generation can occur after a thread-local state has been
+// locked.
 //
-// When a thread-local DRBGs is gated from returning output, we can invoke the
+// We additionally set |thread_local_drbg_shutdown_started| under the
+// linked-list lock so that any thread which has not yet registered a
+// thread-local state cannot do so after this routine has begun zeroization;
+// without this, a fresh thread could allocate a state and bypass zeroization.
+// The linked-list lock itself is released at the end of this function. If we
+// instead held it forever, |thread_local_list_delete_node| (called from a
+// thread's TLS destructor in |rand_thread_local_state_free|) would block
+// indefinitely. On Windows, TLS destructors run under the loader lock, so
+// blocking there causes |ExitProcess| to hang waiting for the loader lock.
+// See https://github.com/aws/aws-lc/issues/3197.
+//
+// When a thread-local DRBG is gated from returning output, we can invoke the
 // entropy source zeroization from |state->entropy_source|. The entropy source
 // implementation can assume that any returned seed is never used to generate
 // any randomness that is later returned to a consumer.
 static void rand_thread_local_state_clear_all(void) {
   CRYPTO_STATIC_MUTEX_lock_write(thread_local_states_list_lock_bss_get());
+
+  // Idempotency guard. Under normal operation this routine runs exactly once
+  // (via |atexit|), but it is also exposed for testing via
+  // |rand_thread_local_state_clear_all_FOR_TESTING|, and re-running would
+  // attempt to write-lock per-state |state_clear_lock|s that are already held
+  // write-locked by the first invocation -- which is UB for a non-recursive
+  // rwlock.
+  if (*thread_local_drbg_shutdown_started_bss_get() != 0) {
+    CRYPTO_STATIC_MUTEX_unlock_write(thread_local_states_list_lock_bss_get());
+    return;
+  }
+  *thread_local_drbg_shutdown_started_bss_get() = 1;
+
   for (struct rand_thread_local_state *state = *thread_states_list_head_bss_get();
     state != NULL; state = state->next) {
     CRYPTO_MUTEX_lock_write(&state->state_clear_lock);
@@ -90,13 +123,34 @@ static void rand_thread_local_state_clear_all(void) {
     state != NULL; state = state->next) {
     state->entropy_source->methods->zeroize_thread(state->entropy_source);
   }
+
+  CRYPTO_STATIC_MUTEX_unlock_write(thread_local_states_list_lock_bss_get());
 }
 
-static void thread_local_list_delete_node(
+void rand_thread_local_state_clear_all_FOR_TESTING(void) {
+  rand_thread_local_state_clear_all();
+}
+
+// thread_local_list_delete_node removes |node_delete| from the global
+// linked list and returns 1. If process-wide shutdown zeroization has already
+// begun, the node is left in place and 0 is returned -- the caller must not
+// free the node in that case because |rand_thread_local_state_clear_all| has
+// write-locked its |state_clear_lock| and intentionally never releases it.
+static int thread_local_list_delete_node(
   struct rand_thread_local_state *node_delete) {
 
   // Mutating the global linked list. Need to synchronize over all threads.
   CRYPTO_STATIC_MUTEX_lock_write(thread_local_states_list_lock_bss_get());
+
+  // Re-check the shutdown flag under the lock. This makes the
+  // "free vs. shutdown-zeroize" decision atomic with respect to
+  // |rand_thread_local_state_clear_all|: either we delete and free before
+  // shutdown begins, or shutdown wins and we leak the node deliberately.
+  if (*thread_local_drbg_shutdown_started_bss_get() != 0) {
+    CRYPTO_STATIC_MUTEX_unlock_write(thread_local_states_list_lock_bss_get());
+    return 0;
+  }
+
   struct rand_thread_local_state *node_head = *thread_states_list_head_bss_get();
 
   // We have [node_delete->previous] <--> [node_delete] <--> [node_delete->next]
@@ -127,6 +181,7 @@ static void thread_local_list_delete_node(
   }
 
   CRYPTO_STATIC_MUTEX_unlock_write(thread_local_states_list_lock_bss_get());
+  return 1;
 }
 
 // thread_local_list_add adds the state |node_add| to the linked list. Note that
@@ -140,6 +195,19 @@ static void thread_local_list_add_node(
 
   // Mutating the global linked list. Need to synchronize over all threads.
   CRYPTO_STATIC_MUTEX_lock_write(thread_local_states_list_lock_bss_get());
+
+  // If process-wide zeroization has already started, do not add a new state to
+  // the list -- it would not have been zeroized by
+  // |rand_thread_local_state_clear_all|. Instead, write-lock the state's
+  // |state_clear_lock| and never release it. This causes any subsequent
+  // |RAND_bytes_core| call on this thread to block forever on the read lock,
+  // matching the FIPS-derived guarantee that no output is returned after
+  // shutdown zeroization.
+  if (*thread_local_drbg_shutdown_started_bss_get() != 0) {
+    CRYPTO_MUTEX_lock_write(&node_add->state_clear_lock);
+    CRYPTO_STATIC_MUTEX_unlock_write(thread_local_states_list_lock_bss_get());
+    return;
+  }
 
   // First get a reference to the pointer of the head of the linked list.
   // That is, the pointer to the head node node_head is *thread_states_head.
@@ -171,7 +239,16 @@ static void rand_thread_local_state_free(void *state_in) {
     return;
   }
 
-  thread_local_list_delete_node(state);
+  // If process-wide shutdown zeroization has begun, the per-state
+  // |state_clear_lock| has been write-locked and is intentionally never
+  // released (so any in-flight |RAND_bytes| call cannot return output from a
+  // zeroized state). |thread_local_list_delete_node| therefore detects this
+  // case under the linked-list lock and refuses to delete; we must then leak
+  // the node, since freeing it would destroy a held mutex. The OS reclaims
+  // the memory at process exit. See issue #3197.
+  if (thread_local_list_delete_node(state) == 0) {
+    return;
+  }
 
   // Potentially, something could kill the thread before an entropy source has
   // been associated to the thread-local randomness generator object.

--- a/crypto/fipsmodule/rand/rand_test.cc
+++ b/crypto/fipsmodule/rand/rand_test.cc
@@ -21,12 +21,15 @@
 
 #if defined(OPENSSL_THREADS)
 #include <array>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 #include <vector>
 #endif
 
 #if !defined(OPENSSL_WINDOWS)
 #include <errno.h>
+#include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -523,6 +526,88 @@ TEST_F(randTest, MixedUsageMultiThreaded) {
   }
 }
 #endif  // OPENSSL_THREADS
+
+#if defined(OPENSSL_THREADS) && !defined(OPENSSL_WINDOWS) && \
+    !defined(OPENSSL_IOS) && !defined(OPENSSL_WASM) && \
+    !defined(BORINGSSL_UNSAFE_DETERMINISTIC_MODE)
+// Regression test for https://github.com/aws/aws-lc/issues/3197.
+//
+// Pre-fix, |rand_thread_local_state_clear_all| acquired
+// |thread_local_states_list_lock| and intentionally never released it. A
+// thread that had registered a thread-local state and exited *after* shutdown
+// zeroization would deadlock in its TLS destructor while waiting for that
+// lock. On Windows that destructor runs under the loader lock, which
+// indirectly hangs |ExitProcess|. This test reproduces the same lock cycle
+// (the lock is the same on POSIX -- only the loader-lock fallout is
+// Windows-specific) and verifies the child exits cleanly.
+//
+// We cannot run this in-process because shutdown zeroization permanently
+// disables the RNG for the whole process, breaking any later test. We fork a
+// child, run the scenario, and impose a hard timeout in the parent so a
+// regression manifests as a test failure rather than a hung suite.
+TEST_F(randTest, ShutdownDoesNotDeadlockExitingThread) {
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << "fork failed: " << strerror(errno);
+
+  if (child == 0) {
+    // Register a thread-local DRBG state on a worker thread, then trigger
+    // shutdown zeroization on the main thread, then let the worker exit.
+    std::mutex m;
+    std::condition_variable cv;
+    bool shutdown_done = false;
+    bool worker_registered = false;
+
+    std::thread worker([&] {
+      uint8_t buf[16];
+      RAND_bytes(buf, sizeof(buf));
+      {
+        std::lock_guard<std::mutex> lk(m);
+        worker_registered = true;
+      }
+      cv.notify_one();
+
+      std::unique_lock<std::mutex> lk(m);
+      cv.wait(lk, [&] { return shutdown_done; });
+      // Worker now exits. Pre-fix this exit would block forever in the TLS
+      // destructor; post-fix it returns immediately.
+    });
+
+    {
+      std::unique_lock<std::mutex> lk(m);
+      cv.wait(lk, [&] { return worker_registered; });
+    }
+    rand_thread_local_state_clear_all_FOR_TESTING();
+    {
+      std::lock_guard<std::mutex> lk(m);
+      shutdown_done = true;
+    }
+    cv.notify_one();
+    worker.join();
+    _exit(0);
+  }
+
+  // Parent: enforce a timeout so a regression doesn't hang the suite.
+  constexpr int kTimeoutSeconds = 30;
+  for (int i = 0; i < kTimeoutSeconds * 10; i++) {
+    int status;
+    pid_t ret = waitpid(child, &status, WNOHANG);
+    ASSERT_GE(ret, 0) << "waitpid failed: " << strerror(errno);
+    if (ret == child) {
+      ASSERT_TRUE(WIFEXITED(status))
+          << "child terminated abnormally, status=" << status;
+      ASSERT_EQ(WEXITSTATUS(status), 0);
+      return;
+    }
+    usleep(100 * 1000);
+  }
+
+  kill(child, SIGKILL);
+  waitpid(child, nullptr, 0);
+  FAIL() << "child did not exit within " << kTimeoutSeconds
+         << "s (likely a deadlock in TLS destructor after shutdown)";
+}
+#endif  // OPENSSL_THREADS && !OPENSSL_WINDOWS && !OPENSSL_IOS &&
+        // !OPENSSL_WASM && !BORINGSSL_UNSAFE_DETERMINISTIC_MODE
 
 #if defined(OPENSSL_X86_64) && defined(SUPPORTS_ABI_TEST)
 TEST_F(randTest, RdrandABI) {


### PR DESCRIPTION
### Issues:
Resolves #3197

### Description of changes:
The `atexit`-registered shutdown routine (`rand_thread_local_state_clear_all`) previously acquired `thread_local_states_list_lock` and never released it. Any thread whose TLS destructor fired after that point would deadlock waiting for the same lock. On Windows, TLS destructors run under the loader lock, so this hangs `ExitProcess`.

This change releases the list lock at the end of `clear_all` and instead uses a `thread_local_drbg_shutdown_started` flag (checked under the lock) to coordinate post-shutdown behavior. The per-state `state_clear_lock` — still write-locked forever — continues to enforce the FIPS requirement that no output is returned from a zeroized DRBG.

### Call-outs:
- Post-shutdown, TLS destructors intentionally leak their state node rather than freeing a struct with a permanently-held mutex. This is process-exit-only and the OS reclaims the memory. The DRBG and entropy source have already been zeroized by rand_thread_local_state_clear_all before this path is reached, so no secret material remains in the leaked allocation.
- `clear_all` has an idempotency guard because the new `_FOR_TESTING` entry point means it could theoretically run twice; re-locking already-held per-state rwlocks would be UB.

### Testing:
Adds `randTest.ShutdownDoesNotDeadlockExitingThread` — forks a child that triggers shutdown zeroization on the main thread, then lets a worker thread exit. Parent enforces a 30s timeout so a regression fails the test instead of hanging the suite. Forking is necessary because shutdown zeroization permanently disables the RNG. Test is POSIX-only (the underlying lock cycle is platform-agnostic; the loader-lock symptom is Windows-specific).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
