### PR TITLE
Harden CLI input validation and file output

### DIFF
--- a/tool-openssl/ec.cc
+++ b/tool-openssl/ec.cc
@@ -79,6 +79,9 @@ bool ecTool(const args_list_t &args) {
     goto err;
   }
 
+  if (!pubout && !out_path.empty()) {
+    SetUmaskForPrivateKey();
+  }
   output_bio.reset(out_path.empty() ? BIO_new_fp(stdout, BIO_NOCLOSE)
                                     : BIO_new_file(out_path.c_str(), "wb"));
   if (!output_bio) {

--- a/tool-openssl/ec_test.cc
+++ b/tool-openssl/ec_test.cc
@@ -225,6 +225,22 @@ TEST_F(ECTest, InvalidOutputPath) {
   ASSERT_FALSE(ecTool(args));
 }
 
+// Test that private key output files are created with restrictive permissions
+#if !defined(OPENSSL_WINDOWS)
+TEST_F(ECTest, PrivateKeyFilePermissions) {
+  args_list_t args = {"-in", pem_key_path, "-out", out_path};
+  ASSERT_TRUE(ecTool(args));
+
+  struct stat st;
+  ASSERT_EQ(0, stat(out_path, &st));
+  // File should be owner-only (0600 mask applied via umask 0077)
+  mode_t perms = st.st_mode & 0777;
+  EXPECT_EQ(perms & 0077, 0u)
+      << "Private key file should not be group/world accessible, got: 0"
+      << std::oct << perms;
+}
+#endif
+
 TEST_F(ECTest, CompareWithOpenSSLPEMOutput) {
   if (tool_executable_path == nullptr || openssl_executable_path == nullptr) {
     GTEST_SKIP() << "Skipping test: AWSLC_TOOL_PATH and/or OPENSSL_TOOL_PATH "

--- a/tool-openssl/ec_test.cc
+++ b/tool-openssl/ec_test.cc
@@ -235,7 +235,7 @@ TEST_F(ECTest, PrivateKeyFilePermissions) {
   ASSERT_EQ(0, stat(out_path, &st));
   // File should be owner-only (0600 mask applied via umask 0077)
   mode_t perms = st.st_mode & 0777;
-  EXPECT_EQ(perms & 0077, 0u)
+  EXPECT_EQ(static_cast<mode_t>(perms & 0077), static_cast<mode_t>(0))
       << "Private key file should not be group/world accessible, got: 0"
       << std::oct << perms;
 }

--- a/tool-openssl/pkcs8.cc
+++ b/tool-openssl/pkcs8.cc
@@ -217,6 +217,7 @@ bool pkcs8Tool(const args_list_t &args) {
   }
 
   if (!out_path.empty()) {
+    SetUmaskForPrivateKey();
     out.reset(BIO_new_file(out_path.c_str(), "wb"));
   } else {
     out.reset(BIO_new_fp(stdout, BIO_NOCLOSE));

--- a/tool-openssl/pkcs8.cc
+++ b/tool-openssl/pkcs8.cc
@@ -260,6 +260,11 @@ bool pkcs8Tool(const args_list_t &args) {
                               ? EVP_aes_256_cbc()
                               : EVP_get_cipherbyname(v2_cipher.c_str()));
 
+    if (!nocrypt && cipher == nullptr) {
+      fprintf(stderr, "Unsupported PKCS#8 cipher: %s\n", v2_cipher.c_str());
+      return false;
+    }
+
     result = (outform == "PEM")
                  ? PEM_write_bio_PKCS8PrivateKey(
                        out.get(), pkey.get(), cipher,

--- a/tool-openssl/pkcs8_test.cc
+++ b/tool-openssl/pkcs8_test.cc
@@ -211,6 +211,24 @@ TEST_F(PKCS8Test, UnsupportedPRF) {
   ASSERT_FALSE(result);
 }
 
+// Test that invalid -v2 cipher name is rejected (not silently unencrypted)
+TEST_F(PKCS8Test, InvalidV2CipherRejected) {
+  std::string passout = std::string("file:") + pass_path;
+  args_list_t args = {"-in",      in_path,         "-out",
+                      out_path,   "-topk8",        "-v2",
+                      "aes-256-ccb",  "-passout", passout.c_str()};
+
+  testing::internal::CaptureStderr();
+  bool result = pkcs8Tool(args);
+  std::string captured_stderr = testing::internal::GetCapturedStderr();
+
+  ASSERT_FALSE(result) << "Expected pkcs8Tool to fail with invalid cipher name";
+  EXPECT_TRUE(captured_stderr.find("Unsupported PKCS#8 cipher") !=
+              std::string::npos)
+      << "Expected 'Unsupported PKCS#8 cipher' in stderr, but got: "
+      << captured_stderr;
+}
+
 class PKCS8OptionUsageErrorsTest : public PKCS8Test {
  protected:
   static void TestOptionUsageErrors(const std::vector<std::string> &args) {

--- a/tool-openssl/pkey.cc
+++ b/tool-openssl/pkey.cc
@@ -140,6 +140,11 @@ bool pkeyTool(const args_list_t &args) {
   }
 
   // Set up output BIO
+  // Set restrictive permissions when writing private keys to file
+  if (!pubout && !pubin && !out_path.empty()) {
+    SetUmaskForPrivateKey();
+  }
+
   bssl::UniquePtr<BIO> output_bio;
   if (out_path.empty()) {
     output_bio.reset(BIO_new_fp(stdout, BIO_NOCLOSE));

--- a/tool-openssl/pkey_test.cc
+++ b/tool-openssl/pkey_test.cc
@@ -186,6 +186,22 @@ TEST_F(PKeyOptionUsageErrorsTest, InvalidFormatOptionsTest) {
   }
 }
 
+// Test that private key output files are created with restrictive permissions
+#if !defined(OPENSSL_WINDOWS)
+TEST_F(PKeyTest, PrivateKeyFilePermissions) {
+  args_list_t args = {"-in", in_path, "-out", out_path};
+  bool result = pkeyTool(args);
+  ASSERT_TRUE(result);
+
+  struct stat st;
+  ASSERT_EQ(0, stat(out_path, &st));
+  mode_t perms = st.st_mode & 0777;
+  EXPECT_EQ(perms & 0077, 0u)
+      << "Private key file should not be group/world accessible, got: 0"
+      << std::oct << perms;
+}
+#endif
+
 // -------------------- PKey OpenSSL Comparison Tests --------------------------
 
 // Comparison tests cannot run without set up of environment variables:

--- a/tool-openssl/pkey_test.cc
+++ b/tool-openssl/pkey_test.cc
@@ -196,7 +196,7 @@ TEST_F(PKeyTest, PrivateKeyFilePermissions) {
   struct stat st;
   ASSERT_EQ(0, stat(out_path, &st));
   mode_t perms = st.st_mode & 0777;
-  EXPECT_EQ(perms & 0077, 0u)
+  EXPECT_EQ(static_cast<mode_t>(perms & 0077), static_cast<mode_t>(0))
       << "Private key file should not be group/world accessible, got: 0"
       << std::oct << perms;
 }

--- a/tool-openssl/s_client_test.cc
+++ b/tool-openssl/s_client_test.cc
@@ -60,3 +60,10 @@ TEST(SClientTest, CipherAndTls1_1) {
   bool result = SClientTool(args);
   ASSERT_TRUE(result);
 }
+
+// Test that s_client returns false (not crash) for unresolvable hostname
+TEST(SClientTest, UnresolvableHost) {
+  args_list_t args = {"-connect", "this.host.does.not.exist.invalid:443"};
+  bool result = SClientTool(args);
+  ASSERT_FALSE(result);
+}

--- a/tool/file.cc
+++ b/tool/file.cc
@@ -10,6 +10,12 @@
 #include <algorithm>
 #include <vector>
 
+#if !defined(OPENSSL_WINDOWS)
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#endif
+
 #include "internal.h"
 
 
@@ -55,4 +61,34 @@ bool WriteToFile(const std::string &path, const uint8_t *in,
     return false;
   }
   return true;
+}
+
+bool WritePrivateKeyToFile(const std::string &path, const uint8_t *in,
+                           size_t in_len) {
+#if defined(OPENSSL_WINDOWS)
+  // On Windows, fall back to standard write. File ACLs are inherited from the
+  // parent directory.
+  return WriteToFile(path, in, in_len);
+#else
+  int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+  if (fd < 0) {
+    fprintf(stderr, "Failed to open '%s': %s\n", path.c_str(), strerror(errno));
+    return false;
+  }
+  const uint8_t *ptr = in;
+  size_t remaining = in_len;
+  while (remaining > 0) {
+    ssize_t written = write(fd, ptr, remaining);
+    if (written < 0) {
+      fprintf(stderr, "Failed to write to '%s': %s\n", path.c_str(),
+              strerror(errno));
+      close(fd);
+      return false;
+    }
+    ptr += written;
+    remaining -= written;
+  }
+  close(fd);
+  return true;
+#endif
 }

--- a/tool/generate_ech.cc
+++ b/tool/generate_ech.cc
@@ -113,7 +113,7 @@ bool GenerateECH(const std::vector<std::string> &args) {
   if (!WriteToFile(
           args_map["-out-ech-config-list"], CBB_data(cbb.get()), CBB_len(cbb.get())) ||
       !WriteToFile(args_map["-out-ech-config"], ech_config, ech_config_len) ||
-      !WriteToFile(args_map["-out-private-key"], private_key, private_key_len)) {
+      !WritePrivateKeyToFile(args_map["-out-private-key"], private_key, private_key_len)) {
     fprintf(stderr, "Failed to write ECHConfig or private key to file\n");
     return false;
   }

--- a/tool/generate_ed25519.cc
+++ b/tool/generate_ed25519.cc
@@ -37,6 +37,6 @@ bool GenerateEd25519Key(const std::vector<std::string> &args) {
   ED25519_keypair(public_key, private_key);
 
   return WriteToFile(args_map["-out-public"], public_key, sizeof(public_key)) &&
-         WriteToFile(args_map["-out-private"], private_key,
+         WritePrivateKeyToFile(args_map["-out-private"], private_key,
                      sizeof(private_key));
 }

--- a/tool/internal.h
+++ b/tool/internal.h
@@ -139,6 +139,11 @@ bool GetExclusiveBoolArgument(std::string *out_arg, const argument_t *templates,
 bool ReadAll(std::vector<uint8_t> *out, FILE *in);
 bool WriteToFile(const std::string &path, const uint8_t *in, size_t in_len);
 
+// WritePrivateKeyToFile writes |in_len| bytes from |in| to |path| with
+// owner-only permissions (0600 on POSIX). Use this for private key material.
+bool WritePrivateKeyToFile(const std::string &path, const uint8_t *in,
+                           size_t in_len);
+
 // DoClient is a common function used to support the s_client option in both
 // bssl and openssl tools. It takes an additional parameter |tool| to indicate
 // which tool's s_client is being invoked. A value of true indicates openssl

--- a/tool/transport_common.cc
+++ b/tool/transport_common.cc
@@ -136,19 +136,21 @@ bool Connect(int *out_sock, const std::string &hostname_and_port, bool quiet) {
     hostname = hostname.substr(1, hostname.size() - 2);
   }
 
-  struct addrinfo hint, *result;
+  struct addrinfo hint, *result = nullptr;
   OPENSSL_memset(&hint, 0, sizeof(hint));
   hint.ai_family = AF_UNSPEC;
   hint.ai_socktype = SOCK_STREAM;
 
   int ret = getaddrinfo(hostname.c_str(), port.c_str(), &hint, &result);
-  if (ret != 0 && !quiet) {
+  if (ret != 0) {
+    if (!quiet) {
 #if defined(OPENSSL_WINDOWS)
-    const char *error = gai_strerrorA(ret);
+      const char *error = gai_strerrorA(ret);
 #else
-    const char *error = gai_strerror(ret);
+      const char *error = gai_strerror(ret);
 #endif
-    fprintf(stderr, "getaddrinfo returned: %s\n", error);
+      fprintf(stderr, "getaddrinfo returned: %s\n", error);
+    }
     return false;
   }
 


### PR DESCRIPTION
### Issues:
Resolves P469904855

### Description of changes: 
Fixes input validation gaps and tightens file permissions in the CLI tool:
- Always fail on DNS resolution errors in s_client regardless of quiet mode
- Reject unrecognized -v2 cipher names in pkcs8 -topk8 instead of falling through
- Set restrictive permissions (0600) when writing private key files

### Testing:
Tests added for each change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
