### PR TITLE
Remove dead P-256 nistz asm under OPENSSL_SMALL and extend the size-check harness

### DIFF
--- a/.github/workflows/openssl-small.yml
+++ b/.github/workflows/openssl-small.yml
@@ -114,6 +114,10 @@ jobs:
           fi
           echo "PASS: ${reduction}% reduction meets the ${EXPECTED_REDUCTION_PERCENT}% threshold"
       - name: Measure GC-enabled consumer and EVP key-parsing anchor
+        # Intentionally single-toolchain (clang + GNU ld on Linux, like the
+        # whole job): the matrix legs vary only by architecture, so the
+        # reported numbers are per-arch, not a gcc cross-check. The anchor
+        # cost is a reachability property and ~compiler-independent anyway.
         run: |
           set -euo pipefail
           # Link against the section-GC library build (the aws-lc-rs-like

--- a/.github/workflows/openssl-small.yml
+++ b/.github/workflows/openssl-small.yml
@@ -65,6 +65,19 @@ jobs:
           cmake -GNinja -B build-small -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=OFF -DOPENSSL_SMALL=ON
           cmake --build build-small --target crypto
+      - name: Build libcrypto.a (OPENSSL_SMALL, section-GC)
+        # Same as build-small but compiled with -ffunction-sections
+        # -fdata-sections, so --gc-sections can strip at function granularity
+        # inside bcm.c.o. This mirrors how aws-lc-rs (CcBuilder) compiles the
+        # library, and is the configuration where anchor-driven retention is
+        # measurable: without it, any reference into bcm.c.o retains the whole
+        # object and masks what the anchors actually pin.
+        run: |
+          cmake -GNinja -B build-small-gc -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=OFF -DOPENSSL_SMALL=ON \
+            -DCMAKE_C_FLAGS="-ffunction-sections -fdata-sections" \
+            -DCMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections"
+          cmake --build build-small-gc --target crypto
       - name: Link consumer against each libcrypto and compare
         env:
           EXPECTED_REDUCTION_PERCENT: ${{ matrix.expected_reduction_percent }}
@@ -78,6 +91,8 @@ jobs:
           ./consumer-small
           size_default=$(stat -c %s consumer-default)
           size_small=$(stat -c %s consumer-small)
+          archive_default=$(stat -c %s build-default/crypto/libcrypto.a)
+          archive_small=$(stat -c %s build-small/crypto/libcrypto.a)
           if [ "$size_default" -le 0 ]; then
             echo "ERROR: default consumer binary has zero size"
             exit 1
