### PR TITLE
ci: fix Windows CI breakage from VS2026 (MSVC 14.51) image bump

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -111,11 +111,11 @@ jobs:
       - name: Build/Test (x64)
         if: "!endsWith(matrix.os, '-arm')"
         run: |
-          ./tests/ci/run_windows_tests.bat "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          ./tests/ci/run_windows_tests.bat auto x64
       - name: Build/Test (ARM64)
         if: endsWith(matrix.os, '-arm')
         run: |
-          ./tests/ci/run_windows_tests.bat "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+          ./tests/ci/run_windows_tests.bat auto arm64
 
   macOS-ARM-FIPS:
     if: github.repository_owner == 'aws'

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -86,7 +86,10 @@ jobs:
           - x64_arm64
     runs-on: windows-latest
     env:
-      CMAKE_GENERATOR: "Visual Studio 17 2022"
+      # Keep CMAKE_GENERATOR pinned: the ClangCL toolset is ignored unless it is
+      # set, and CMake then silently uses MSVC (breaking the ARM64 ClangCL
+      # guard). Bump the version on the next VS upgrade.
+      CMAKE_GENERATOR: "Visual Studio 18 2026"
       CMAKE_GENERATOR_TOOLSET: "ClangCL,host=x64"
     steps:
       - if: ${{ matrix.target  == 'x64' }}

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -59,7 +59,8 @@ jobs:
         uses: KyleMayes/install-llvm-action@v2
         id: clang
         with:
-          version: 19
+          # VS2026 MSVC STL requires Clang >= 20 (yvals_core.h STL1000).
+          version: 20
           env: true
       - name: Setup CMake
         uses: threeal/cmake-action@v2.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,8 +845,19 @@ elseif(MSVC)
                             ${MSVC_DISABLED_WARNINGS_LIST})
   string(REPLACE "C" " -w4" MSVC_LEVEL4_WARNINGS_STR
                             ${MSVC_LEVEL4_WARNINGS_LIST})
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
+  # Newer MSVC (VS2026/14.51) emits C4865 from Windows SDK headers; with -WX
+  # that fails the build over warnings we don't own. Mark the toolchain/SDK
+  # include dirs external so -WX only covers our code. /external: is stable
+  # since MSVC 19.29; exclude clang-cl (it never emits C4865 and can error on
+  # an unrecognized /external:env: arg under -WX).
+  if(MSVC_VERSION GREATER_EQUAL 1929 AND CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    set(MSVC_EXTERNAL_WARNINGS_STR
+        "/external:W0 /external:env:INCLUDE /external:env:EXTERNAL_INCLUDE")
+  else()
+    set(MSVC_EXTERNAL_WARNINGS_STR "")
+  endif()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR} ${MSVC_EXTERNAL_WARNINGS_STR}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR} ${MSVC_EXTERNAL_WARNINGS_STR}")
 endif()
 
 # If we're using MSVC on Windows in FIPS mode with RelWithDebInfo then we want to override some of the default RelWithDebInfo flags.

--- a/tests/ci/run_windows_tests.bat
+++ b/tests/ci/run_windows_tests.bat
@@ -2,13 +2,42 @@
 set SRC_ROOT=%cd%
 set BUILD_DIR=%TEMP%\awslc
 
-@rem %1 contains the path to the setup batch file for the version of of visual studio that was passed in from the build spec file.
-@rem %2 specifies the architecture option to build against: https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line
-@rem %3 is to indicate running SDE simulation tests. If not set, SDE tests are not run.
-set MSVC_PATH=%1
+@rem %1 path to vcvarsall.bat, or "auto" to auto-detect the newest VS via
+@rem    vswhere (an empty or non-existent path also auto-detects). An explicit
+@rem    existing path (windows-omnibus pins a specific VS) is honored as-is.
+@rem    Pass "auto" rather than "": PowerShell drops empty-string arguments to
+@rem    native commands, which would shift %2 into %1.
+@rem %2 architecture: https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line
+@rem %3 run SDE simulation tests. If unset, SDE tests are not run.
+set MSVC_PATH=%~1
 set ARCH_OPTION=%2
 if "%~3"=="" ( set RUN_SDE=false ) else ( set RUN_SDE=%3 )
