### PR TITLE
Make FIPS compiler wrapper unconditional

### DIFF
--- a/util/compiler_wrapper/CompilerWrapper.cmake
+++ b/util/compiler_wrapper/CompilerWrapper.cmake
@@ -24,6 +24,10 @@
 # wrapper unconditionally strips -c when -S is present, making the build
 # correct for all compilers.
 
+# Save the directory of this file at include-time. Inside functions,
+# CMAKE_CURRENT_LIST_DIR reflects the *caller's* directory, not ours.
+set(_COMPILER_WRAPPER_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
 # Generate wrapper scripts with hardcoded compiler paths
 function(generate_compiler_wrapper)
   # Get current timestamp for generated file header
@@ -34,7 +38,7 @@ function(generate_compiler_wrapper)
   file(MAKE_DIRECTORY "${WRAPPER_OUTPUT_DIR}")
 
   # Generate shell script wrapper (Unix/Linux/macOS)
-  set(SHELL_TEMPLATE "${CMAKE_SOURCE_DIR}/util/compiler_wrapper/compiler_wrapper_template.sh.in")
+  set(SHELL_TEMPLATE "${_COMPILER_WRAPPER_DIR}/compiler_wrapper_template.sh.in")
   set(SHELL_OUTPUT "${WRAPPER_OUTPUT_DIR}/compiler_wrapper.sh")
 
   if(EXISTS "${SHELL_TEMPLATE}")
@@ -52,7 +56,7 @@ function(generate_compiler_wrapper)
   endif()
 
   # Generate batch file wrapper (Windows)
-  set(BAT_TEMPLATE "${CMAKE_SOURCE_DIR}/util/compiler_wrapper/compiler_wrapper_template.bat.in")
+  set(BAT_TEMPLATE "${_COMPILER_WRAPPER_DIR}/compiler_wrapper_template.bat.in")
   set(BAT_OUTPUT "${WRAPPER_OUTPUT_DIR}/compiler_wrapper.bat")
 
   if(EXISTS "${BAT_TEMPLATE}")

--- a/util/compiler_wrapper/CompilerWrapper.cmake
+++ b/util/compiler_wrapper/CompilerWrapper.cmake
@@ -23,9 +23,6 @@
 # compilers (Clang 20+, Zig) reject or mishandle the conflicting flags. The
 # wrapper unconditionally strips -c when -S is present, making the build
 # correct for all compilers.
-function(compiler_wrapper_needed result_var)
-  set(${result_var} TRUE PARENT_SCOPE)
-endfunction()
 
 # Generate wrapper scripts with hardcoded compiler paths
 function(generate_compiler_wrapper)
@@ -86,14 +83,6 @@ endfunction()
 
 # Set up the compiler wrapper system
 function(setup_compiler_wrapper)
-  # Check if we need the wrapper
-  compiler_wrapper_needed(NEED_WRAPPER)
-  if(NOT NEED_WRAPPER)
-    message(STATUS "Compiler wrapper not needed for current compiler version")
-    set(COMPILER_WRAPPER_AVAILABLE FALSE CACHE INTERNAL "Whether compiler wrapper is available")
-    return()
-  endif()
-
   # Determine the compiler to wrap
   set(REAL_COMPILER "${CMAKE_C_COMPILER}")
   if(NOT REAL_COMPILER)

--- a/util/compiler_wrapper/CompilerWrapper.cmake
+++ b/util/compiler_wrapper/CompilerWrapper.cmake
@@ -3,8 +3,10 @@
 
 # CompilerWrapper.cmake
 #
-# CMake module for handling compiler flag conflicts, particularly the -S/-c conflict
-# in newer Clang versions when generating assembly output.
+# CMake module for handling the -S/-c flag conflict that arises when CMake
+# generates the compile command for the bcm_c_generated_asm target. CMake's
+# static library rules always include -c, but we set COMPILE_OPTIONS "-S" to
+# produce textual assembly. The wrapper strips -c when -S is present.
 #
 # This module dynamically generates wrapper scripts with hardcoded compiler paths,
 # eliminating the need for complex compiler discovery logic.
@@ -14,24 +16,15 @@
 #   setup_compiler_wrapper()
 #   use_compiler_wrapper_for_target(my_target)
 
-cmake_minimum_required(VERSION 3.5)
-
-# Check if we need the compiler wrapper based on compiler version
+# The bcm_c_generated_asm target uses COMPILE_OPTIONS "-S" on a normal CMake
+# static library, which causes CMake to emit both -S and -c in the same
+# command. This is semantically contradictory (-S = emit assembly, -c = emit
+# object code). GCC and older Clang versions silently let -S win, but other
+# compilers (Clang 20+, Zig) reject or mishandle the conflicting flags. The
+# wrapper unconditionally strips -c when -S is present, making the build
+# correct for all compilers.
 function(compiler_wrapper_needed result_var)
-  set(${result_var} FALSE PARENT_SCOPE)
-
-  # Check C compiler
-  if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER MATCHES "clang")
-    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER "19.99.99")
-      set(${result_var} TRUE PARENT_SCOPE)
-      return()
-    endif()
-  endif()
-
-  # Allow manual override via CMake variable
-  if(FORCE_COMPILER_WRAPPER)
-    set(${result_var} TRUE PARENT_SCOPE)
-  endif()
+  set(${result_var} TRUE PARENT_SCOPE)
 endfunction()
 
 # Generate wrapper scripts with hardcoded compiler paths