@@ -86,11 +101,11 @@ jobs:
           {
             echo "## OPENSSL_SMALL static-link size (${{ matrix.name }})"
             echo ""
-            echo "| Build | Consumer binary |"
-            echo "|-------|-----------------|"
-            echo "| Default | $(numfmt --to=iec "$size_default") (${size_default} B) |"
-            echo "| OPENSSL_SMALL | $(numfmt --to=iec "$size_small") (${size_small} B) |"
-            echo "| **Reduction** | **${reduction}%** |"
+            echo "| Build | libcrypto.a | Consumer binary |"
+            echo "|-------|-------------|-----------------|"
+            echo "| Default | $(numfmt --to=iec "$archive_default") | $(numfmt --to=iec "$size_default") (${size_default} B) |"
+            echo "| OPENSSL_SMALL | $(numfmt --to=iec "$archive_small") | $(numfmt --to=iec "$size_small") (${size_small} B) |"
+            echo "| **Reduction** | | **${reduction}%** |"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "default=${size_default} small=${size_small} reduction=${reduction}%"
           if [ "$reduction" -lt "$EXPECTED_REDUCTION_PERCENT" ]; then
@@ -98,6 +113,48 @@ jobs:
             exit 1
           fi
           echo "PASS: ${reduction}% reduction meets the ${EXPECTED_REDUCTION_PERCENT}% threshold"
+      - name: Measure GC-enabled consumer and EVP key-parsing anchor
+        run: |
+          set -euo pipefail
+          # Link against the section-GC library build (the aws-lc-rs-like
+          # configuration). The EVP-parse variant adds one
+          # EVP_parse_public_key call, which anchors asn1_evp_pkey_methods[]
+          # (crypto/evp_extra/p_methods.c) and with it every key type's ASN.1
+          # machinery -- currently including all of ML-KEM/ML-DSA -- even
+          # under full section GC. The delta between the two binaries
+          # quantifies what key-parsing consumers inherit. Advisory only; not
+          # thresholded (yet).
+          common="-O2 -I include -ffunction-sections -fdata-sections"
+          libs="-lpthread -ldl -lm -Wl,--gc-sections"
+          clang $common tests/binary-size/main.c build-small-gc/crypto/libcrypto.a $libs -o consumer-gc
+          clang $common -DAWSLC_SIZE_CHECK_EVP_PARSE tests/binary-size/main.c \
+            build-small-gc/crypto/libcrypto.a $libs -o consumer-gc-evp
+          echo "Sanity: run the GC-enabled consumers"
+          ./consumer-gc
+          ./consumer-gc-evp
+          size_gc=$(stat -c %s consumer-gc)
+          size_gc_evp=$(stat -c %s consumer-gc-evp)
+          evp_overhead=$(( size_gc_evp - size_gc ))
+          {
+            echo "### GC-enabled consumer (OPENSSL_SMALL + section GC, ${{ matrix.name }})"
+            echo ""
+            echo "| Consumer | Binary size |"
+            echo "|----------|-------------|"
+            echo "| base | $(numfmt --to=iec "$size_gc") (${size_gc} B) |"
+            echo "| base + \`EVP_parse_public_key\` | $(numfmt --to=iec "$size_gc_evp") (${size_gc_evp} B) |"
+            echo "| **EVP key-parsing anchor cost** | **$(numfmt --to=iec "$evp_overhead") (${evp_overhead} B)** |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "gc=${size_gc} gc_evp=${size_gc_evp} evp_overhead=${evp_overhead}"
+          for bin in consumer-gc consumer-gc-evp; do
+            {
+              echo "<details><summary>Largest retained symbols: ${bin}</summary>"
+              echo ""
+              echo '```'
+              nm -S --size-sort --radix=d "$bin" | tail -25 | tac
+              echo '```'
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
+          done
 
   small-tests:
     if: github.repository_owner == 'aws'

--- a/crypto/fipsmodule/CMakeLists.txt
+++ b/crypto/fipsmodule/CMakeLists.txt
@@ -117,6 +117,26 @@ if(ARCH STREQUAL "ppc64le")
   )
 endif()
 
+# Under OPENSSL_SMALL, the P-256 nistz implementation (p256-nistz.c) is
+# compiled out entirely -- ec.c dispatches P-256 to the fiat-crypto
+# implementation (p256.c) instead -- leaving the nistz assembly fully
+# unreferenced on both x86_64 and aarch64. Drop it from the build. (The
+# large precomputed base-point table is in p256-nistz-table.h, included
+# from C code that is already gated, not in the assembly.)
+if(OPENSSL_SMALL)
+  if(ARCH STREQUAL "x86_64")
+    list(REMOVE_ITEM BCM_ASM_SOURCES
+      p256-x86_64-asm.${ASM_EXT}
+      p256_beeu-x86_64-asm.${ASM_EXT}
+    )
+  elseif(ARCH STREQUAL "aarch64")
+    list(REMOVE_ITEM BCM_ASM_SOURCES
+      p256-armv8-asm.${ASM_EXT}
+      p256_beeu-armv8-asm.${ASM_EXT}
+    )
+  endif()
+endif()
+
 if(PERL_EXECUTABLE)
   perlasm(aesni-gcm-x86_64.${ASM_EXT} modes/asm/aesni-gcm-x86_64.pl)
   perlasm(aesni-gcm-avx512.${ASM_EXT} modes/asm/aesni-gcm-avx512.pl)

--- a/tests/binary-size/main.c
+++ b/tests/binary-size/main.c
@@ -8,6 +8,14 @@
 // workflow builds this twice -- against a default libcrypto and against one
 // built with OPENSSL_SMALL -- and compares the resulting binary sizes.
 //
+// When AWSLC_SIZE_CHECK_EVP_PARSE is defined, the consumer additionally
+// marshals and parses an EVP public key. Parsing any EVP key references the
+// asn1_evp_pkey_methods[] table (crypto/evp_extra/p_methods.c), which
+// transitively retains every linked-in key type's ASN.1 machinery --
+// including, at present, all of ML-KEM and ML-DSA -- even under
+// --gc-sections. The workflow builds this variant too and reports the size
+// delta, quantifying what key-parsing consumers inherit.
+//
 // It is intentionally small and standalone (compiled directly by the workflow,
 // not part of the main CMake build).
 
@@ -21,6 +29,12 @@
 #include <openssl/ecdsa.h>
 #include <openssl/nid.h>
 #include <openssl/sha.h>
+
+#if defined(AWSLC_SIZE_CHECK_EVP_PARSE)
+#include <openssl/bytestring.h>
+#include <openssl/evp.h>
+#include <openssl/mem.h>
+#endif
 
 static int do_sha256(void) {
   uint8_t in[64], out[SHA256_DIGEST_LENGTH];
@@ -71,12 +85,51 @@ static int do_ed25519(void) {
   return ED25519_verify(msg, sizeof(msg), sig, public_key);
 }
 
+#if defined(AWSLC_SIZE_CHECK_EVP_PARSE)
+static int do_evp_parse(void) {
+  uint8_t public_key[32], private_key[64];
+  ED25519_keypair(public_key, private_key);
+  EVP_PKEY *pkey = EVP_PKEY_new_raw_public_key(EVP_PKEY_ED25519, NULL,
+                                               public_key, sizeof(public_key));
+  if (pkey == NULL) {
+    return 0;
+  }
+  // Marshal to a DER SubjectPublicKeyInfo and parse it back.
+  // |EVP_parse_public_key| is the call that anchors the full EVP method
+  // table (see the file comment).
+  int ok = 0;
+  uint8_t *der = NULL;
+  size_t der_len;
+  CBB cbb;
+  if (CBB_init(&cbb, 64) && EVP_marshal_public_key(&cbb, pkey) &&
+      CBB_finish(&cbb, &der, &der_len)) {
+    CBS cbs;
+    CBS_init(&cbs, der, der_len);
+    EVP_PKEY *parsed = EVP_parse_public_key(&cbs);
+    ok = parsed != NULL && CBS_len(&cbs) == 0 &&
+         EVP_PKEY_cmp(pkey, parsed) == 1;
+    EVP_PKEY_free(parsed);
+  } else {
+    CBB_cleanup(&cbb);
+  }
+  OPENSSL_free(der);
+  EVP_PKEY_free(pkey);
+  return ok;
+}
+#endif
+
 int main(void) {
   if (!do_sha256() || !do_aes_256_gcm() || !do_ecdsa_p256() || !do_x25519() ||
       !do_ed25519()) {
     fprintf(stderr, "crypto self-check failed\n");
     return 1;
   }
+#if defined(AWSLC_SIZE_CHECK_EVP_PARSE)
+  if (!do_evp_parse()) {
+    fprintf(stderr, "EVP parse self-check failed\n");
+    return 1;
+  }
+#endif
   printf("ok\n");
   return 0;
 }


### PR DESCRIPTION
### Issues:
Addresses: aws/aws-lc-rs#745, P353434599
Related: #3319, #3320

### Description of changes:
Follow-up to the `OPENSSL_SMALL` size work in #3319/#3320. Two independent changes, one per commit:

1. **Drop P-256 nistz assembly under `OPENSSL_SMALL`.** `p256-nistz.c` is compiled out entirely in this configuration (`ec.c` dispatches P-256 to the fiat-crypto implementation), so the nistz assembly -- `p256-{x86_64,armv8}-asm` and `p256_beeu-{x86_64,armv8}-asm` -- is fully unreferenced on both architectures. This removes it from the build using the same `if(OPENSSL_SMALL)` list-removal pattern established for s2n-bignum in #3320. Like the EC removal there, this is pure dead-code elimination: it shrinks shared-library artifacts, but static consumers were already dropping these unreferenced objects at link time. The non-`OPENSSL_SMALL` build is unchanged.

2. **Extend the binary-size CI harness (from #3320) to measure GC-enabled consumers and the key-parsing anchor.** The most important chunk a static consumer inherits from libcrypto is the ML-KEM/ML-DSA code retained by `asn1_evp_pkey_methods[]`: any consumer that parses an EVP key pulls it in, and no linker or `OPENSSL_SMALL`-style change can drop it -- only a future API-reduction build option can. This adds a second, section-GC library build (matching how aws-lc-rs/CcBuilder compiles the library) and a variant of the consumer that calls `EVP_parse_public_key`, so CI reports the anchor cost on every run. This makes the motivation for that future work concrete and quantifiable, and gives subsequent size PRs a realistic consumer-impact number rather than just an archive-size delta.

### Call-outs:
- The two commits are unrelated and could be reviewed independently; they are bundled because commit 1 is ~20 lines.
- The default-compiled size harness is behaviorally unchanged, so the size-reduction thresholds calibrated in #3320 remain valid. The new anchor measurement is advisory (not thresholded).
- The section-GC library build in the harness is deliberate: without `-ffunction-sections -fdata-sections`, any reference into `bcm.c.o` retains the whole object and masks the anchor.

### Testing:
- Covered by the existing `openssl-small.yml` matrix (full test suite, x86_64 + aarch64, gcc + clang) and the shared-library link (which proves no removed object is still referenced).
- Locally (arm64 macOS): `OPENSSL_SMALL` shared-lib links cleanly, `nm` confirms the previously-dead `ecp_nistz256_*`/`beeu_*` symbols are gone, and the full `crypto_test` suite passes.
- The harness self-checks run in CI (both consumer variants execute before their sizes are compared). On Linux/GNU ld, a base consumer retains zero ML-KEM/ML-DSA code, while adding a single `EVP_parse_public_key` call pulls in ~574 KB (x86_64) / ~634 KB (aarch64), per the CI runs of this PR -- confirming the anchor the harness is meant to track.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
