### PR TITLE
ci: harden GitHub Actions workflows against script injection

### DIFF
--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -33,7 +33,7 @@ jobs:
           docker build -t abidiff .
       - name: Perform libcrypto ABI Diff
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff crypto
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" abidiff crypto
 
   libssl-incremental:
     if: github.repository_owner == 'aws'
@@ -54,7 +54,7 @@ jobs:
           docker build -t abidiff .
       - name: Perform libssl ABI Diff
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff ssl
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" abidiff ssl
 
   libcrypto-release:
     if: github.repository_owner == 'aws'
@@ -80,7 +80,7 @@ jobs:
           docker build -t abidiff .
       - name: Perform libcrypto ABI Diff against release
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff crypto
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" abidiff crypto
 
   libssl-release:
     if: github.repository_owner == 'aws'
@@ -107,4 +107,4 @@ jobs:
           docker build -t abidiff .
       - name: Perform libssl ABI Diff against release
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff ssl
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" abidiff ssl

--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -33,7 +33,7 @@ jobs:
           docker build -t abidiff .
       - name: Perform libcrypto ABI Diff
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff crypto
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" abidiff crypto
 
   libssl-incremental:
     if: github.repository_owner == 'aws'
@@ -54,7 +54,7 @@ jobs:
           docker build -t abidiff .
       - name: Perform libssl ABI Diff
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff ssl
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" abidiff ssl
 
   libcrypto-release:
     if: github.repository_owner == 'aws'
@@ -80,7 +80,7 @@ jobs:
           docker build -t abidiff .
       - name: Perform libcrypto ABI Diff against release
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff crypto
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" abidiff crypto
 
   libssl-release:
     if: github.repository_owner == 'aws'
@@ -107,18 +107,18 @@ jobs:
           docker build -t abidiff .
       - name: Perform libssl ABI Diff against release
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next abidiff ssl
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" abidiff ssl
 
   libcrypto-symbols-incremental:
     if: github.repository_owner == 'aws'
     name: libcrypto symbol check (incremental)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'push' && github.event.ref || github.event.pull_request.head.sha }}
           path: ${{ github.workspace }}/next
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           path: ${{ github.workspace }}/previous
@@ -128,18 +128,18 @@ jobs:
           docker build -t symbol_check .
       - name: Check libcrypto symbols
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next symbol_check crypto incremental
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" symbol_check crypto incremental
 
   libssl-symbols-incremental:
     if: github.repository_owner == 'aws'
     name: libssl symbol check (incremental)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'push' && github.event.ref || github.event.pull_request.head.sha }}
           path: ${{ github.workspace }}/next
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           path: ${{ github.workspace }}/previous
@@ -149,60 +149,60 @@ jobs:
           docker build -t symbol_check .
       - name: Check libssl symbols
         run: |
-          docker run -v ${{ github.workspace }}/previous:/previous -v ${{ github.workspace }}/next:/next symbol_check ssl incremental
+          docker run -v "${GITHUB_WORKSPACE}/previous:/previous" -v "${GITHUB_WORKSPACE}/next:/next" symbol_check ssl incremental
 
   libcrypto-symbols-baseline:
     if: github.repository_owner == 'aws'
     name: libcrypto symbol check (baseline)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build Docker Image
         working-directory: .github/docker_images/symbol_check
         run: |
           docker build -t symbol_check .
       - name: Check libcrypto symbols against baseline
         run: |
-          docker run -v ${{ github.workspace }}:/workspace symbol_check crypto baseline
+          docker run -v "${GITHUB_WORKSPACE}:/workspace" symbol_check crypto baseline
 
   libssl-symbols-baseline:
     if: github.repository_owner == 'aws'
     name: libssl symbol check (baseline)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build Docker Image
         working-directory: .github/docker_images/symbol_check
         run: |
           docker build -t symbol_check .
       - name: Check libssl symbols against baseline
         run: |
-          docker run -v ${{ github.workspace }}:/workspace symbol_check ssl baseline
+          docker run -v "${GITHUB_WORKSPACE}:/workspace" symbol_check ssl baseline
 
   libcrypto-symbols-mapcheck:
     if: github.repository_owner == 'aws'
     name: libcrypto version script drift check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build Docker Image
         working-directory: .github/docker_images/symbol_check
         run: |
           docker build -t symbol_check .
       - name: Check libcrypto version script is in sync with registry
         run: |
-          docker run -v ${{ github.workspace }}:/workspace symbol_check crypto mapcheck
+          docker run -v "${GITHUB_WORKSPACE}:/workspace" symbol_check crypto mapcheck
 
   libssl-symbols-mapcheck:
     if: github.repository_owner == 'aws'
     name: libssl version script drift check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build Docker Image
         working-directory: .github/docker_images/symbol_check
         run: |
           docker build -t symbol_check .
       - name: Check libssl version script is in sync with registry
         run: |
-          docker run -v ${{ github.workspace }}:/workspace symbol_check ssl mapcheck
+          docker run -v "${GITHUB_WORKSPACE}:/workspace" symbol_check ssl mapcheck

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -199,7 +199,10 @@ jobs:
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
       - name: Setup Build
