### PR TITLE
[FIPS 4.0] Add COHABITANT_BINARIES option to install tool binaries with 'aws-lc-…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,17 @@ option(ENABLE_FIPS_ENTROPY_CPU_JITTER "Enable FIPS entropy source: CPU Jitter" O
 option(ENABLE_DATA_INDEPENDENT_TIMING "Enable automatic setting/resetting Data-Independent Timing
 (DIT) flag in cryptographic functions. Currently only applicable to Arm64 (except on Windows)" OFF)
 option(ENABLE_PRE_SONAME_BUILD "Build AWS-LC without SONAME configuration for shared library builds" ON)
+option(COHABITANT_BINARIES "Install tool binaries with an 'aws-lc-' prefix to avoid conflicts with OpenSSL" OFF)
 option(GENERATE_RUST_BINDINGS "Generate Rust bindings using bindgen-cli" OFF)
 set(RUST_BINDINGS_TARGET_VERSION "1.70" CACHE STRING "Minimum Rust version for generated bindings")
+
+# Set the install binary prefix based on whether cohabitation is desired
+if(COHABITANT_BINARIES)
+  set(AWSLC_BIN_PREFIX "aws-lc-")
+else()
+  set(AWSLC_BIN_PREFIX "")
+endif()
+message(STATUS "COHABITANT_BINARIES: ${COHABITANT_BINARIES}")
 
 include(cmake/go.cmake)
 

--- a/tool-openssl/CMakeLists.txt
+++ b/tool-openssl/CMakeLists.txt
@@ -44,10 +44,19 @@ endif()
 
 target_add_awslc_include_paths(TARGET openssl SCOPE PRIVATE)
 
+if(COHABITANT_BINARIES)
+  set_target_properties(openssl PROPERTIES OUTPUT_NAME "${AWSLC_BIN_PREFIX}openssl")
+endif()
+
 install(TARGETS openssl
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+set(C_REHASH_INSTALL_NAME "c_rehash")
+if(COHABITANT_BINARIES)
+  set(C_REHASH_INSTALL_NAME "${AWSLC_BIN_PREFIX}c_rehash")
+endif()
 
 file(INSTALL
     ${CMAKE_CURRENT_SOURCE_DIR}/c_rehash.sh
@@ -64,7 +73,7 @@ file(INSTALL
 
 install(
     PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/c_rehash.sh
-    RENAME c_rehash
+    RENAME ${C_REHASH_INSTALL_NAME}
     DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -41,6 +41,10 @@ else()
   endif()
 endif()
 
+if(COHABITANT_BINARIES)
+  set_target_properties(bssl PROPERTIES OUTPUT_NAME "${AWSLC_BIN_PREFIX}bssl")
+endif()
+
 install(TARGETS bssl
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
### Issues:
Addresses P460497046

### Description of changes:
Backports #3116 (`COHABITANT_BINARIES` support) to the FIPS 4.0 branch. When `-DCOHABITANT_BINARIES=ON` is passed to CMake, the installed tool binaries are renamed with an `aws-lc-` prefix (`aws-lc-bssl`, `aws-lc-openssl`, `aws-lc-c_rehash`) to avoid filename conflicts when AWS-LC-FIPS coexists with OpenSSL in the same install prefix.

### Call-outs:
This is NOT strictly a cherry-pick of upstream commit 96514809cf. That commit depends on the `ENABLE_DIST_PKG` / `COHABITANT_HEADERS` infrastructure introduced in PR #3042, which is a larger refactor (10 files, 600+ insertions).

The option defaults to OFF so there is no behavioral change for existing consumers.

### Testing:
Verified CMake configures cleanly with both `-DCOHABITANT_BINARIES=ON` and `-DCOHABITANT_BINARIES=OFF`. Confirmed via generated build rules that binaries are correctly prefixed (ON) or unchanged (OFF).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
