### PR TITLE
Concurrency is not generally supported for EVP_AEAD_CTX_foo functions

### DIFF
--- a/include/openssl/aead.h
+++ b/include/openssl/aead.h
@@ -271,8 +271,9 @@ OPENSSL_EXPORT void EVP_AEAD_CTX_cleanup(EVP_AEAD_CTX *ctx);
 // authenticates |ad_len| bytes from |ad| and writes the result to |out|. It
 // returns one on success and zero otherwise.
 //
-// This function may be called concurrently with itself or any other seal/open
-// function on the same |EVP_AEAD_CTX|.
+// This function generally CANNOT be called concurrently with itself or any
+// other seal/open function on the same |EVP_AEAD_CTX|. Which |EVP_AEAD|
+// implementations that support concurrency is not documented.
 //
 // At most |max_out_len| bytes are written to |out| and, in order to ensure
 // success, |max_out_len| should be |in_len| plus the result of
@@ -297,8 +298,9 @@ OPENSSL_EXPORT int EVP_AEAD_CTX_seal(const EVP_AEAD_CTX *ctx, uint8_t *out,
 // from |ad| and decrypts at most |in_len| bytes into |out|. It returns one on
 // success and zero otherwise.
 //
-// This function may be called concurrently with itself or any other seal/open
-// function on the same |EVP_AEAD_CTX|.
+// This function generally CANNOT be called concurrently with itself or any
+// other seal/open function on the same |EVP_AEAD_CTX|. Which |EVP_AEAD|
+// implementations that support concurrency is not documented.
 //
 // At most |in_len| bytes are written to |out|. In order to ensure success,
 // |max_out_len| should be at least |in_len|. On successful return, |*out_len|
@@ -323,8 +325,9 @@ OPENSSL_EXPORT int EVP_AEAD_CTX_open(const EVP_AEAD_CTX *ctx, uint8_t *out,
 // ciphertext to |out| and the authentication tag to |out_tag|. It returns one
 // on success and zero otherwise.
 //
-// This function may be called concurrently with itself or any other seal/open
-// function on the same |EVP_AEAD_CTX|.
+// This function generally CANNOT be called concurrently with itself or any
+// other seal/open function on the same |EVP_AEAD_CTX|. Which |EVP_AEAD|
+// implementations that support concurrency is not documented.
 //
 // Exactly |in_len| bytes are written to |out|, and up to
 // |EVP_AEAD_max_overhead+extra_in_len| bytes to |out_tag|. On successful
@@ -358,8 +361,9 @@ OPENSSL_EXPORT int EVP_AEAD_CTX_seal_scatter(
 // authentication tag from |in_tag|. If successful, it writes |in_len| bytes of
 // plaintext to |out|. It returns one on success and zero otherwise.
 //
-// This function may be called concurrently with itself or any other seal/open
-// function on the same |EVP_AEAD_CTX|.
+// This function generally CANNOT be called concurrently with itself or any
+// other seal/open function on the same |EVP_AEAD_CTX|. Which |EVP_AEAD|
+// implementations that support concurrency is not documented.
 //
 // The length of |nonce|, |nonce_len|, must be equal to the result of
 // |EVP_AEAD_nonce_length| for this AEAD.


### PR DESCRIPTION
### Description of changes: 

Concurrency on `EVP_AEAD_CTX_foo()` functions with the same `EVP_AEAD_CTX` is not generally supported. See e.g. TLS-specific implementations.

We might be able to document which does and ensure it remains stable over time. But just invert the description for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
