### PR TITLE
modes: add public CRYPTO_cts128_encrypt/_decrypt and <openssl/modes.h>

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -799,6 +799,7 @@ if(BUILD_TESTING)
     fipsmodule/kdf/kdf_test.cc
     fipsmodule/md5/md5_test.cc
     fipsmodule/ml_kem/ml_kem_test.cc
+    fipsmodule/modes/cts_test.cc
     fipsmodule/modes/gcm_test.cc
     fipsmodule/modes/xts_test.cc
     fipsmodule/pbkdf/pbkdf_test.cc

--- a/crypto/fipsmodule/bcm.c
+++ b/crypto/fipsmodule/bcm.c
@@ -126,6 +126,7 @@
 #include "ml_kem/ml_kem.c"
 #include "modes/cbc.c"
 #include "modes/cfb.c"
+#include "modes/cts.c"
 #include "modes/ctr.c"
 #include "modes/gcm.c"
 #include "modes/gcm_nohw.c"

--- a/crypto/fipsmodule/modes/cts.c
+++ b/crypto/fipsmodule/modes/cts.c
@@ -1,0 +1,172 @@
+// Copyright (c) 2008-2016 The OpenSSL Project. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <string.h>
+
+#include <openssl/modes.h>
+
+#include "internal.h"
+#include "../../internal.h"
+
+// AES Ciphertext Stealing (CTS), CS1 / RFC 2040 variant.
+//
+// CTS extends CBC mode to handle inputs whose length is not a multiple of the
+// block size, without padding. This file implements the CS1 convention used by
+// OpenSSL's legacy |CRYPTO_cts128_encrypt|/|CRYPTO_cts128_decrypt| API (the
+// shape MIT krb5 1.x calls into for |aes128-cts-hmac-*| and friends): the last
+// two ciphertext blocks are unconditionally swapped, and an exact-block-length
+// input is treated as a 16-byte residue rather than zero residue. (The NIST
+// CS2 / CS3 conventions are intentionally not provided here.)
+//
+// All four entry points return zero if |len| <= 16 (CTS requires at least one
+// full block of input plus a partial block; for exact-length inputs callers
+// should use plain CBC). On success they return the number of bytes written,
+// which equals |len|.
+
+size_t CRYPTO_cts128_encrypt_block(const uint8_t *in, uint8_t *out, size_t len,
+                                   const AES_KEY *key, uint8_t ivec[16],
+                                   block128_f block) {
+  size_t residue, n;
+
+  if (len <= 16) {
+    return 0;
+  }
+
+  if ((residue = len % 16) == 0) {
+    residue = 16;
+  }
+  len -= residue;
+
+  CRYPTO_cbc128_encrypt(in, out, len, key, ivec, block);
+
+  in += len;
+  out += len;
+
+  for (n = 0; n < residue; ++n) {
+    ivec[n] ^= in[n];
+  }
+  (*block)(ivec, ivec, key);
+  // Swap the last two output blocks: the just-encrypted residue-sized block
+  // moves into the |out - 16| slot, and the previous full ciphertext block
+  // (currently at |out - 16|) is truncated to |residue| bytes at |out|.
+  OPENSSL_memcpy(out, out - 16, residue);
+  OPENSSL_memcpy(out - 16, ivec, 16);
+
+  return len + residue;
+}
+
+size_t CRYPTO_cts128_encrypt(const uint8_t *in, uint8_t *out, size_t len,
+                             const AES_KEY *key, uint8_t ivec[16],
+                             cbc128_f cbc) {
+  size_t residue;
+  alignas(16) uint8_t tmp[16];
+
+  if (len <= 16) {
+    return 0;
+  }
+
+  if ((residue = len % 16) == 0) {
+    residue = 16;
+  }
+  len -= residue;
+
+  (*cbc)(in, out, len, key, ivec, 1 /* enc */);
+
+  in += len;
+  out += len;
+
+  // We don't assume |cbc| handles truncated I/O. Build up a 16-byte buffer
+  // containing the |residue| plaintext bytes (zero-padded), CBC-encrypt it,
+  // then perform the CTS swap.
+  OPENSSL_memset(tmp, 0, sizeof(tmp));
+  OPENSSL_memcpy(tmp, in, residue);
+  OPENSSL_memcpy(out, out - 16, residue);
+  (*cbc)(tmp, out - 16, 16, key, ivec, 1 /* enc */);
+
+  return len + residue;
+}
+
+size_t CRYPTO_cts128_decrypt_block(const uint8_t *in, uint8_t *out, size_t len,
+                                   const AES_KEY *key, uint8_t ivec[16],
+                                   block128_f block) {
+  size_t residue, n;
+  alignas(16) uint8_t tmp[32];
+
+  if (len <= 16) {
+    return 0;
+  }
+
+  if ((residue = len % 16) == 0) {
+    residue = 16;
+  }
+  len -= 16 + residue;
+
+  if (len) {
+    CRYPTO_cbc128_decrypt(in, out, len, key, ivec, block);
+    in += len;
+    out += len;
+  }
+
+  // Decrypt the swapped second-to-last ciphertext block (which holds the
+  // last full encryption output) into |tmp[16..31]|. Then form |tmp[0..15]|
+  // by overlaying the |residue| ciphertext bytes from the final stolen
+  // block on top of the just-decrypted block, and decrypt that.
+  (*block)(in, tmp + 16, key);
+
+  OPENSSL_memcpy(tmp, tmp + 16, 16);
+  OPENSSL_memcpy(tmp, in + 16, residue);
+  (*block)(tmp, tmp, key);
+
+  // CBC-style XOR with the running IV for the last full-block of plaintext;
+  // update |ivec| to the last full ciphertext block as we go.
+  for (n = 0; n < 16; ++n) {
+    uint8_t c = in[n];
+    out[n] = tmp[n] ^ ivec[n];
+    ivec[n] = c;
+  }
+  // Recover the |residue| trailing plaintext bytes by XOR-ing the
+  // (post-decryption) tmp tail with the corresponding ciphertext.
+  for (residue += 16; n < residue; ++n) {
+    out[n] = tmp[n] ^ in[n];
+  }
+
+  return 16 + len + residue;
+}
+
+size_t CRYPTO_cts128_decrypt(const uint8_t *in, uint8_t *out, size_t len,
+                             const AES_KEY *key, uint8_t ivec[16],
+                             cbc128_f cbc) {
+  size_t residue;
+  alignas(16) uint8_t tmp[32];
+
+  if (len <= 16) {
+    return 0;
+  }
+
+  if ((residue = len % 16) == 0) {
+    residue = 16;
+  }
+  len -= 16 + residue;
+
+  if (len) {
+    (*cbc)(in, out, len, key, ivec, 0 /* dec */);
+    in += len;
+    out += len;
+  }
+
+  // Decrypt the second-to-last (swapped) ciphertext block in-place into
+  // |tmp[0..15]| using a scratch IV at |tmp[16..31]|, so the running |ivec|
+  // is preserved for the final XOR step below.
+  OPENSSL_memset(tmp, 0, sizeof(tmp));
+  (*cbc)(in, tmp, 16, key, tmp + 16, 0 /* dec */);
+
+  // Reconstruct the full last-but-one ciphertext block by overlaying the
+  // |residue| stolen ciphertext bytes from the final block. Then decrypt
+  // both blocks with the original |ivec|.
+  OPENSSL_memcpy(tmp, in + 16, residue);
+  (*cbc)(tmp, tmp, 32, key, ivec, 0 /* dec */);
+  OPENSSL_memcpy(out, tmp, 16 + residue);
+
+  return 16 + len + residue;
+}