-        run: cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=${{matrix.fips}} -DBUILD_SHARED_LIBS=${{matrix.shared}}
+        env:
+          MATRIX_FIPS: ${{ matrix.fips }}
+          MATRIX_SHARED: ${{ matrix.shared }}
+        run: cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS="${MATRIX_FIPS}" -DBUILD_SHARED_LIBS="${MATRIX_SHARED}"
       - name: Build Project
         run: cmake --build ./build --target all
       - name: Run tests
@@ -265,10 +268,12 @@ jobs:
         env:
           GTEST_TOTAL_SHARDS: ${{ matrix.config.total_shards }}
           GTEST_SHARD_INDEX: ${{ matrix.shard_index }}
+          MATRIX_SANITIZER: ${{ matrix.config.sanitizer }}
+          MATRIX_EXTRA_CMAKE_ARGS: ${{ matrix.config.extra_cmake_args }}
         run: |
-          ./util/build_and_test.sh --sanitizer ${{ matrix.config.sanitizer }} \
+          ./util/build_and_test.sh --sanitizer "${MATRIX_SANITIZER}" \
             --test crypto_test --build-target all_tests \
-            -DCMAKE_BUILD_TYPE=Release ${{ matrix.config.extra_cmake_args }}
+            -DCMAKE_BUILD_TYPE=Release ${MATRIX_EXTRA_CMAKE_ARGS}
       - name: Run ssl_test
         if: matrix.shard_index == 0
         run: ./build/ssl/ssl_test
@@ -334,8 +339,10 @@ jobs:
         run: |
           echo "CXXFLAGS=-Wno-stringop-overflow -Wno-array-bounds" >> $GITHUB_ENV
       - name: Setup ${{ (matrix.fips == 1 && 'FIPS') || 'non-FIPS' }} Build
+        env:
+          MATRIX_FIPS: ${{ matrix.fips }}
         run: |
-          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=${{matrix.fips}}
+          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS="${MATRIX_FIPS}"
       - name: Build Project
         run: cmake --build ./build --target all
       - name: Run tests
@@ -362,14 +369,18 @@ jobs:
         with:
           go-version: ">=1.18"
       - name: Install build dependencies
+        env:
+          MATRIX_CLANG_VERSION: ${{ matrix.clang_version }}
         run: |
           apt-get update
-          apt-get install -y build-essential cmake ninja-build clang-${{ matrix.clang_version }}
-          echo "CC=/usr/bin/clang-${{ matrix.clang_version }}" >> $GITHUB_ENV
-          echo "CXX=/usr/bin/clang++-${{ matrix.clang_version }}" >> $GITHUB_ENV
+          apt-get install -y build-essential cmake ninja-build "clang-${MATRIX_CLANG_VERSION}"
+          echo "CC=/usr/bin/clang-${MATRIX_CLANG_VERSION}" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++-${MATRIX_CLANG_VERSION}" >> $GITHUB_ENV
       - name: Setup ${{ (matrix.fips == 1 && 'FIPS') || 'non-FIPS' }} Build
+        env:
+          MATRIX_FIPS: ${{ matrix.fips }}
         run: |
-          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=${{matrix.fips}}
+          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS="${MATRIX_FIPS}"
       - name: Build Project
         run: cmake --build ./build --target all
       - name: Run tests
@@ -400,14 +411,18 @@ jobs:
         with:
           go-version: ">=1.18"
       - name: Install build dependencies
+        env:
+          MATRIX_CLANG_VERSION: ${{ matrix.clang_version }}
         run: |
           apt-get update
-          apt-get install -y build-essential cmake ninja-build clang-${{ matrix.clang_version }}
-          echo "CC=/usr/bin/clang-${{ matrix.clang_version }}" >> $GITHUB_ENV
-          echo "CXX=/usr/bin/clang++-${{ matrix.clang_version }}" >> $GITHUB_ENV
+          apt-get install -y build-essential cmake ninja-build "clang-${MATRIX_CLANG_VERSION}"
+          echo "CC=/usr/bin/clang-${MATRIX_CLANG_VERSION}" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++-${MATRIX_CLANG_VERSION}" >> $GITHUB_ENV
       - name: Setup ${{ (matrix.fips == 1 && 'FIPS') || 'non-FIPS' }} Build
+        env:
+          MATRIX_FIPS: ${{ matrix.fips }}
         run: |
-          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=${{matrix.fips}}
+          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS="${MATRIX_FIPS}"
       - name: Build Project
         run: cmake --build ./build --target all
       - name: Run tests
@@ -434,14 +449,18 @@ jobs:
         with:
           go-version: ">=1.18"
       - name: Install build dependencies
+        env:
+          MATRIX_CLANG_VERSION: ${{ matrix.clang_version }}
         run: |
           apt-get update
