### PR TITLE
Reduce CI deployment noise

### DIFF
--- a/.github/actions/cleanup-deployments/action.yml
+++ b/.github/actions/cleanup-deployments/action.yml
@@ -11,7 +11,7 @@ runs:
       with:
         script: |
           const sha = context.payload.pull_request?.head?.sha || context.sha;
-          for (const env of ['auto-approve', 'manual-approval']) {
+          for (const env of ['auto-approve']) {
             const deployments = await github.rest.repos.listDeployments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/actions/cleanup-deployments/action.yml
+++ b/.github/actions/cleanup-deployments/action.yml
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+name: 'cleanup-deployments'
+description: 'Removes deployment entries from the PR timeline created by environment-gated jobs. Marks each deployment as inactive then deletes it. Does not affect CI check results.'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/github-script@v8
+      if: github.event_name == 'pull_request_target'
+      with:
+        script: |
+          const sha = context.payload.pull_request?.head?.sha || context.sha;
+          for (const env of ['auto-approve', 'manual-approval']) {
+            const deployments = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: env,
+              sha: sha,
+              per_page: 100,
+            });
+            console.log(`Found ${deployments.data.length} deployments for ${env} (sha: ${sha})`);
+            for (const d of deployments.data) {
+              try {
+                await github.rest.repos.createDeploymentStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: d.id,
+                  state: 'inactive',
+                });
+                await github.rest.repos.deleteDeployment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: d.id,
+                });
+              } catch (e) {
+                console.log(`Failed to delete deployment ${d.id}: ${e.message}`);
+              }
+            }
+          }

--- a/.github/workflows/android-omnibus.yml
+++ b/.github/workflows/android-omnibus.yml
@@ -16,6 +16,7 @@ env:
 permissions:
   id-token: write
   contents: read
+  deployments: write
 
 jobs:
   authorization-check:
@@ -76,3 +77,14 @@ jobs:
             --release ${{ matrix.release }} \
             --shared ${{ matrix.shared }} \
             --action start-job
+
+
+  cleanup-deployments:
+    if: always()
+    needs: [device-farm]
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/cleanup-deployments

--- a/.github/workflows/image-build-android.yml
+++ b/.github/workflows/image-build-android.yml
@@ -31,6 +31,7 @@ env:
 permissions:
   id-token: write
   contents: read
+  deployments: write
 
 jobs:
   authorization-check:
@@ -123,3 +124,14 @@ jobs:
       - name: Push Images
         run: |
           docker push ${{ steps.images.outputs.latest }}
+
+
+  cleanup-deployments:
+    if: always()
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/cleanup-deployments

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -8,6 +8,7 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
+  deployments: write
 
 jobs:
   authorize:
@@ -82,3 +83,13 @@ jobs:
             -H "Authorization: token ${GH_TOKEN}" \
             "${STATUS_URL}" \
             -d "{\"state\":\"${STATE}\",\"context\":\"security-review / report\",\"target_url\":\"${REPORT_URL}\"}"
+
+  cleanup-deployments:
+    if: always()
+    needs: [execute]
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cleanup-deployments


### PR DESCRIPTION
### Description of changes: 
Deployment notifications have been especially noisy in PRs. They provide no meaningful information, except for when an external contributor needs us to approve the CI. Otherwise, they make it very hard to review conversations when the history gets too long. 

This change removes `auto-approve` deployments from history once the triggering tests have finished (regardless of success status). As a result, it will also remove notifications like `XYZ temporarily deployed to auto-approve 2 weeks ago — with GitHub Actions` from the PRs. This does not impact Github CI checks, as CI statuses will still be present in the PRs.

### Callouts:
Only `auto-approve` deployments will be deleted. As the name suggests, `auto-approve` deployments are always approved for AWS-LC members, so keeping them has no value to us. `manual-approval` deployments remain untouched, in case we want a track of the requesters and approvers of those deployments.

### Testing:
Verified that it worked on my personal fork. Changes will only be applied after this PR is merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.