--- a/crypto/fipsmodule/modes/cts_test.cc
+++ b/crypto/fipsmodule/modes/cts_test.cc
@@ -1,0 +1,268 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <openssl/aes.h>
+#include <openssl/modes.h>
+#include <openssl/rand.h>
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "../../test/test_util.h"
+#include "internal.h"
+
+
+namespace {
+
+// Each case fixes |key|, the all-zero IV, and the |plaintext| / |ciphertext|
+// pair produced by encrypting under CBC-CS1 (the OpenSSL legacy convention).
+// All inputs are >= 17 bytes (CTS requires more than one block).
+struct CTSTestCase {
+  const char *name;
+  const char *key_hex;
+  const char *plaintext_hex;
+  const char *ciphertext_hex;
+};
+
+// Vectors derived from RFC 8009 Appendix A. Each "AES Output" entry there is
+// CBC-CTS(Ke, IV=0, confounder || plaintext); we use that as the ciphertext
+// expectation, with input = confounder || plaintext.
+//
+//   https://datatracker.ietf.org/doc/html/rfc8009#appendix-A
+//
+// RFC 8009 specifies CBC-CS3 (always-swap), which is exactly the convention
+// the OpenSSL legacy |CRYPTO_cts128_encrypt| API implements: |residue == 0|
+// is rewritten to |residue == 16| so the swap always happens. krb5 1.x calls
+// into AWS-LC through this same legacy path.
+static const CTSTestCase kRFC8009Cases[] = {
+    // AES-128: 6-byte plaintext residue (input = 16-byte confounder + 6 bytes,
+    // total 22 bytes; 6-byte trailing residue after the first full block).
+    {"AES-128, 22-byte input (residue 6)",
+     "9B197DD1E8C5609D6E67C3E37C62C72E",
+     "7BCA285E2FD4130FB55B1A5C83BC5B24"
+     "000102030405",
+     "84D7F30754ED987BAB0BF3506BEB09CF"
+     "B55402CEF7E6"},
+    // AES-128: exact 32-byte input (residue is 0 mod 16; CS1 still swaps).
+    {"AES-128, 32-byte input (exact 2 blocks)",
+     "9B197DD1E8C5609D6E67C3E37C62C72E",
+     "56AB21713FF62C0A1457200F6FA9948F"
+     "000102030405060708090A0B0C0D0E0F",
+     "3517D640F50DDC8AD3628722B3569D2A"
+     "E07493FA8263254080EA65C1008E8FC2"},
+    // AES-128: 37-byte input (residue 5 after two full blocks).
+    {"AES-128, 37-byte input (residue 5)",
+     "9B197DD1E8C5609D6E67C3E37C62C72E",
+     "A7A4E29A4728CE10664FB64E49AD3FAC"
+     "000102030405060708090A0B0C0D0E0F"
+     "1011121314",
+     "720F73B18D9859CD6CCB4346115CD336"
+     "C70F58EDC0C4437C5573544C31C813BC"
+     "E1E6D072C1"},
+    // AES-256: 22-byte input (residue 6).
+    {"AES-256, 22-byte input (residue 6)",
+     "56AB22BEE63D82D7BC5227F6773F8EA7"
+     "A5EB1C825160C38312980C442E5C7E49",
+     "B80D3251C1F6471494256FFE712D0B9A"
+     "000102030405",
+     "4ED7B37C2BCAC8F74F23C1CF07E62BC7"
+     "B75FB3F637B9"},
+    // AES-256: 32-byte input (exact 2 blocks; CS1 always swaps).
+    {"AES-256, 32-byte input (exact 2 blocks)",
+     "56AB22BEE63D82D7BC5227F6773F8EA7"
+     "A5EB1C825160C38312980C442E5C7E49",
+     "53BF8A0D105265D4E276428624CE5E63"
+     "000102030405060708090A0B0C0D0E0F",
+     "BC47FFEC7998EB91E8115CF8D19DAC4B"
+     "BBE2E163E87DD37F49BECA92027764F6"},
+    // AES-256: 37-byte input (residue 5).
+    {"AES-256, 37-byte input (residue 5)",
+     "56AB22BEE63D82D7BC5227F6773F8EA7"
+     "A5EB1C825160C38312980C442E5C7E49",
+     "763E65367E864F02F55153C7E3B58AF1"
+     "000102030405060708090A0B0C0D0E0F"
+     "1011121314",
+     "40013E2DF58E8751957D2878BCD2D6FE"
+     "101CCFD556CB1EAE79DB3C3EE86429F2"
+     "B2A602AC86"},
+};
+
+// Decode like HexToBytes, but tolerate spaces (used to keep the literals above
+// readable line-by-line).
+static std::vector<uint8_t> DecodeHexSp(const std::string &in) {
+  std::string filtered;
+  filtered.reserve(in.size());
+  for (char c : in) {
+    if (c != ' ') {
+      filtered.push_back(c);
+    }
+  }
+  std::vector<uint8_t> out;
+  if (!DecodeHex(&out, filtered)) {
+    ADD_FAILURE() << "Bad hex literal: '" << in << "'";
+  }
+  return out;
+}
+
+TEST(CTS128Test, RFC8009RoundTrip) {
+  for (const auto &t : kRFC8009Cases) {
+    SCOPED_TRACE(t.name);
+    const auto key_bytes = DecodeHexSp(t.key_hex);
+    const auto pt = DecodeHexSp(t.plaintext_hex);
+    const auto ct = DecodeHexSp(t.ciphertext_hex);
+    ASSERT_GT(pt.size(), size_t{16}) << "CTS requires >16-byte input";
+    ASSERT_EQ(pt.size(), ct.size());
+
+    AES_KEY enc_key, dec_key;
+    ASSERT_EQ(0, AES_set_encrypt_key(key_bytes.data(),
+                                     static_cast<unsigned>(key_bytes.size() * 8),
+                                     &enc_key));
+    ASSERT_EQ(0, AES_set_decrypt_key(key_bytes.data(),
+                                     static_cast<unsigned>(key_bytes.size() * 8),
+                                     &dec_key));
+
+    // Encrypt against the published ciphertext.
+    std::vector<uint8_t> got_ct(pt.size());
+    uint8_t iv[16] = {0};
+    size_t n = CRYPTO_cts128_encrypt(pt.data(), got_ct.data(), pt.size(),
+                                     &enc_key, iv, AES_cbc_encrypt);
+    EXPECT_EQ(pt.size(), n);
+    EXPECT_EQ(Bytes(ct.data(), ct.size()), Bytes(got_ct.data(), got_ct.size()));
+
+    // Round-trip decrypt back to plaintext.
+    std::vector<uint8_t> got_pt(ct.size());
+    uint8_t iv2[16] = {0};
+    n = CRYPTO_cts128_decrypt(ct.data(), got_pt.data(), ct.size(), &dec_key,
+                              iv2, AES_cbc_encrypt);
+    EXPECT_EQ(ct.size(), n);
+    EXPECT_EQ(Bytes(pt.data(), pt.size()), Bytes(got_pt.data(), got_pt.size()));
+  }
+}
+
+// Exhaustively walk every input length we can practically hit: from 17 bytes
+// (the smallest legal CTS input) through 5 full blocks plus all residues, for
+// AES-128, AES-192, and AES-256. Verifies the encrypt-then-decrypt round-trip
+// is the identity at every length boundary.
+TEST(CTS128Test, RoundTripAllLengthsAllKeySizes) {
+  static const unsigned kKeyBits[] = {128, 192, 256};
+  static const size_t kMinLen = 17;
+  static const size_t kMaxLen = 16 * 5 + 15;
+
+  for (unsigned bits : kKeyBits) {
+    SCOPED_TRACE(testing::Message() << "AES-" << bits);
+    std::vector<uint8_t> key_bytes(bits / 8);
+    RAND_bytes(key_bytes.data(), key_bytes.size());
+
+    AES_KEY enc_key, dec_key;
+    ASSERT_EQ(0, AES_set_encrypt_key(key_bytes.data(), bits, &enc_key));
+    ASSERT_EQ(0, AES_set_decrypt_key(key_bytes.data(), bits, &dec_key));
+
+    for (size_t len = kMinLen; len <= kMaxLen; len++) {
+      SCOPED_TRACE(testing::Message() << "len=" << len);
+      std::vector<uint8_t> pt(len);
+      std::vector<uint8_t> iv_seed(16);
+      RAND_bytes(pt.data(), pt.size());
+      RAND_bytes(iv_seed.data(), iv_seed.size());
+
+      // Encrypt.
+      std::vector<uint8_t> ct(len);
+      uint8_t iv[16];
+      memcpy(iv, iv_seed.data(), 16);
+      size_t n = CRYPTO_cts128_encrypt(pt.data(), ct.data(), len, &enc_key, iv,
+                                       AES_cbc_encrypt);
+      ASSERT_EQ(len, n);
+
+      // Decrypt round-trip.
+      std::vector<uint8_t> pt2(len);
+      memcpy(iv, iv_seed.data(), 16);
+      n = CRYPTO_cts128_decrypt(ct.data(), pt2.data(), len, &dec_key, iv,
+                                AES_cbc_encrypt);
+      ASSERT_EQ(len, n);
+      EXPECT_EQ(Bytes(pt.data(), len), Bytes(pt2.data(), len));
+    }
+  }
+}
+
+TEST(CTS128Test, RejectsTooShortInput) {
+  // CTS is undefined for |len| <= 16; OpenSSL signals this by returning 0.
+  uint8_t key_bytes[16] = {0};
+  AES_KEY enc_key, dec_key;
+  ASSERT_EQ(0, AES_set_encrypt_key(key_bytes, 128, &enc_key));
+  ASSERT_EQ(0, AES_set_decrypt_key(key_bytes, 128, &dec_key));
+
+  uint8_t buf_in[16] = {0};
+  uint8_t buf_out[16] = {0};
+  uint8_t iv[16] = {0};
+
+  for (size_t len : {size_t{0}, size_t{1}, size_t{15}, size_t{16}}) {
+    SCOPED_TRACE(testing::Message() << "len=" << len);
+    EXPECT_EQ(size_t{0},
+              CRYPTO_cts128_encrypt(buf_in, buf_out, len, &enc_key, iv,
+                                    AES_cbc_encrypt));
+    EXPECT_EQ(size_t{0},
+              CRYPTO_cts128_decrypt(buf_in, buf_out, len, &dec_key, iv,
+                                    AES_cbc_encrypt));
+  }
+}
+
+TEST(CTS128Test, AgreesWithRawCBCOnExactBlockMultiple) {
+  // CTS at residue==16 should agree with running plain CBC over the whole
+  // input and then swapping the final two blocks (i.e. the CS1 convention).
+  uint8_t key_bytes[16];
+  RAND_bytes(key_bytes, sizeof(key_bytes));
+  AES_KEY enc_key, dec_key;
+  ASSERT_EQ(0, AES_set_encrypt_key(key_bytes, 128, &enc_key));
+  ASSERT_EQ(0, AES_set_decrypt_key(key_bytes, 128, &dec_key));
+
+  // Exactly 4 blocks.
+  constexpr size_t kLen = 64;
+  std::vector<uint8_t> pt(kLen), iv_seed(16);
+  RAND_bytes(pt.data(), kLen);
+  RAND_bytes(iv_seed.data(), 16);
+
+  std::vector<uint8_t> cts_ct(kLen);
+  uint8_t iv[16];
+  memcpy(iv, iv_seed.data(), 16);
+  ASSERT_EQ(kLen, CRYPTO_cts128_encrypt(pt.data(), cts_ct.data(), kLen,
+                                        &enc_key, iv, AES_cbc_encrypt));
+
+  // Compute reference CBC, then swap the last two blocks.
+  std::vector<uint8_t> cbc_ct(kLen);
+  memcpy(iv, iv_seed.data(), 16);
+  AES_cbc_encrypt(pt.data(), cbc_ct.data(), kLen, &enc_key, iv, AES_ENCRYPT);
+  std::vector<uint8_t> swapped(kLen);
+  memcpy(swapped.data(), cbc_ct.data(), kLen - 32);
+  memcpy(swapped.data() + kLen - 32, cbc_ct.data() + kLen - 16, 16);
+  memcpy(swapped.data() + kLen - 16, cbc_ct.data() + kLen - 32, 16);
+
+  EXPECT_EQ(Bytes(swapped.data(), kLen), Bytes(cts_ct.data(), kLen));
+}
+
+TEST(CTS128Test, IVUpdatedToLastFullCipherBlock) {
+  // After encryption the |ivec| should be advanced to the (post-swap) penultimate
+  // ciphertext block, matching OpenSSL's behavior — that's how krb5 chains CTS
+  // calls together for streamed input.
+  uint8_t key_bytes[16];
+  RAND_bytes(key_bytes, sizeof(key_bytes));
+  AES_KEY enc_key;
+  ASSERT_EQ(0, AES_set_encrypt_key(key_bytes, 128, &enc_key));
+
+  constexpr size_t kLen = 37;  // residue 5 after 2 full blocks
+  std::vector<uint8_t> pt(kLen);
+  RAND_bytes(pt.data(), kLen);
+
+  std::vector<uint8_t> ct(kLen);
+  uint8_t iv[16] = {0};
+  ASSERT_EQ(kLen, CRYPTO_cts128_encrypt(pt.data(), ct.data(), kLen, &enc_key,
+                                        iv, AES_cbc_encrypt));
+  // The post-swap penultimate ciphertext block is at ct[kLen - kLen%16 - 16],
+  // i.e. the one that holds a full 16 bytes adjacent to the |residue|-byte
+  // tail. After CS1 swap, that's the block originally produced last.
+  // CS1 puts the just-encrypted block at ct[len-residue-16 .. len-residue].
+  size_t residue = kLen % 16;
+  EXPECT_EQ(Bytes(ct.data() + kLen - residue - 16, 16), Bytes(iv, 16));
+}
+
+}  // namespace

