### PR TITLE
ci: harden security-review.yml against script injection

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -104,6 +104,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REVIEW_STATUS: ${{ steps.codebuild.outputs.review_status }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [[ "$REVIEW_STATUS" == "PASS" ]]; then
             STATE="success"
@@ -114,22 +117,24 @@ jobs:
           fi
           ARGS=(-f state="$STATE" -f context="security-review / report")
           if [[ "$STATE" != "error" ]]; then
-            ARGS+=(-f target_url="https://d225oy8drgbol2.cloudfront.net/${{ github.event.repository.name }}/findings.html?pr=${{ github.event.pull_request.number }}")
+            ARGS+=(-f target_url="https://d225oy8drgbol2.cloudfront.net/${REPO_NAME}/findings.html?pr=${PR_NUMBER}")
           else
             ARGS+=(-f description="Review did not complete successfully")
           fi
-          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" "${ARGS[@]}"
+          gh api "repos/${{ github.repository }}/statuses/${PR_HEAD_SHA}" "${ARGS[@]}"
 
       - name: Post review comment
         if: always() && github.event.action != 'closed' && (steps.codebuild.outputs.review_status == 'PASS' || steps.codebuild.outputs.review_status == 'BLOCKING')
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if ! gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+          if ! gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             --jq '.[].body' | grep -q "security-review-comment"; then
-            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
               -f body="<!-- security-review-comment -->
-          🔒 **Security Review** — [View Report](https://d225oy8drgbol2.cloudfront.net/${{ github.event.repository.name }}/findings.html?pr=${{ github.event.pull_request.number }})
+          🔒 **Security Review** — [View Report](https://d225oy8drgbol2.cloudfront.net/${REPO_NAME}/findings.html?pr=${PR_NUMBER})
 
           Please review before merging."
           fi


### PR DESCRIPTION
### Issues:
Addresses V2265233159

### Description of changes:
Continuation of aws/aws-lc@8afd2f6, extending the same script-injection hardening to `security-review.yml`.

Directly interpolating `${{ github.event.* }}` context expressions into `run:` shell bodies lets Actions splice them in as text before the shell runs — a script-injection risk. This PR hoists each flagged value into the step's `env:` block and references it as a quoted shell variable instead. Behavior is unchanged.

- `Update commit status`: hoist `github.event.repository.name`, `github.event.pull_request.number`, and `github.event.pull_request.head.sha` into `env`.
- `Post review comment`: hoist `github.event.repository.name` and `github.event.pull_request.number` into `env`.

### Call-outs:
- This workflow runs on `pull_request_target`, so hardening these interpolations matters even though the flagged fields (repo name, PR number, commit SHA) are format-constrained.
- `${{ github.repository }}` is left inline — it is not `github.event.*` attacker-influenced input.

### Testing:
CI-config-only, no product code impact. File parses as valid YAML; no `${{ github.event.* }}` interpolations remain in any `run:` body.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.