### PR TITLE
Reject negative pass_len in PEM_ASN1_write_bio

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -269,11 +269,11 @@ int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp, void *x,
         callback = PEM_def_callback;
       }
       pass_len = (*callback)(buf, PEM_BUFSIZE, 1, u);
-      if (pass_len < 0) {
-        OPENSSL_PUT_ERROR(PEM, PEM_R_READ_KEY);
-        goto err;
-      }
       pass = (const unsigned char *)buf;
+    }
+    if (pass_len < 0) {
+      OPENSSL_PUT_ERROR(PEM, PEM_R_READ_KEY);
+      goto err;
     }
     assert(iv_len <= sizeof(iv));
     AWSLC_ABORT_IF_NOT_ONE(RAND_bytes(iv, iv_len));  // Generate a salt

--- a/crypto/pem/pem_test.cc
+++ b/crypto/pem/pem_test.cc
@@ -132,6 +132,7 @@ TEST(PEMTest, WriteReadRSAPem) {
   ASSERT_TRUE(write_bio);
   const EVP_CIPHER* cipher = EVP_get_cipherbynid(NID_aes_256_cbc);
   ASSERT_TRUE(cipher);
+  EXPECT_FALSE(PEM_write_bio_RSAPrivateKey(write_bio.get(), rsa.get(), cipher, (unsigned char*)SECRET, -1, nullptr, nullptr));
   ASSERT_TRUE(PEM_write_bio_RSAPrivateKey(write_bio.get(), rsa.get(), cipher, (unsigned char*)SECRET, (int)BUF_strnlen(SECRET, 256), nullptr, nullptr));
 
   const uint8_t* content;


### PR DESCRIPTION
### Issues:
Addresses `V2196133741`

### Description of changes:
When a caller passes a non-NULL password with a negative `pass_len`, `PEM_ASN1_write_bio` hands the negative length straight to `EVP_BytesToKey`, which interprets it as a very large unsigned size. The `pass == NULL` path already rejects negative lengths returned by the callback; this mirrors that check for the caller-supplied case using the same `PEM_R_READ_KEY` error code.

### Call-outs:
None.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