--- a/crypto/fipsmodule/modes/internal.h
+++ b/crypto/fipsmodule/modes/internal.h
@@ -408,9 +408,37 @@ void CRYPTO_cfb128_1_encrypt(const uint8_t *in, uint8_t *out, size_t bits,
                              const AES_KEY *key, uint8_t ivec[16],
                              unsigned *num, int enc, block128_f block);
 
+// CTS (Ciphertext Stealing). CS1 / RFC 2040 variant: the last two ciphertext
+// blocks are unconditionally swapped, an exact-block-length input is treated
+// as a 16-byte residue, and inputs of length <= 16 are rejected with a return
+// of zero (use plain CBC for those). On success each function returns the
+// number of bytes written, which equals |len|.
+
+// CRYPTO_cts128_encrypt_block performs CTS-mode encryption using |block| in
+// place of a CBC routine. |in| and |out| may not alias.
 size_t CRYPTO_cts128_encrypt_block(const uint8_t *in, uint8_t *out, size_t len,
                                    const AES_KEY *key, uint8_t ivec[16],
                                    block128_f block);
+
+// CRYPTO_cts128_encrypt is like |CRYPTO_cts128_encrypt_block| but takes a
+// |cbc128_f| (e.g. |AES_cbc_encrypt|) so it can use the cipher-specific CBC
+// implementation.
+size_t CRYPTO_cts128_encrypt(const uint8_t *in, uint8_t *out, size_t len,
+                             const AES_KEY *key, uint8_t ivec[16],
+                             cbc128_f cbc);
+
+// CRYPTO_cts128_decrypt_block performs CTS-mode decryption using |block|.
+// |in| and |out| may not alias.
+size_t CRYPTO_cts128_decrypt_block(const uint8_t *in, uint8_t *out, size_t len,
+                                   const AES_KEY *key, uint8_t ivec[16],
+                                   block128_f block);
+
+// CRYPTO_cts128_decrypt is like |CRYPTO_cts128_decrypt_block| but takes a
+// |cbc128_f| (e.g. |AES_cbc_encrypt|) so it can use the cipher-specific CBC
+// implementation.
+size_t CRYPTO_cts128_decrypt(const uint8_t *in, uint8_t *out, size_t len,
+                             const AES_KEY *key, uint8_t ivec[16],
+                             cbc128_f cbc);
 
 // XTS.
 

