### PR TITLE
Symbol versioning follow-ups: register peer cert APIs, fix dist_pkg_tests matrix

### DIFF
--- a/.github/workflows/linux-multi-arch-omnibus.yml
+++ b/.github/workflows/linux-multi-arch-omnibus.yml
@@ -394,12 +394,8 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - uses: ./.github/actions/codebuild-docker-run
         name: Run Container (${{ matrix.image }})
-        env:
-          AWSLC_32BIT: ${{ matrix.build32 || 0 }}
         with:
           image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/${{ matrix.image }}
-          env: |
-            AWSLC_32BIT
           run: |
             source /opt/compiler-env/setup-${{ matrix.compiler }}.sh
             ./tests/ci/run_dist_pkg_${{ matrix.test }}_tests.sh

--- a/.github/workflows/linux-multi-arch-omnibus.yml
+++ b/.github/workflows/linux-multi-arch-omnibus.yml
@@ -381,52 +381,12 @@ jobs:
         instance-size:large
     strategy:
       fail-fast: false
+      # AmazonLinux 2023 only, latest gcc and clang, across x86_64 and aarch64.
       matrix:
-        test:
-          - install
-          - run
-        include:
-          # Ubuntu 24.04
-          - image: ubuntu:24.04
-            arch: x86_64
-            compiler: gcc-14
-          - image: ubuntu:24.04
-            arch: x86_64
-            compiler: clang-19
-          - image: ubuntu:24.04
-            arch: aarch64
-            compiler: gcc-14
-          - image: ubuntu:24.04
-            arch: aarch64
-            compiler: clang-19
-
-          # AmazonLinux 2
-          - image: amazonlinux:2
-            arch: x86_64
-            compiler: gcc-7
-          - image: amazonlinux:2
-            arch: x86_64
-            compiler: clang-11
-          - image: amazonlinux:2
-            arch: aarch64
-            compiler: gcc-7
-          - image: amazonlinux:2
-            arch: aarch64
-            compiler: clang-11
-
-          # AmazonLinux 2023
-          - image: amazonlinux:2023
-            arch: x86_64
-            compiler: gcc-11
-          - image: amazonlinux:2023
-            arch: x86_64
-            compiler: clang-15
-          - image: amazonlinux:2023
-            arch: aarch64
-            compiler: gcc-11
-          - image: amazonlinux:2023
-            arch: aarch64
-            compiler: clang-15
+        test: [install, run]
+        arch: [x86_64, aarch64]
+        compiler: [gcc-11, clang-15]
+        image: ["amazonlinux:2023"]
     steps:
       - uses: actions/checkout@v7
       - name: Login to Amazon ECR

--- a/ssl/libssl.map
+++ b/ssl/libssl.map
@@ -338,6 +338,7 @@ AWS_LC_1.0 {
     SSL_get0_ocsp_response;
     SSL_get0_param;
     SSL_get0_peer_application_settings;
+    SSL_get0_peer_certificate;
     SSL_get0_peer_certificates;
     SSL_get0_peer_delegation_algorithms;
     SSL_get0_peer_verify_algorithms;
@@ -346,6 +347,7 @@ AWS_LC_1.0 {
     SSL_get0_session_id_context;
     SSL_get0_signed_cert_timestamp_list;
     SSL_get0_verified_chain;
+    SSL_get1_peer_certificate;
     SSL_get1_session;
     SSL_get_SSL_CTX;
     SSL_get_all_cipher_names;

--- a/ssl/libssl.txt
+++ b/ssl/libssl.txt
@@ -331,6 +331,7 @@ SSL_get0_next_proto_negotiated AWS_LC_1.0 PUBLIC
 SSL_get0_ocsp_response AWS_LC_1.0 PUBLIC
 SSL_get0_param AWS_LC_1.0 PUBLIC
 SSL_get0_peer_application_settings AWS_LC_1.0 PUBLIC
+SSL_get0_peer_certificate AWS_LC_1.0 PUBLIC
 SSL_get0_peer_certificates AWS_LC_1.0 PUBLIC
 SSL_get0_peer_delegation_algorithms AWS_LC_1.0 PUBLIC
 SSL_get0_peer_verify_algorithms AWS_LC_1.0 PUBLIC
@@ -339,6 +340,7 @@ SSL_get0_server_requested_CAs AWS_LC_1.0 PUBLIC
 SSL_get0_session_id_context AWS_LC_1.0 PUBLIC
 SSL_get0_signed_cert_timestamp_list AWS_LC_1.0 PUBLIC
 SSL_get0_verified_chain AWS_LC_1.0 PUBLIC
+SSL_get1_peer_certificate AWS_LC_1.0 PUBLIC
 SSL_get1_session AWS_LC_1.0 PUBLIC
 SSL_get_SSL_CTX AWS_LC_1.0 PUBLIC
 SSL_get_all_cipher_names AWS_LC_1.0 PUBLIC

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -54,7 +54,7 @@ function run_build {
   mkdir -p "$BUILD_ROOT"
   cd "$BUILD_ROOT" || exit 1
 
-  if [[ "${AWSLC_32BIT}" == "1" ]]; then
+  if [[ "${AWSLC_32BIT:-0}" == "1" ]]; then
     cflags+=("-DCMAKE_TOOLCHAIN_FILE=${SRC_ROOT}/util/32-bit-toolchain.cmake")
   fi
 


### PR DESCRIPTION
### Description

Follow-ups to #3096 (Add Symbol Versioning Support), addressing a CI failure and a matrix bug it surfaced.

**1. Register `SSL_get0_peer_certificate` / `SSL_get1_peer_certificate` in the libssl symbol registry**

Both are public `OPENSSL_EXPORT` APIs (`include/openssl/ssl.h`) added in #3331, which merged *before* symbol versioning landed, so they were never captured in the initial registry. In the versioned shared build they were hidden by `local: *;`, which the dist-pkg symbol version test flagged as silently dropped exported symbols.

**2. Fix `dist_pkg_tests` matrix to parameterize over arch and compiler**

The `dist_pkg_tests` matrix had a single real axis (`test: [install, run]`) plus a list of `include` entries that all shared the same keys (`image`/`arch`/`compiler`). Per GitHub Actions matrix semantics, such include entries with identical added keys collapse onto the base combinations and only the last survives — so the job effectively only parameterized over install/run, always using one image/arch/compiler.

Replaced the include list with real cross-multiplying axes scoped to AmazonLinux 2023 with the latest gcc (11) and clang (15) across x86_64 and aarch64. This drops the Ubuntu 24.04 and Amazon Linux 2 dimensions and yields 8 well-defined jobs (test × arch × compiler).

**3. Drop dead `AWSLC_32BIT` plumbing**

The `dist_pkg_tests` matrix no longer has a `build32` dimension, so `matrix.build32` was always empty and `AWSLC_32BIT` always resolved to `0`. Removed the now-inert env passthrough.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.