### PR TITLE
Include trailing NUL in BIO_ADDR_rawaddress AF_UNIX length

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -151,7 +151,10 @@ int BIO_ADDR_rawaddress(const BIO_ADDR *ap, void *p, size_t *l) {
     return 0;
   }
   if (l != NULL) {
-    *l = len;
+    // AF_UNIX includes the trailing NUL written below so |*l| matches the
+    // bytes written to |p| and reflects sockaddr_un's NUL-terminated path.
+    // OpenSSL does not write this NUL; aws-lc intentionally does.
+    *l = (ap->sa.sa_family == AF_UNIX) ? len + 1 : len;
   }
 
   if (p != NULL) {

--- a/crypto/bio/bio_socket_test.cc
+++ b/crypto/bio/bio_socket_test.cc
@@ -130,7 +130,7 @@ struct SockaddrStorage {
         if (1 !=
             BIO_ADDR_rawmake(
                 bap, AF_UNIX, &sock->sun_path,
-                OPENSSL_strnlen(sock->sun_path, sizeof(sock->sun_path)) + 1,
+                OPENSSL_strnlen(sock->sun_path, sizeof(sock->sun_path)),
                 0)) {
           BIO_ADDR_free(bap);
           bap = nullptr;
@@ -962,6 +962,24 @@ TEST_F(BIOAddrTest, CopySpecifiedAddressUnix) {
             1);
   EXPECT_EQ(BIO_ADDR_copy(addr1, addr2), 1);
   EXPECT_EQ(BIO_ADDR_cmp(addr1, addr2), 0);
+}
+
+// |BIO_ADDR_rawaddress| writes a NUL terminator after the AF_UNIX path. The
+// reported |*l| must include that NUL so that callers using the standard
+// probe-then-allocate-exactly-|*l| pattern allocate a buffer large enough to
+// hold both the path and the terminator.
+TEST_F(BIOAddrTest, RawAddressUnixLengthIncludesNul) {
+  const char *path = "/tmp/test.sock";
+  const size_t path_len = strlen(path);
+  ASSERT_EQ(BIO_ADDR_rawmake(addr1, AF_UNIX, path, path_len, 0), 1);
+
+  size_t len = 0;
+  ASSERT_EQ(BIO_ADDR_rawaddress(addr1, nullptr, &len), 1);
+  EXPECT_EQ(len, path_len + 1);
+
+  char buf[sizeof(sockaddr_un::sun_path)] = {};
+  ASSERT_EQ(BIO_ADDR_rawaddress(addr1, buf, &len), 1);
+  EXPECT_STREQ(buf, path);
 }
 #endif
 

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -776,9 +776,9 @@ OPENSSL_EXPORT int BIO_ADDR_family(const BIO_ADDR *ap);
 // The address data from |ap| is copied into the buffer |p| if |p| is not NULL.
 // If |l| is not NULL, |*l| will be updated with the size of the address data.
 // For AF_INET, this is the 4-byte IPv4 address; for AF_INET6, the 16-byte IPv6
-// address; for AF_UNIX, the socket path. With AF_UNIX addresses, the buffer |p|
-// must be large enough for both the path and a NUL terminator. The function will
-// write the terminator to the buffer, but the length stored in |*l| excludes it.
+// address; for AF_UNIX, the socket path followed by a NUL terminator. The
+// length stored in |*l| includes the NUL for AF_UNIX so that it matches the
+// number of bytes written to |p|.
 // Returns 1 on success, 0 if the address family is unsupported or |ap| is NULL.
 OPENSSL_EXPORT int BIO_ADDR_rawaddress(const BIO_ADDR *ap, void *p, size_t *l);
 


### PR DESCRIPTION
### Issues:
Addresses V2196133741 (F4 — BIO_ADDR_rawaddress writes len+1 after reporting len)

### Description of changes:
For `AF_UNIX`, `BIO_ADDR_rawaddress` wrote a NUL terminator to `p[len]` while reporting `*l = len` (NUL excluded). A caller sizing `p` from the returned `*l` would take a 1-byte out-of-bounds write.

Changes `*l` to include the trailing NUL for AF_UNIX so that the reported length matches the bytes written and reflects the  NULL-terminated path convention. The public contract in `include/openssl/bio.h` is updated to match. Non-UNIX families (`AF_INET`, `AF_INET6`) are unchanged.

### Call-outs:
 callers who previously read `*l` for AF_UNIX now receive `strlen(path) + 1` instead of `strlen(path)`. The existing `bio_socket_test` already allocates `len + 1` buffers and is unaffected; out-of-tree callers that feed `*l` back into `BIO_ADDR_rawmake` will now pass the NUL-inclusive length, which `BIO_ADDR_rawmake` already tolerates.

### Testing:
Existing `bio_socket_test` continues to pass.
  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.