### PR TITLE
ci: turn on gtest reporting;summerize

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} with FIPS mode
         run: |
           ./tests/ci/run_fips_tests.sh
+      - name: gtest timing summary
+        if: always()
+        run: python3 tests/ci/gtest_summary.py test_reports >> $GITHUB_STEP_SUMMARY
 
   macOS-ARM:
     if: github.repository_owner == 'aws'

--- a/tests/ci/gtest_summary.py
+++ b/tests/ci/gtest_summary.py
@@ -81,7 +81,7 @@ def write_summary(suites, output):
 
 def main():
     report_dir = sys.argv[1] if len(sys.argv) > 1 else os.environ.get(
-        "GTEST_REPORT_DIR", "build/test_reports"
+        "GTEST_REPORT_DIR", "test_reports"
     )
 
     if not os.path.isdir(report_dir):

--- a/tests/ci/gtest_summary.py
+++ b/tests/ci/gtest_summary.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+"""Parse gtest JSON reports and write a GitHub Actions step summary."""
+
+import json
+import glob
+import os
+import sys
+
+def parse_reports(report_dir):
+    """Parse all JSON reports and return per-suite timing data."""
+    suites = {}  # {test_binary: {shard_times: [], total: float, slowest_tests: []}}
+
+    for f in sorted(glob.glob(os.path.join(report_dir, "*_shard_*.json"))):
+        basename = os.path.basename(f)
+        # e.g. crypto_test_shard_2.json -> crypto_test
+        parts = basename.rsplit("_shard_", 1)
+        suite_name = parts[0]
+
+        with open(f) as fh:
+            data = json.load(fh)
+
+        shard_time = float(data.get("time", "0s").rstrip("s"))
+
+        if suite_name not in suites:
+            suites[suite_name] = {"shard_times": [], "slowest_tests": []}
+
+        suites[suite_name]["shard_times"].append(shard_time)
+
+        # Collect individual test times
+        for ts in data.get("testsuites", []):
+            for test in ts.get("testsuite", []):
+                t = float(test.get("time", "0s").rstrip("s"))
+                suites[suite_name]["slowest_tests"].append(
+                    (t, f"{ts['name']}.{test['name']}")
+                )
+
+    return suites
+
+
+def write_summary(suites, output):
+    """Write markdown summary to output file."""
+    lines = []
+    lines.append("## 🧪 gtest Timing Summary\n")
+    lines.append("| Test Binary | Wall-clock (longest shard) | Shards | Total tests |")
+    lines.append("|-------------|---------------------------|--------|-------------|")
+
+    for name, data in sorted(suites.items(), key=lambda x: max(x[1]["shard_times"]), reverse=True):
+        longest = max(data["shard_times"])
+        num_shards = len(data["shard_times"])
+        num_tests = len(data["slowest_tests"])
+        if longest >= 60:
+            time_str = f"{longest/60:.1f}m"
+        else:
+            time_str = f"{longest:.1f}s"
+        lines.append(f"| `{name}` | {time_str} | {num_shards} | {num_tests} |")
+
+    # Top 5 slowest individual tests across all suites
+    all_tests = []
+    for data in suites.values():
+        all_tests.extend(data["slowest_tests"])
+    all_tests.sort(reverse=True)
+
+    if all_tests:
+        lines.append("\n### ⏱️ Top 5 Slowest Tests\n")
+        lines.append("| Test | Time |")
+        lines.append("|------|------|")
+        for t, name in all_tests[:5]:
+            if t >= 60:
+                time_str = f"{t/60:.1f}m"
+            else:
+                time_str = f"{t:.1f}s"
+            disabled = " ⚠️" if "DISABLED_" in name else ""
+            lines.append(f"| `{name}`{disabled} | {time_str} |")
+
+    lines.append("")
+    output.write("\n".join(lines))
+
+
+def main():
+    report_dir = sys.argv[1] if len(sys.argv) > 1 else os.environ.get(
+        "GTEST_REPORT_DIR", "build/test_reports"
+    )
+
+    if not os.path.isdir(report_dir):
+        print(f"No report directory found at {report_dir}", file=sys.stderr)
+        sys.exit(0)  # Don't fail the build
+
+    reports = glob.glob(os.path.join(report_dir, "*_shard_*.json"))
+    if not reports:
+        print(f"No JSON reports found in {report_dir}", file=sys.stderr)
+        sys.exit(0)
+
+    suites = parse_reports(report_dir)
+
+    # Write to GITHUB_STEP_SUMMARY if available, otherwise stdout
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            write_summary(suites, f)
+    else:
+        write_summary(suites, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ci/gtest_util.sh
+++ b/tests/ci/gtest_util.sh
@@ -12,7 +12,7 @@ function shard_gtest() {
 
     local TEST_NAME
     TEST_NAME=$(basename "${1%% *}")
-    local REPORT_DIR="${BUILD_ROOT}/test_reports"
+    local REPORT_DIR="${SRC_ROOT}/test_reports"
     mkdir -p "${REPORT_DIR}"
 
     echo shard_gtest-Command: ${1}

--- a/tests/ci/gtest_util.sh
+++ b/tests/ci/gtest_util.sh
@@ -10,11 +10,17 @@ function shard_gtest() {
         GTEST_TOTAL_SHARDS=4
     fi
 
+    local TEST_NAME
+    TEST_NAME=$(basename "${1%% *}")
+    local REPORT_DIR="${BUILD_ROOT}/test_reports"
+    mkdir -p "${REPORT_DIR}"
+
     echo shard_gtest-Command: ${1}
     PIDS=()
     COUNTER=0
     while [ $COUNTER -lt $GTEST_TOTAL_SHARDS ]; do
         export GTEST_SHARD_INDEX=$COUNTER
+        export GTEST_OUTPUT="json:${REPORT_DIR}/${TEST_NAME}_shard_${COUNTER}.json"
         ${1} &
         PIDS[${COUNTER}]=$!
         COUNTER=$(( COUNTER+1 ))
@@ -30,6 +36,7 @@ function shard_gtest() {
     done
     unset GTEST_SHARD_INDEX
     unset GTEST_TOTAL_SHARDS
+    unset GTEST_OUTPUT
 
     if [ $RESULT -ne "0" ]; then
       #  Run w/o sharding to isolate the problem


### PR DESCRIPTION
### Description of changes: 

Turn on gtest json reporting and summarize the findings.

 ## Sample output (rendered in GitHub Actions summary tab)

  ### 🧪 gtest Timing Summary

  | Test Binary | Wall-clock (longest shard) | Shards | Total tests |
  |-------------|---------------------------|--------|-------------|
  | `crypto_test` | 11.2m | 4 | 2721 |
  | `ssl_test` | 8.3s | 4 | 2621 |
  | `tree_drbg_jitter_entropy_isolated_test` | 0.5s | 4 | 5 |
  | `rand_isolated_test` | 0.0s | 4 | 5 |
  | `mem_set_test` | 0.0s | 4 | 1 |
  | `mem_test` | 0.0s | 4 | 2 |

  #### ⏱️  Top 5 Slowest Tests

  | Test | Time |
  |------|------|
  | `ECTest.DISABLED_ScalarBaseMultVectorsTwoPoint` ⚠️  | 9.4m |
  | `X25519Test.DISABLED_IteratedLarge` ⚠️  | 32.3s |
  | `BNTest.DISABLED_WycheproofPrimality` ⚠️  | 21.1s |
  | `BNTest.PrimeChecking` | 12.0s |
  | `BNTest.GCDTestVectors` | 8.9s |

  > ⚠️  = `DISABLED_` test (only runs with `--gtest_also_run_disabled_tests`)

### Call-outs:
This was a first attempt; the reporting and analysis could likely be improved upon.
Targeting Mac as one of the the next slowest CI jobs.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
