### PR TITLE
[DRAFT] ci: fix zig C++ link failure on Windows x86_64

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -45,6 +45,12 @@ jobs:
         uses: jiacai2050/my-works@8707121a859749b56c1a553e16cec59d1dddb24e # zigcc v1.1.0
         with:
           zig-version: 0.15.2
+      - name: Exclude zig cache from Windows Defender
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}\.zig-cache"
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}\build"
       - name: Set compiler wrappers
         shell: bash
         run: |
@@ -79,8 +85,10 @@ jobs:
           probe zig env
 
           echo 'int main(void){return 0;}' > hello.c
+          echo 'int main(){return 0;}' > hello.cpp
 
           probe "${ZIGCC}" -v -c hello.c -o hello.o
+          probe "${ZIGCXX}" -v -c hello.cpp -o hello_cpp.o
 
           if [[ "${{ matrix.config.target_system }}" == "Windows" ]]; then
             probe "${ZIGCC}" -v hello.c -o hello_trivial.exe
@@ -90,9 +98,17 @@ jobs:
               -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 \
               -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32
             [[ -x ./hello.exe ]] && probe ./hello.exe
+            probe "${ZIGCXX}" -v hello.cpp -o hello_cpp.exe \
+              -Wl,--out-implib,hellocpp.dll.a \
+              -Wl,--major-image-version,0,--minor-image-version,0 \
+              -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 \
+              -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32
+            [[ -x ./hello_cpp.exe ]] && probe ./hello_cpp.exe
           else
             probe "${ZIGCC}" -v hello.c -o hello
             [[ -x ./hello ]] && probe ./hello
+            probe "${ZIGCXX}" -v hello.cpp -o hello_cpp
+            [[ -x ./hello_cpp ]] && probe ./hello_cpp
           fi
       - name: Create toolchain
         shell: bash


### PR DESCRIPTION
### Description of changes: 
- Exclude `.zig-cache` and `build` directories from Windows Defender real-time scanning to prevent file lock contention that causes LLD's `UnableToWriteArchive` during zig's libcxx/libcxxabi sub-compilation
- Add C++ compile and link probes to the self-test step so this class of failure surfaces early with clear output rather than buried in CMake's TryCompile error envelope

### Testing:
- [ ] Verify `windows-latest` x86_64 zig job passes (previously consistently failing)
- [ ] Verify other matrix entries (windows-11-arm, ubuntu, macos) remain green
- [ ] Confirm self-test step now exercises both `zig-cc` and `zig-c++` link paths

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
