### PR TITLE
Enable Windows 7 compat path on MinGW builds

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -607,6 +607,15 @@ function(build_libcrypto)
   endif()
   if(WIN32)
     target_link_libraries(${arg_NAME} PUBLIC ws2_32)
+    # MinGW (non-Clang) builds target Windows 7 (see the top-level
+    # CMakeLists.txt, which adds -D_WIN32_WINNT=_WIN32_WINNT_WIN7), so
+    # `crypto/rand_extra/windows.c` compiles under the AWSLC_WINDOWS_7_COMPAT
+    # branch and calls BCryptGenRandom from bcrypt.dll. On MSVC this is
+    # handled by `#pragma comment(lib, "bcrypt.lib")` in that file, but
+    # MinGW ignores that pragma so we need to add the link explicitly.
+    if(MINGW)
+      target_link_libraries(${arg_NAME} PUBLIC bcrypt)
+    endif()
   endif()
 
   if(AWSLC_LINK_THREADS)

--- a/crypto/rand_extra/windows.c
+++ b/crypto/rand_extra/windows.c
@@ -16,7 +16,10 @@ OPENSSL_MSVC_PRAGMA(warning(push, 3))
 #include <windows.h>
 
 // ProcessPrng (from `bcryptprimitives.dll`) is only available on Windows 8+.
-#if !defined(__MINGW32__) && defined(_WIN32_WINNT) && _WIN32_WINNT <= _WIN32_WINNT_WIN7
+// Fall back to BCryptGenRandom when targeting Windows 7 or earlier. This applies
+// to both MSVC and MinGW-w64 toolchains; MinGW-w64 ships `bcrypt.h` and can link
+// against `libbcrypt.a` / `bcrypt.dll`.
+#if defined(_WIN32_WINNT) && _WIN32_WINNT <= _WIN32_WINNT_WIN7
 #define AWSLC_WINDOWS_7_COMPAT
 #endif
 


### PR DESCRIPTION
### Issues:
Addresses aws/aws-lc-rs#1111

### Description of changes:
`crypto/rand_extra/windows.c` gates the Windows 7 compatibility branch (`AWSLC_WINDOWS_7_COMPAT`, which uses `BCryptGenRandom` instead of `ProcessPrng`) on:

```
#if !defined(__MINGW32__) && defined(_WIN32_WINNT) && _WIN32_WINNT <= _WIN32_WINNT_WIN7
```

The `!defined(__MINGW32__)` guard was suppressing that branch on MinGW even though the top-level `CMakeLists.txt` already forces `-D_WIN32_WINNT=_WIN32_WINNT_WIN7` for `MINGW AND NOT CLANG`. So MinGW builds were effectively configured to target Windows 7 but then took the `ProcessPrng`/`bcryptprimitives.dll` path, which aborts at runtime on Windows 7 because `GetProcAddress` for `ProcessPrng` returns NULL there.

This change drops the MinGW guard so the Win7 path is taken when `_WIN32_WINNT` targets Win7, regardless of toolchain, and adds an explicit `target_link_libraries(... bcrypt)` for MinGW in `crypto/CMakeLists.txt`. The link is required because MinGW ignores the `#pragma comment(lib, "bcrypt.lib")` that MSVC uses inside the same file.

### Call-outs:
* The `bcrypt` link is added unconditionally on MinGW rather than mirroring the preprocessor condition, since detecting the effective `_WIN32_WINNT` at configure time is fragile. `bcrypt.dll` exists on all supported Windows versions, and the extra PE import is negligible when the Win7 branch isn't active.
* The existing `cross-mingw` CI job (which sets `_WIN32_WINNT=_WIN32_WINNT_WIN7` via the top-level `CMakeLists.txt`) will now naturally exercise `AWSLC_WINDOWS_7_COMPAT`; no new CI job is needed.
* A follow-up is needed in aws-lc-rs to handle the `x86_64-win7-windows-gnu` Rust target in its builder once this change is pulled in via submodule bump.

### Testing:
Local cross-compile from macOS with `x86_64-w64-mingw32-gcc` 14.0.0:

* Static `libcrypto.a` builds; `nm` on `rand_extra/windows.c.obj` shows only `U BCryptGenRandom`.
* Shared `libcrypto.dll` links cleanly; `objdump -x` shows `bcrypt.dll` / `BCryptGenRandom` in the import table and no `bcryptprimitives.dll` / `ProcessPrng` references.

The existing `cross-mingw` CI job will now exercise this code path end-to-end under Wine (Wine implements `BCryptGenRandom`).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
