### PR TITLE
Enable optimized Arm assembly on Neoverse N2

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -809,6 +809,7 @@ if(BUILD_TESTING)
     fipsmodule/service_indicator/service_indicator_test.cc
     fipsmodule/sha/sha_test.cc
     fipsmodule/sha/sha3_test.cc
+    fipsmodule/cpucap/cpu_aarch64_test.cc
     fipsmodule/cpucap/cpu_arm_linux_test.cc
     fipsmodule/cpucap/cpu_aarch64_dit_test.cc
     fipsmodule/hkdf/hkdf_test.cc

--- a/crypto/fipsmodule/bn/bn_test.cc
+++ b/crypto/fipsmodule/bn/bn_test.cc
@@ -2944,6 +2944,30 @@ TEST_F(BNTest, BNMulMontABI) {
 }
 #endif   // OPENSSL_BN_ASM_MONT && SUPPORTS_ABI_TEST
 
+#if defined(BORINGSSL_DISPATCH_TEST) && !defined(OPENSSL_NO_ASM) && \
+    defined(OPENSSL_AARCH64) && defined(OPENSSL_BN_ASM_MONT) &&     \
+    (defined(OPENSSL_LINUX) || defined(OPENSSL_APPLE) ||             \
+     defined(OPENSSL_OPENBSD) || defined(OPENSSL_FREEBSD) ||         \
+     defined(OPENSSL_NETBSD))
+TEST_F(BNTest, MontgomeryN2Dispatch) {
+#if defined(OPENSSL_STATIC_ARMCAP_NEOVERSE_N2)
+  EXPECT_TRUE(CRYPTO_is_ARMv8_wide_multiplier_capable());
+#endif
+
+  const uint32_t saved_armcap = OPENSSL_armcap_P;
+
+  OPENSSL_armcap_P = ARMV7_NEON;
+  EXPECT_TRUE(bn_montgomery_use_s2n_bignum_for_testing(8));
+  EXPECT_FALSE(bn_montgomery_use_s2n_bignum_for_testing(7));
+
+  OPENSSL_armcap_P = ARMV7_NEON | ARMV8_NEOVERSE_N2;
+  EXPECT_TRUE(CRYPTO_is_ARMv8_wide_multiplier_capable());
+  EXPECT_FALSE(bn_montgomery_use_s2n_bignum_for_testing(8));
+
+  OPENSSL_armcap_P = saved_armcap;
+}
+#endif
+
 #if defined(OPENSSL_BN_ASM_MONT5) && defined(SUPPORTS_ABI_TEST)
 TEST_F(BNTest, BNMulMont5ABI) {
   for (size_t words : {4, 5, 6, 7, 8, 16, 32}) {

--- a/crypto/fipsmodule/bn/internal.h
+++ b/crypto/fipsmodule/bn/internal.h
@@ -270,6 +270,10 @@ int bn_rand_secret_range(BIGNUM *r, int *out_is_uniform, BN_ULONG min_inclusive,
 // values for other operations.
 #define BN_MONTGOMERY_MAX_WORDS (8 * 1024 / sizeof(BN_ULONG))
 
+#if defined(BORINGSSL_DISPATCH_TEST)
+int bn_montgomery_use_s2n_bignum_for_testing(unsigned int num);
+#endif
+
 #if !defined(OPENSSL_NO_ASM) &&                         \
     (defined(OPENSSL_X86) || defined(OPENSSL_X86_64) || \
      defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64))

--- a/crypto/fipsmodule/bn/montgomery.c
+++ b/crypto/fipsmodule/bn/montgomery.c
@@ -52,6 +52,12 @@ OPENSSL_INLINE int montgomery_use_s2n_bignum(unsigned int num) {
 
 #endif
 
+#if defined(BORINGSSL_DISPATCH_TEST)
+int bn_montgomery_use_s2n_bignum_for_testing(unsigned int num) {
+  return montgomery_use_s2n_bignum(num);
+}
+#endif
+
 void bn_mont_ctx_init(BN_MONT_CTX *mont) {
   OPENSSL_memset(mont, 0, sizeof(BN_MONT_CTX));
   BN_init(&mont->RR);

--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -76,6 +76,9 @@ void OPENSSL_cpuid_setup(void) {
     if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_N1)) {
       OPENSSL_armcap_P |= ARMV8_NEOVERSE_N1;
     }
+    if (MIDR_IS_NEOVERSE_N2(OPENSSL_arm_midr)) {
+      OPENSSL_armcap_P |= ARMV8_NEOVERSE_N2;
+    }
     if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V1)) {
       OPENSSL_armcap_P |= ARMV8_NEOVERSE_V1;
       // CPU capabilities of N1 are a subset of CPU capabilities of V1

--- a/crypto/fipsmodule/cpucap/cpu_aarch64_test.cc
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_test.cc
@@ -1,0 +1,33 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <openssl/base.h>
+
+#if defined(OPENSSL_AARCH64)
+
+#include <openssl/arm_arch.h>
+
+#include <gtest/gtest.h>
+
+TEST(AArch64CPUTest, NeoverseN2MIDR) {
+  struct {
+    uint64_t midr;
+    bool is_neoverse_n2;
+  } kTests[] = {
+      {MIDR_CPU_MODEL(ARM_CPU_IMP_ARM, ARM_CPU_PART_N2), true},
+      {MIDR_CPU_MODEL(ARM_CPU_IMP_MICROSOFT,
+                      MICROSOFT_CPU_PART_AZURE_COBALT_100),
+       true},
+      {MIDR_CPU_MODEL(ARM_CPU_IMP_ARM, ARM_CPU_PART_N2) | (1UL << 20) | 1,
+       true},
+      {MIDR_CPU_MODEL(0x42, ARM_CPU_PART_N2), false},
+      {MIDR_CPU_MODEL(ARM_CPU_IMP_ARM, ARM_CPU_PART_V2), false},
+  };
+
+  for (const auto &test : kTests) {
+    SCOPED_TRACE(test.midr);
+    EXPECT_EQ(test.is_neoverse_n2, MIDR_IS_NEOVERSE_N2(test.midr));
+  }
+}
+
+#endif  // OPENSSL_AARCH64

--- a/crypto/fipsmodule/cpucap/cpucap.c
+++ b/crypto/fipsmodule/cpucap/cpucap.c
@@ -77,6 +77,9 @@ HIDDEN uint32_t OPENSSL_armcap_P =
 #if defined(OPENSSL_STATIC_ARMCAP_NEOVERSE_V2) || defined(__ARM_FEATURE_NEOVERSE_V2)
     ARMV8_NEOVERSE_V2 |
 #endif
+#if defined(OPENSSL_STATIC_ARMCAP_NEOVERSE_N2) || defined(__ARM_FEATURE_NEOVERSE_N2)
+    ARMV8_NEOVERSE_N2 |
+#endif
     0;
 
 #else

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -249,6 +249,7 @@ OPENSSL_INLINE int CRYPTO_is_ARMv8_GCM_8x_capable(void) {
 OPENSSL_INLINE int CRYPTO_is_ARMv8_wide_multiplier_capable(void) {
   return (OPENSSL_armcap_P & ARMV8_NEOVERSE_V1) != 0 ||
            (OPENSSL_armcap_P & ARMV8_NEOVERSE_V2) != 0 ||
+           (OPENSSL_armcap_P & ARMV8_NEOVERSE_N2) != 0 ||
            (OPENSSL_armcap_P & ARMV8_APPLE_M) != 0;
 }
 

--- a/include/openssl/arm_arch.h
+++ b/include/openssl/arm_arch.h
@@ -38,17 +38,18 @@
 // "Test algorithm dispatch without CPU indicator or Neon extension capability bits"
 // in util/all_tests.json
 
-// The Neoverse N1, V1, V2, and Apple M1 micro-architectures are detected to
-// allow selecting the fasted implementations for SHA3/SHAKE and AES-GCM.
-// Combination of all CPU indicator bits: 0x7080
+// The Neoverse N1, N2, V1, V2, and Apple M micro-architectures are detected to
+// allow selecting optimized implementations for BN, SHA3/SHAKE, and AES-GCM.
+// Combination of all CPU indicator bits: 0x47080
 // NOTE: If you add further CPU indicator bits, adjust
 // "Test algorithm dispatch without CPU indicator bits" in util/all_tests.json.
 #define ARMV8_NEOVERSE_N1 (1 << 7)
 #define ARMV8_NEOVERSE_V1 (1 << 12)
 #define ARMV8_APPLE_M (1 << 13)
 #define ARMV8_NEOVERSE_V2 (1 << 14)
+#define ARMV8_NEOVERSE_N2 (1 << 18)
 
-// Combination of CPU indicator bits and Armv8 Neon extension bits: 0x78fc
+// Combination of CPU indicator bits and Armv8 Neon extension bits: 0x478fc
 
 // ARMV8_DIT indicates support for the Data-Independent Timing (DIT) flag.
 #define ARMV8_DIT (1 << 15)
@@ -72,11 +73,14 @@
 //
 
 # define ARM_CPU_IMP_ARM           0x41
+# define ARM_CPU_IMP_MICROSOFT     0x6D
 
 # define ARM_CPU_PART_CORTEX_A72   0xD08
 # define ARM_CPU_PART_N1           0xD0C
+# define ARM_CPU_PART_N2           0xD49
 # define ARM_CPU_PART_V1           0xD40
 # define ARM_CPU_PART_V2           0xD4F
+# define MICROSOFT_CPU_PART_AZURE_COBALT_100 0xD49
 
 # define MIDR_PARTNUM_SHIFT       4
 # define MIDR_PARTNUM_MASK        (0xfffUL << MIDR_PARTNUM_SHIFT)
@@ -105,6 +109,11 @@
 
 # define MIDR_IS_CPU_MODEL(midr, imp, partnum) \
            (((midr) & MIDR_CPU_MODEL_MASK) == MIDR_CPU_MODEL(imp, partnum))
+
+# define MIDR_IS_NEOVERSE_N2(midr) \
+           (MIDR_IS_CPU_MODEL((midr), ARM_CPU_IMP_ARM, ARM_CPU_PART_N2) || \
+            MIDR_IS_CPU_MODEL((midr), ARM_CPU_IMP_MICROSOFT, \
+                              MICROSOFT_CPU_PART_AZURE_COBALT_100))
 
 #endif  // ARM || AARCH64
 

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -37,7 +37,7 @@
   {
     "comment": "Test algorithm dispatch without CPU indicator bits",
     "cmd": ["crypto/crypto_test"],
-    "env": ["OPENSSL_armcap=~0x7080"],
+    "env": ["OPENSSL_armcap=~0x47080"],
     "target_arch": "arm",
     "skip_valgrind": true,
     "shard": true
@@ -45,7 +45,7 @@
   {
     "comment": "Test algorithm dispatch without CPU indicator or Neon extension capability bits",
     "cmd": ["crypto/crypto_test"],
-    "env": ["OPENSSL_armcap=~0x78fc"],
+    "env": ["OPENSSL_armcap=~0x478fc"],
     "target_arch": "arm",
     "skip_valgrind": true,
     "shard": true


### PR DESCRIPTION
### Description of changes:

AWS-LC currently treats Neoverse N2 as a narrow-multiplier CPU. On N2, the existing native Montgomery implementation and s2n-bignum `_alt` curve implementations are faster.

This change:

* detects Arm Neoverse N2 (`0x41/0xd49`) and Microsoft Cobalt 100 (`0x6d/0xd49`);
* adds runtime and static N2 capability support; and
* classifies N2 as wide-multiplier capable, selecting the native generic Montgomery path and existing `_alt` implementations for P-256, P-384, P-521, X25519, and Ed25519.

The CPU IDs follow the [Linux definitions](https://github.com/torvalds/linux/blob/master/arch/arm64/include/asm/cputype.h). Linux also documents [Cobalt 100 as N2-based](https://github.com/torvalds/linux/commit/fb091ff394792c018527b3211bbdfae93ea4ac02).

### Call-outs:

This is dispatch-only. It does not add or change any cryptographic arithmetic. Generic Montgomery switches between existing implementations. The curve `_alt` pairs compute the same results with instruction scheduling intended for CPUs with higher multiply throughput.

### Testing:

Added tests for both N2 MIDRs, static capability configuration, the wide-multiplier classification, and generic Montgomery dispatch. Updated the Arm capability-mask test configurations.

Test results:

* Debug: 2,721 passed, 1 environment-dependent skip
* Release: 2,689 passed, 1 environment-dependent skip
* `OPENSSL_NO_ASM`: 2,671 passed, 1 environment-dependent skip
* FIPS: 3,776 passed, 2 expected skips
* Neoverse N2: 2,687 passed, 2 expected skips
* AArch64 cross-builds and static-N2 dispatch tests passed under QEMU

Benchmarks were pinned to one core on Neoverse N2 r0p0 (`MIDR_EL1=0x410fd490`). RSA values are medians of 15 samples. Curve values are medians of three paired samples comparing the otherwise identical narrow and wide N2 dispatch.

| Operation | Previous dispatch | N2 wide dispatch | Change |
|---|---:|---:|---:|
| RSA 2048 sign | 884.1 ops/s | 1,534.6 ops/s | +73.6% |
| RSA 3072 sign | 252.5 ops/s | 483.2 ops/s | +91.4% |
| RSA 4096 sign | 132.8 ops/s | 216.4 ops/s | +63.0% |
| ECDH P-256 | 14,423 ops/s | 18,392 ops/s | +27.5% |
| ECDH P-384 | 4,101 ops/s | 4,852 ops/s | +18.3% |
| ECDH P-521 | 2,099 ops/s | 3,029 ops/s | +44.3% |
| ECDH X25519 | 23,909 ops/s | 29,547 ops/s | +23.6% |
| Ed25519 sign | 97,998 ops/s | 129,481 ops/s | +32.1% |
| Ed25519 verify | 18,461 ops/s | 25,858 ops/s | +40.1% |

P-256 signing, verification, key generation, point addition, and point doubling changed by less than 0.1%.

Reproduction:

```sh
taskset -c <cpu> ./tool/bssl speed -filter RSA -timeout 5 -json
taskset -c <cpu> env OPENSSL_armcap=~0x40000 \
  ./tool/bssl speed -filter RSA -timeout 5 -json
taskset -c <cpu> ./tool/bssl speed \
  -filter P-256,P-384,P-521,25519 -timeout 1 -json
taskset -c <cpu> env OPENSSL_armcap=~0x40000 \
  ./tool/bssl speed -filter P-256,P-384,P-521,25519 -timeout 1 -json
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.