### PR TITLE
Bump AWSLC_FIPS_VERSION to 5 for next FIPS branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 set(SOFTWARE_NAME "awslc")
 set(SOFTWARE_VERSION "5.0.0")
-set(AWSLC_FIPS_VERSION 4)
+set(AWSLC_FIPS_VERSION 5)
 set(ABI_VERSION 0)
 set(CRYPTO_LIB_NAME "crypto")
 set(SSL_LIB_NAME "ssl")

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -70,7 +70,7 @@ extern "C" {
 // AWSLC_FIPS_VERSION_NUMBER is the FIPS version number of mainline AWS-LC,
 // independent of |AWSLC_VERSION_NUMBER_STRING|. It is incremented each time a
 // new FIPS branch is cut from mainline.
-#define AWSLC_FIPS_VERSION_NUMBER 4
+#define AWSLC_FIPS_VERSION_NUMBER 5
 
 #if defined(BORINGSSL_SHARED_LIBRARY)
 


### PR DESCRIPTION
Increments the FIPS module version number ahead of cutting the next FIPS branch for validation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
