### PR TITLE
Gate s2n-bignum _alt variants under OPENSSL_SMALL

### DIFF
--- a/.github/workflows/openssl-small.yml
+++ b/.github/workflows/openssl-small.yml
@@ -1,0 +1,118 @@
+# Validates the OPENSSL_SMALL build: it must shrink a statically-linked
+# consumer binary and must still pass the full test suite.
+#
+# The size-reduction job is intentionally advisory (continue-on-error) because
+# the exact reduction depends on platform/compiler and the threshold below has
+# not been finely calibrated yet. Once the observed numbers are stable, drop
+# `continue-on-error` and/or mark this job as a required check in branch
+# protection. The small-tests jobs are real correctness gates and should block.
+name: OPENSSL_SMALL
+on:
+  push:
+    branches: ['*']
+  pull_request:
+    branches: ['*']
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+env:
+  GOPROXY: https://proxy.golang.org,direct
+  # Minimum static-link size reduction expected from OPENSSL_SMALL vs the
+  # default build, measured on the tests/binary-size consumer. Measured at ~25%
+  # on x86_64 Linux (higher once OPENSSL_SMALL also disables AVX-512); threshold
+  # set conservatively below that with margin for compiler/platform variance.
+  EXPECTED_REDUCTION_PERCENT: 15
+permissions:
+  contents: read
+
+jobs:
+  size-reduction:
+    if: github.repository_owner == 'aws'
+    name: OPENSSL_SMALL size reduction (x86_64 Linux)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
+          sudo apt-get -y --no-install-recommends install cmake clang ninja-build golang
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v6
+      - name: Build libcrypto.a (default)
+        run: |
+          cmake -GNinja -B build-default -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=OFF
+          cmake --build build-default --target crypto
+      - name: Build libcrypto.a (OPENSSL_SMALL)
+        run: |
+          cmake -GNinja -B build-small -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=OFF -DOPENSSL_SMALL=ON
+          cmake --build build-small --target crypto
+      - name: Link consumer against each libcrypto and compare
+        run: |
+          set -euo pipefail
+          common="-O2 -I include -ffunction-sections -fdata-sections"
+          libs="-lpthread -ldl -lm -Wl,--gc-sections -s"
+          clang $common tests/binary-size/main.c build-default/crypto/libcrypto.a $libs -o consumer-default
+          clang $common tests/binary-size/main.c build-small/crypto/libcrypto.a   $libs -o consumer-small
+          echo "Sanity: run the OPENSSL_SMALL-linked consumer"
+          ./consumer-small
+          size_default=$(stat -c %s consumer-default)
+          size_small=$(stat -c %s consumer-small)
+          if [ "$size_default" -le 0 ]; then
+            echo "ERROR: default consumer binary has zero size"
+            exit 1
+          fi
+          reduction=$(( (size_default - size_small) * 100 / size_default ))
+          {
+            echo "## OPENSSL_SMALL static-link size"
+            echo ""
+            echo "| Build | Consumer binary |"
+            echo "|-------|-----------------|"
+            echo "| Default | $(numfmt --to=iec "$size_default") (${size_default} B) |"
+            echo "| OPENSSL_SMALL | $(numfmt --to=iec "$size_small") (${size_small} B) |"
+            echo "| **Reduction** | **${reduction}%** |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "default=${size_default} small=${size_small} reduction=${reduction}%"
+          if [ "$reduction" -lt "$EXPECTED_REDUCTION_PERCENT" ]; then
+            echo "FAIL: expected >= ${EXPECTED_REDUCTION_PERCENT}% reduction, got ${reduction}%"
+            exit 1
+          fi
+          echo "PASS: ${reduction}% reduction meets the ${EXPECTED_REDUCTION_PERCENT}% threshold"
+
+  small-tests:
+    if: github.repository_owner == 'aws'
+    name: Tests (OPENSSL_SMALL, ${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # x86_64 covers both compilers; aarch64 is the platform where Phase 2's
+        # s2n-bignum variant pinning is the sole size mechanism (and the only one
+        # once OPENSSL_SMALL also disables AVX-512 on x86_64), so it is covered on
+        # both compilers too. The aarch64 legs use GitHub-hosted Arm64 runners
+        # (available for public repos); swap `runner` for a CodeBuild Arm runner
+        # if preferred.
+        include:
+          - { name: "x86_64 gcc",    runner: ubuntu-latest,    cc: gcc,   cxx: g++ }
+          - { name: "x86_64 clang",  runner: ubuntu-latest,    cc: clang, cxx: clang++ }
+          - { name: "aarch64 gcc",   runner: ubuntu-24.04-arm, cc: gcc,   cxx: g++ }
+          - { name: "aarch64 clang", runner: ubuntu-24.04-arm, cc: clang, cxx: clang++ }
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
+          sudo apt-get -y --no-install-recommends install cmake ninja-build clang gcc g++
+          echo "CC=${{ matrix.cc }}" >> "$GITHUB_ENV"
+          echo "CXX=${{ matrix.cxx }}" >> "$GITHUB_ENV"
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.18'
+      - uses: actions/checkout@v6
+      - name: Build and run tests (OPENSSL_SMALL)
+        run: |
+          cmake -GNinja -B build-small -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=0 -DOPENSSL_SMALL=ON
+          cmake --build build-small --target all
+          cmake --build build-small --target run_tests

--- a/.github/workflows/openssl-small.yml
+++ b/.github/workflows/openssl-small.yml
@@ -18,9 +18,10 @@ concurrency:
 env:
   GOPROXY: https://proxy.golang.org,direct
   # Minimum static-link size reduction expected from OPENSSL_SMALL vs the
-  # default build, measured on the tests/binary-size consumer. Measured at ~25%
-  # on x86_64 Linux (higher once OPENSSL_SMALL also disables AVX-512); threshold
-  # set conservatively below that with margin for compiler/platform variance.
+  # default build, measured on the tests/binary-size consumer. Measured at ~37%
+  # on x86_64 Linux (with AVX-512 disabled via MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX);
+  # threshold set conservatively below that with margin for compiler/platform
+  # variance.
   EXPECTED_REDUCTION_PERCENT: 15
 permissions:
   contents: read
@@ -88,12 +89,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # x86_64 covers both compilers; aarch64 is the platform where Phase 2's
-        # s2n-bignum variant pinning is the sole size mechanism (and the only one
-        # once OPENSSL_SMALL also disables AVX-512 on x86_64), so it is covered on
-        # both compilers too. The aarch64 legs use GitHub-hosted Arm64 runners
-        # (available for public repos); swap `runner` for a CodeBuild Arm runner
-        # if preferred.
+        # x86_64 covers both compilers; aarch64 is the platform where the
+        # s2n-bignum variant pinning is the sole size mechanism (on x86_64,
+        # OPENSSL_SMALL disables s2n-bignum entirely via
+        # MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX), so it is covered on both compilers
+        # too.
         include:
           - { name: "x86_64 gcc",    runner: ubuntu-latest,    cc: gcc,   cxx: g++ }
           - { name: "x86_64 clang",  runner: ubuntu-latest,    cc: clang, cxx: clang++ }

--- a/.github/workflows/openssl-small.yml
+++ b/.github/workflows/openssl-small.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
 # Validates the OPENSSL_SMALL build: it must shrink a statically-linked
 # consumer binary and must still pass the full test suite.
 #
@@ -17,21 +20,30 @@ concurrency:
   cancel-in-progress: true
 env:
   GOPROXY: https://proxy.golang.org,direct
-  # Minimum static-link size reduction expected from OPENSSL_SMALL vs the
-  # default build, measured on the tests/binary-size consumer. Measured at ~37%
-  # on x86_64 Linux (with AVX-512 disabled via MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX);
-  # threshold set conservatively below that with margin for compiler/platform
-  # variance.
-  EXPECTED_REDUCTION_PERCENT: 15
 permissions:
   contents: read
 
 jobs:
   size-reduction:
     if: github.repository_owner == 'aws'
-    name: OPENSSL_SMALL size reduction (x86_64 Linux)
-    runs-on: ubuntu-latest
+    name: OPENSSL_SMALL size reduction (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        # Minimum static-link size reduction expected from OPENSSL_SMALL vs the
+        # default build, measured on the tests/binary-size consumer.
+        #
+        # - x86_64: measured at ~37% (s2n-bignum is disabled entirely via the
+        #   OPENSSL_SMALL -> MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX implication,
+        #   see #3319); threshold set conservatively below that.
+        # - aarch64: the reduction comes from dropping the unreachable EC
+        #   s2n-bignum objects (P-256/P-384/P-521, all variants) and the
+        #   curve25519 _alt variants; threshold not yet calibrated, set low.
+        include:
+          - { name: "x86_64 Linux",  runner: ubuntu-latest,    expected_reduction_percent: 15 }
+          - { name: "aarch64 Linux", runner: ubuntu-24.04-arm, expected_reduction_percent: 3 }
     steps:
       - name: Install dependencies
         run: |
@@ -51,6 +63,8 @@ jobs:
             -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=OFF -DOPENSSL_SMALL=ON
           cmake --build build-small --target crypto
       - name: Link consumer against each libcrypto and compare
+        env:
+          EXPECTED_REDUCTION_PERCENT: ${{ matrix.expected_reduction_percent }}
         run: |
           set -euo pipefail
           common="-O2 -I include -ffunction-sections -fdata-sections"
@@ -67,7 +81,7 @@ jobs:
           fi
           reduction=$(( (size_default - size_small) * 100 / size_default ))
           {
-            echo "## OPENSSL_SMALL static-link size"
+            echo "## OPENSSL_SMALL static-link size (${{ matrix.name }})"
             echo ""
             echo "| Build | Consumer binary |"
             echo "|-------|-----------------|"
@@ -90,8 +104,8 @@ jobs:
       fail-fast: false
       matrix:
         # x86_64 covers both compilers; aarch64 is the platform where the
-        # s2n-bignum variant pinning is the sole size mechanism (on x86_64,
-        # OPENSSL_SMALL disables s2n-bignum entirely via
+        # s2n-bignum removal and curve25519 variant pinning are the size
+        # mechanism (on x86_64, OPENSSL_SMALL disables s2n-bignum entirely via
         # MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX), so it is covered on both compilers
         # too.
         include:

--- a/.github/workflows/openssl-small.yml
+++ b/.github/workflows/openssl-small.yml
@@ -4,11 +4,12 @@
 # Validates the OPENSSL_SMALL build: it must shrink a statically-linked
 # consumer binary and must still pass the full test suite.
 #
-# The size-reduction job is intentionally advisory (continue-on-error) because
-# the exact reduction depends on platform/compiler and the threshold below has
-# not been finely calibrated yet. Once the observed numbers are stable, drop
-# `continue-on-error` and/or mark this job as a required check in branch
-# protection. The small-tests jobs are real correctness gates and should block.
+# The size-reduction job is intentionally advisory (continue-on-error). The
+# thresholds are calibrated from measured CI runs (see the matrix below), but
+# have not yet been observed across enough runs to trust as a blocking gate.
+# Once the numbers prove stable, drop `continue-on-error` and/or mark this job
+# as a required check in branch protection. The small-tests jobs are real
+# correctness gates and should block.
 name: OPENSSL_SMALL
 on:
   push:
@@ -33,17 +34,19 @@ jobs:
       fail-fast: false
       matrix:
         # Minimum static-link size reduction expected from OPENSSL_SMALL vs the
-        # default build, measured on the tests/binary-size consumer.
+        # default build, measured on the tests/binary-size consumer. Thresholds
+        # are set conservatively below the measured values (first CI runs of
+        # this workflow) to allow for compiler/runner variance:
         #
-        # - x86_64: measured at ~37% (s2n-bignum is disabled entirely via the
-        #   OPENSSL_SMALL -> MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX implication,
-        #   see #3319); threshold set conservatively below that.
-        # - aarch64: the reduction comes from dropping the unreachable EC
-        #   s2n-bignum objects (P-256/P-384/P-521, all variants) and the
-        #   curve25519 _alt variants; threshold not yet calibrated, set low.
+        # - x86_64: measured 55%. OPENSSL_SMALL disables s2n-bignum entirely
+        #   via the MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX implication (#3319).
+        # - aarch64: measured 31%. The default build links both variants of
+        #   every s2n-bignum EC operation (~500 KB), the nistz256 table
+        #   (~150 KB), and the P-384/P-521 implementations and tables; the
+        #   OPENSSL_SMALL build has none of these.
         include:
-          - { name: "x86_64 Linux",  runner: ubuntu-latest,    expected_reduction_percent: 15 }
-          - { name: "aarch64 Linux", runner: ubuntu-24.04-arm, expected_reduction_percent: 3 }
+          - { name: "x86_64 Linux",  runner: ubuntu-latest,    expected_reduction_percent: 40 }
+          - { name: "aarch64 Linux", runner: ubuntu-24.04-arm, expected_reduction_percent: 20 }
     steps:
       - name: Install dependencies
         run: |

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -326,10 +326,21 @@ if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) OR
     endif()
   endif()
 
-  # Under OPENSSL_SMALL on aarch64, pin each s2n-bignum operation to the
-  # non-_alt (generic) variant and drop the _alt (wide-multiplier) form to save
-  # binary size. This mirrors the compile-time pinning in
-  # third_party/s2n-bignum/s2n-bignum_aws-lc.h.
+  # Under OPENSSL_SMALL on aarch64, drop the s2n-bignum code that becomes
+  # unreachable:
+  #
+  # - All EC (P-256/P-384/P-521) files, both non-_alt and _alt variants and
+  #   their helpers: the EC implementations that call them (p256-nistz.c,
+  #   p384.c, p521.c) are compiled out entirely under OPENSSL_SMALL. ec.c
+  #   dispatches P-256 to the fiat-crypto implementation (p256.c) and
+  #   P-384/P-521 to the generic Montgomery method instead.
+  # - The curve25519 _alt (wide-multiplier) variants: curve25519 is the only
+  #   remaining s2n-bignum selector user under OPENSSL_SMALL, and it is pinned
+  #   to the non-_alt variant at compile time (see
+  #   third_party/s2n-bignum/s2n-bignum_aws-lc.h).
+  #
+  # The fastmul/generic files (used by RSA/BN Montgomery arithmetic) and the
+  # sha3 files (used by keccak1600.c) remain reachable and are kept.
   #
   # On x86_64, OPENSSL_SMALL implies MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX (see
   # #3319), which makes the enclosing condition false -- s2n-bignum is not
@@ -337,15 +348,39 @@ if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) OR
   if(OPENSSL_SMALL)
     if(ARCH STREQUAL "aarch64")
       list(REMOVE_ITEM BCM_ASM_SOURCES
+        ${S2N_BIGNUM_DIR}/p256/p256_montjscalarmul.S
         ${S2N_BIGNUM_DIR}/p256/p256_montjscalarmul_alt.S
+        ${S2N_BIGNUM_DIR}/p256/bignum_montinv_p256.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_add_p384.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_sub_p384.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_neg_p384.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_tomont_p384.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_deamont_p384.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_montmul_p384.S
         ${S2N_BIGNUM_DIR}/p384/bignum_montmul_p384_alt.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_montsqr_p384.S
         ${S2N_BIGNUM_DIR}/p384/bignum_montsqr_p384_alt.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_nonzero_6.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_littleendian_6.S
+        ${S2N_BIGNUM_DIR}/p384/p384_montjdouble.S
         ${S2N_BIGNUM_DIR}/p384/p384_montjdouble_alt.S
+        ${S2N_BIGNUM_DIR}/p384/p384_montjscalarmul.S
         ${S2N_BIGNUM_DIR}/p384/p384_montjscalarmul_alt.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_montinv_p384.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_add_p521.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_sub_p521.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_neg_p521.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_mul_p521.S
         ${S2N_BIGNUM_DIR}/p521/bignum_mul_p521_alt.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_sqr_p521.S
         ${S2N_BIGNUM_DIR}/p521/bignum_sqr_p521_alt.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_tolebytes_p521.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_fromlebytes_p521.S
+        ${S2N_BIGNUM_DIR}/p521/p521_jdouble.S
         ${S2N_BIGNUM_DIR}/p521/p521_jdouble_alt.S
+        ${S2N_BIGNUM_DIR}/p521/p521_jscalarmul.S
         ${S2N_BIGNUM_DIR}/p521/p521_jscalarmul_alt.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_inv_p521.S
         ${S2N_BIGNUM_DIR}/curve25519/bignum_madd_n25519_alt.S
         ${S2N_BIGNUM_DIR}/curve25519/edwards25519_decode_alt.S
         ${S2N_BIGNUM_DIR}/curve25519/edwards25519_scalarmulbase_alt.S

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -326,43 +326,16 @@ if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) OR
     endif()
   endif()
 
-  # Under OPENSSL_SMALL, pin each s2n-bignum operation to a single,
-  # universally-compatible variant and drop the other to save binary size. This
-  # mirrors the compile-time pinning in
-  # third_party/s2n-bignum/s2n-bignum_aws-lc.h:
-  #   - x86_64: keep _alt (generic, no BMI2/ADX); drop the primary.
-  #   - aarch64: keep non-_alt (generic); drop _alt (wide-multiplier).
-  # REMOVE_ITEM silently ignores entries that are not in the list, and the
-  # selectors reference only the kept symbols, so the dropped objects are
-  # unreferenced. The kept/dropped sets are the exact mirror of the selector
-  # pinning, which keeps this correct independent of whether OPENSSL_SMALL also
-  # implies MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX:
-  #   - With that implication in effect, the enclosing condition is false on
-  #     x86_64 (no s2n-bignum was appended), so the x86_64 branch is a no-op and
-  #     aarch64 is the sole beneficiary.
-  #   - Without it, the x86_64 branch is the operative path.
+  # Under OPENSSL_SMALL on aarch64, pin each s2n-bignum operation to the
+  # non-_alt (generic) variant and drop the _alt (wide-multiplier) form to save
+  # binary size. This mirrors the compile-time pinning in
+  # third_party/s2n-bignum/s2n-bignum_aws-lc.h.
+  #
+  # On x86_64, OPENSSL_SMALL implies MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX (see
+  # #3319), which makes the enclosing condition false -- s2n-bignum is not
+  # compiled at all, so no removal is needed.
   if(OPENSSL_SMALL)
-    if(ARCH STREQUAL "x86_64")
-      list(REMOVE_ITEM BCM_ASM_SOURCES
-        ${S2N_BIGNUM_DIR}/p256/p256_montjscalarmul.S
-        ${S2N_BIGNUM_DIR}/p384/bignum_montmul_p384.S
-        ${S2N_BIGNUM_DIR}/p384/bignum_montsqr_p384.S
-        ${S2N_BIGNUM_DIR}/p384/bignum_tomont_p384.S
-        ${S2N_BIGNUM_DIR}/p384/bignum_deamont_p384.S
-        ${S2N_BIGNUM_DIR}/p384/p384_montjdouble.S
-        ${S2N_BIGNUM_DIR}/p384/p384_montjscalarmul.S
-        ${S2N_BIGNUM_DIR}/p521/bignum_mul_p521.S
-        ${S2N_BIGNUM_DIR}/p521/bignum_sqr_p521.S
-        ${S2N_BIGNUM_DIR}/p521/p521_jdouble.S
-        ${S2N_BIGNUM_DIR}/p521/p521_jscalarmul.S
-        ${S2N_BIGNUM_DIR}/curve25519/bignum_madd_n25519.S
-        ${S2N_BIGNUM_DIR}/curve25519/edwards25519_decode.S
-        ${S2N_BIGNUM_DIR}/curve25519/edwards25519_scalarmulbase.S
-        ${S2N_BIGNUM_DIR}/curve25519/edwards25519_scalarmuldouble.S
-        ${S2N_BIGNUM_DIR}/curve25519/curve25519_x25519.S
-        ${S2N_BIGNUM_DIR}/curve25519/curve25519_x25519base.S
-      )
-    elseif(ARCH STREQUAL "aarch64")
+    if(ARCH STREQUAL "aarch64")
       list(REMOVE_ITEM BCM_ASM_SOURCES
         ${S2N_BIGNUM_DIR}/p256/p256_montjscalarmul_alt.S
         ${S2N_BIGNUM_DIR}/p384/bignum_montmul_p384_alt.S

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -326,6 +326,63 @@ if((((ARCH STREQUAL "x86_64") AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX) OR
     endif()
   endif()
 
+  # Under OPENSSL_SMALL, pin each s2n-bignum operation to a single,
+  # universally-compatible variant and drop the other to save binary size. This
+  # mirrors the compile-time pinning in
+  # third_party/s2n-bignum/s2n-bignum_aws-lc.h:
+  #   - x86_64: keep _alt (generic, no BMI2/ADX); drop the primary.
+  #   - aarch64: keep non-_alt (generic); drop _alt (wide-multiplier).
+  # REMOVE_ITEM silently ignores entries that are not in the list, and the
+  # selectors reference only the kept symbols, so the dropped objects are
+  # unreferenced. The kept/dropped sets are the exact mirror of the selector
+  # pinning, which keeps this correct independent of whether OPENSSL_SMALL also
+  # implies MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX:
+  #   - With that implication in effect, the enclosing condition is false on
+  #     x86_64 (no s2n-bignum was appended), so the x86_64 branch is a no-op and
+  #     aarch64 is the sole beneficiary.
+  #   - Without it, the x86_64 branch is the operative path.
+  if(OPENSSL_SMALL)
+    if(ARCH STREQUAL "x86_64")
+      list(REMOVE_ITEM BCM_ASM_SOURCES
+        ${S2N_BIGNUM_DIR}/p256/p256_montjscalarmul.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_montmul_p384.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_montsqr_p384.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_tomont_p384.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_deamont_p384.S
+        ${S2N_BIGNUM_DIR}/p384/p384_montjdouble.S
+        ${S2N_BIGNUM_DIR}/p384/p384_montjscalarmul.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_mul_p521.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_sqr_p521.S
+        ${S2N_BIGNUM_DIR}/p521/p521_jdouble.S
+        ${S2N_BIGNUM_DIR}/p521/p521_jscalarmul.S
+        ${S2N_BIGNUM_DIR}/curve25519/bignum_madd_n25519.S
+        ${S2N_BIGNUM_DIR}/curve25519/edwards25519_decode.S
+        ${S2N_BIGNUM_DIR}/curve25519/edwards25519_scalarmulbase.S
+        ${S2N_BIGNUM_DIR}/curve25519/edwards25519_scalarmuldouble.S
+        ${S2N_BIGNUM_DIR}/curve25519/curve25519_x25519.S
+        ${S2N_BIGNUM_DIR}/curve25519/curve25519_x25519base.S
+      )
+    elseif(ARCH STREQUAL "aarch64")
+      list(REMOVE_ITEM BCM_ASM_SOURCES
+        ${S2N_BIGNUM_DIR}/p256/p256_montjscalarmul_alt.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_montmul_p384_alt.S
+        ${S2N_BIGNUM_DIR}/p384/bignum_montsqr_p384_alt.S
+        ${S2N_BIGNUM_DIR}/p384/p384_montjdouble_alt.S
+        ${S2N_BIGNUM_DIR}/p384/p384_montjscalarmul_alt.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_mul_p521_alt.S
+        ${S2N_BIGNUM_DIR}/p521/bignum_sqr_p521_alt.S
+        ${S2N_BIGNUM_DIR}/p521/p521_jdouble_alt.S
+        ${S2N_BIGNUM_DIR}/p521/p521_jscalarmul_alt.S
+        ${S2N_BIGNUM_DIR}/curve25519/bignum_madd_n25519_alt.S
+        ${S2N_BIGNUM_DIR}/curve25519/edwards25519_decode_alt.S
+        ${S2N_BIGNUM_DIR}/curve25519/edwards25519_scalarmulbase_alt.S
+        ${S2N_BIGNUM_DIR}/curve25519/edwards25519_scalarmuldouble_alt.S
+        ${S2N_BIGNUM_DIR}/curve25519/curve25519_x25519_byte_alt.S
+        ${S2N_BIGNUM_DIR}/curve25519/curve25519_x25519base_byte_alt.S
+      )
+    endif()
+  endif()
+
 endif()
 
 # Include s2n-bignum files in Windows AArch64 which replace similar implementation that was available on Windows

--- a/tests/binary-size/main.c
+++ b/tests/binary-size/main.c
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+//
+// Minimal AWS-LC consumer used by the OPENSSL_SMALL binary-size CI check
+// (.github/workflows/openssl-small.yml). It links libcrypto statically and
+// exercises a representative TLS-ish crypto surface (SHA-256, AES-256-GCM,
+// ECDSA P-256, X25519, Ed25519) so the linker pulls in real code paths. The
+// workflow builds this twice -- against a default libcrypto and against one
+// built with OPENSSL_SMALL -- and compares the resulting binary sizes.
+//
+// It is intentionally small and standalone (compiled directly by the workflow,
+// not part of the main CMake build).
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/aead.h>
+#include <openssl/curve25519.h>
+#include <openssl/ec_key.h>
+#include <openssl/ecdsa.h>
+#include <openssl/nid.h>
+#include <openssl/sha.h>
+
+static int do_sha256(void) {
+  uint8_t in[64], out[SHA256_DIGEST_LENGTH];
+  memset(in, 7, sizeof(in));
+  return SHA256(in, sizeof(in), out) != NULL;
+}
+
+static int do_aes_256_gcm(void) {
+  uint8_t key[32] = {0}, nonce[12] = {0}, in[32] = {0}, out[64];
+  size_t out_len = 0;
+  EVP_AEAD_CTX *ctx = EVP_AEAD_CTX_new(EVP_aead_aes_256_gcm(), key, sizeof(key),
+                                       EVP_AEAD_DEFAULT_TAG_LENGTH);
+  if (ctx == NULL) {
+    return 0;
+  }
+  int ok = EVP_AEAD_CTX_seal(ctx, out, &out_len, sizeof(out), nonce,
+                             sizeof(nonce), in, sizeof(in), NULL, 0);
+  EVP_AEAD_CTX_free(ctx);
+  return ok && out_len > 0;
+}
+
+static int do_ecdsa_p256(void) {
+  EC_KEY *key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+  if (key == NULL) {
+    return 0;
+  }
+  uint8_t digest[32] = {1}, sig[256];
+  unsigned int sig_len = sizeof(sig);
+  int ok = EC_KEY_generate_key(key) &&
+           ECDSA_sign(0, digest, sizeof(digest), sig, &sig_len, key) &&
+           ECDSA_verify(0, digest, sizeof(digest), sig, sig_len, key);
+  EC_KEY_free(key);
+  return ok;
+}
+
+static int do_x25519(void) {
+  uint8_t our_public[32], our_private[32], peer_public[32] = {9}, shared[32];
+  X25519_keypair(our_public, our_private);
+  return X25519(shared, our_private, peer_public);
+}
+
+static int do_ed25519(void) {
+  uint8_t public_key[32], private_key[64], sig[64];
+  static const uint8_t msg[] = "aws-lc OPENSSL_SMALL binary-size check";
+  ED25519_keypair(public_key, private_key);
+  ED25519_sign(sig, msg, sizeof(msg), private_key);
+  return ED25519_verify(msg, sizeof(msg), sig, public_key);
+}
+
+int main(void) {
+  if (!do_sha256() || !do_aes_256_gcm() || !do_ecdsa_p256() || !do_x25519() ||
+      !do_ed25519()) {
+    fprintf(stderr, "crypto self-check failed\n");
+    return 1;
+  }
+  printf("ok\n");
+  return 0;
+}

--- a/tests/binary-size/main.c
+++ b/tests/binary-size/main.c
@@ -29,7 +29,8 @@ static int do_sha256(void) {
 }
 
 static int do_aes_256_gcm(void) {
-  uint8_t key[32] = {0}, nonce[12] = {0}, in[32] = {0}, out[64];
+  uint8_t key[32] = {0}, nonce[12] = {0}, in[32] = {0};
+  uint8_t out[sizeof(in) + EVP_AEAD_MAX_OVERHEAD];
   size_t out_len = 0;
   EVP_AEAD_CTX *ctx = EVP_AEAD_CTX_new(EVP_aead_aes_256_gcm(), key, sizeof(key),
                                        EVP_AEAD_DEFAULT_TAG_LENGTH);

--- a/third_party/s2n-bignum/s2n-bignum_aws-lc.h
+++ b/third_party/s2n-bignum/s2n-bignum_aws-lc.h
@@ -35,15 +35,13 @@
 // non-_alt version to run. By default this selection happens at runtime via
 // use_s2n_bignum_alt().
 //
-// Under OPENSSL_SMALL we instead pin each operation to a single,
+// Under OPENSSL_SMALL we instead pin each operation to the single,
 // universally-compatible variant at compile time and drop the other from the
 // build (see crypto/fipsmodule/CMakeLists.txt). This trades the
-// microarchitecture-specific fast path for a smaller binary:
-//
-//      - On x86_64 we pin to the "_alt" (generic, no BMI2/ADX) variant, which
-//        runs on every x86_64 CPU.
-//      - On aarch64 we pin to the non-"_alt" (generic) variant, which runs on
-//        every ARMv8 CPU.
+// microarchitecture-specific fast path for a smaller binary. On aarch64 we pin
+// to the non-"_alt" (generic) variant, which runs on every ARMv8 CPU. On
+// x86_64, OPENSSL_SMALL implies MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX which
+// disables s2n-bignum entirely, so this header is not reached (see #3319).
 
 #define S2NBIGNUM_KSQR_16_32_TEMP_NWORDS 24
 #define S2NBIGNUM_KMUL_16_32_TEMP_NWORDS 32
@@ -54,143 +52,78 @@
 
 // OPENSSL_SMALL: compile-time pinning to the universally-compatible variant.
 // The dropped variant's assembly is not compiled (see CMakeLists.txt), so each
-// selector must reference only the pinned symbol -- referencing the other would
-// produce an undefined symbol at link time.
+// selector must reference only the pinned symbol.
+//
+// Only aarch64 is handled here. On x86_64, OPENSSL_SMALL implies
+// MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX (see #3319), which prevents s2n-bignum
+// from being compiled at all -- so this code is unreachable on x86_64.
 
 static inline void p256_montjscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 12], const uint64_t scalar[S2N_BIGNUM_STATIC 4], uint64_t point[S2N_BIGNUM_STATIC 12]) {
-#if defined(OPENSSL_X86_64)
-  p256_montjscalarmul_alt(res, scalar, point);
-#else
   p256_montjscalarmul(res, scalar, point);
-#endif
 }
 
 static inline void bignum_deamont_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6]) {
-#if defined(OPENSSL_X86_64)
-  bignum_deamont_p384_alt(z, x);
-#else
   bignum_deamont_p384(z, x);
-#endif
 }
 
 static inline void bignum_montmul_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6], const uint64_t y[S2N_BIGNUM_STATIC 6]) {
-#if defined(OPENSSL_X86_64)
-  bignum_montmul_p384_alt(z, x, y);
-#else
   bignum_montmul_p384(z, x, y);
-#endif
 }
 
 static inline void bignum_montsqr_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6]) {
-#if defined(OPENSSL_X86_64)
-  bignum_montsqr_p384_alt(z, x);
-#else
   bignum_montsqr_p384(z, x);
-#endif
 }
 
 static inline void bignum_tomont_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6]) {
-#if defined(OPENSSL_X86_64)
-  bignum_tomont_p384_alt(z, x);
-#else
   bignum_tomont_p384(z, x);
-#endif
 }
 
 static inline void p384_montjdouble_selector(uint64_t p3[S2N_BIGNUM_STATIC 18],uint64_t p1[S2N_BIGNUM_STATIC 18]) {
-#if defined(OPENSSL_X86_64)
-  p384_montjdouble_alt(p3, p1);
-#else
   p384_montjdouble(p3, p1);
-#endif
 }
 
 static inline void p384_montjscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 18], const uint64_t scalar[S2N_BIGNUM_STATIC 6], uint64_t point[S2N_BIGNUM_STATIC 18]) {
-#if defined(OPENSSL_X86_64)
-  p384_montjscalarmul_alt(res, scalar, point);
-#else
   p384_montjscalarmul(res, scalar, point);
-#endif
 }
 
 static inline void bignum_mul_p521_selector(uint64_t z[S2N_BIGNUM_STATIC 9], const uint64_t x[S2N_BIGNUM_STATIC 9], const uint64_t y[S2N_BIGNUM_STATIC 9]) {
-#if defined(OPENSSL_X86_64)
-  bignum_mul_p521_alt(z, x, y);
-#else
   bignum_mul_p521(z, x, y);
-#endif
 }
 
 static inline void bignum_sqr_p521_selector(uint64_t z[S2N_BIGNUM_STATIC 9], const uint64_t x[S2N_BIGNUM_STATIC 9]) {
-#if defined(OPENSSL_X86_64)
-  bignum_sqr_p521_alt(z, x);
-#else
   bignum_sqr_p521(z, x);
-#endif
 }
 
 static inline void p521_jdouble_selector(uint64_t p3[S2N_BIGNUM_STATIC 27],uint64_t p1[S2N_BIGNUM_STATIC 27]) {
-#if defined(OPENSSL_X86_64)
-  p521_jdouble_alt(p3, p1);
-#else
   p521_jdouble(p3, p1);
-#endif
 }
 
 static inline void p521_jscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 27], const uint64_t scalar[S2N_BIGNUM_STATIC 9], const uint64_t point[S2N_BIGNUM_STATIC 27]) {
-#if defined(OPENSSL_X86_64)
-  p521_jscalarmul_alt(res, scalar, point);
-#else
   p521_jscalarmul(res, scalar, point);
-#endif
 }
 
 static inline void curve25519_x25519_byte_selector(uint8_t res[S2N_BIGNUM_STATIC 32], const uint8_t scalar[S2N_BIGNUM_STATIC 32], const uint8_t point[S2N_BIGNUM_STATIC 32]) {
-#if defined(OPENSSL_X86_64)
-  curve25519_x25519_byte_alt(res, scalar, point);
-#else
   curve25519_x25519_byte(res, scalar, point);
-#endif
 }
 
 static inline void curve25519_x25519base_byte_selector(uint8_t res[S2N_BIGNUM_STATIC 32], const uint8_t scalar[S2N_BIGNUM_STATIC 32]) {
-#if defined(OPENSSL_X86_64)
-  curve25519_x25519base_byte_alt(res, scalar);
-#else
   curve25519_x25519base_byte(res, scalar);
-#endif
 }
 
 static inline void bignum_madd_n25519_selector(uint64_t z[S2N_BIGNUM_STATIC 4], uint64_t x[S2N_BIGNUM_STATIC 4], uint64_t y[S2N_BIGNUM_STATIC 4], uint64_t c[S2N_BIGNUM_STATIC 4]) {
-#if defined(OPENSSL_X86_64)
-  bignum_madd_n25519_alt(z, x, y, c);
-#else
   bignum_madd_n25519(z, x, y, c);
-#endif
 }
 
 static inline uint64_t edwards25519_decode_selector(uint64_t z[S2N_BIGNUM_STATIC 8], const uint8_t c[S2N_BIGNUM_STATIC 32]) {
-#if defined(OPENSSL_X86_64)
-  return edwards25519_decode_alt(z, c);
-#else
   return edwards25519_decode(z, c);
-#endif
 }
 
 static inline void edwards25519_scalarmulbase_selector(uint64_t res[S2N_BIGNUM_STATIC 8], uint64_t scalar[S2N_BIGNUM_STATIC 4]) {
-#if defined(OPENSSL_X86_64)
-  edwards25519_scalarmulbase_alt(res, scalar);
-#else
   edwards25519_scalarmulbase(res, scalar);
-#endif
 }
 
 static inline void edwards25519_scalarmuldouble_selector(uint64_t res[S2N_BIGNUM_STATIC 8], uint64_t scalar[S2N_BIGNUM_STATIC 4], uint64_t point[S2N_BIGNUM_STATIC 8], uint64_t bscalar[S2N_BIGNUM_STATIC 4]) {
-#if defined(OPENSSL_X86_64)
-  edwards25519_scalarmuldouble_alt(res, scalar, point, bscalar);
-#else
   edwards25519_scalarmuldouble(res, scalar, point, bscalar);
-#endif
 }
 
 #else  // !OPENSSL_SMALL

