### PR TITLE
Ensure no trailing data for PKCS8 EVP_parse_private_key

### DIFF
--- a/crypto/evp_extra/evp_asn1.c
+++ b/crypto/evp_extra/evp_asn1.c
@@ -172,8 +172,7 @@ EVP_PKEY *EVP_parse_private_key(CBS *cbs) {
     has_pub = 1;
   }
 
-  // Reject trailing data within the SEQUENCE, matching the strictness of
-  // EVP_parse_public_key.
+  // Reject trailing data within the SEQUENCE.
   if (CBS_len(&pkcs8) != 0) {
     OPENSSL_PUT_ERROR(EVP, EVP_R_DECODE_ERROR);
     return NULL;

--- a/crypto/evp_extra/evp_asn1.c
+++ b/crypto/evp_extra/evp_asn1.c
@@ -172,6 +172,13 @@ EVP_PKEY *EVP_parse_private_key(CBS *cbs) {
     has_pub = 1;
   }
 
+  // Reject trailing data within the SEQUENCE, matching the strictness of
+  // EVP_parse_public_key.
+  if (CBS_len(&pkcs8) != 0) {
+    OPENSSL_PUT_ERROR(EVP, EVP_R_DECODE_ERROR);
+    return NULL;
+  }
+
   // Set up an |EVP_PKEY| of the appropriate type.
   EVP_PKEY *ret = EVP_PKEY_new();
   if (ret == NULL) {

--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -1683,6 +1683,30 @@ TEST(EVPExtraTest, Ed25519) {
   ERR_clear_error();
 }
 
+// EVP_parse_private_key must reject trailing data inside the PrivateKeyInfo
+// SEQUENCE.
+TEST(EVPExtraTest, ParsePrivateKeyRejectsTrailingData) {
+  // Ed25519 PKCS#8 (the kPrivateKeyPKCS8 vector from EVPExtraTest.Ed25519)
+  // with two extra bytes (ASN.1 NULL: 05 00) appended inside the outer
+  // SEQUENCE. The SEQUENCE length byte is bumped 0x2e -> 0x30 to cover
+  // the extra bytes, so the outer TLV is itself well-formed.
+  static const uint8_t kDERWithTrailing[] = {
+      0x30, 0x30, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,
+      0x04, 0x22, 0x04, 0x20, 0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60,
+      0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c, 0xc4, 0x44, 0x49, 0xc5, 0x69,
+      0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae, 0x7f, 0x60,
+      0x05, 0x00,
+  };
+
+  CBS cbs;
+  CBS_init(&cbs, kDERWithTrailing, sizeof(kDERWithTrailing));
+  ERR_clear_error();
+  bssl::UniquePtr<EVP_PKEY> parsed(EVP_parse_private_key(&cbs));
+  EXPECT_FALSE(parsed);
+  EXPECT_TRUE(ErrorEquals(ERR_get_error(), ERR_LIB_EVP, EVP_R_DECODE_ERROR));
+  ERR_clear_error();
+}
+
 // EVP_PKEY_get_private_seed returns an error for key types that don't
 // provide a get_priv_seed method. It must also reject NULL |key| regardless of
 // key type.


### PR DESCRIPTION
### Description of changes: 

Similar to `EVP_parse_public_key()`, don't allow trailing data. This matches what `EVP_parse_public_key()` does.

### Testing:

Cover this with a test case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
