### PR TITLE
CI: exclude a test from bsd

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -577,8 +577,9 @@ jobs:
         uses: cross-platform-actions/action@2d97d42e1972a17b045fd709a422f7e55a86230d
         env:
           AWS_LC_GO_TEST_TIMEOUT: 120m
+          AWS_LC_NO_SLOW_TESTS: ${{ matrix.arch != 'x86-64' && '1' || '0' }}
         with:
-          environment_variables: AWS_LC_GO_TEST_TIMEOUT
+          environment_variables: AWS_LC_GO_TEST_TIMEOUT AWS_LC_NO_SLOW_TESTS
           operating_system: openbsd
           cpu_count: 3
           memory: 12G
@@ -612,6 +613,7 @@ jobs:
             sudo su -c unlimited -s /usr/local/bin/bash -l runner <<EOF
             set -x
             export AWS_LC_GO_TEST_TIMEOUT=${AWS_LC_GO_TEST_TIMEOUT}
+            export AWS_LC_NO_SLOW_TESTS=${AWS_LC_NO_SLOW_TESTS}
             cd $(pwd)
             export PATH="${HOME}/bin:${PATH}"
             env
@@ -713,9 +715,10 @@ jobs:
           AWS_LC_GO_TEST_TIMEOUT: 90m
           AWS_LC_SSL_RUNNER_IDLE_TIMEOUT: 120s
           AWS_LC_SSL_RUNNER_RETRY_ON_TIMEOUT: 1
+          AWS_LC_NO_SLOW_TESTS: ${{ matrix.arch != 'x86-64' && '1' || '0' }}
           GOFLAGS: "-buildvcs=false"
         with:
-          environment_variables: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_SSL_RUNNER_IDLE_TIMEOUT AWS_LC_SSL_RUNNER_RETRY_ON_TIMEOUT GOFLAGS"
+          environment_variables: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_SSL_RUNNER_IDLE_TIMEOUT AWS_LC_SSL_RUNNER_RETRY_ON_TIMEOUT AWS_LC_NO_SLOW_TESTS GOFLAGS"
           operating_system: freebsd
           architecture: ${{ matrix.arch }}
           version: ${{ matrix.version }}
@@ -746,9 +749,10 @@ jobs:
         uses: cross-platform-actions/action@2d97d42e1972a17b045fd709a422f7e55a86230d
         env:
           AWS_LC_GO_TEST_TIMEOUT: 90m
+          AWS_LC_NO_SLOW_TESTS: ${{ matrix.arch != 'x86-64' && '1' || '0' }}
           GOFLAGS: "-buildvcs=false"
         with:
-          environment_variables: "AWS_LC_GO_TEST_TIMEOUT GOFLAGS"
+          environment_variables: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_NO_SLOW_TESTS GOFLAGS"
           operating_system: netbsd
           architecture: ${{ matrix.arch }}
           version: ${{ matrix.version }}

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -564,61 +564,34 @@ jobs:
 
   OpenBSD:
     needs: [sanity-test-run]
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     name: OpenBSD ${{ matrix.version }} (${{ matrix.arch }}) test
     strategy:
       fail-fast: false
       matrix:
-        arch: ["x86-64", "arm64"]
+        arch: ["x86_64", "aarch64"]
         version: ["7.5", "7.6"]
     steps:
       - uses: actions/checkout@v6
       - name: OpenBSD
-        uses: cross-platform-actions/action@2d97d42e1972a17b045fd709a422f7e55a86230d
+        uses: vmactions/openbsd-vm@v1
         env:
           AWS_LC_GO_TEST_TIMEOUT: 120m
-          AWS_LC_NO_SLOW_TESTS: ${{ matrix.arch != 'x86-64' && '1' || '0' }}
+          AWS_LC_NO_SLOW_TESTS: ${{ matrix.arch != 'x86_64' && '1' || '0' }}
         with:
-          environment_variables: AWS_LC_GO_TEST_TIMEOUT AWS_LC_NO_SLOW_TESTS
-          operating_system: openbsd
-          cpu_count: 3
-          memory: 12G
-          architecture: ${{ matrix.arch }}
-          version: "${{ matrix.version }}"
-          shell: bash
+          release: "${{ matrix.version }}"
+          arch: ${{ matrix.arch }}
+          usesh: true
+          copyback: false
+          envs: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_NO_SLOW_TESTS"
+          prepare: |
+            pkg_add cmake ninja go gmake
           run: |
             set -x
