### PR TITLE
Update MySQL CI integration to mysql-cluster-9.7.1

### DIFF
--- a/tests/ci/integration/run_mysql_integration.sh
+++ b/tests/ci/integration/run_mysql_integration.sh
@@ -6,7 +6,7 @@ set -exu
 
 source tests/ci/common_posix_setup.sh
 
-MYSQL_VERSION_TAG="mysql-cluster-9.7.0"
+MYSQL_VERSION_TAG="mysql-cluster-9.7.1"
 # This directory is specific to the docker image used. Use -DDOWNLOAD_BOOST=1 -DWITH_BOOST=<directory>
 # with mySQL to download a compatible boost version locally.
 BOOST_INSTALL_FOLDER=/home/dependencies/boost


### PR DESCRIPTION
### Description of changes:
MySQL published mysql-cluster-9.7.1. We pin the MySQL CI integration to a specific tag for stability, so this bumps the pinned `MYSQL_VERSION_TAG` from `mysql-cluster-9.7.0` to `mysql-cluster-9.7.1`. This is the version `git tag --sort=-taggerdate | tail -1` resolves to upstream, which is the same value the in-script `mysql_patch_reminder` compares against to drive the alarm.

### Call-outs:
Patch-level bump (9.7.0 -> 9.7.1), so no patch/skiplist churn is expected. If the integration job surfaces new missing-symbol or test failures, those should be triaged and tracked in separate SIMs per the runbook rather than blocking this version bump.

### Testing:
Relies on the `run_mysql_integration.sh` CI job, which builds AWS-LC against MySQL and runs the mtr suite.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
