### PR TITLE
Fix wherelen handling in BIO_ADDR_rawmake AF_UNIX path

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -110,12 +110,12 @@ int BIO_ADDR_rawmake(BIO_ADDR *ap, int family, const void *where,
     GUARD_PTR(where);
     // wherelen is expected to be the length of the path string
     // not including the terminating NUL.
-    if (wherelen + 1 > sizeof(ap->s_un.sun_path)) {
+    if (wherelen >= sizeof(ap->s_un.sun_path)) {
       return 0;
     }
     OPENSSL_cleanse(&ap->s_un, sizeof(ap->s_un));
     ap->s_un.sun_family = family;
-    OPENSSL_strlcpy(ap->s_un.sun_path, where, wherelen);
+    OPENSSL_memcpy(ap->s_un.sun_path, where, wherelen);
     return 1;
   }
 #endif


### PR DESCRIPTION
### Issues:
Addresses `V2196133741`

### Description of changes:
Two issues in the `AF_UNIX` branch of `BIO_ADDR_rawmake`:

1. `wherelen + 1 > sizeof(...)` wraps to 0 when `wherelen == SIZE_MAX`, bypassing the bound check. Rewritten as `wherelen >= sizeof(...)`.
2. `OPENSSL_strlcpy(dst, src, wherelen)` treats its third argument as the destination buffer size, not the number of source bytes, so only `wherelen - 1` bytes were copied and `src` was required to be NUL-terminated even though the comment above states it isn't. Replaced with `OPENSSL_memcpy`; the preceding `OPENSSL_cleanse` of `ap->s_un` already leaves a trailing NUL.

### Call-outs:
None.

### Testing:
Existing `bio_socket_test` cases continue to pass. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.