### PR TITLE
ci: cache NTP tarball to avoid external download flakiness

### DIFF
--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -393,6 +393,12 @@ jobs:
       ACCP_FIPS: ${{ matrix.accp_fips || '' }}
     steps:
       - uses: actions/checkout@v6
+      - name: Setup integration cache directory
+        run: mkdir -p .cache/integration
+      - uses: actions/cache@v5
+        with:
+          path: .cache/integration
+          key: integration-${{ matrix.name }}-${{ hashFiles('tests/ci/integration/run_ntp_integration.sh') }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2

--- a/tests/ci/integration/run_ntp_integration.sh
+++ b/tests/ci/integration/run_ntp_integration.sh
@@ -20,16 +20,9 @@ source tests/ci/common_posix_setup.sh
 
 # Assumes script is executed from the root of aws-lc directory
 SCRATCH_FOLDER="${SYS_ROOT}/NTP_BUILD_ROOT"
-NTP_WEBSITE_URL="https://downloads.nwtime.org/ntp/"
-
-# - curl fetches the HTML content of the website,
-# - the first grep searches for all occurrences of href attributes in anchor tags and outputs only the URLs,
-# - sed removes the href=" and trailing " from the URLs,
-# - the second grep filters only the links ending with .tar.gz,
-# - "head -n 1" gets only the first matching line
-# - cut strips "/ntp/" from the link and retains only the tar name.
-NTP_TAR=$(curl -s ${NTP_WEBSITE_URL} | grep -o 'href="[^"]*"' | sed 's/href="//;s/"$//' | grep '.tar.gz$' | head -n 1 | cut -d '/' -f3)
-NTP_DOWNLOAD_URL="${NTP_WEBSITE_URL}/${NTP_TAR}"
+NTP_VERSION="4.2.8p18"
+NTP_TAR="ntp-${NTP_VERSION}.tar.gz"
+NTP_DOWNLOAD_URL="https://downloads.nwtime.org/ntp/${NTP_TAR}"
 NTP_SRC_FOLDER="${SCRATCH_FOLDER}/ntp-src"
 NTP_PATCH_FOLDER="${SRC_ROOT}/tests/ci/integration/ntp_patch"
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
@@ -57,7 +50,18 @@ mkdir -p "$SCRATCH_FOLDER"
 rm -rf "${SCRATCH_FOLDER:?}/*"
 cd "$SCRATCH_FOLDER"
 
-wget -q $NTP_DOWNLOAD_URL
+# Use cached tarball from workspace if available, otherwise download.
+CACHE_DIR="${SRC_ROOT}/.cache/integration"
+if [[ -n "${NTP_TAR}" && -f "${CACHE_DIR}/${NTP_TAR}" ]]; then
+  echo "Using cached tarball: ${CACHE_DIR}/${NTP_TAR}"
+  cp "${CACHE_DIR}/${NTP_TAR}" .
+else
+  wget -q $NTP_DOWNLOAD_URL
+  # Cache the tarball for future runs if directory exists
+  if [[ -n "${NTP_TAR}" && -d "${CACHE_DIR}" ]]; then
+    cp "${NTP_TAR}" "${CACHE_DIR}/"
+  fi
+fi
 mkdir -p "$NTP_SRC_FOLDER"
 tar -xzf "$NTP_TAR" -C "$NTP_SRC_FOLDER" --strip-components=1
 


### PR DESCRIPTION
Add actions/cache to integration_omnibus workflow to persist
downloaded tarballs between runs. The NTP integration script
now checks for a cached tarball before downloading from
downloads.nwtime.org, which is intermittently unreachable.

This pattern can be extended to other integration tests that
fetch from external origins.

### Issues:
Resolves #ISSUE-NUMBER1
Addresses #ISSUE-NUMBER2

### Description of changes: 
Describe AWS-LC’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
