### PR TITLE
[CHERRYPICK FIPS 4.x] Fix SSL_CTX_add_extra_chain_cert slot routing for chains added before the leaf

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -978,7 +978,27 @@ OPENSSL_EXPORT int SSL_CTX_add1_chain_cert(SSL_CTX *ctx, X509 *x509);
 // it returns one and takes ownership of |x509|. Otherwise, it returns zero.
 OPENSSL_EXPORT int SSL_add0_chain_cert(SSL *ssl, X509 *x509);
 
-// SSL_CTX_add_extra_chain_cert calls |SSL_CTX_add0_chain_cert|.
+// SSL_CTX_add_extra_chain_cert appends |x509| to |ctx|'s certificate chain. On
+// success it returns one and takes ownership of |x509|; otherwise it returns
+// zero.
+//
+// OpenSSL keeps extra chain certs on a single global stack and uses it
+// whenever a certificate has no chain of its own. AWS-LC instead stores chains
+// per key-type slot, so this routes |x509| to a slot: if a leaf certificate is
+// already configured, |x509| joins the current certificate's slot (so a chain
+// built leaf-first stays together, including cross-type chains such as an RSA
+// intermediate for an ECDSA leaf); if no leaf is set yet, |x509| goes to the
+// slot matching its own key type (so chains built intermediate-first land
+// correctly once the matching leaf is added).
+//
+// To append an intermediate whose key type differs from a not-yet-configured
+// leaf (e.g. an RSA intermediate for an ECDSA leaf added before the leaf), set
+// the leaf first, or use |SSL_CTX_set1_chain|, |SSL_CTX_add1_chain_cert|, or
+// |SSL_CTX_use_certificate_chain_file|.
+//
+// |SSL_CTX_get_extra_chain_certs| and |SSL_CTX_clear_extra_chain_certs| always
+// act on the current certificate's slot, so they may target a different slot
+// than an add that routed by key type.
 OPENSSL_EXPORT int SSL_CTX_add_extra_chain_cert(SSL_CTX *ctx, X509 *x509);
 
 // SSL_add1_chain_cert appends |x509| to |ctx|'s certificate chain. It returns

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -1838,6 +1838,122 @@ TEST_P(MultipleCertificateSlotTest, MissingPrivateKey) {
       {certificate_key_param().corresponding_sigalg}, -1, false);
 }
 