--- a/third_party/s2n-bignum/s2n-bignum_aws-lc.h
+++ b/third_party/s2n-bignum/s2n-bignum_aws-lc.h
@@ -30,8 +30,170 @@
 //
 //      - On ARM, the "_alt" forms target machines with higher multiplier
 //        throughput, generally offering higher performance there.
-// For each of those, we define a _selector function that selects, in runtime,
-// the _alt or non-_alt version to run.
+//
+// For each of those, we define a _selector function that picks the _alt or
+// non-_alt version to run. By default this selection happens at runtime via
+// use_s2n_bignum_alt().
+//
+// Under OPENSSL_SMALL we instead pin each operation to a single,
+// universally-compatible variant at compile time and drop the other from the
+// build (see crypto/fipsmodule/CMakeLists.txt). This trades the
+// microarchitecture-specific fast path for a smaller binary:
+//
+//      - On x86_64 we pin to the "_alt" (generic, no BMI2/ADX) variant, which
+//        runs on every x86_64 CPU.
+//      - On aarch64 we pin to the non-"_alt" (generic) variant, which runs on
+//        every ARMv8 CPU.
+
+#define S2NBIGNUM_KSQR_16_32_TEMP_NWORDS 24
+#define S2NBIGNUM_KMUL_16_32_TEMP_NWORDS 32
+#define S2NBIGNUM_KSQR_32_64_TEMP_NWORDS 72
+#define S2NBIGNUM_KMUL_32_64_TEMP_NWORDS 96
+
+#if defined(OPENSSL_SMALL)
+
+// OPENSSL_SMALL: compile-time pinning to the universally-compatible variant.
+// The dropped variant's assembly is not compiled (see CMakeLists.txt), so each
+// selector must reference only the pinned symbol -- referencing the other would
+// produce an undefined symbol at link time.
+
+static inline void p256_montjscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 12], const uint64_t scalar[S2N_BIGNUM_STATIC 4], uint64_t point[S2N_BIGNUM_STATIC 12]) {
+#if defined(OPENSSL_X86_64)
+  p256_montjscalarmul_alt(res, scalar, point);
+#else
+  p256_montjscalarmul(res, scalar, point);
+#endif
+}
+
+static inline void bignum_deamont_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6]) {
+#if defined(OPENSSL_X86_64)
+  bignum_deamont_p384_alt(z, x);
+#else
+  bignum_deamont_p384(z, x);
+#endif
+}
+
+static inline void bignum_montmul_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6], const uint64_t y[S2N_BIGNUM_STATIC 6]) {
+#if defined(OPENSSL_X86_64)
+  bignum_montmul_p384_alt(z, x, y);
+#else
+  bignum_montmul_p384(z, x, y);
+#endif
+}
+
+static inline void bignum_montsqr_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6]) {
+#if defined(OPENSSL_X86_64)
+  bignum_montsqr_p384_alt(z, x);
+#else
+  bignum_montsqr_p384(z, x);
+#endif
+}
+
+static inline void bignum_tomont_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6]) {
+#if defined(OPENSSL_X86_64)
+  bignum_tomont_p384_alt(z, x);
+#else
+  bignum_tomont_p384(z, x);
+#endif
+}
+
+static inline void p384_montjdouble_selector(uint64_t p3[S2N_BIGNUM_STATIC 18],uint64_t p1[S2N_BIGNUM_STATIC 18]) {
+#if defined(OPENSSL_X86_64)
+  p384_montjdouble_alt(p3, p1);
+#else
+  p384_montjdouble(p3, p1);
+#endif
+}
+
+static inline void p384_montjscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 18], const uint64_t scalar[S2N_BIGNUM_STATIC 6], uint64_t point[S2N_BIGNUM_STATIC 18]) {
+#if defined(OPENSSL_X86_64)
+  p384_montjscalarmul_alt(res, scalar, point);
+#else
+  p384_montjscalarmul(res, scalar, point);
+#endif
+}
+
+static inline void bignum_mul_p521_selector(uint64_t z[S2N_BIGNUM_STATIC 9], const uint64_t x[S2N_BIGNUM_STATIC 9], const uint64_t y[S2N_BIGNUM_STATIC 9]) {
+#if defined(OPENSSL_X86_64)
+  bignum_mul_p521_alt(z, x, y);
+#else
+  bignum_mul_p521(z, x, y);
+#endif
+}
+
+static inline void bignum_sqr_p521_selector(uint64_t z[S2N_BIGNUM_STATIC 9], const uint64_t x[S2N_BIGNUM_STATIC 9]) {
+#if defined(OPENSSL_X86_64)
+  bignum_sqr_p521_alt(z, x);
+#else
+  bignum_sqr_p521(z, x);
+#endif
+}
+
+static inline void p521_jdouble_selector(uint64_t p3[S2N_BIGNUM_STATIC 27],uint64_t p1[S2N_BIGNUM_STATIC 27]) {
+#if defined(OPENSSL_X86_64)
+  p521_jdouble_alt(p3, p1);
+#else
+  p521_jdouble(p3, p1);
+#endif
+}
+
+static inline void p521_jscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 27], const uint64_t scalar[S2N_BIGNUM_STATIC 9], const uint64_t point[S2N_BIGNUM_STATIC 27]) {
+#if defined(OPENSSL_X86_64)
+  p521_jscalarmul_alt(res, scalar, point);
+#else
+  p521_jscalarmul(res, scalar, point);
+#endif
+}
+
+static inline void curve25519_x25519_byte_selector(uint8_t res[S2N_BIGNUM_STATIC 32], const uint8_t scalar[S2N_BIGNUM_STATIC 32], const uint8_t point[S2N_BIGNUM_STATIC 32]) {
+#if defined(OPENSSL_X86_64)
+  curve25519_x25519_byte_alt(res, scalar, point);
+#else
+  curve25519_x25519_byte(res, scalar, point);
+#endif
+}
+
+static inline void curve25519_x25519base_byte_selector(uint8_t res[S2N_BIGNUM_STATIC 32], const uint8_t scalar[S2N_BIGNUM_STATIC 32]) {
+#if defined(OPENSSL_X86_64)
+  curve25519_x25519base_byte_alt(res, scalar);
+#else
+  curve25519_x25519base_byte(res, scalar);
+#endif
+}
+
+static inline void bignum_madd_n25519_selector(uint64_t z[S2N_BIGNUM_STATIC 4], uint64_t x[S2N_BIGNUM_STATIC 4], uint64_t y[S2N_BIGNUM_STATIC 4], uint64_t c[S2N_BIGNUM_STATIC 4]) {
+#if defined(OPENSSL_X86_64)
+  bignum_madd_n25519_alt(z, x, y, c);
+#else
+  bignum_madd_n25519(z, x, y, c);
+#endif
+}
+
+static inline uint64_t edwards25519_decode_selector(uint64_t z[S2N_BIGNUM_STATIC 8], const uint8_t c[S2N_BIGNUM_STATIC 32]) {
+#if defined(OPENSSL_X86_64)
+  return edwards25519_decode_alt(z, c);
+#else
+  return edwards25519_decode(z, c);
+#endif
+}
+
+static inline void edwards25519_scalarmulbase_selector(uint64_t res[S2N_BIGNUM_STATIC 8], uint64_t scalar[S2N_BIGNUM_STATIC 4]) {
+#if defined(OPENSSL_X86_64)
+  edwards25519_scalarmulbase_alt(res, scalar);
+#else
+  edwards25519_scalarmulbase(res, scalar);
+#endif
+}
+
+static inline void edwards25519_scalarmuldouble_selector(uint64_t res[S2N_BIGNUM_STATIC 8], uint64_t scalar[S2N_BIGNUM_STATIC 4], uint64_t point[S2N_BIGNUM_STATIC 8], uint64_t bscalar[S2N_BIGNUM_STATIC 4]) {
+#if defined(OPENSSL_X86_64)
+  edwards25519_scalarmuldouble_alt(res, scalar, point, bscalar);
+#else
+  edwards25519_scalarmuldouble(res, scalar, point, bscalar);
+#endif
+}
+
+#else  // !OPENSSL_SMALL
 
 #if defined(OPENSSL_X86_64)
 // On x86_64 platforms s2n-bignum uses bmi2 and adx instruction sets
