### PR TITLE
Add SHRT_MAX caps to bound iteration and input lengths

### DIFF
--- a/crypto/bytestring/cbb.c
+++ b/crypto/bytestring/cbb.c
@@ -614,6 +614,11 @@ int CBB_add_asn1_oid_from_text(CBB *cbb, const char *text, size_t len) {
     return 0;
   }
 
+  if (len > (size_t)SHRT_MAX) {
+    OPENSSL_PUT_ERROR(CRYPTO, ERR_R_OVERFLOW);
+    return 0;
+  }
+
   CBS cbs;
   CBS_init(&cbs, (const uint8_t *)text, len);
 

--- a/crypto/fipsmodule/kdf/sskdf.c
+++ b/crypto/fipsmodule/kdf/sskdf.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 #include <assert.h>
+#include <limits.h>
 #include <openssl/base.h>
 #include <openssl/digest.h>
 #include <openssl/hmac.h>
@@ -327,6 +328,11 @@ int SSKDF_hmac(uint8_t *out_key, size_t out_len, const EVP_MD *digest,
 
   sskdf_variant_ctx ctx = {0};
   int ret = 0;
+
+  if (salt_len > SHRT_MAX) {
+    OPENSSL_PUT_ERROR(EVP, ERR_R_OVERFLOW);
+    goto end;
+  }
 
   if (!sskdf_variant_hmac_ctx_init(&ctx, digest, salt, salt_len)) {
     FIPS_service_indicator_unlock_state();

--- a/crypto/ocsp/ocsp_verify.c
+++ b/crypto/ocsp/ocsp_verify.c
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+#include <limits.h>
 #include <string.h>
 #include "../internal.h"
 #include "internal.h"
@@ -343,6 +344,11 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs, X509_STORE *st,
                       unsigned long flags) {
   if (bs == NULL || st == NULL) {
     OPENSSL_PUT_ERROR(OCSP, ERR_R_PASSED_NULL_PARAMETER);
+    return -1;
+  }
+
+  if (sk_X509_num(certs) > SHRT_MAX || sk_X509_num(bs->certs) > SHRT_MAX) {
+    OPENSSL_PUT_ERROR(OCSP, ERR_R_OVERFLOW);
     return -1;
   }
 

--- a/crypto/pkcs7/pkcs7.c
+++ b/crypto/pkcs7/pkcs7.c
@@ -3,6 +3,7 @@
 
 #include <openssl/pkcs7.h>
 
+#include <limits.h>
 #include <openssl/bytestring.h>
 #include <openssl/err.h>
 #include <openssl/mem.h>
@@ -748,6 +749,10 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio) {
   }
 
 
+  if (md_sk != NULL && sk_X509_ALGOR_num(md_sk) > SHRT_MAX) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_OVERFLOW);
+    goto err;
+  }
   for (size_t i = 0; i < sk_X509_ALGOR_num(md_sk); i++) {
     if (!pkcs7_bio_add_digest(&out, sk_X509_ALGOR_value(md_sk, i))) {
       goto err;
@@ -1269,6 +1274,11 @@ static BIO *pkcs7_data_decode(PKCS7 *p7, EVP_PKEY *pkey, X509 *pcert) {
     goto err;
   }
 
+  if (sk_PKCS7_RECIP_INFO_num(rsk) > SHRT_MAX) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_OVERFLOW);
+    goto err;
+  }
+
   if ((cipher_bio = BIO_new(BIO_f_cipher())) == NULL) {
     OPENSSL_PUT_ERROR(PKCS7, ERR_R_BIO_LIB);
     goto err;
@@ -1665,6 +1675,10 @@ int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
   STACK_OF(PKCS7_SIGNER_INFO) *sinfos = PKCS7_get_signer_info(p7);
   if (sinfos == NULL || sk_PKCS7_SIGNER_INFO_num(sinfos) == 0UL) {
     OPENSSL_PUT_ERROR(PKCS7, PKCS7_R_NO_SIGNATURES_ON_DATA);
+    goto out;
+  }
+  if (sk_PKCS7_SIGNER_INFO_num(sinfos) > SHRT_MAX) {
+    OPENSSL_PUT_ERROR(PKCS7, ERR_R_OVERFLOW);
     goto out;
   }
 

--- a/crypto/x509/x509spki.c
+++ b/crypto/x509/x509spki.c
@@ -2,6 +2,7 @@
 // Copyright (c) 1999 The OpenSSL Project.  All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <limits.h>
 #include <string.h>
 
 #include <openssl/base64.h>
@@ -37,6 +38,10 @@ NETSCAPE_SPKI *NETSCAPE_SPKI_b64_decode(const char *str, ossl_ssize_t len) {
   }
   if (len <= 0) {
     len = strlen(str);
+  }
+  if (len > SHRT_MAX) {
+    OPENSSL_PUT_ERROR(X509, ERR_R_OVERFLOW);
+    return NULL;
   }
   if (!EVP_DecodedLength(&spki_len, len)) {
     OPENSSL_PUT_ERROR(X509, X509_R_BASE64_DECODE_ERROR);


### PR DESCRIPTION
### Issues:
Addresses `P409219367`

### Description of changes: 
This PR adds iteration/input length bound checks across PKCS7, OCSP, SSKDF, X509 SPKI, and ASN.1 OID parsing to address the Penpal findings covering unbounded iteration counts and input lengths.

### Call-outs:
-  The relevant RFCs don't specify upper bounds, and choosing a tight limit would require knowing sizes typically seen in real data, which isn't easy to determine. We apply `SHRT_MAX` as a conservative cap to protect against bad input. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
