### PR TITLE
Fix SSL_CTX_add_extra_chain_cert slot routing for chains added before the leaf

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -852,8 +852,8 @@ OPENSSL_EXPORT int SSL_add0_chain_cert(SSL *ssl, X509 *x509);
 // OpenSSL keeps extra chain certs on a single global stack and uses it
 // whenever a certificate has no chain of its own. AWS-LC instead stores chains
 // per key-type slot, so this routes |x509| to a slot: if a leaf certificate is
-// already configured, |x509| joins that leaf's slot (so a chain built
-// leaf-first stays together, including cross-type chains such as an RSA
+// already configured, |x509| joins the current certificate's slot (so a chain
+// built leaf-first stays together, including cross-type chains such as an RSA
 // intermediate for an ECDSA leaf); if no leaf is set yet, |x509| goes to the
 // slot matching its own key type (so chains built intermediate-first land
 // correctly once the matching leaf is added).

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -863,6 +863,12 @@ OPENSSL_EXPORT int SSL_add0_chain_cert(SSL *ssl, X509 *x509);
 //
 // For either case, use |SSL_CTX_set1_chain|, |SSL_CTX_add1_chain_cert|, or
 // |SSL_CTX_use_certificate_chain_file|.
+//
+// This is the only chain API that routes by key type; the others
+// (|SSL_CTX_set1_chain|, |SSL_CTX_add1_chain_cert|,
+// |SSL_CTX_get_extra_chain_certs|, |SSL_CTX_clear_extra_chain_certs|) act on
+// the current certificate's slot, so a get or clear after an add may target a
+// different slot.
 OPENSSL_EXPORT int SSL_CTX_add_extra_chain_cert(SSL_CTX *ctx, X509 *x509);
 
 // SSL_add1_chain_cert appends |x509| to |ctx|'s certificate chain. It returns

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -845,7 +845,24 @@ OPENSSL_EXPORT int SSL_CTX_add1_chain_cert(SSL_CTX *ctx, X509 *x509);
 // it returns one and takes ownership of |x509|. Otherwise, it returns zero.
 OPENSSL_EXPORT int SSL_add0_chain_cert(SSL *ssl, X509 *x509);
 
-// SSL_CTX_add_extra_chain_cert calls |SSL_CTX_add0_chain_cert|.
+// SSL_CTX_add_extra_chain_cert appends |x509| to the chain for the slot whose
+// key type matches |x509|'s public key. On success it returns one and takes
+// ownership of |x509|; otherwise it returns zero.
+//
+// OpenSSL compatibility: OpenSSL 1.0.2/1.1.1 store extra chain certs on a
+// single global stack on the |SSL_CTX| and fall back to it when the per-cert
+// chain is empty. AWS-LC has no such global stack; intermediates are routed
+// to the per-slot chain matching |x509|'s public key. This handles the
+// common same-type case (e.g. RSA intermediate with an RSA leaf) but leaves
+// two gaps:
+//
+//   - Cross-type chains (e.g. an RSA CA signing an ECC leaf) cannot be
+//     routed by this API.
+//   - An intermediate added via this API is pinned to one slot; sharing one
+//     chain across multiple leaf types requires per-slot configuration.
+//
+// For either case, use |SSL_CTX_set1_chain|, |SSL_CTX_add1_chain_cert|, or
+// |SSL_CTX_use_certificate_chain_file|.
 OPENSSL_EXPORT int SSL_CTX_add_extra_chain_cert(SSL_CTX *ctx, X509 *x509);
 
 // SSL_add1_chain_cert appends |x509| to |ctx|'s certificate chain. It returns

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -845,30 +845,27 @@ OPENSSL_EXPORT int SSL_CTX_add1_chain_cert(SSL_CTX *ctx, X509 *x509);
 // it returns one and takes ownership of |x509|. Otherwise, it returns zero.
 OPENSSL_EXPORT int SSL_add0_chain_cert(SSL *ssl, X509 *x509);
 
-// SSL_CTX_add_extra_chain_cert appends |x509| to the chain for the slot whose
-// key type matches |x509|'s public key. On success it returns one and takes
-// ownership of |x509|; otherwise it returns zero.
+// SSL_CTX_add_extra_chain_cert appends |x509| to |ctx|'s certificate chain. On
+// success it returns one and takes ownership of |x509|; otherwise it returns
+// zero.
 //