+// SSL_CTX_add_extra_chain_cert routes the intermediate to the current
+// certificate's slot when one is configured, and falls back to the slot
+// matching the intermediate's own key type when no leaf is set yet. The
+// fallback fixes the Ruby + AWS-LC ordering, where
+// |Net::HTTP#extra_chain_cert=| appends before any leaf is configured.
+
+// Leaf-first, cross-type: an RSA intermediate added after an ECDSA leaf must
+// join the ECDSA leaf's slot, not the RSA slot. This is the common case of an
+// RSA intermediate for an ECDSA leaf, which key-type routing would misplace.
+TEST(SSLTest, ExtraChainCertCrossTypeLeafFirst) {
+  bssl::UniquePtr<SSL_CTX> ctx(CreateContextWithCertificate(
+      TLS_method(), GetECDSATestCertificate(), GetECDSATestKey()));
+  ASSERT_TRUE(ctx);
+  ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_ECC);
+
+  bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
+  ASSERT_TRUE(rsa_intermediate);
+  ASSERT_TRUE(
+      SSL_CTX_add_extra_chain_cert(ctx.get(), rsa_intermediate.release()));
+
+  // The intermediate joins the ECDSA leaf's slot (leaf at index 0,
+  // intermediate at index 1); the RSA slot stays empty.
+  const auto &ecc_chain = ctx->cert->cert_private_keys[SSL_PKEY_ECC].chain;
+  const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
+  ASSERT_TRUE(ecc_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(ecc_chain.get()), 2u);
+  EXPECT_FALSE(rsa_chain);
+}
+
+// No leaf configured yet: routing falls back to the intermediate's own key
+// type. Append the RSA intermediate to a fresh ctx, then set the matching
+// RSA leaf + key; both must end up in the RSA slot.
+TEST(SSLTest, ExtraChainCertAppendedBeforeLeaf) {
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+
+  bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
+  ASSERT_TRUE(rsa_intermediate);
+  ASSERT_TRUE(
+      SSL_CTX_add_extra_chain_cert(ctx.get(), rsa_intermediate.release()));
+
+  ASSERT_TRUE(
+      SSL_CTX_use_certificate(ctx.get(), GetChainTestCertificate().get()));
+  ASSERT_TRUE(SSL_CTX_use_PrivateKey(ctx.get(), GetChainTestKey().get()));
+  ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_RSA);
+
+  // The RSA slot holds the leaf at index 0 and the intermediate at index 1.
+  const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
+  ASSERT_TRUE(rsa_chain);
+  ASSERT_EQ(sk_CRYPTO_BUFFER_num(rsa_chain.get()), 2u);
+  EXPECT_TRUE(sk_CRYPTO_BUFFER_value(rsa_chain.get(), 0) != nullptr);
+  EXPECT_TRUE(sk_CRYPTO_BUFFER_value(rsa_chain.get(), 1) != nullptr);
+}
+
+// End-to-end Ruby ordering: append the intermediate before the leaf, then
+// complete a TLS 1.2 handshake. The server must send leaf + intermediate.
+TEST(SSLTest, ExtraChainCertSentDuringHandshake) {
+  bssl::UniquePtr<SSL_CTX> server_ctx(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(server_ctx);
+  ASSERT_TRUE(client_ctx);
+
+  ASSERT_TRUE(SSL_CTX_set_min_proto_version(server_ctx.get(), TLS1_2_VERSION));
+  ASSERT_TRUE(SSL_CTX_set_max_proto_version(server_ctx.get(), TLS1_2_VERSION));
+  ASSERT_TRUE(SSL_CTX_set_min_proto_version(client_ctx.get(), TLS1_2_VERSION));
+  ASSERT_TRUE(SSL_CTX_set_max_proto_version(client_ctx.get(), TLS1_2_VERSION));
+
+  // Append the intermediate first (no leaf yet, so routing falls back to the
+  // intermediate's key type), then set the matching leaf + key.
+  bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
+  ASSERT_TRUE(rsa_intermediate);
+  ASSERT_TRUE(SSL_CTX_add_extra_chain_cert(server_ctx.get(),
+                                            rsa_intermediate.release()));
+  ASSERT_TRUE(
+      SSL_CTX_use_certificate(server_ctx.get(), GetChainTestCertificate().get()));
+  ASSERT_TRUE(SSL_CTX_use_PrivateKey(server_ctx.get(), GetChainTestKey().get()));
+
+  // We are asserting what the server sends, not what the client validates.
+  SSL_CTX_set_custom_verify(
+      client_ctx.get(), SSL_VERIFY_PEER,
+      [](SSL *ssl, uint8_t *out_alert) -> ssl_verify_result_t {
+        return ssl_verify_ok;
+      });
+
+  bssl::UniquePtr<SSL> client, server;
+  ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx.get(),
+                                     server_ctx.get()));
+
+  const STACK_OF(CRYPTO_BUFFER) *peer_chain =
+      SSL_get0_peer_certificates(client.get());
+  ASSERT_TRUE(peer_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(peer_chain), 2u);
+}
+
+// Regression guard: SSL_CTX_add0_chain_cert still routes by
+// |cert_private_key_idx|, unchanged by the fix.
+TEST(SSLTest, Add0ChainCertCrossTypeRoutingUnchanged) {
+  bssl::UniquePtr<SSL_CTX> ctx(CreateContextWithCertificate(
+      TLS_method(), GetECDSATestCertificate(), GetECDSATestKey()));
+  ASSERT_TRUE(ctx);
+  ASSERT_EQ(ctx->cert->cert_private_key_idx, SSL_PKEY_ECC);
+
+  bssl::UniquePtr<X509> rsa_intermediate = GetChainTestIntermediate();
+  ASSERT_TRUE(rsa_intermediate);
+  ASSERT_TRUE(
+      SSL_CTX_add0_chain_cert(ctx.get(), rsa_intermediate.release()));
+
+  // RSA intermediate lands in the ECC slot because |cert_private_key_idx|
+  // points there.
+  const auto &ecc_chain = ctx->cert->cert_private_keys[SSL_PKEY_ECC].chain;
+  const auto &rsa_chain = ctx->cert->cert_private_keys[SSL_PKEY_RSA].chain;
+  ASSERT_TRUE(ecc_chain);
+  EXPECT_EQ(sk_CRYPTO_BUFFER_num(ecc_chain.get()), 2u);
+  EXPECT_FALSE(rsa_chain);
+}
+
 
 struct MultiTransferReadWriteTestParams {
   const char suite[50];

--- a/ssl/ssl_x509.cc
+++ b/ssl/ssl_x509.cc
@@ -892,19 +892,12 @@ static int ssl_cert_set1_chain(CERT *cert, STACK_OF(X509) *chain) {
   return 1;
 }
 
-static int ssl_cert_append_cert(CERT *cert, X509 *x509) {
-  assert(cert->x509_method);
-  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
-    return 0;
-  }
-
-  UniquePtr<CRYPTO_BUFFER> buffer = x509_to_buffer(x509);
-  if (!buffer) {
-    return 0;
-  }
-
+// ssl_cert_append_cert_to_slot appends |buffer| to slot |slot_index|'s chain,
+// creating a leafless chain if the slot is empty. It consumes |buffer|.
+static int ssl_cert_append_cert_to_slot(CERT *cert, int slot_index,
+                                         UniquePtr<CRYPTO_BUFFER> buffer) {
   UniquePtr<STACK_OF(CRYPTO_BUFFER)> &chain =
-      cert->cert_private_keys[cert->cert_private_key_idx].chain;
+      cert->cert_private_keys[slot_index].chain;
   if (chain != nullptr) {
     return PushToStack(chain.get(), std::move(buffer));
   }
@@ -916,6 +909,21 @@ static int ssl_cert_append_cert(CERT *cert, X509 *x509) {
   }
 
   return 1;
+}
+
+static int ssl_cert_append_cert(CERT *cert, X509 *x509) {
+  assert(cert->x509_method);
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
+    return 0;
+  }
+
+  UniquePtr<CRYPTO_BUFFER> buffer = x509_to_buffer(x509);
+  if (!buffer) {
+    return 0;
+  }
+
+  return ssl_cert_append_cert_to_slot(cert, cert->cert_private_key_idx,
+                                      std::move(buffer));
 }
 
 static int ssl_cert_add0_chain_cert(CERT *cert, X509 *x509) {
@@ -974,9 +982,65 @@ int SSL_CTX_add1_chain_cert(SSL_CTX *ctx, X509 *x509) {
   return ssl_cert_add1_chain_cert(ctx->cert.get(), x509);
 }
 
+// slot_has_leaf returns true if |slot_index| is valid and that slot holds a
+// leaf certificate (a non-NULL element 0 in its chain).
+static bool slot_has_leaf(const CERT *cert, int slot_index) {
+  if (slot_index < 0) {
+    return false;
+  }
+  const UniquePtr<STACK_OF(CRYPTO_BUFFER)> &chain =
+      cert->cert_private_keys[slot_index].chain;
+  return chain != nullptr && sk_CRYPTO_BUFFER_value(chain.get(), 0) != nullptr;
+}
+
+// ssl_cert_append_extra_chain_cert appends |x509| to the current certificate's
+// slot if a leaf is configured there, and otherwise to the slot matching
+// |x509|'s own key type. See |SSL_CTX_add_extra_chain_cert|.
+static int ssl_cert_append_extra_chain_cert(CERT *cert, X509 *x509) {
+  assert(cert->x509_method);
+  if (!ssl_cert_check_cert_private_keys_usage(cert)) {
+    return 0;
+  }
+
+  UniquePtr<CRYPTO_BUFFER> buffer = x509_to_buffer(x509);
+  if (!buffer) {
+    return 0;
+  }
+
+  // When a leaf is already configured, append to its slot so a chain set up
+  // leaf-first lands with its leaf, including cross-type chains (e.g. an RSA
+  // intermediate for an ECDSA leaf). Only when no leaf is set yet do we route
+  // by the intermediate's own key type, which fixes appends made before the
+  // leaf.
+  int slot_index = cert->cert_private_key_idx;
+  if (!slot_has_leaf(cert, slot_index)) {
+    CBS cert_cbs;
+    CRYPTO_BUFFER_init_CBS(buffer.get(), &cert_cbs);
+    UniquePtr<EVP_PKEY> pubkey = ssl_cert_parse_pubkey(&cert_cbs);
+    if (!pubkey) {
+      OPENSSL_PUT_ERROR(SSL, SSL_R_DECODE_ERROR);
+      return 0;
+    }
+    slot_index = ssl_get_certificate_slot_index(pubkey.get());
+    if (slot_index < 0) {
+      OPENSSL_PUT_ERROR(SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
+      return 0;
+    }
+  }
+
+  if (!ssl_cert_append_cert_to_slot(cert, slot_index, std::move(buffer))) {
+    return 0;
+  }
+
+  X509_free(cert->x509_stash);
+  cert->x509_stash = x509;
+  ssl_crypto_x509_cert_flush_cached_chain(cert);
+  return 1;
+}
+
 int SSL_CTX_add_extra_chain_cert(SSL_CTX *ctx, X509 *x509) {
   check_ssl_ctx_x509_method(ctx);
-  return SSL_CTX_add0_chain_cert(ctx, x509);
+  return ssl_cert_append_extra_chain_cert(ctx->cert.get(), x509);
 }
 
 int SSL_add0_chain_cert(SSL *ssl, X509 *x509) {


### PR DESCRIPTION
In OpenSSL, `SSL_CTX_add_extra_chain_cert` appends to a single global `ctx->extra_certs` stack on the `SSL_CTX`. The handshake falls back to that
stack when the per-cert chain is empty (`ssl/ssl_cert.c` `ssl_add_cert_chain`).
Only one such chain can be configured per `SSL_CTX`; for anything more, OpenSSL
recommends the `SSL_CTX_set1_chain` / `SSL_CTX_add1_chain_cert` family.

AWS-LC stores chains in per-key-type slots rather than on a global stack.
`SSL_CTX_add_extra_chain_cert` was aliased to `SSL_CTX_add0_chain_cert`, which
  appends to the slot tracked by `cert_private_key_idx` (the "current
certificate"). That index defaults to `SSL_PKEY_RSA` and only moves once a leaf
is set, so an intermediate added before any leaf landed in the RSA slot regardless of which leaf it chained from. The per-slot chain was then leaf-only
  at handshake time and the peer never saw the intermediate.

The fix routes the intermediate by slot: if a leaf is already configured, the
intermediate joins that leaf's slot, so leaf-first chains stay together (including cross-type chains such as an RSA intermediate for an ECDSA leaf); if
no leaf is set yet, it falls back to the slot matching the intermediate's own
  key type. The `add0` / `add1` family is unchanged.

  ### Call-outs:
Adding a cross-type intermediate before its leaf is configured is still unsupported, as it was before this change: at append time there is no leaf to
match against, and the intermediate's own key type points at the wrong slot.
Those callers should use `SSL_CTX_set1_chain`,
`SSL_CTX_add1_chain_cert`, or
  `SSL_CTX_use_certificate_chain_file`.

  ### Testing:
  Four new unit tests in `ssl/ssl_test.cc`:
  * `ExtraChainCertCrossTypeLeafFirst`
  * `ExtraChainCertAppendedBeforeLeaf`
  * `ExtraChainCertSentDuringHandshake`
  * `Add0ChainCertCrossTypeRoutingUnchanged`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

(cherry picked from commit 53695e3ae0dfaa8363d9028758486af030cf72d3)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