-            sudo pkg_add cmake ninja go gmake
-            sudo pfctl -d
-            mkdir "${HOME}/bin"
-            ln -s /usr/local/bin/gmake "${HOME}/bin/make"
-            cat << EOF | sudo tee /etc/login.conf.d/unlimited
-            unlimited:\
-                :datasize-cur=infinity:\
-                :datasize-max=infinity:\
-                :stacksize-cur=infinity:\
-                :stacksize-max=infinity:\
-                :memoryuse-cur=infinity:\
-                :memoryuse-max=infinity:\
-                :maxproc-cur=infinity:\
-                :maxproc-max=infinity:\
-                :openfiles-cur=infinity:\
-                :openfiles-max=infinity:\
-                :cpuuse-cur=infinity:\
-                :cpuuse-max=infinity:\
-                :priority=0:\
-                :ignoretime:
-            EOF
-            sudo usermod -L unlimited runner
-            sudo su -c unlimited -s /usr/local/bin/bash -l runner <<EOF
-            set -x
-            export AWS_LC_GO_TEST_TIMEOUT=${AWS_LC_GO_TEST_TIMEOUT}
-            export AWS_LC_NO_SLOW_TESTS=${AWS_LC_NO_SLOW_TESTS}
-            cd $(pwd)
-            export PATH="${HOME}/bin:${PATH}"
-            env
+            pfctl -d || true
+            ln -s /usr/local/bin/gmake /usr/local/bin/make
+            export PATH="/usr/local/bin:${PATH}"
             tests/ci/run_bsd_tests.sh
-            EOF
   gcc-4_8:
     needs: [sanity-test-run]
     runs-on: ubuntu-latest
@@ -695,13 +668,13 @@ jobs:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     name: FreeBSD ${{ matrix.version }} (${{ matrix.arch }}) test
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         arch:
-          - "x86-64"
-          - "arm64"
+          - "x86_64"
+          - "aarch64"
         version:
           - "14.2"
           - "15.0"
@@ -709,65 +682,63 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - name: Prepare VM
-        uses: cross-platform-actions/action@v0.32.0
+      - name: FreeBSD
+        uses: vmactions/freebsd-vm@v1
         env:
           AWS_LC_GO_TEST_TIMEOUT: 90m
           AWS_LC_SSL_RUNNER_IDLE_TIMEOUT: 120s
           AWS_LC_SSL_RUNNER_RETRY_ON_TIMEOUT: 1
-          AWS_LC_NO_SLOW_TESTS: ${{ matrix.arch != 'x86-64' && '1' || '0' }}
+          AWS_LC_NO_SLOW_TESTS: ${{ matrix.arch != 'x86_64' && '1' || '0' }}
           GOFLAGS: "-buildvcs=false"
         with:
-          environment_variables: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_SSL_RUNNER_IDLE_TIMEOUT AWS_LC_SSL_RUNNER_RETRY_ON_TIMEOUT AWS_LC_NO_SLOW_TESTS GOFLAGS"
-          operating_system: freebsd
-          architecture: ${{ matrix.arch }}
-          version: ${{ matrix.version }}
-          shell: bash
-          memory: 12G
-          cpu_count: 3
+          release: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+          usesh: true
+          copyback: false
+          envs: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_SSL_RUNNER_IDLE_TIMEOUT AWS_LC_SSL_RUNNER_RETRY_ON_TIMEOUT AWS_LC_NO_SLOW_TESTS GOFLAGS"
+          prepare: |
+            pkg install -y git gmake cmake go ninja
           run: |
-            sudo pkg install -y git gmake cmake go ninja
             tests/ci/run_bsd_tests.sh
   netbsd:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     name: NetBSD ${{ matrix.version }} (${{ matrix.arch }}) test
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         arch:
-          - "x86-64"
-          - "arm64"
+          - "x86_64"
+          - "aarch64"
         version:
           - "10.1"
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - name: Prepare VM
-        uses: cross-platform-actions/action@2d97d42e1972a17b045fd709a422f7e55a86230d
+      - name: NetBSD
+        uses: vmactions/netbsd-vm@v1
         env:
           AWS_LC_GO_TEST_TIMEOUT: 90m