-// OpenSSL compatibility: OpenSSL 1.0.2/1.1.1 store extra chain certs on a
-// single global stack on the |SSL_CTX| and fall back to it when the per-cert
-// chain is empty. AWS-LC has no such global stack; intermediates are routed
-// to the per-slot chain matching |x509|'s public key. This handles the
-// common same-type case (e.g. RSA intermediate with an RSA leaf) but leaves
-// two gaps:
+// OpenSSL keeps extra chain certs on a single global stack and uses it
+// whenever a certificate has no chain of its own. AWS-LC instead stores chains
+// per key-type slot, so this routes |x509| to a slot: if a leaf certificate is
+// already configured, |x509| joins that leaf's slot (so a chain built
+// leaf-first stays together, including cross-type chains such as an RSA
+// intermediate for an ECDSA leaf); if no leaf is set yet, |x509| goes to the
+// slot matching its own key type (so chains built intermediate-first land
+// correctly once the matching leaf is added).
 //
-//   - Cross-type chains (e.g. an RSA CA signing an ECC leaf) cannot be
-//     routed by this API.
-//   - An intermediate added via this API is pinned to one slot; sharing one
-//     chain across multiple leaf types requires per-slot configuration.
-//
-// For either case, use |SSL_CTX_set1_chain|, |SSL_CTX_add1_chain_cert|, or
+// To append an intermediate whose key type differs from a not-yet-configured
+// leaf (e.g. an RSA intermediate for an ECDSA leaf added before the leaf), set
+// the leaf first, or use |SSL_CTX_set1_chain|, |SSL_CTX_add1_chain_cert|, or
 // |SSL_CTX_use_certificate_chain_file|.
 //
-// This is the only chain API that routes by key type; the others
-// (|SSL_CTX_set1_chain|, |SSL_CTX_add1_chain_cert|,
-// |SSL_CTX_get_extra_chain_certs|, |SSL_CTX_clear_extra_chain_certs|) act on
-// the current certificate's slot, so a get or clear after an add may target a
-// different slot.
+// |SSL_CTX_get_extra_chain_certs| and |SSL_CTX_clear_extra_chain_certs| always
+// act on the current certificate's slot, so they may target a different slot
+// than an add that routed by key type.
 OPENSSL_EXPORT int SSL_CTX_add_extra_chain_cert(SSL_CTX *ctx, X509 *x509);
 
 // SSL_add1_chain_cert appends |x509| to |ctx|'s certificate chain. It returns

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -1958,6 +1958,146 @@ TEST_P(MultipleCertificateSlotTest, MissingPrivateKey) {
       {certificate_key_param().corresponding_sigalg}, -1, false);
 }
 
