### PR TITLE
Fix libgit2, xtrabackup, grpc tests and add OSSL3 peer cert APIs

### DIFF
--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -340,14 +340,24 @@ jobs:
             compiler: gcc-12
             run: ./tests/ci/integration/run_libwebsockets_integration.sh
 
-          # GRPC Integration Tests
+          # GRPC Integration Tests (pinned release - blocking)
           - name: grpc
             arch: x86_64
             size: 2xlarge
             image: ubuntu:22.04
             compiler: gcc-12
             ipv6: true
-            run: ./tests/ci/integration/run_grpc_integration.sh
+            allow_failure: false
+            run: ./tests/ci/integration/run_grpc_integration.sh v1.72.2
+          # GRPC (tracking upstream master - informational, allowed to fail)
+          - name: grpc-master
+            arch: x86_64
+            size: 2xlarge
+            image: ubuntu:22.04
+            compiler: gcc-12
+            ipv6: true
+            allow_failure: true
+            run: ./tests/ci/integration/run_grpc_integration.sh master
 
           # Bind9 Integration Tests
           - name: bind9

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1810,9 +1810,20 @@ OPENSSL_EXPORT int SSL_in_init(const SSL *ssl);
 // See also |SSL_MODE_ENABLE_FALSE_START|.
 OPENSSL_EXPORT int SSL_in_false_start(const SSL *ssl);
 
-// SSL_get_peer_certificate returns the peer's leaf certificate or NULL if the
+// SSL_get0_peer_certificate returns the peer's leaf certificate or NULL if the
+// peer did not use certificates. The caller does not own the result and must
+// not call |X509_free| on it. The returned certificate is valid for as long as
+// the associated |SSL_SESSION| is.
+OPENSSL_EXPORT X509 *SSL_get0_peer_certificate(const SSL *ssl);
+
+// SSL_get1_peer_certificate returns the peer's leaf certificate or NULL if the
 // peer did not use certificates. The caller must call |X509_free| on the
 // result to release it.
+OPENSSL_EXPORT X509 *SSL_get1_peer_certificate(const SSL *ssl);
+
+// SSL_get_peer_certificate returns the peer's leaf certificate or NULL if the
+// peer did not use certificates. The caller must call |X509_free| on the
+// result to release it. This is an alias for |SSL_get1_peer_certificate|.
 OPENSSL_EXPORT X509 *SSL_get_peer_certificate(const SSL *ssl);
 
 // SSL_get_peer_cert_chain returns the peer's certificate chain or NULL if