@@ -51,11 +213,6 @@ static inline uint8_t use_s2n_bignum_alt(void) {
   return CRYPTO_is_ARMv8_wide_multiplier_capable();
 }
 #endif
-
-#define S2NBIGNUM_KSQR_16_32_TEMP_NWORDS 24
-#define S2NBIGNUM_KMUL_16_32_TEMP_NWORDS 32
-#define S2NBIGNUM_KSQR_32_64_TEMP_NWORDS 72
-#define S2NBIGNUM_KMUL_32_64_TEMP_NWORDS 96
 
 static inline void p256_montjscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 12], const uint64_t scalar[S2N_BIGNUM_STATIC 4], uint64_t point[S2N_BIGNUM_STATIC 12]) {
   if (use_s2n_bignum_alt()) { p256_montjscalarmul_alt(res, scalar, point); }
@@ -141,5 +298,7 @@ static inline void edwards25519_scalarmuldouble_selector(uint64_t res[S2N_BIGNUM
   if (use_s2n_bignum_alt()) { edwards25519_scalarmuldouble_alt(res, scalar, point, bscalar); }
   else { edwards25519_scalarmuldouble(res, scalar, point, bscalar); }
 }
+
+#endif // OPENSSL_SMALL
 
 #endif // S2N_BIGNUM_AWS_LC_H

--- a/third_party/s2n-bignum/s2n-bignum_aws-lc.h
+++ b/third_party/s2n-bignum/s2n-bignum_aws-lc.h
@@ -42,6 +42,12 @@
 // to the non-"_alt" (generic) variant, which runs on every ARMv8 CPU. On
 // x86_64, OPENSSL_SMALL implies MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX which
 // disables s2n-bignum entirely, so this header is not reached (see #3319).
+//
+// Under OPENSSL_SMALL, only the curve25519 selectors are defined: the EC
+// implementations that use the P-256/P-384/P-521 selectors (p256-nistz.c,
+// p384.c, p521.c) are compiled out entirely in that configuration (ec.c
+// dispatches those curves to fiat-crypto / generic Montgomery instead), and
+// the corresponding s2n-bignum assembly is dropped from the build.
 
 #define S2NBIGNUM_KSQR_16_32_TEMP_NWORDS 24
 #define S2NBIGNUM_KMUL_16_32_TEMP_NWORDS 32
@@ -49,58 +55,6 @@
 #define S2NBIGNUM_KMUL_32_64_TEMP_NWORDS 96
 
 #if defined(OPENSSL_SMALL)
-
-// OPENSSL_SMALL: compile-time pinning to the universally-compatible variant.
-// The dropped variant's assembly is not compiled (see CMakeLists.txt), so each
-// selector must reference only the pinned symbol.
-//
-// Only aarch64 is handled here. On x86_64, OPENSSL_SMALL implies
-// MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX (see #3319), which prevents s2n-bignum
-// from being compiled at all -- so this code is unreachable on x86_64.
-
-static inline void p256_montjscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 12], const uint64_t scalar[S2N_BIGNUM_STATIC 4], uint64_t point[S2N_BIGNUM_STATIC 12]) {
-  p256_montjscalarmul(res, scalar, point);
-}
-
-static inline void bignum_deamont_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6]) {
-  bignum_deamont_p384(z, x);
-}
-
-static inline void bignum_montmul_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6], const uint64_t y[S2N_BIGNUM_STATIC 6]) {
-  bignum_montmul_p384(z, x, y);
-}
-
-static inline void bignum_montsqr_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6]) {
-  bignum_montsqr_p384(z, x);
-}
-
-static inline void bignum_tomont_p384_selector(uint64_t z[S2N_BIGNUM_STATIC 6], const uint64_t x[S2N_BIGNUM_STATIC 6]) {
-  bignum_tomont_p384(z, x);
-}
-
-static inline void p384_montjdouble_selector(uint64_t p3[S2N_BIGNUM_STATIC 18],uint64_t p1[S2N_BIGNUM_STATIC 18]) {
-  p384_montjdouble(p3, p1);
-}
-
-static inline void p384_montjscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 18], const uint64_t scalar[S2N_BIGNUM_STATIC 6], uint64_t point[S2N_BIGNUM_STATIC 18]) {
-  p384_montjscalarmul(res, scalar, point);
-}
-
-static inline void bignum_mul_p521_selector(uint64_t z[S2N_BIGNUM_STATIC 9], const uint64_t x[S2N_BIGNUM_STATIC 9], const uint64_t y[S2N_BIGNUM_STATIC 9]) {
-  bignum_mul_p521(z, x, y);
-}
-
-static inline void bignum_sqr_p521_selector(uint64_t z[S2N_BIGNUM_STATIC 9], const uint64_t x[S2N_BIGNUM_STATIC 9]) {
-  bignum_sqr_p521(z, x);
-}
-
-static inline void p521_jdouble_selector(uint64_t p3[S2N_BIGNUM_STATIC 27],uint64_t p1[S2N_BIGNUM_STATIC 27]) {
-  p521_jdouble(p3, p1);
-}
-
-static inline void p521_jscalarmul_selector(uint64_t res[S2N_BIGNUM_STATIC 27], const uint64_t scalar[S2N_BIGNUM_STATIC 9], const uint64_t point[S2N_BIGNUM_STATIC 27]) {
-  p521_jscalarmul(res, scalar, point);
-}
 
 static inline void curve25519_x25519_byte_selector(uint8_t res[S2N_BIGNUM_STATIC 32], const uint8_t scalar[S2N_BIGNUM_STATIC 32], const uint8_t point[S2N_BIGNUM_STATIC 32]) {
   curve25519_x25519_byte(res, scalar, point);


### PR DESCRIPTION
### Issues
Addresses: aws/aws-lc-rs#745, P353434599



### Description of changes:
Under `OPENSSL_SMALL` on aarch64, AWS-LC still compiles every s2n-bignum EC and curve25519 object even though most of them are unreachable in that configuration. This change drops the dead code and pins the rest:

- **EC (P-256/P-384/P-521):** all s2n-bignum objects (non-`_alt`, `_alt`, and helpers) are removed from the build. Their only callers (`p256-nistz.c`, `p384.c`, `p521.c`) are already compiled out under `OPENSSL_SMALL` -- `ec.c` dispatches P-256 to the fiat-crypto implementation and P-384/P-521 to the generic Montgomery method. Credit to @manastasova for spotting this; it roughly doubles the aarch64 savings vs. only dropping `_alt`.
- **curve25519 (X25519/Ed25519):** the only s2n-bignum consumer still live under `OPENSSL_SMALL`. Each operation is pinned at compile time to the universally-compatible non-`_alt` variant and the `_alt` (wide-multiplier) form is dropped from the build.

On x86_64, `OPENSSL_SMALL` implies `MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX` (#3319), which disables s2n-bignum entirely -- nothing to do there.

The non-`OPENSSL_SMALL` build is byte-for-byte unchanged. Only the AWS-LC-maintained selector header and CMakeLists are touched; no imported s2n-bignum files are modified, so this survives the next s2n-bignum import.

### Call-outs:
- Depends on #3319 landing first (see above).
- The only *runtime* behavior change is the curve25519 pinning: `OPENSSL_SMALL` aarch64 builds lose the `_alt` fast path on wide-multiplier cores (Graviton 3, Apple M-series). The EC removal is pure dead-code elimination -- it mainly shrinks shared-library builds, since static linking was already dropping those unreferenced objects at final link.
- P-384/P-521 performance under `OPENSSL_SMALL` is poor (generic Montgomery), but that is pre-existing dispatch behavior, not something this PR changes. Switching them to the existing fiat-crypto backend would recover most of it at some size cost; deferred to a possible follow-up PR.

### Testing:
New CI workflow (`.github/workflows/openssl-small.yml`) runs the full test suite under `OPENSSL_SMALL` on x86_64 and aarch64 with gcc and clang, and an advisory binary-size check on both architectures with per-platform thresholds (aarch64 threshold is uncalibrated until the first run). Locally validated on arm64 macOS: shared-library `OPENSSL_SMALL` build links cleanly (proving no removed object is still referenced), `nm` confirms no EC s2n-bignum or curve25519 `_alt` symbols remain, and the EC/ECDSA/ECDH/X25519/Ed25519 `crypto_test` suites pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