--- a/util/compiler_wrapper/compiler_wrapper_template.bat.in
+++ b/util/compiler_wrapper/compiler_wrapper_template.bat.in
@@ -8,8 +8,10 @@
 :: Real compiler: @REAL_COMPILER@
 :: Generated on: @CURRENT_TIMESTAMP@
 ::
-:: Purpose: Filter out conflicting -c flags when -S flag is present
-:: to avoid issues with newer Clang versions (20+)
+:: Purpose: Filter out conflicting -c flags when -S flag is present.
+:: CMake always emits -c for static library targets, but the bcm_c_generated_asm
+:: target uses -S to produce textual assembly. The two flags are contradictory;
+:: this wrapper ensures -S wins regardless of compiler.
 
 setlocal enabledelayedexpansion
 

--- a/util/compiler_wrapper/compiler_wrapper_template.sh.in
+++ b/util/compiler_wrapper/compiler_wrapper_template.sh.in
@@ -8,8 +8,10 @@
 # Real compiler: @REAL_COMPILER@
 # Generated on: @CURRENT_TIMESTAMP@
 #
-# Purpose: Filter out conflicting -c flags when -S flag is present
-# to avoid issues with newer Clang versions (20+)
+# Purpose: Filter out conflicting -c flags when -S flag is present.
+# CMake always emits -c for static library targets, but the bcm_c_generated_asm
+# target uses -S to produce textual assembly. The two flags are contradictory;
+# this wrapper ensures -S wins regardless of compiler.
 
 set -e
 


### PR DESCRIPTION
### Issues:
Addresses #3261

### Description of changes:

The `bcm_c_generated_asm` target uses `COMPILE_OPTIONS "-S"` on a CMake static library, which causes CMake to emit both `-S` and `-c` in the same compile command. These flags are semantically contradictory (`-S` = emit assembly, `-c` = emit object code). GCC and older Clang silently let `-S` win, but Zig produces an object file instead of textual assembly, causing `delocate` to fail with a parse error.

We already had a `CompilerWrapper` that strips `-c` when `-S` is present, but it was gated to only activate for Clang ≥ 20. This change removes the version check so the wrapper applies unconditionally, making the build correct for all compilers.

### Call-outs:

This fixes the immediate build failure reported in #3261 but does not guarantee full end-to-end FIPS support with Zig. Other parts of the delocate pipeline (e.g., `-E -dI` preprocessing, assembly parsing) haven't been validated with Zig yet.

### Testing:

Verified that CMake configure succeeds for the `FIPS_DELOCATE` path and that the wrapper is generated and applied to `bcm_c_generated_asm`. Existing CI (including the Zig workflow and FIPS builds with GCC/Clang) will exercise both sides.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
