### PR TITLE
[FIPS 2025 CHERRYPICK] Add SSL_use_cert_and_key for per-connection cert/key setting (#3114)

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1351,6 +1351,25 @@ OPENSSL_EXPORT int SSL_CTX_use_cert_and_key(SSL_CTX *ctx, X509 *x509,
                                             EVP_PKEY *privatekey,
                                             STACK_OF(X509) *chain, int override);
 
+// SSL_use_cert_and_key sets |x509|, |privatekey|, and |chain| on |ssl|.
+// The |privatekey| argument must be the private key of the certificate |x509|.
+// If the override argument is 0, then |x509|, |privatekey|, and |chain| are
+// set only if all were not previously set. If override is non-0, then the
+// certificate, private key and chain certs are always set. |privatekey| and
+// |x509| are not copied or duplicated, their reference counts are incremented.
+// In OpenSSL, a shallow copy of |chain| is stored with a reference count
+// increment for all |X509| objects in the chain. In AWS-LC,
+// we represent X509 chains as a CRYPTO_BUFFER stack. Therefore, we create a
+// an internal copy and leave the |chain| parameter untouched. This means,
+// changes to |chain| after this function is called will not update in |ssl|.
+// This is different from OpenSSL which stores a reference to the X509
+// certificates in the |chain| object.
+//
+// Returns one on success and zero on error.
+OPENSSL_EXPORT int SSL_use_cert_and_key(SSL *ssl, X509 *x509,
+                                        EVP_PKEY *privatekey,
+                                        STACK_OF(X509) *chain, int override);
+
 // Certificate and private key convenience functions.
 
 // SSL_CTX_set_chain_and_key sets the certificate chain and private key for a

--- a/ssl/ssl_cert.cc
+++ b/ssl/ssl_cert.cc
@@ -1010,16 +1010,14 @@ int SSL_CTX_set_chain_and_key(SSL_CTX *ctx, CRYPTO_BUFFER *const *certs,
                                 privkey_method);
 }
 
-int SSL_CTX_use_cert_and_key(SSL_CTX *ctx, X509 *x509, EVP_PKEY *privatekey,
-                             STACK_OF(X509) *chain, int override) {
-
+static int cert_use_cert_and_key(CERT *cert, X509 *x509, EVP_PKEY *privatekey,
+                                 STACK_OF(X509) *chain, int override) {
   if (privatekey == nullptr || x509 == nullptr) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_PASSED_NULL_PARAMETER);
     return 0;
   }
 
   // Check override value
-  CERT *cert = ctx->cert.get();
   int idx = ssl_get_certificate_slot_index(privatekey);
   if (idx < 0) {
     OPENSSL_PUT_ERROR(SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
@@ -1070,7 +1068,7 @@ int SSL_CTX_use_cert_and_key(SSL_CTX *ctx, X509 *x509, EVP_PKEY *privatekey,
     }
   }
 
-  // Call SSL_CTX_set_chain_and_key to set the chain and key
+  // Set the chain and key
   if (!cert_set_chain_and_key(cert, leaf_and_chain,
                               sk_CRYPTO_BUFFER_num(leaf_and_chain.get()),
                               privatekey, nullptr)) {
@@ -1084,6 +1082,21 @@ int SSL_CTX_use_cert_and_key(SSL_CTX *ctx, X509 *x509, EVP_PKEY *privatekey,
   X509_up_ref(x509);
   cert_pkey->x509_leaf = x509;
   return 1;
+}
+
+int SSL_CTX_use_cert_and_key(SSL_CTX *ctx, X509 *x509, EVP_PKEY *privatekey,
+                             STACK_OF(X509) *chain, int override) {
+  return cert_use_cert_and_key(ctx->cert.get(), x509, privatekey, chain,
+                               override);
+}
+
+int SSL_use_cert_and_key(SSL *ssl, X509 *x509, EVP_PKEY *privatekey,
+                         STACK_OF(X509) *chain, int override) {
+  if (!ssl->config) {
+    return 0;
+  }
+  return cert_use_cert_and_key(ssl->config->cert.get(), x509, privatekey,
+                               chain, override);
 }
 
 void SSL_certs_clear(SSL *ssl) {

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -1258,6 +1258,49 @@ TEST(SSLTest, SetLeafChainAndKey) {
   ERR_clear_error();
 }
 
+TEST(SSLTest, SSLUseCertAndKey) {
+  bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(client_ctx);
+  bssl::UniquePtr<SSL_CTX> server_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(server_ctx);
+
+  bssl::UniquePtr<EVP_PKEY> key = GetChainTestKey();
+  ASSERT_TRUE(key);
+  bssl::UniquePtr<X509> leaf = GetChainTestCertificate();
+  ASSERT_TRUE(leaf);
+  bssl::UniquePtr<X509> intermediate = GetChainTestIntermediate();
+  bssl::UniquePtr<STACK_OF(X509)> chain(sk_X509_new_null());
+  ASSERT_TRUE(chain);
+  ASSERT_TRUE(PushToStack(chain.get(), std::move(intermediate)));
+
+  bssl::UniquePtr<SSL> server(SSL_new(server_ctx.get()));
+  ASSERT_TRUE(server);
+
+  // Setting cert and key on the SSL object should succeed.
+  ASSERT_TRUE(SSL_use_cert_and_key(server.get(), leaf.get(), key.get(),
+                                   chain.get(), 1));
+
+  // Without override, setting again should fail.
+  ASSERT_FALSE(SSL_use_cert_and_key(server.get(), leaf.get(), key.get(),
+                                    chain.get(), 0));
+  ERR_clear_error();
+
+  SSL_CTX_set_custom_verify(
+      client_ctx.get(), SSL_VERIFY_PEER,
+      [](SSL *ssl, uint8_t *out_alert) -> ssl_verify_result_t {
+        return ssl_verify_ok;
+      });
+
+  bssl::UniquePtr<SSL> client;
+  // Reset server SSL for the connection test using CreateClientAndServer.
+  server.reset();
+  ASSERT_TRUE(CreateClientAndServer(&client, &server, client_ctx.get(),
+                                    server_ctx.get()));
+  ASSERT_TRUE(SSL_use_cert_and_key(server.get(), leaf.get(), key.get(),
+                                   chain.get(), 1));
+  ASSERT_TRUE(CompleteHandshakes(client.get(), server.get()));
+}
+
 TEST(SSLTest, BuffersFailWithoutCustomVerify) {
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_with_buffers_method()));
   ASSERT_TRUE(client_ctx);


### PR DESCRIPTION
Cherry-pick #3114 onto the FIPS 2025 branch.

------
### Issues:
Addresses P400736589

### Description of changes:
Postgres recently started calling SSL_use_cert_and_key (the per-SSL variant) which AWS-LC did not implement. This broke the postgres integration test on both x86_64 and aarch64 with an undefined reference linker error.

Extract the body of SSL_CTX_use_cert_and_key into a static helper cert_use_cert_and_key(CERT *) and add SSL_use_cert_and_key as a thin wrapper, following the established pattern used by SSL_use_PrivateKey, ssl_set_cert, and cert_set_chain_and_key.

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.