--- a/ssl/ssl_version_test.cc
+++ b/ssl/ssl_version_test.cc
@@ -369,6 +369,20 @@ TEST_P(SSLVersionTest, GetPeerCertificate) {
   ASSERT_TRUE(peer);
   ASSERT_EQ(X509_cmp(cert_.get(), peer.get()), 0);
 
+  // |SSL_get0_peer_certificate| returns the same certificate without taking a
+  // reference (the caller must not free it).
+  X509 *peer0 = SSL_get0_peer_certificate(client_.get());
+  ASSERT_TRUE(peer0);
+  ASSERT_EQ(X509_cmp(cert_.get(), peer0), 0);
+  // Calling it again returns the same object, confirming no ownership transfer.
+  ASSERT_EQ(peer0, SSL_get0_peer_certificate(client_.get()));
+
+  // |SSL_get1_peer_certificate| returns the same certificate and takes a
+  // reference the caller must release.
+  bssl::UniquePtr<X509> peer1(SSL_get1_peer_certificate(client_.get()));
+  ASSERT_TRUE(peer1);
+  ASSERT_EQ(peer0, peer1.get());
+
   // However, for historical reasons, the X509 chain includes the leaf on the
   // client, but does not on the server.
   EXPECT_EQ(sk_X509_num(SSL_get_peer_cert_chain(client_.get())), 1u);
@@ -390,6 +404,8 @@ TEST_P(SSLVersionTest, NoPeerCertificate) {
   // Server should not see a peer certificate.
   bssl::UniquePtr<X509> peer(SSL_get_peer_certificate(server_.get()));
   ASSERT_FALSE(peer);
+  ASSERT_FALSE(SSL_get0_peer_certificate(server_.get()));
+  ASSERT_FALSE(SSL_get1_peer_certificate(server_.get()));
   ASSERT_FALSE(SSL_get0_peer_certificates(server_.get()));
 }
 

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -434,17 +434,28 @@ BSSL_NAMESPACE_END
 
 using namespace bssl;
 
-X509 *SSL_get_peer_certificate(const SSL *ssl) {
+X509 *SSL_get0_peer_certificate(const SSL *ssl) {
   check_ssl_x509_method(ssl);
   if (ssl == NULL) {
     return NULL;
   }
   SSL_SESSION *session = SSL_get_session(ssl);
-  if (session == NULL || session->x509_peer == NULL) {
+  if (session == NULL) {
     return NULL;
   }
-  X509_up_ref(session->x509_peer);
   return session->x509_peer;
+}
+
+X509 *SSL_get1_peer_certificate(const SSL *ssl) {
+  X509 *cert = SSL_get0_peer_certificate(ssl);
+  if (cert != NULL) {
+    X509_up_ref(cert);
+  }
+  return cert;
+}
+
+X509 *SSL_get_peer_certificate(const SSL *ssl) {
+  return SSL_get1_peer_certificate(ssl);
 }
 
 STACK_OF(X509) *SSL_get_peer_cert_chain(const SSL *ssl) {

--- a/tests/ci/integration/run_grpc_integration.sh
+++ b/tests/ci/integration/run_grpc_integration.sh
@@ -6,6 +6,11 @@ set -exu
 
 source tests/ci/common_posix_setup.sh
 
+# Optional first argument: grpc git ref (release tag, branch, or commit SHA).
+# Defaults to a pinned stable release so per-PR CI has a stable signal; the
+# nightly build passes 'master' to track upstream (informational).
+GRPC_REF="${1:-v1.72.2}"
+
 # SYS_ROOT
 #  |
 #  - SRC_ROOT(aws-lc)
@@ -29,7 +34,7 @@ rm -rf ${SCRATCH_FOLDER}/*
 cd ${SCRATCH_FOLDER}
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 
-git clone --depth 1 https://github.com/grpc/grpc.git ${GRPC_SRC_FOLDER}
+git clone --depth 1 --branch "${GRPC_REF}" https://github.com/grpc/grpc.git ${GRPC_SRC_FOLDER}
 cd ${GRPC_SRC_FOLDER}
 git submodule update --recursive --init
 

--- a/tests/ci/integration/run_libgit2_integration.sh
+++ b/tests/ci/integration/run_libgit2_integration.sh
@@ -76,10 +76,20 @@ function libgit2_run_tests() {
   #                        still covered by online::clone::certificate_invalid).
   #   online::customcert - clones test.libgit2.org with no timeout, and that host
   #                        is unreachable from our CI and dev networks, so it hangs.
+  # The bitbucket-specific clone tests clone
+  # bitbucket.org/libgit2-test/testgitrepository.git, which Bitbucket has
+  # removed (the endpoint now returns HTTP 410 Gone). These are dead upstream
+  # fixtures unrelated to AWS-LC, so exclude them individually:
+  #   online::clone::credentials_via_custom_headers
+  #   online::clone::bitbucket_style
+  #   online::clone::bitbucket_uses_creds_in_url
   # 'timeout' is a backstop so a future unresponsive endpoint fails fast instead
   # of hanging indefinitely.
   timeout --kill-after=60s 1200s \
-    "${LIBGIT2_BUILD_FOLDER}/libgit2_tests" -v -sonline -xonline::customcert -xonline::badssl
+    "${LIBGIT2_BUILD_FOLDER}/libgit2_tests" -v -sonline -xonline::customcert -xonline::badssl \
+      -xonline::clone::credentials_via_custom_headers \
+      -xonline::clone::bitbucket_style \
+      -xonline::clone::bitbucket_uses_creds_in_url
 }
 
 # Fetch the requested libgit2 ref (tag, branch, or commit).


### PR DESCRIPTION
## Summary

Fixes the four failing jobs in the `integration-omnibus` workflow on `main` (`libgit2-x86_64`, `libgit2-main-x86_64`, `xtrabackup-x86_64`, `grpc-x86_64`). Each is a distinct root cause.

### libgit2 — dead upstream test fixture
Three `online::clone` tests clone `bitbucket.org/libgit2-test/testgitrepository.git`, which Bitbucket has removed (now returns HTTP 410 Gone). This dead fixture is unrelated to AWS-LC but fails both the pinned (`v1.9.4`) and `main` libgit2 jobs. Exclude the three affected tests individually, alongside the existing `online::customcert` / `online::badssl` exclusions.

### xtrabackup — missing OpenSSL-compat API
percona-xtrabackup's `NetClientOpenSSL.cpp` calls `SSL_get0_peer_certificate`, which AWS-LC did not provide (only `SSL_get_peer_certificate` and the plural `SSL_get0_peer_certificates`), causing a compile error. Add the OpenSSL 3.0 API:
- `SSL_get0_peer_certificate` — borrowed reference (no refcount bump, caller must not free)
- `SSL_get1_peer_certificate` — owned reference (caller frees)
- `SSL_get_peer_certificate` — now an alias for the `get1` variant (semantics unchanged)

Extends `SSLVersionTest` to cover the reference semantics of both new getters.

### grpc — unpinned upstream drift
The grpc integration test cloned grpc at HEAD, so grpc-master changes could block unrelated AWS-LC PRs. A newly added grpc test, `CertSelectionOffloadTest.SyncCertSelectionWithStaticKeySucceeds` (absent at v1.72.2), started failing with a `PEM NO_START_LINE` error. Following the existing `libgit2` / `openssh-master` convention:
- `run_grpc_integration.sh` now takes an optional grpc ref (default `v1.72.2`), cloned via `--branch`.
- The blocking `grpc` job pins `v1.72.2`; a new informational `grpc-master` job (`allow_failure: true`) tracks upstream master so drift is visible without blocking PRs.

## Testing

- `SSL_get0_peer_certificate` / `SSL_get1_peer_certificate`: built and ran `ssl_test` locally (amazonlinux:2023 / clang) — all `SSLVersionTest` cases pass.
- Verified the failing grpc test file does not exist at the pinned `v1.72.2` tag (it is a grpc-master addition), and that the pinned `--branch v1.72.2` clone works.
- libgit2 change is an exclusion-only test-runner change.
- Full end-to-end integration builds (grpc/xtrabackup) rely on CI to confirm.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.