+// SSL_CTX_add_extra_chain_cert must route by the intermediate's public key
+// type, not by |cert_private_key_idx|. Regression seen in Ruby + AWS-LC,
+// where |Net::HTTP#extra_chain_cert=| calls this API before the leaf is
+// configured and |cert_private_key_idx| still holds its default.
+
+// RSA intermediate must land in the RSA slot even when
+// |cert_private_key_idx| points at ECC.
+TEST(SSLTest, ExtraChainCertRoutesByPubkeyTypeRSA) {
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+
+  ASSERT_TRUE(SSL_CTX_use_certificate(ctx.get(),
+                                      GetECDSATestCertificate().get()));
+  ASSERT_TRUE(SSL_CTX_use_PrivateKey(ctx.get(), GetECDSATestKey().get()));
+  ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_ECC);
+
+  bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
+  ASSERT_TRUE(rsa_intermediate);
+  ASSERT_TRUE(
+      SSL_CTX_add_extra_chain_cert(ctx.get(), rsa_intermediate.release()));
+
+  // Leafless chain layout: index 0 is the (NULL) leaf placeholder, the
+  // appended intermediate sits at index 1.
+  const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
+  const auto &ecc_chain = ctx->cert->cert_private_keys[SSL_PKEY_ECC].chain;
+  ASSERT_TRUE(rsa_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 2u);
+  ASSERT_TRUE(ecc_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(ecc_chain.get()), 1u);
+}
+
+// ECDSA intermediate must land in the ECC slot even when
+// |cert_private_key_idx| points at RSA.
+TEST(SSLTest, ExtraChainCertRoutesByPubkeyTypeECC) {
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+
+  ASSERT_TRUE(SSL_CTX_use_certificate(ctx.get(), GetTestCertificate().get()));
+  ASSERT_TRUE(SSL_CTX_use_PrivateKey(ctx.get(), GetTestKey().get()));
+  ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_RSA);
+
+  bssl::UniquePtr<X509> ecdsa_intermediate = GetECDSATestCertificate();
+  ASSERT_TRUE(ecdsa_intermediate);
+  ASSERT_TRUE(
+      SSL_CTX_add_extra_chain_cert(ctx.get(), ecdsa_intermediate.release()));
+
+  const auto &ecc_chain = ctx->cert->cert_private_keys[SSL_PKEY_ECC].chain;
+  const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
+  ASSERT_TRUE(ecc_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(ecc_chain.get()), 2u);
+  ASSERT_TRUE(rsa_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 1u);
+}
+
+// End-to-end: server sends leaf + intermediate over TLS 1.2 even when
+// |cert_private_key_idx| drifts to a different slot before the
+// intermediate is appended.
+TEST(SSLTest, ExtraChainCertSentDuringHandshake) {
+  bssl::UniquePtr<SSL_CTX> server_ctx(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(server_ctx);
+  ASSERT_TRUE(client_ctx);
+
+  ASSERT_TRUE(SSL_CTX_set_min_proto_version(server_ctx.get(), TLS1_2_VERSION));
+  ASSERT_TRUE(SSL_CTX_set_max_proto_version(server_ctx.get(), TLS1_2_VERSION));
+  ASSERT_TRUE(SSL_CTX_set_min_proto_version(client_ctx.get(), TLS1_2_VERSION));
+  ASSERT_TRUE(SSL_CTX_set_max_proto_version(client_ctx.get(), TLS1_2_VERSION));
+
+  bssl::UniquePtr<X509> rsa_leaf = GetChainTestCertificate();
+  bssl::UniquePtr<EVP_PKEY> rsa_key = GetChainTestKey();
+  bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
+  ASSERT_TRUE(rsa_leaf && rsa_key && rsa_intermediate);
+  ASSERT_TRUE(SSL_CTX_use_certificate(server_ctx.get(), rsa_leaf.get()));
+  ASSERT_TRUE(SSL_CTX_use_PrivateKey(server_ctx.get(), rsa_key.get()));
+
+  // Configuring an ECDSA leaf+key drifts |cert_private_key_idx| to
+  // SSL_PKEY_ECC. Pre-fix, the RSA intermediate appended below would file
+  // into the ECC slot.
+  ASSERT_TRUE(SSL_CTX_use_certificate(server_ctx.get(),
+                                      GetECDSATestCertificate().get()));
+  ASSERT_TRUE(SSL_CTX_use_PrivateKey(server_ctx.get(),
+                                     GetECDSATestKey().get()));
+  ASSERT_EQ(server_ctx->cert->cert_private_key_idx, SSL_PKEY_ECC);
+
+  ASSERT_TRUE(SSL_CTX_add_extra_chain_cert(server_ctx.get(),
+                                            rsa_intermediate.release()));
+
+  // Force RSA negotiation. Mirrors
+  // |MultipleCertificateSlotTest::StandardCertificateSlotIndexTests|.
+  const uint16_t rsa_only[] = {SSL_SIGN_RSA_PSS_RSAE_SHA256,
+                                SSL_SIGN_RSA_PKCS1_SHA256};
+  ASSERT_TRUE(SSL_CTX_set_signing_algorithm_prefs(
+      client_ctx.get(), rsa_only, OPENSSL_ARRAY_SIZE(rsa_only)));
+  ASSERT_TRUE(SSL_CTX_set_verify_algorithm_prefs(
+      client_ctx.get(), rsa_only, OPENSSL_ARRAY_SIZE(rsa_only)));
+  ASSERT_TRUE(SSL_CTX_set_cipher_list(client_ctx.get(),
+                                      "TLS_RSA_WITH_AES_256_CBC_SHA:"));
+
+  // We are asserting what the server sends, not what the client validates.
+  SSL_CTX_set_custom_verify(
+      client_ctx.get(), SSL_VERIFY_PEER,
+      [](SSL *ssl, uint8_t *out_alert) -> ssl_verify_result_t {
+        return ssl_verify_ok;
+      });
+
+  bssl::UniquePtr<SSL> client, server;
+  ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx.get(),
+                                     server_ctx.get()));
+
+  const STACK_OF(CRYPTO_BUFFER) *peer_chain =
+      SSL_get0_peer_certificates(client.get());
+  ASSERT_TRUE(peer_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(peer_chain), 2u);
+}
+
+// Regression guard: SSL_CTX_add0_chain_cert still routes by
+// |cert_private_key_idx|, unchanged by the fix.
+TEST(SSLTest, Add0ChainCertCrossTypeRoutingUnchanged) {
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+
+  ASSERT_TRUE(SSL_CTX_use_certificate(ctx.get(),
+                                      GetECDSATestCertificate().get()));
+  ASSERT_TRUE(SSL_CTX_use_PrivateKey(ctx.get(), GetECDSATestKey().get()));
+  ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_ECC);
+
+  bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
+  ASSERT_TRUE(rsa_intermediate);
+  ASSERT_TRUE(
+      SSL_CTX_add0_chain_cert(ctx.get(), rsa_intermediate.release()));
+
+  // RSA intermediate lands in the ECC slot because |cert_private_key_idx|
+  // points there.
+  const auto &ecc_chain = ctx->cert->cert_private_keys[SSL_PKEY_ECC].chain;
+  const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
+  ASSERT_TRUE(ecc_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(ecc_chain.get()), 2u);
+  EXPECT_FALSE(rsa_chain);
+}
+
 
 // ML-DSA TLS 1.3 signature-scheme tests (draft-ietf-tls-mldsa). These
 // exercise the plumbing in ssl_privkey.cc / ssl_cipher.cc that wires

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -1958,20 +1958,19 @@ TEST_P(MultipleCertificateSlotTest, MissingPrivateKey) {
       {certificate_key_param().corresponding_sigalg}, -1, false);
 }
 
