### PR TITLE
Pin required libssh2 integration to a release; track main separately

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -22,6 +22,11 @@ jobs:
           sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
           sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
       - uses: actions/checkout@v7
+      # Pinned to a libssh2 release for a stable required check. If you bump
+      # this version, revisit the openssh_server Dockerfile patch in
+      # run_libssh2_integration.sh: the patch is keyed to the floating
+      # `debian:testing-slim` base image used by current releases and may be a
+      # no-op (or need updating) for a different release's test fixture.
       - name: Run libssh2 integration tests
         run: |
           ./tests/ci/integration/run_libssh2_integration.sh 'libssh2-1.11.1'

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -24,6 +24,22 @@ jobs:
       - uses: actions/checkout@v7
       - name: Run libssh2 integration tests
         run: |
+          ./tests/ci/integration/run_libssh2_integration.sh 'libssh2-1.11.1'
+  # Tracks libssh2 main to catch upstream breakages early. Non-blocking: main
+  # can break against AWS-LC for reasons outside our control (e.g. upstream
+  # -Werror changes), so this job is allowed to fail without failing CI.
+  libssh2-main:
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Install OS Dependencies
+        run: |
+          sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
+          sudo apt-get -y --no-install-recommends install cmake gcc ninja-build golang make
+      - uses: actions/checkout@v7
+      - name: Run libssh2 integration tests (main)
+        run: |
           ./tests/ci/integration/run_libssh2_integration.sh
   libevent:
     if: github.repository_owner == 'aws'

--- a/tests/ci/integration/run_libssh2_integration.sh
+++ b/tests/ci/integration/run_libssh2_integration.sh
@@ -60,6 +60,8 @@ fi
 # Older libssh2 releases use a floating debian:testing-slim base image in the
 # openssh_server test fixture, which no longer ships the `adduser` package.
 # Patch the Dockerfile to install it explicitly so ctest can build the fixture.
+# NOTE: this patch is keyed to the release pinned in
+# .github/workflows/integrations.yml; revisit it if that pin changes.
 OPENSSH_DOCKERFILE="${LIBSSH2_SRC_FOLDER}/tests/openssh_server/Dockerfile"
 if grep -q "debian:testing-slim" "${OPENSSH_DOCKERFILE}" 2>/dev/null; then
   sed -i 's/install -y openssh-server/install -y openssh-server adduser/' "${OPENSSH_DOCKERFILE}"

--- a/tests/ci/integration/run_libssh2_integration.sh
+++ b/tests/ci/integration/run_libssh2_integration.sh
@@ -6,6 +6,10 @@ set -exu
 
 source tests/ci/common_posix_setup.sh
 
+# Optional first argument: the libssh2 git ref (tag or branch) to test against.
+# Defaults to the default branch (main) when unset so local runs keep working.
+LIBSSH2_REF="${1:-}"
+
 # Set up environment.
 
 # SYS_ROOT
@@ -45,8 +49,13 @@ function libssh2_run_tests() {
 
 pushd "${SCRATCH_FOLDER}"
 
-# Get latest libssh2 version.
-git clone https://github.com/libssh2/libssh2.git "${LIBSSH2_SRC_FOLDER}"
+# Clone libssh2. When LIBSSH2_REF is set (e.g. a release tag), check out that
+# ref; otherwise track the default branch (main).
+if [[ -n "${LIBSSH2_REF}" ]]; then
+  git clone --depth 1 --branch "${LIBSSH2_REF}" https://github.com/libssh2/libssh2.git "${LIBSSH2_SRC_FOLDER}"
+else
+  git clone https://github.com/libssh2/libssh2.git "${LIBSSH2_SRC_FOLDER}"
+fi
 mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${LIBSSH2_BUILD_FOLDER}" "${LIBSSH2_INSTALL_FOLDER}"
 ls
 

--- a/tests/ci/integration/run_libssh2_integration.sh
+++ b/tests/ci/integration/run_libssh2_integration.sh
@@ -56,6 +56,14 @@ if [[ -n "${LIBSSH2_REF}" ]]; then
 else
   git clone https://github.com/libssh2/libssh2.git "${LIBSSH2_SRC_FOLDER}"
 fi
+
+# Older libssh2 releases use a floating debian:testing-slim base image in the
+# openssh_server test fixture, which no longer ships the `adduser` package.
+# Patch the Dockerfile to install it explicitly so ctest can build the fixture.
+OPENSSH_DOCKERFILE="${LIBSSH2_SRC_FOLDER}/tests/openssh_server/Dockerfile"
+if grep -q "debian:testing-slim" "${OPENSSH_DOCKERFILE}" 2>/dev/null; then
+  sed -i 's/install -y openssh-server/install -y openssh-server adduser/' "${OPENSSH_DOCKERFILE}"
+fi
 mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${LIBSSH2_BUILD_FOLDER}" "${LIBSSH2_INSTALL_FOLDER}"
 ls
 


### PR DESCRIPTION
### Description

The `libssh2` integration job clones libssh2 **main** unpinned, so an upstream commit that fails to build against AWS-LC breaks the required check through no fault of AWS-LC.

That is happening now: a main-only change in `src/openssl.c` (`ssh2_ed25519_verify`) passes a `uint32_t` to a `%lu` format specifier, which trips `-Werror=format=` under libssh2's `-DENABLE_WERROR=ON` build:

```
src/openssl.c:3570:19: error: format '%lu' expects argument of type 'long unsigned int',
  but argument 5 has type 'uint32_t' {aka 'unsigned int'} [-Werror=format=]
cc1: all warnings being treated as errors
```

### Changes

1. **Pin the required `libssh2` job** to the latest release, `libssh2-1.11.1`, which builds cleanly against AWS-LC (the offending code is main-only).
2. **Add a non-required `libssh2-main` job** (`continue-on-error: true`) that keeps tracking libssh2 `main`, so we still get early signal on upstream breakage without gating PRs on things outside our control.
3. **Parameterize `run_libssh2_integration.sh`** with an optional git-ref argument. When unset it tracks `main` as before (preserving local-run behavior); the required job passes `libssh2-1.11.1`.

### Testing

- Verified in an `ubuntu:24.04` container that `libssh2-1.11.1` compiles and links against a freshly built AWS-LC — the `-Werror=format` failure that breaks the current required job is absent in the release.
- libssh2's ctest suite additionally builds an `openssh_server` Docker image to run its read/hostkey tests, so full test execution is exercised by CI (`ubuntu-latest`) rather than locally.
- Workflow YAML and shell script validated (`ruby -ryaml`, `bash -n`, `shellcheck`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.