### PR TITLE
ci: declare contents: read on zig compiler workflow

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -7,6 +7,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   zig:
     if: github.repository_owner == 'aws'


### PR DESCRIPTION
The zig compiler workflow runs `zig` cross-compile builds + tests on Windows/Linux/aarch64 matrices. Of the 43 workflows in `.github/workflows/`, 42 already declare permissions; this brings `zig.yml` in line.