### PR TITLE
Fix PostgreSQL integration: match upstream revoked-cert alert regex

### DIFF
--- a/tests/ci/integration/run_postgres_integration.sh
+++ b/tests/ci/integration/run_postgres_integration.sh
@@ -45,10 +45,13 @@ function postgres_run_tests() {
 # SSL tests expect the OpenSSL style of error messages. We patch this to expect AWS-LC's style.
 # TODO: Remove this when we make an upstream contribution.
 function postgres_patch() {
-  POSTGRES_ERROR_STRING=("certificate verify failed" "bad decrypt" "ssl\[a\-z0\-9\/\]\* alert certificate revoked" "tlsv1 alert unknown ca" "unrecognized name" "handshake failure")
+  # Note: the revoked-cert pattern uses an alternation "(ssl...|tls) alert"
+  # (introduced upstream for OpenSSL 4 compatibility), so the substitutions
+  # below use '#' as the sed delimiter to allow a literal '|' in the patterns.
+  POSTGRES_ERROR_STRING=("certificate verify failed" "bad decrypt" "(ssl\[a\-z0\-9\/\]\*|tls) alert certificate revoked" "tlsv1 alert unknown ca" "unrecognized name" "handshake failure")
   AWS_LC_EXPECTED_ERROR_STRING=("CERTIFICATE_VERIFY_FAILED" "BAD_DECRYPT" "SSLV3_ALERT_CERTIFICATE_REVOKED" "TLSV1_ALERT_UNKNOWN_CA" "TLSV1_ALERT_UNRECOGNIZED_NAME" "unknown error")
   for i in "${!POSTGRES_ERROR_STRING[@]}"; do
-    find ./src/test/ssl/t/ -type f -name "*.pl" | xargs sed -i -e "s|${POSTGRES_ERROR_STRING[$i]}|${AWS_LC_EXPECTED_ERROR_STRING[$i]}|g"
+    find ./src/test/ssl/t/ -type f -name "*.pl" | xargs sed -i -e "s#${POSTGRES_ERROR_STRING[$i]}#${AWS_LC_EXPECTED_ERROR_STRING[$i]}#g"
   done
   # Some tests use shorter error string patterns (e.g. just "unknown ca" instead
   # of "tlsv1 alert unknown ca"). Apply these after the longer replacements above


### PR DESCRIPTION
### Description of changes:
Our postgres integration test started failing on `main` with 3 subtest failures in `src/test/ssl/t/001_ssltests.pl` (the revoked client cert / CRL cases). Upstream postgres commit `89d243d5218` ("Fix compilation with OpenSSL 4") changed the revoked-cert error pattern to add a `(ssl[a-z0-9/]*|tls)` alternation, so the full-form `sed` substitution in our patch script no longer matched. Only the short-form fallback applied, leaving a half-converted regex `(ssl[a-z0-9/]*|tls) alert CERTIFICATE_REVOKED` that can't match AWS-LC's actual output `SSLV3_ALERT_CERTIFICATE_REVOKED`. This change updates the patch pattern to account for the new grouping so the whole alert description is rewritten to the AWS-LC form.

### Call-outs:
The one non-obvious bit: the substitution loop uses `sed s|...|...|g`, but the updated pattern now contains a literal `|` (from the `(...|tls)` alternation). To avoid `sed` treating that `|` as the `s` delimiter, this switches that loop's delimiter to `#` (no pattern or replacement contains `#`). I left the existing short-form block in place — after this fix it's a no-op for these lines but remains a safety net for genuinely short-form patterns in other `.pl` files. This remains a test-harness-only patch tracking an upstream error-string change (the existing `TODO` to upstream a contribution still stands).

### Testing:
Replayed the exact `sed` substitutions against the pristine upstream `001_ssltests.pl`: all 3 `expected_stderr` lines become `qr!SSL error: SSLV3_ALERT_CERTIFICATE_REVOKED!` (matching AWS-LC's output), while the `log_like` lines containing the lowercase `certificate revoked` from X509 verification are correctly preserved. The full integration run (`run_postgres_integration.sh`) should now pass `check-world` with `PG_TEST_EXTRA='ssl'`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
