### PR TITLE
Free existing responderId union arm in OCSP_RESPID setters

### DIFF
--- a/crypto/ocsp/ocsp_server.c
+++ b/crypto/ocsp/ocsp_server.c
@@ -65,14 +65,33 @@ int OCSP_basic_add1_cert(OCSP_BASICRESP *resp, X509 *cert) {
   return 1;
 }
 
+// ocsp_respid_clear frees any previously-installed content of |respid| using
+// the destructor matching the current |respid->type|, so callers can install
+// a new value without leaking or triggering a type-confused free.
+static void ocsp_respid_clear(OCSP_RESPID *respid) {
+  switch (respid->type) {
+    case V_OCSP_RESPID_NAME:
+      X509_NAME_free(respid->value.byName);
+      respid->value.byName = NULL;
+      break;
+    case V_OCSP_RESPID_KEY:
+      ASN1_OCTET_STRING_free(respid->value.byKey);
+      respid->value.byKey = NULL;
+      break;
+  }
+}
+
 static int OCSP_RESPID_set_by_name(OCSP_RESPID *respid, X509 *cert) {
   GUARD_PTR(respid);
   GUARD_PTR(cert);
-  if (!X509_NAME_set(&respid->value.byName, X509_get_subject_name(cert))) {
+
+  X509_NAME *byName = X509_NAME_dup(X509_get_subject_name(cert));
+  if (byName == NULL) {
     return 0;
   }
-
+  ocsp_respid_clear(respid);
   respid->type = V_OCSP_RESPID_NAME;
+  respid->value.byName = byName;
   return 1;
 }
 
@@ -95,6 +114,7 @@ static int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert) {
     ASN1_OCTET_STRING_free(byKey);
     return 0;
   }
+  ocsp_respid_clear(respid);
   respid->type = V_OCSP_RESPID_KEY;
   respid->value.byKey = byKey;
 

--- a/crypto/ocsp/ocsp_test.cc
+++ b/crypto/ocsp/ocsp_test.cc
@@ -1293,6 +1293,38 @@ TEST(OCSPResponseSignTestExtended, OCSPResponseSign) {
                               pkey.get(), EVP_sha256(), additional_cert.get(),
                               OCSP_NOCERTS));
   EXPECT_EQ((int)sk_X509_num(basic_response.get()->certs), 0);
+
+  // Regression: re-signing the same |OCSP_BASICRESP| through any sequence of
+  // |OCSP_RESPID_KEY| flag combinations must not leak or free the prior
+  // responderId union arm through the wrong destructor. ASAN should flag any
+  // misuse.
+  basic_response.reset(OCSP_BASICRESP_new());
+  ASSERT_TRUE(basic_response);
+  EXPECT_TRUE(OCSP_basic_sign(basic_response.get(), signer_cert.get(),
+                              pkey.get(), EVP_sha256(), additional_cert.get(),
+                              0));
+  EXPECT_EQ(basic_response.get()->tbsResponseData->responderId->type,
+            V_OCSP_RESPID_NAME);
+  EXPECT_TRUE(OCSP_basic_sign(basic_response.get(), signer_cert.get(),
+                              pkey.get(), EVP_sha256(), additional_cert.get(),
+                              OCSP_RESPID_KEY));
+  EXPECT_EQ(basic_response.get()->tbsResponseData->responderId->type,
+            V_OCSP_RESPID_KEY);
+  EXPECT_TRUE(OCSP_basic_sign(basic_response.get(), signer_cert.get(),
+                              pkey.get(), EVP_sha256(), additional_cert.get(),
+                              OCSP_RESPID_KEY));
+  EXPECT_EQ(basic_response.get()->tbsResponseData->responderId->type,
+            V_OCSP_RESPID_KEY);
+  EXPECT_TRUE(OCSP_basic_sign(basic_response.get(), signer_cert.get(),
+                              pkey.get(), EVP_sha256(), additional_cert.get(),
+                              0));
+  EXPECT_EQ(basic_response.get()->tbsResponseData->responderId->type,
+            V_OCSP_RESPID_NAME);
+  EXPECT_TRUE(OCSP_basic_sign(basic_response.get(), signer_cert.get(),
+                              pkey.get(), EVP_sha256(), additional_cert.get(),
+                              0));
+  EXPECT_EQ(basic_response.get()->tbsResponseData->responderId->type,
+            V_OCSP_RESPID_NAME);
 }
 
 static const char extended_good_http_request_hdr[] =


### PR DESCRIPTION
### Issues:
Addresses V2196133741 (F9 — OCSP_RESPID_set_by_{key,name}: type-confused free on responderId union)
  
### Description of changes:
`OCSP_RESPID` stores either an `X509_NAME*` (byName) or an `ASN1_OCTET_STRING*` (byKey) in a union. Re-setting the responderId leaked the prior arm or freed it through the wrong destructor, depending on the transition. Both setters now call a small `ocsp_respid_clear` helper that frees the arm matching the current `respid->type` before installing the new value, so every sequence (name↔name, name↔key, key↔key, key↔name) is correct.
  
### Call-outs:
None.

### Testing:
Extends `OCSPResponseSignTestExtended.OCSPResponseSign` with four sequential `OCSP_basic_sign` calls on one `OCSP_BASICRESP`, covering all four responderId transitions. ASAN in CI will surface any leak or misuse.
  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.