### PR TITLE
Null-guard EVP_AEAD_CTX_cleanup for fork+shm safety

### DIFF
--- a/crypto/fipsmodule/cipher/aead.c
+++ b/crypto/fipsmodule/cipher/aead.c
@@ -95,7 +95,9 @@ void EVP_AEAD_CTX_cleanup(EVP_AEAD_CTX *ctx) {
   if (ctx->aead == NULL) {
     return;
   }
-  ctx->aead->cleanup(ctx);
+  if (ctx->aead->cleanup != NULL) {
+    ctx->aead->cleanup(ctx);
+  }
   ctx->aead = NULL;
 }
 


### PR DESCRIPTION
### Issues: AWS-LC-1117

When a process forks and uses shared memory for TLS connection state, the parent's AEAD vtable may be uninitialized (all zeros in `.bss`) because `CRYPTO_once` was only triggered in the child. `EVP_AEAD_CTX_cleanup` then dereferences a NULL `cleanup` function pointer, causing a SIGSEGV.

### Description of changes:

Add a null-check on `ctx->aead->cleanup` before calling it in `EVP_AEAD_CTX_cleanup`. This is safe because all GCM cleanup functions are no-ops, and in the cross-process cleanup case skipping is the correct behavior.

### Call-outs:

None.

### Testing:

Existing AEAD tests continue to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.