### PR TITLE
Reject len < -1 in ASN1_mbstring_ncopy

### DIFF
--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -33,6 +33,10 @@ OPENSSL_DECLARE_ERROR_REASON(ASN1, INVALID_UTF8STRING)
 int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in,
                         ossl_ssize_t len, int inform, unsigned long mask,
                         ossl_ssize_t minsize, ossl_ssize_t maxsize) {
+  if (len < -1) {
+    OPENSSL_PUT_ERROR(ASN1, ASN1_R_ILLEGAL_FORMAT);
+    return -1;
+  }
   if (len == -1) {
     len = strlen((const char *)in);
   }

--- a/crypto/asn1/asn1_test.cc
+++ b/crypto/asn1/asn1_test.cc
@@ -1711,6 +1711,25 @@ TEST(ASN1Test, MBString) {
     ERR_clear_error();
     EXPECT_EQ(nullptr, str);
   }
+
+  // |len| values below -1 must be rejected; only -1 is special-cased to mean
+  // "call strlen on |in|". Any other negative value would otherwise be cast
+  // to a huge |size_t| by |CBS_init|.
+  static const uint8_t kDummy[] = {'a'};
+  ASN1_STRING *str = nullptr;
+  EXPECT_EQ(-1, ASN1_mbstring_ncopy(&str, kDummy, -2, MBSTRING_UTF8,
+                                    B_ASN1_UTF8STRING, /*minsize=*/0,
+                                    /*maxsize=*/0));
+  EXPECT_EQ(nullptr, str);
+  ERR_clear_error();
+
+  // |len == -1| treats |in| as NUL-terminated and should succeed.
+  ASN1_STRING *str_from_strlen = nullptr;
+  EXPECT_GE(ASN1_mbstring_ncopy(&str_from_strlen, (const uint8_t *)"a", -1,
+                                MBSTRING_UTF8, B_ASN1_UTF8STRING,
+                                /*minsize=*/0, /*maxsize=*/0),
+            0);
+  ASN1_STRING_free(str_from_strlen);
 }
 
 TEST(ASN1Test, StringByNID) {


### PR DESCRIPTION
### Issues:
Addresses `V2196133741`

### Description of changes:
`ASN1_mbstring_ncopy` treats `len == -1` as "call strlen on in". Any other negative value fell through unchanged and was cast to `size_t` by `CBS_init`, producing a huge length. Adds an explicit early reject for `len < -1` with `ASN1_R_ILLEGAL_FORMAT`; `-1` and non-negative values continue to behave as before.

### Call-outs:
None.

### Testing:
Existing ASN.1 string tests continue to pass. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.