-          AWS_LC_NO_SLOW_TESTS: ${{ matrix.arch != 'x86-64' && '1' || '0' }}
+          AWS_LC_NO_SLOW_TESTS: ${{ matrix.arch != 'x86_64' && '1' || '0' }}
           GOFLAGS: "-buildvcs=false"
         with:
-          environment_variables: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_NO_SLOW_TESTS GOFLAGS"
-          operating_system: netbsd
-          architecture: ${{ matrix.arch }}
-          version: ${{ matrix.version }}
-          shell: bash
-          memory: 12G
-          cpu_count: 3
+          release: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+          usesh: true
+          copyback: false
+          envs: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_NO_SLOW_TESTS GOFLAGS"
+          prepare: |
+            export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/${{ matrix.arch }}/${{ matrix.version }}/All"
+            pkg_add -u curl cmake gmake perl mozilla-rootcerts
           run: |
             set -x
-            export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/${{ (matrix.arch == 'arm64' && 'aarch64') || 'x86_64' }}/${{ matrix.version }}/All"
-            sudo -E pkg_add -u curl cmake gmake perl mozilla-rootcerts
-            ARCH=${{ (matrix.arch == 'x86-64' && 'amd') || 'arm' }}
             export PATH="/usr/pkg/bin:/usr/pkg/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
+            ARCH=${{ matrix.arch == 'x86_64' && 'amd' || 'arm' }}
             curl -O https://dl.google.com/go/go1.25.2.netbsd-${ARCH}64.tar.gz
-            sudo mkdir -p /usr/local
-            sudo tar -C /usr/local -xzf go1.25.2.netbsd-${ARCH}64.tar.gz
+            mkdir -p /usr/local
+            tar -C /usr/local -xzf go1.25.2.netbsd-${ARCH}64.tar.gz
             export GOROOT=/usr/local/go
             export PATH="$PATH:$GOROOT/bin"
             tests/ci/run_bsd_tests.sh

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -573,6 +573,10 @@ jobs:
         version: ["7.5", "7.6"]
     steps:
       - uses: actions/checkout@v6
+      - name: Host runner info
+        run: |
+          nproc
+          lscpu
       - name: OpenBSD
         uses: vmactions/openbsd-vm@v1
         env:
@@ -585,7 +589,7 @@ jobs:
           copyback: false
           envs: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_NO_SLOW_TESTS"
           prepare: |
-            pkg_add cmake ninja go gmake
+            pkg_add bash cmake ninja go gmake
           run: |
             set -x
             pfctl -d || true
@@ -682,6 +686,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
+      - name: Host runner info
+        run: |
+          nproc
+          lscpu
       - name: FreeBSD
         uses: vmactions/freebsd-vm@v1
         env:
@@ -697,7 +705,7 @@ jobs:
           copyback: false
           envs: "AWS_LC_GO_TEST_TIMEOUT AWS_LC_SSL_RUNNER_IDLE_TIMEOUT AWS_LC_SSL_RUNNER_RETRY_ON_TIMEOUT AWS_LC_NO_SLOW_TESTS GOFLAGS"
           prepare: |
-            pkg install -y git gmake cmake go ninja
+            pkg install -y bash git gmake cmake go ninja
           run: |
             tests/ci/run_bsd_tests.sh
   netbsd:
@@ -717,6 +725,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
+      - name: Host runner info
+        run: |
+          nproc
+          lscpu
       - name: NetBSD
         uses: vmactions/netbsd-vm@v1
         env:

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -564,7 +564,7 @@ jobs:
 
   OpenBSD:
     needs: [sanity-test-run]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     name: OpenBSD ${{ matrix.version }} (${{ matrix.arch }}) test
     strategy:
       fail-fast: false
@@ -695,7 +695,7 @@ jobs:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     name: FreeBSD ${{ matrix.version }} (${{ matrix.arch }}) test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -732,7 +732,7 @@ jobs:
     if: github.repository_owner == 'aws'
     needs: [sanity-test-run]
     name: NetBSD ${{ matrix.version }} (${{ matrix.arch }}) test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/tests/ci/gtest_util.sh