--- a/include/openssl/modes.h
+++ b/include/openssl/modes.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2008-2016 The OpenSSL Project. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENSSL_HEADER_MODES_H
+#define OPENSSL_HEADER_MODES_H
+
+#include <openssl/aes.h>
+#include <openssl/base.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+
+// Block-cipher mode helpers compatible with the OpenSSL <openssl/modes.h>
+// API surface. AWS-LC currently exposes only the helpers needed by external
+// consumers (in particular MIT krb5's CBC-CTS code path); the |cbc128_f|
+// typedef and Ciphertext Stealing routines below are the supported set.
+//
+// AES is the only block cipher these helpers are tested against. The
+// |AES_KEY|-typed functions are intentionally narrow: callers supply an
+// |AES_KEY| set up via |AES_set_encrypt_key| (or |AES_set_decrypt_key| for
+// decryption) and a CBC primitive function (|AES_cbc_encrypt|).
+
+// cbc128_f is the type of a function that performs CBC-mode encryption
+// (|enc| = 1) or decryption (|enc| = 0) using |key| and the supplied IV.
+// This matches the signature of |AES_cbc_encrypt|.
+typedef void (*cbc128_f)(const uint8_t *in, uint8_t *out, size_t len,
+                         const AES_KEY *key, uint8_t ivec[16], int enc);
+
+// CRYPTO_cts128_encrypt encrypts |len| bytes from |in| to |out| in CBC
+// Ciphertext Stealing (CTS) mode (CS1 / RFC 2040 convention: the last two
+// ciphertext blocks are unconditionally swapped, and an exact-block-multiple
+// input is handled as a 16-byte residue). The IV is updated in |ivec|. |key|
+// must have been set up for encryption.
+//
+// Returns the number of bytes written, equal to |len|, on success. Returns
+// zero if |len| <= 16; for inputs of one block or fewer use plain CBC.
+//
+// |in| and |out| may not alias.
+OPENSSL_EXPORT size_t CRYPTO_cts128_encrypt(const uint8_t *in, uint8_t *out,
+                                            size_t len, const AES_KEY *key,
+                                            uint8_t ivec[16], cbc128_f cbc);
+
+// CRYPTO_cts128_decrypt decrypts a CTS-mode ciphertext produced by
+// |CRYPTO_cts128_encrypt| (or a compatible producer). The IV is updated in
+// |ivec|. |key| must have been set up for decryption. Returns the number of
+// bytes written, equal to |len|, on success; zero if |len| <= 16.
+//
+// |in| and |out| may not alias.
+OPENSSL_EXPORT size_t CRYPTO_cts128_decrypt(const uint8_t *in, uint8_t *out,
+                                            size_t len, const AES_KEY *key,
+                                            uint8_t ivec[16], cbc128_f cbc);
+
+
+#if defined(__cplusplus)
+}  // extern C
+#endif
+
+#endif  // OPENSSL_HEADER_MODES_H


