### PR TITLE
Skip MariaDB socket conflict test unable to run as root

### DIFF
--- a/tests/ci/integration/run_mariadb_integration.sh
+++ b/tests/ci/integration/run_mariadb_integration.sh
@@ -62,6 +62,7 @@ main.flush_logs_not_windows : query 'flush logs' succeeded - should have failed 
 main.mysql_upgrade_noengine : upgrade output order does not match the expected
 main.plugin_load : This test generates a warning in Codebuild. Skip over since this isn't relevant to AWS-LC.
 main.desc_index_min_max : This test is flaky and unrelated to aws-lc.
+main.socket_conflict : mariadbd refuses to run as root in CI container; not relevant to AWS-LC.
 "> skiplist
   ./mtr --suite=main --force --parallel=auto --skip-test-list=${MARIADB_BUILD_FOLDER}/mysql-test/skiplist --retry-failure=2
   popd


### PR DESCRIPTION
### Issues:
Resolves V2229329372

### Description of changes: 

MariaDB [added a socket conflict test](https://github.com/MariaDB/server/commit/fa054d13e4788b95d30e15013895718067533514) that cannot run as root. The test is around socket business behavior, not TLS/crypto, so is fine for us to skip.

### Call-outs:

n/a

### Testing:

CI

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
