### PR TITLE
Define OPENSSL_INIT_NO_ATEXIT as a no-op

### DIFF
--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -185,6 +185,7 @@ OPENSSL_EXPORT void OPENSSL_load_builtin_modules(void);
 #define OPENSSL_INIT_NO_LOAD_CONFIG 0
 #define OPENSSL_INIT_ENGINE_ALL_BUILTIN 0
 #define OPENSSL_INIT_ATFORK 0
+#define OPENSSL_INIT_NO_ATEXIT 0
 
 // OPENSSL_init_crypto calls |CRYPTO_library_init| and returns one.
 OPENSSL_EXPORT int OPENSSL_init_crypto(uint64_t opts,


### PR DESCRIPTION
### Issues:
Resolves grpc CI failure

### Description of changes: 
AWS-LC already shims the sibling `OPENSSL_INIT_*` flags to 0: init options are ignored, and `OPENSSL_cleanup` is already a no-op, so there is no `atexit` handler to suppress. Defining `OPENSSL_INIT_NO_ATEXIT` to 0 alongside them lets software that passes the flag build unchanged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