+++ b/tests/ci/gtest_util.sh
@@ -10,11 +10,17 @@ function shard_gtest() {
         GTEST_TOTAL_SHARDS=4
     fi
 
+    local TEST_NAME
+    TEST_NAME=$(basename "${1%% *}")
+    local REPORT_DIR="${BUILD_ROOT}/test_reports"
+    mkdir -p "${REPORT_DIR}"
+
     echo shard_gtest-Command: ${1}
     PIDS=()
     COUNTER=0
     while [ $COUNTER -lt $GTEST_TOTAL_SHARDS ]; do
         export GTEST_SHARD_INDEX=$COUNTER
+        export GTEST_OUTPUT="json:${REPORT_DIR}/${TEST_NAME}_shard_${COUNTER}.json"
         ${1} &
         PIDS[${COUNTER}]=$!
         COUNTER=$(( COUNTER+1 ))
@@ -30,6 +36,7 @@ function shard_gtest() {
     done
     unset GTEST_SHARD_INDEX
     unset GTEST_TOTAL_SHARDS
+    unset GTEST_OUTPUT
 
     if [ $RESULT -ne "0" ]; then
       #  Run w/o sharding to isolate the problem

--- a/tests/ci/run_bsd_tests.sh
+++ b/tests/ci/run_bsd_tests.sh
@@ -15,9 +15,11 @@ if [ "$PLATFORM" != "amd64" ] && [ "$PLATFORM" != "x86_64" ]; then
 
     run_build all
 
-    shard_gtest ${BUILD_ROOT}/crypto/crypto_test
-    # This one test is 1-2 hours on Qemu+arm, disabled it to validate timings across flavors.
-    #${BUILD_ROOT}/crypto/crypto_test --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_*
+    if [[ "${AWS_LC_NO_SLOW_TESTS:-0}" == "0" ]]; then
+        shard_gtest "${BUILD_ROOT}/crypto/crypto_test --gtest_also_run_disabled_tests"
+    else
+        shard_gtest ${BUILD_ROOT}/crypto/crypto_test
+    fi
     shard_gtest ${BUILD_ROOT}/crypto/urandom_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_set_test

--- a/tests/ci/run_bsd_tests.sh
+++ b/tests/ci/run_bsd_tests.sh
@@ -15,7 +15,7 @@ if [ "$PLATFORM" != "amd64" ] && [ "$PLATFORM" != "x86_64" ]; then
 
     run_build all
 
-    shard_gtest "${BUILD_ROOT}/crypto/crypto_test --gtest_also_run_disabled_tests"
+    shard_gtest "${BUILD_ROOT}/crypto/crypto_test
     shard_gtest ${BUILD_ROOT}/crypto/urandom_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_set_test

--- a/tests/ci/run_bsd_tests.sh
+++ b/tests/ci/run_bsd_tests.sh
@@ -15,7 +15,9 @@ if [ "$PLATFORM" != "amd64" ] && [ "$PLATFORM" != "x86_64" ]; then
 
     run_build all
 
-    shard_gtest "${BUILD_ROOT}/crypto/crypto_test
+    shard_gtest ${BUILD_ROOT}/crypto/crypto_test
+    #Don't co-mingle this with any sharded tests
+    ${BUILD_ROOT}/crypto/crypto_test --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_*
     shard_gtest ${BUILD_ROOT}/crypto/urandom_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_set_test

--- a/tests/ci/run_bsd_tests.sh
+++ b/tests/ci/run_bsd_tests.sh
@@ -16,8 +16,8 @@ if [ "$PLATFORM" != "amd64" ] && [ "$PLATFORM" != "x86_64" ]; then
     run_build all
 
     shard_gtest ${BUILD_ROOT}/crypto/crypto_test
-    #Don't co-mingle this with any sharded tests
-    ${BUILD_ROOT}/crypto/crypto_test --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_*
+    # This one test is 1-2 hours on Qemu+arm, disabled it to validate timings across flavors.
+    #${BUILD_ROOT}/crypto/crypto_test --gtest_also_run_disabled_tests --gtest_filter=*DISABLED_*
     shard_gtest ${BUILD_ROOT}/crypto/urandom_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_test
     shard_gtest ${BUILD_ROOT}/crypto/mem_set_test


### PR DESCRIPTION
### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
The long pole for CI runs currently are the BSD cross-platform runs, some taking in excess of 3 hours.
Flip an environment variable on if we're using cross-platform and disable a set of tests for those runs.

We don't have individual test timing data- tell gtest to record it (report uploads come later).

### Call-outs:
GHA Arm runners might also accelerate these runs; try in a future iteration.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