-// SSL_CTX_add_extra_chain_cert must route by the intermediate's public key
-// type, not by |cert_private_key_idx|. Regression seen in Ruby + AWS-LC,
-// where |Net::HTTP#extra_chain_cert=| calls this API before the leaf is
-// configured and |cert_private_key_idx| still holds its default.
+// SSL_CTX_add_extra_chain_cert routes the intermediate to the current
+// certificate's slot when one is configured, and falls back to the slot
+// matching the intermediate's own key type when no leaf is set yet. The
+// fallback fixes the Ruby + AWS-LC ordering, where
+// |Net::HTTP#extra_chain_cert=| appends before any leaf is configured.
 
-// RSA intermediate must land in the RSA slot even when
-// |cert_private_key_idx| points at ECC.
-TEST(SSLTest, ExtraChainCertRoutesByPubkeyTypeRSA) {
-  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+// Leaf-first, cross-type: an RSA intermediate added after an ECDSA leaf must
+// join the ECDSA leaf's slot, not the RSA slot. This is the common case of an
+// RSA intermediate for an ECDSA leaf, which key-type routing would misplace.
+TEST(SSLTest, ExtraChainCertCrossTypeLeafFirst) {
+  bssl::UniquePtr<SSL_CTX> ctx(CreateContextWithCertificate(
+      TLS_method(), GetECDSATestCertificate(), GetECDSATestKey()));
   ASSERT_TRUE(ctx);
-
-  ASSERT_TRUE(SSL_CTX_use_certificate(ctx.get(),
-                                      GetECDSATestCertificate().get()));
-  ASSERT_TRUE(SSL_CTX_use_PrivateKey(ctx.get(), GetECDSATestKey().get()));
   ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_ECC);
 
   bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
@@ -1979,41 +1978,18 @@ TEST(SSLTest, ExtraChainCertRoutesByPubkeyTypeRSA) {
   ASSERT_TRUE(
       SSL_CTX_add_extra_chain_cert(ctx.get(), rsa_intermediate.release()));
 
-  // Leafless chain layout: index 0 is the (NULL) leaf placeholder, the
-  // appended intermediate sits at index 1.
-  const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
-  const auto &ecc_chain = ctx->cert->cert_private_keys[SSL_PKEY_ECC].chain;
-  ASSERT_TRUE(rsa_chain);
-  EXPECT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 2u);
-  ASSERT_TRUE(ecc_chain);
-  EXPECT_EQ(sk_CRYPTO_BUFFER_num(ecc_chain.get()), 1u);
-}
-
-// ECDSA intermediate must land in the ECC slot even when
-// |cert_private_key_idx| points at RSA.
-TEST(SSLTest, ExtraChainCertRoutesByPubkeyTypeECC) {
-  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
-  ASSERT_TRUE(ctx);
-
-  ASSERT_TRUE(SSL_CTX_use_certificate(ctx.get(), GetTestCertificate().get()));
-  ASSERT_TRUE(SSL_CTX_use_PrivateKey(ctx.get(), GetTestKey().get()));
-  ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_RSA);
-
-  bssl::UniquePtr<X509> ecdsa_intermediate = GetECDSATestCertificate();
-  ASSERT_TRUE(ecdsa_intermediate);
-  ASSERT_TRUE(
-      SSL_CTX_add_extra_chain_cert(ctx.get(), ecdsa_intermediate.release()));
-
+  // The intermediate joins the ECDSA leaf's slot (leaf at index 0,
+  // intermediate at index 1); the RSA slot stays empty.
   const auto &ecc_chain = ctx->cert->cert_private_keys[SSL_PKEY_ECC].chain;
   const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
   ASSERT_TRUE(ecc_chain);
   EXPECT_EQ(sk_CRYPTO_BUFFER_num(ecc_chain.get()), 2u);
-  ASSERT_TRUE(rsa_chain);
-  EXPECT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 1u);
+  EXPECT_FALSE(rsa_chain);
 }
 