-          apt-get install -y build-essential cmake ninja-build clang-${{ matrix.clang_version }}
-          echo "CC=/usr/bin/clang-${{ matrix.clang_version }}" >> $GITHUB_ENV
-          echo "CXX=/usr/bin/clang++-${{ matrix.clang_version }}" >> $GITHUB_ENV
+          apt-get install -y build-essential cmake ninja-build "clang-${MATRIX_CLANG_VERSION}"
+          echo "CC=/usr/bin/clang-${MATRIX_CLANG_VERSION}" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++-${MATRIX_CLANG_VERSION}" >> $GITHUB_ENV
       - name: Setup ${{ (matrix.fips == 1 && 'FIPS') || 'non-FIPS' }} Build
+        env:
+          MATRIX_FIPS: ${{ matrix.fips }}
         run: |
-          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=${{matrix.fips}}
+          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS="${MATRIX_FIPS}"
       - name: Build Project
         run: cmake --build ./build --target all
       - name: Run tests
@@ -468,14 +487,18 @@ jobs:
         with:
           go-version: ">=1.18"
       - name: Install build dependencies
+        env:
+          MATRIX_CLANG_VERSION: ${{ matrix.clang_version }}
         run: |
           apt-get update
-          apt-get install -y build-essential cmake ninja-build clang-${{ matrix.clang_version }}
-          echo "CC=/usr/bin/clang-${{ matrix.clang_version }}" >> $GITHUB_ENV
-          echo "CXX=/usr/bin/clang++-${{ matrix.clang_version }}" >> $GITHUB_ENV
+          apt-get install -y build-essential cmake ninja-build "clang-${MATRIX_CLANG_VERSION}"
+          echo "CC=/usr/bin/clang-${MATRIX_CLANG_VERSION}" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++-${MATRIX_CLANG_VERSION}" >> $GITHUB_ENV
       - name: Setup ${{ (matrix.fips == 1 && 'FIPS') || 'non-FIPS' }} Build
+        env:
+          MATRIX_FIPS: ${{ matrix.fips }}
         run: |
-          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS=${{matrix.fips}}
+          cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=Release -DFIPS="${MATRIX_FIPS}"
       - name: Build Project
         run: cmake --build ./build --target all
       - name: Run tests
@@ -575,7 +598,7 @@ jobs:
           docker build -t "gcc-4.8"  .
       - name: Build using pre-generated assembly
         run: |
-          docker run -v "${{ github.workspace }}:/awslc" "gcc-4.8"
+          docker run -v "${GITHUB_WORKSPACE}:/awslc" "gcc-4.8"
 
   alpine-linux-x86:
     needs: [sanity-test-run]
@@ -599,12 +622,16 @@ jobs:
       - uses: actions/checkout@v7
       - name: Build Docker Image
         working-directory: .github/docker_images/alpine-linux
+        env:
+          MATRIX_COMPILER: ${{ matrix.compiler }}
         run: |
-          docker build -t alpine_linux ${{ matrix.compiler }} .
+          docker build -t alpine_linux ${MATRIX_COMPILER} .
       - name: Run tests
+        env:
+          MATRIX_TESTS: ${{ matrix.tests }}
         run: |
-          docker run -v "${{ github.workspace }}:/awslc" \
-          alpine_linux ${{ matrix.tests }}
+          docker run -v "${GITHUB_WORKSPACE}:/awslc" \
+          alpine_linux "${MATRIX_TESTS}"
 
     # TODO: Investigate sudden hanging tests and failures in GHA runners (P114059413)
   #  MSVC-SDE-32-bit:

--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -45,13 +45,17 @@ jobs:
 
     - if: ${{ github.event.pull_request != null }}
       name: Check PR description
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         # License statement we want present.
         LICENSE_STATEMENT="By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license."
 
         # Fetches the PR description.
-        PR_DESCRIPTION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r .body)
+        PR_DESCRIPTION=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
+          "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}" | jq -r .body)
 
         printf "PR description:\n%s" "${PR_DESCRIPTION}"
         echo ""


### PR DESCRIPTION
### Issues:
Addresses V2265233159

### Description of changes:
Several workflows interpolate GitHub Actions context expressions (`${{ ... }}`) directly into `run:` shell bodies, where Actions splices them in as text before the shell runs — a script-injection risk. This PR hoists each into the step's `env:` block and references it as a shell variable instead. Behavior is unchanged.

- `misc-tests.yml` (`Check PR description`): hoist `secrets.GITHUB_TOKEN`, `github.repository`, `github.event.pull_request.number` into `env`. This is the step the scanner flagged.
- `actions-ci.yml`, `abidiff.yml`: hoist `matrix.*` values into `env` and replace `${{ github.workspace }}` in `docker run` with the equivalent runner-provided `${GITHUB_WORKSPACE}`.

### Call-outs:
- `misc-tests.yml` is the only flagged step (it consumes external PR input); the rest is defense-in-depth on trusted sources.
- `matrix.config.extra_cmake_args` and `matrix.compiler` are referenced **unquoted** on purpose — they expand to multiple shell words, so quoting would break the build.

### Testing:
CI-config-only, no product code impact. All three files parse as valid YAML; the steps run on push/PR and are exercised by this branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
