### PR TITLE
OPENSSL_SMALL: imply MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX on x86_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1044,6 +1044,13 @@ endif()
 
 if(OPENSSL_SMALL)
   add_definitions(-DOPENSSL_SMALL)
+  # OPENSSL_SMALL implies disabling AVX-512 optimizations on x86_64 for size.
+  # This is also enforced in include/openssl/target.h for non-CMake builds.
+  if(NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
+    set(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX ON)
+    add_definitions(-DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
+    message(STATUS "OPENSSL_SMALL implies MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX, removing ADX, AVX2 and AVX512 optimisations")
+  endif()
 endif()
 
 if(CONSTANT_TIME_VALIDATION)

--- a/include/openssl/target.h
+++ b/include/openssl/target.h
@@ -254,4 +254,24 @@
 #endif
 #endif  // OPENSSL_ASM_INCOMPATIBLE
 
+// Assembler-capability flag implications.
+//
+// MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX implies MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX.
+// CMakeLists.txt enforces this for CMake builds, but it must also be enforced
+// here for builds that pass defines directly via CFLAGS (e.g., the aws-lc-sys
+// CcBuilder path).
+#if defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) && \
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
+#  define MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+#endif
+
+// OPENSSL_SMALL implies disabling AVX-512 code paths on x86_64. The AVX-512
+// assembly (AES-GCM, XTS, RSAZ) is the largest single contributor to binary
+// size on x86_64 (~912 KB of object code). The performance cost is borne only
+// on AVX-512-capable CPUs (Ice Lake+, Zen 4+) for bulk symmetric operations.
+#if defined(OPENSSL_SMALL) && defined(OPENSSL_X86_64) && \
+    !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX)
+#  define MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+#endif
+
 #endif  // OPENSSL_HEADER_TARGET_H


### PR DESCRIPTION
### Issues:
Addresses: aws/aws-lc-rs#745, P353434599

### Description of changes: 
When OPENSSL_SMALL is defined on x86_64, automatically define MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX. This eliminates ~912 KB of AVX-512 assembly (AES-GCM, AES-XTS, RSAZ) from the binary, which is the single largest contributor to object code size on x86_64. Combined with the existing EC precomputed table gating, this reduces libcrypto.a from 5.6 MB to 3.5 MB under OPENSSL_SMALL.

### Call out
* This enforces the implication `MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX -> MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX` in "target.h". Previously this was only enforced by CMakeLists.txt, meaning builds that pass defines directly via CFLAGS (e.g., the aws-lc-sys CcBuilder) did not get the implication.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.