-// Intermediate-first ordering: append the intermediate to a fresh ctx, then
-// set the matching leaf + key. The intermediate must end up in the same slot.
+// No leaf configured yet: routing falls back to the intermediate's own key
+// type. Append the RSA intermediate to a fresh ctx, then set the matching
+// RSA leaf + key; both must end up in the RSA slot.
 TEST(SSLTest, ExtraChainCertAppendedBeforeLeaf) {
   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
   ASSERT_TRUE(ctx);
@@ -2023,7 +1999,6 @@ TEST(SSLTest, ExtraChainCertAppendedBeforeLeaf) {
   ASSERT_TRUE(
       SSL_CTX_add_extra_chain_cert(ctx.get(), rsa_intermediate.release()));
 
-  // Now set the RSA leaf + key into the same slot.
   ASSERT_TRUE(
       SSL_CTX_use_certificate(ctx.get(), GetChainTestCertificate().get()));
   ASSERT_TRUE(SSL_CTX_use_PrivateKey(ctx.get(), GetChainTestKey().get()));
@@ -2035,9 +2010,8 @@ TEST(SSLTest, ExtraChainCertAppendedBeforeLeaf) {
   EXPECT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 2u);
 }
 
-// End-to-end: server sends leaf + intermediate over TLS 1.2 even when
-// |cert_private_key_idx| drifts to a different slot before the
-// intermediate is appended.
+// End-to-end Ruby ordering: append the intermediate before the leaf, then
+// complete a TLS 1.2 handshake. The server must send leaf + intermediate.
 TEST(SSLTest, ExtraChainCertSentDuringHandshake) {
   bssl::UniquePtr<SSL_CTX> server_ctx(SSL_CTX_new(TLS_method()));
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
@@ -2049,35 +2023,15 @@ TEST(SSLTest, ExtraChainCertSentDuringHandshake) {
   ASSERT_TRUE(SSL_CTX_set_min_proto_version(client_ctx.get(), TLS1_2_VERSION));
   ASSERT_TRUE(SSL_CTX_set_max_proto_version(client_ctx.get(), TLS1_2_VERSION));
 
-  bssl::UniquePtr<X509> rsa_leaf = GetChainTestCertificate();
-  bssl::UniquePtr<EVP_PKEY> rsa_key = GetChainTestKey();
+  // Append the intermediate first (no leaf yet, so routing falls back to the
+  // intermediate's key type), then set the matching leaf + key.
   bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
-  ASSERT_TRUE(rsa_leaf && rsa_key && rsa_intermediate);
-  ASSERT_TRUE(SSL_CTX_use_certificate(server_ctx.get(), rsa_leaf.get()));
-  ASSERT_TRUE(SSL_CTX_use_PrivateKey(server_ctx.get(), rsa_key.get()));
-
-  // Configuring an ECDSA leaf+key drifts |cert_private_key_idx| to
-  // SSL_PKEY_ECC. Pre-fix, the RSA intermediate appended below would file
-  // into the ECC slot.
-  ASSERT_TRUE(SSL_CTX_use_certificate(server_ctx.get(),
-                                      GetECDSATestCertificate().get()));
-  ASSERT_TRUE(SSL_CTX_use_PrivateKey(server_ctx.get(),
-                                     GetECDSATestKey().get()));
-  ASSERT_EQ(server_ctx->cert->cert_private_key_idx, SSL_PKEY_ECC);
-
+  ASSERT_TRUE(rsa_intermediate);
   ASSERT_TRUE(SSL_CTX_add_extra_chain_cert(server_ctx.get(),
                                             rsa_intermediate.release()));
-
-  // Force RSA negotiation. Mirrors
-  // |MultipleCertificateSlotTest::StandardCertificateSlotIndexTests|.
-  const uint16_t rsa_only[] = {SSL_SIGN_RSA_PSS_RSAE_SHA256,
-                                SSL_SIGN_RSA_PKCS1_SHA256};
-  ASSERT_TRUE(SSL_CTX_set_signing_algorithm_prefs(
-      client_ctx.get(), rsa_only, OPENSSL_ARRAY_SIZE(rsa_only)));
-  ASSERT_TRUE(SSL_CTX_set_verify_algorithm_prefs(
-      client_ctx.get(), rsa_only, OPENSSL_ARRAY_SIZE(rsa_only)));
-  ASSERT_TRUE(SSL_CTX_set_cipher_list(client_ctx.get(),
-                                      "TLS_RSA_WITH_AES_256_CBC_SHA:"));
+  ASSERT_TRUE(
+      SSL_CTX_use_certificate(server_ctx.get(), GetChainTestCertificate().get()));
+  ASSERT_TRUE(SSL_CTX_use_PrivateKey(server_ctx.get(), GetChainTestKey().get()));
 
   // We are asserting what the server sends, not what the client validates.
   SSL_CTX_set_custom_verify(
@@ -2099,12 +2053,9 @@ TEST(SSLTest, ExtraChainCertSentDuringHandshake) {
 // Regression guard: SSL_CTX_add0_chain_cert still routes by
 // |cert_private_key_idx|, unchanged by the fix.
 TEST(SSLTest, Add0ChainCertCrossTypeRoutingUnchanged) {
-  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL_CTX> ctx(CreateContextWithCertificate(
+      TLS_method(), GetECDSATestCertificate(), GetECDSATestKey()));
   ASSERT_TRUE(ctx);
-
-  ASSERT_TRUE(SSL_CTX_use_certificate(ctx.get(),
-                                      GetECDSATestCertificate().get()));
-  ASSERT_TRUE(SSL_CTX_use_PrivateKey(ctx.get(), GetECDSATestKey().get()));
   ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_ECC);
 
   bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -2007,7 +2007,9 @@ TEST(SSLTest, ExtraChainCertAppendedBeforeLeaf) {
   // The RSA slot holds the leaf at index 0 and the intermediate at index 1.
   const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
   ASSERT_TRUE(rsa_chain);
-  EXPECT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 2u);
+  ASSERT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 2u);
+  EXPECT_TRUE(sk_CRYPTO_BUFFER_value(rsa_chain.get(), 0) != nullptr);
+  EXPECT_TRUE(sk_CRYPTO_BUFFER_value(rsa_chain.get(), 1) != nullptr);
 }
 
 // End-to-end Ruby ordering: append the intermediate before the leaf, then

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -2012,6 +2012,29 @@ TEST(SSLTest, ExtraChainCertRoutesByPubkeyTypeECC) {
   EXPECT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 1u);
 }
 
+// Intermediate-first ordering: append the intermediate to a fresh ctx, then
+// set the matching leaf + key. The intermediate must end up in the same slot.
+TEST(SSLTest, ExtraChainCertAppendedBeforeLeaf) {
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+
+  bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
+  ASSERT_TRUE(rsa_intermediate);
+  ASSERT_TRUE(
+      SSL_CTX_add_extra_chain_cert(ctx.get(), rsa_intermediate.release()));
+
+  // Now set the RSA leaf + key into the same slot.
+  ASSERT_TRUE(
+      SSL_CTX_use_certificate(ctx.get(), GetChainTestCertificate().get()));
+  ASSERT_TRUE(SSL_CTX_use_PrivateKey(ctx.get(), GetChainTestKey().get()));
+  ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_RSA);
+
+  // The RSA slot holds the leaf at index 0 and the intermediate at index 1.
+  const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
+  ASSERT_TRUE(rsa_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 2u);
+}
+
 // End-to-end: server sends leaf + intermediate over TLS 1.2 even when
 // |cert_private_key_idx| drifts to a different slot before the
 // intermediate is appended.

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -856,8 +856,20 @@ int SSL_CTX_add1_chain_cert(SSL_CTX *ctx, X509 *x509) {
   return ssl_cert_add1_chain_cert(ctx->cert.get(), x509);
 }
 
-// ssl_cert_append_extra_chain_cert appends |x509| to the slot whose key type
-// matches |x509|'s public key. See |SSL_CTX_add_extra_chain_cert|.
+// slot_has_leaf returns true if |slot_index| is valid and that slot holds a
+// leaf certificate (a non-NULL element 0 in its chain).
+static bool slot_has_leaf(const CERT *cert, int slot_index) {
+  if (slot_index < 0) {
+    return false;
+  }
+  const UniquePtr<STACK_OF(CRYPTO_BUFFER)> &chain =
+      cert->cert_private_keys[slot_index].chain;
+  return chain != nullptr && sk_CRYPTO_BUFFER_value(chain.get(), 0) != nullptr;
+}
+
+// ssl_cert_append_extra_chain_cert appends |x509| to the current certificate's
+// slot if a leaf is configured there, and otherwise to the slot matching
+// |x509|'s own key type. See |SSL_CTX_add_extra_chain_cert|.
 static int ssl_cert_append_extra_chain_cert(CERT *cert, X509 *x509) {
   assert(cert->x509_method);
   if (!ssl_cert_check_cert_private_keys_usage(cert)) {
@@ -869,18 +881,25 @@ static int ssl_cert_append_extra_chain_cert(CERT *cert, X509 *x509) {
     return 0;
   }
 
-  // Route by the certificate's key type, like |ssl_set_cert|.
-  CBS cert_cbs;
-  CRYPTO_BUFFER_init_CBS(buffer.get(), &cert_cbs);
-  UniquePtr<EVP_PKEY> pubkey = ssl_cert_parse_pubkey(&cert_cbs);
-  if (!pubkey) {
-    OPENSSL_PUT_ERROR(SSL, SSL_R_DECODE_ERROR);
-    return 0;
-  }
-  int slot_index = ssl_get_certificate_slot_index(pubkey.get());
-  if (slot_index < 0) {
-    OPENSSL_PUT_ERROR(SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
-    return 0;
+  // When a leaf is already configured, append to its slot so a chain set up
+  // leaf-first lands with its leaf, including cross-type chains (e.g. an RSA
+  // intermediate for an ECDSA leaf). Only when no leaf is set yet do we route
+  // by the intermediate's own key type, which fixes appends made before the
+  // leaf.
+  int slot_index = cert->cert_private_key_idx;
+  if (!slot_has_leaf(cert, slot_index)) {
+    CBS cert_cbs;
+    CRYPTO_BUFFER_init_CBS(buffer.get(), &cert_cbs);
+    UniquePtr<EVP_PKEY> pubkey = ssl_cert_parse_pubkey(&cert_cbs);
+    if (!pubkey) {
+      OPENSSL_PUT_ERROR(SSL, SSL_R_DECODE_ERROR);
+      return 0;
+    }
+    slot_index = ssl_get_certificate_slot_index(pubkey.get());
+    if (slot_index < 0) {
+      OPENSSL_PUT_ERROR(SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
+      return 0;
+    }
   }
 
   if (!ssl_cert_append_cert_to_slot(cert, slot_index, std::move(buffer))) {

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -766,19 +766,12 @@ static int ssl_cert_set1_chain(CERT *cert, STACK_OF(X509) *chain) {
   return 1;
 }
 
-static int ssl_cert_append_cert(CERT *cert, X509 *x509) {
-  assert(cert->x509_method);
-  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
-    return 0;
-  }
-
-  UniquePtr<CRYPTO_BUFFER> buffer = x509_to_buffer(x509);
-  if (!buffer) {
-    return 0;
-  }
-
+// ssl_cert_append_cert_to_slot appends |buffer| to slot |slot_index|'s chain,
+// creating a leafless chain if the slot is empty. It consumes |buffer|.
+static int ssl_cert_append_cert_to_slot(CERT *cert, int slot_index,
+                                         UniquePtr<CRYPTO_BUFFER> buffer) {
   UniquePtr<STACK_OF(CRYPTO_BUFFER)> &chain =
-      cert->cert_private_keys[cert->cert_private_key_idx].chain;
+      cert->cert_private_keys[slot_index].chain;
   if (chain != nullptr) {
     return PushToStack(chain.get(), std::move(buffer));
   }
@@ -790,6 +783,21 @@ static int ssl_cert_append_cert(CERT *cert, X509 *x509) {
   }
 
   return 1;
+}
+
+static int ssl_cert_append_cert(CERT *cert, X509 *x509) {
+  assert(cert->x509_method);
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
+    return 0;
+  }
+
+  UniquePtr<CRYPTO_BUFFER> buffer = x509_to_buffer(x509);
+  if (!buffer) {
+    return 0;
+  }
+
+  return ssl_cert_append_cert_to_slot(cert, cert->cert_private_key_idx,
+                                      std::move(buffer));
 }
 
 static int ssl_cert_add0_chain_cert(CERT *cert, X509 *x509) {
@@ -861,6 +869,7 @@ static int ssl_cert_append_extra_chain_cert(CERT *cert, X509 *x509) {
     return 0;
   }
 
+  // Route by the certificate's key type, like |ssl_set_cert|.
   CBS cert_cbs;
   CRYPTO_BUFFER_init_CBS(buffer.get(), &cert_cbs);
   UniquePtr<EVP_PKEY> pubkey = ssl_cert_parse_pubkey(&cert_cbs);
@@ -874,18 +883,8 @@ static int ssl_cert_append_extra_chain_cert(CERT *cert, X509 *x509) {
     return 0;
   }
 
-  UniquePtr<STACK_OF(CRYPTO_BUFFER)> &chain =
-      cert->cert_private_keys[slot_index].chain;
-  if (chain != nullptr) {
-    if (!PushToStack(chain.get(), std::move(buffer))) {
-      return 0;
-    }
-  } else {
-    chain = new_leafless_chain();
-    if (!chain || !PushToStack(chain.get(), std::move(buffer))) {
-      chain.reset();
-      return 0;
-    }
+  if (!ssl_cert_append_cert_to_slot(cert, slot_index, std::move(buffer))) {
+    return 0;
   }
 
   X509_free(cert->x509_stash);

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -848,9 +848,55 @@ int SSL_CTX_add1_chain_cert(SSL_CTX *ctx, X509 *x509) {
   return ssl_cert_add1_chain_cert(ctx->cert.get(), x509);
 }
 
+// ssl_cert_append_extra_chain_cert appends |x509| to the slot whose key type
+// matches |x509|'s public key. See |SSL_CTX_add_extra_chain_cert|.
+static int ssl_cert_append_extra_chain_cert(CERT *cert, X509 *x509) {
+  assert(cert->x509_method);
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
+    return 0;
+  }
+
+  UniquePtr<CRYPTO_BUFFER> buffer = x509_to_buffer(x509);
+  if (!buffer) {
+    return 0;
+  }
+
+  CBS cert_cbs;
+  CRYPTO_BUFFER_init_CBS(buffer.get(), &cert_cbs);
+  UniquePtr<EVP_PKEY> pubkey = ssl_cert_parse_pubkey(&cert_cbs);
+  if (!pubkey) {
+    OPENSSL_PUT_ERROR(SSL, SSL_R_DECODE_ERROR);
+    return 0;
+  }
+  int slot_index = ssl_get_certificate_slot_index(pubkey.get());
+  if (slot_index < 0) {
+    OPENSSL_PUT_ERROR(SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
+    return 0;
+  }
+
+  UniquePtr<STACK_OF(CRYPTO_BUFFER)> &chain =
+      cert->cert_private_keys[slot_index].chain;
+  if (chain != nullptr) {
+    if (!PushToStack(chain.get(), std::move(buffer))) {
+      return 0;
+    }
+  } else {
+    chain = new_leafless_chain();
+    if (!chain || !PushToStack(chain.get(), std::move(buffer))) {
+      chain.reset();
+      return 0;
+    }
+  }
+
+  X509_free(cert->x509_stash);
+  cert->x509_stash = x509;
+  ssl_crypto_x509_cert_flush_cached_chain(cert);
+  return 1;
+}
+
 int SSL_CTX_add_extra_chain_cert(SSL_CTX *ctx, X509 *x509) {
   check_ssl_ctx_x509_method(ctx);
-  return SSL_CTX_add0_chain_cert(ctx, x509);
+  return ssl_cert_append_extra_chain_cert(ctx->cert.get(), x509);
 }
 
 int SSL_add0_chain_cert(SSL *ssl, X509 *x509) {


### PR DESCRIPTION
 ### Issues:
  Resolves P386362542
  
  ### Description of changes:
  In OpenSSL, `SSL_CTX_add_extra_chain_cert` appends to a single global
  `ctx->extra_certs` stack on the `SSL_CTX`. The handshake falls back to that
  stack when the per-cert chain is empty (`ssl/ssl_cert.c` `ssl_add_cert_chain`).
  Only one such chain can be configured per `SSL_CTX`; for anything more, OpenSSL
  recommends the `SSL_CTX_set1_chain` / `SSL_CTX_add1_chain_cert` family. 
  
  AWS-LC stores chains in per-key-type slots rather than on a global stack.
  `SSL_CTX_add_extra_chain_cert` was aliased to `SSL_CTX_add0_chain_cert`, which
  appends to the slot tracked by `cert_private_key_idx` (the "current
  certificate"). That index defaults to `SSL_PKEY_RSA` and only moves once a leaf
  is set, so an intermediate added before any leaf landed in the RSA slot
  regardless of which leaf it chained from. The per-slot chain was then leaf-only
  at handshake time and the peer never saw the intermediate.
  
  The fix routes the intermediate by slot: if a leaf is already configured, the
  intermediate joins that leaf's slot, so leaf-first chains stay together
  (including cross-type chains such as an RSA intermediate for an ECDSA leaf); if
  no leaf is set yet, it falls back to the slot matching the intermediate's own
  key type. The `add0` / `add1` family is unchanged.
  
  ### Call-outs:
  Adding a cross-type intermediate before its leaf is configured is still
  unsupported, as it was before this change: at append time there is no leaf to
  match against, and the intermediate's own key type points at the wrong slot.
  Those callers should use `SSL_CTX_set1_chain`, `SSL_CTX_add1_chain_cert`, or
  `SSL_CTX_use_certificate_chain_file`.
  
  ### Testing:
  Four new unit tests in `ssl/ssl_test.cc`:
  * `ExtraChainCertCrossTypeLeafFirst`
  * `ExtraChainCertAppendedBeforeLeaf`
  * `ExtraChainCertSentDuringHandshake`
  * `Add0ChainCertCrossTypeRoutingUnchanged`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