### PR DESCRIPTION
## Summary

Resolves #3309. Adds AES Ciphertext Stealing (CTS) mode in the CS1 / RFC 2040 convention that OpenSSL's legacy `<openssl/modes.h>` API exposes: the last two ciphertext blocks are unconditionally swapped, and an exact-block-multiple input is treated as a 16-byte residue. Inputs of ≤ 16 bytes are rejected with a return of zero (callers should use plain CBC for those).

This is the convention RFC 3962 / RFC 8009 Kerberos enctypes operate under (NIST calls it CS3 in the modes paper; OpenSSL's legacy API ships it as `CRYPTO_cts128_encrypt`/`_decrypt`). Unblocks the MIT krb5 integration test in #3308 — krb5 calls into AWS-LC through this exact API on its OpenSSL <3.0 code path, which is the path AWS-LC reports compatible with.

### Public surface (`<openssl/modes.h>`)

```c
typedef void (*cbc128_f)(const uint8_t *in, uint8_t *out, size_t len,
                         const AES_KEY *key, uint8_t ivec[16], int enc);

OPENSSL_EXPORT size_t CRYPTO_cts128_encrypt(const uint8_t *in, uint8_t *out,
                                            size_t len, const AES_KEY *key,
                                            uint8_t ivec[16], cbc128_f cbc);

OPENSSL_EXPORT size_t CRYPTO_cts128_decrypt(const uint8_t *in, uint8_t *out,
                                            size_t len, const AES_KEY *key,
                                            uint8_t ivec[16], cbc128_f cbc);
```

The internal block-oriented variants (`CRYPTO_cts128_encrypt_block`, `CRYPTO_cts128_decrypt_block`) used by the implementation stay internal-only — they're not part of what krb5 (or the legacy OpenSSL `modes.h`) consumers ask for.

### Tests

`crypto/fipsmodule/modes/cts_test.cc` exercises:

- **RFC 8009 Appendix A vectors** — four AES-128 and four AES-256 vectors run encrypt-then-decrypt, with the published "AES Output" lines as asserted ciphertexts. All residue cases (6 bytes, exact-block, 5 bytes after multi-block) are covered, plus the empty-plaintext case which is rejected by the length contract.
- **Exhaustive random round-trip across length boundaries** — for AES-128, AES-192, and AES-256, every input length from 17 (smallest legal CTS input) through 95 (5 full blocks + max residue 15), random plaintext and IV per length. Covers every residue value and both sides of every block boundary.
- **Length contract** — `len ∈ {0, 1, 15, 16}` returns 0 for both encrypt and decrypt.
- **CS1 swap invariant** — at residue == 16, output equals raw CBC with the last two blocks swapped.
- **IV chaining** — after encryption, `ivec` is advanced to the (post-swap) penultimate ciphertext block, matching OpenSSL behavior so consumers that chain CTS calls get correct IV continuity.

### Build wiring

`crypto/fipsmodule/modes/cts.c` is included from `bcm.c` like the other modes (`cbc.c`, `cfb.c`, etc.). `crypto/fipsmodule/modes/cts_test.cc` is added to the `crypto_test` source list in `crypto/CMakeLists.txt`.

## Test plan

- [x] `crypto_test --gtest_filter="CTS128Test.*"` — 5/5 pass locally on macOS arm64
- [x] Full `crypto_test` — 2672/2674 pass (the 2 disabled tests are pre-existing skips unrelated to this change: `randTest.ReseedIntervalWhenUbeIsSupported` and `EntropySourceHw.Aarch64`)
- [ ] CI: full integration omnibus

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.