-call %MSVC_PATH% %ARCH_OPTION% || goto error
+
+@rem "auto" (or an empty / non-existent path) => auto-detect via vswhere so
+@rem hosted runners survive VS version bumps without hard-coded paths.
+if /i "%MSVC_PATH%"=="auto" set "MSVC_PATH="
+if not "%MSVC_PATH%"=="" if exist "%MSVC_PATH%" goto have_vcvars
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+    echo Could not find vswhere.exe to locate Visual Studio.
+    goto error
+)
+set "VSINSTALL="
+for /f "usebackq delims=" %%i in (`"%VSWHERE%" -latest -prerelease -products * -property installationPath`) do set "VSINSTALL=%%i"
+if not defined VSINSTALL (
+    echo vswhere did not find a Visual Studio installation.
+    goto error
+)
+set "MSVC_PATH=%VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat"
+if not exist "%MSVC_PATH%" (
+    echo Could not find vcvarsall.bat at "%MSVC_PATH%".
+    goto error
+)
+
+:have_vcvars
+echo Using Visual Studio environment: "%MSVC_PATH%"
+call "%MSVC_PATH%" %ARCH_OPTION% || goto error
 
 if /i "%ARCH_OPTION%" == "arm64" (
   set "CC=clang-cl"
@@ -31,7 +60,7 @@ goto :EOF
 @rem Run the same builds as run_posix_tests.sh
 @rem Check which version of MSVC we're building with: remove 14.0 from the path to the compiler and check if it matches the
 @rem original string. MSVC 14 has an issue with a missing DLL that causes the debug unit tests to fail
-if x%MSVC_PATH:14.0=%==x%MSVC_PATH% call :build_and_test Debug "" || goto error
+if "%MSVC_PATH:14.0=%"=="%MSVC_PATH%" call :build_and_test Debug "" || goto error
 call :build_and_test Release "" || goto error
 call :build_and_test Release "-DOPENSSL_SMALL=1" || goto error
 call :build_and_test Release "-DOPENSSL_NO_ASM=1" || goto error


### PR DESCRIPTION
### Description of changes:
The `windows-latest` image moved to VS2026 (MSVC 14.51), which broke our Windows CI in several ways:

1. New MSVC emits `C4865` from Windows SDK headers (`wingdi.h`, `winuser.h`); with `-Wall -WX` these fail the build even though they originate in system headers. Mark the toolchain/SDK include dirs (`INCLUDE`/`EXTERNAL_INCLUDE`) external via `/external:W0` so `-WX` still covers our own code.
2. The `windows` job hard-coded the VS2022 `vcvarsall.bat` path, which no longer exists on the VS2026 image. `run_windows_tests.bat` now auto-detects the newest VS via `vswhere`; explicit paths (used by the self-hosted `windows-omnibus` jobs to pin VS2015–2022) are still honored.
3. The `clang-cl-msbuild` job pinned the generator to `Visual Studio 17 2022`, which is gone on the new image; repointed to `Visual Studio 18 2026`.
4. The VS2026 MSVC STL requires Clang >= 20 (`yvals_core.h` STL1000 assert); bump the `clang` job from 19 to 20.

### Call-outs:
- The `/external:` flags are scoped to genuine `cl.exe` (`MSVC_VERSION >= 1929` and `CMAKE_C_COMPILER_ID == MSVC`) so clang-cl is excluded — it never emits `C4865` and can error on unrecognized `/external:` args under `-WX`.
- `clang-cl-msbuild` must keep `CMAKE_GENERATOR` pinned: `CMAKE_GENERATOR_TOOLSET` (ClangCL) is ignored unless `CMAKE_GENERATOR` is also set, and CMake then silently falls back to the MSVC toolset (breaking the ARM64 ClangCL guard). It needs a one-line bump on the next VS upgrade.
- `run_windows_tests.bat` is passed the sentinel `auto` (not `""`) because PowerShell drops empty-string arguments to native commands, which would shift the arch into the path argument.
- If `install-llvm-action@v2` doesn't offer Clang `20` for Windows, bump to whatever >= 20 it provides.

### Testing:
Relies on the existing Windows CI matrix (both `windows` legs incl. `windows-11-arm`, `clang`, `clang-cl-msbuild`/`-ninja`, `path-has-spaces`); the MSVC/PowerShell/arm64 behavior can only be confirmed on the runners. Locally verified the CMake change configures cleanly (macOS). Build/CI config only, no source changes.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
