### PR TITLE
Install OpenSSL-compat libcrypto.pc and libssl.pc with the shim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1815,34 +1815,27 @@ if(INSTALL_OPENSSL_SHIM)
   install_pkgconfig_file(TEMPLATE product.pc.in DEST openssl.pc
                          ${OPENSSL_SHIM_PC_OVERRIDES})
 
-  # Create OpenSSL compatibility symlinks
-  if(BUILD_SHARED_LIBS)
-    if(SET_LIB_SONAME)
-      # When SONAME build is enabled, libraries have -awslc suffix
-      install(CODE "
-        execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
-          lib${CRYPTO_LIB_NAME}.so \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libcrypto.so\")
-      ")
-      if(BUILD_LIBSSL)
-        install(CODE "
-          execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
-            lib${SSL_LIB_NAME}.so \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libssl.so\")
-        ")
-      endif()
+  # Create OpenSSL compatibility symlinks. Like the compat pc files above,
+  # these are only needed when the native libraries carry a suffix.
+  if(SET_LIB_SONAME)
+    if(BUILD_SHARED_LIBS)
+      set(SHIM_LIB_EXT "so")
+      set(SHIM_LINK_COMPONENT "")
+    else()
+      set(SHIM_LIB_EXT "a")
+      # Preserves the pre-existing component split: only the static symlinks
+      # are assigned to the Development component.
+      set(SHIM_LINK_COMPONENT COMPONENT Development)
     endif()
-  else()
-    if(SET_LIB_SONAME)
-      # When SONAME build is enabled, libraries have -awslc suffix
+    install(CODE "
+      execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
+        lib${CRYPTO_LIB_NAME}.${SHIM_LIB_EXT} \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libcrypto.${SHIM_LIB_EXT}\")
+    " ${SHIM_LINK_COMPONENT})
+    if(BUILD_LIBSSL)
       install(CODE "
         execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
-          lib${CRYPTO_LIB_NAME}.a \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libcrypto.a\")
-      " COMPONENT Development)
-      if(BUILD_LIBSSL)
-        install(CODE "
-          execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
-            lib${SSL_LIB_NAME}.a \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libssl.a\")
-        " COMPONENT Development)
-      endif()
+          lib${SSL_LIB_NAME}.${SHIM_LIB_EXT} \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libssl.${SHIM_LIB_EXT}\")
+      " ${SHIM_LINK_COMPONENT})
     endif()
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1763,6 +1763,13 @@ function(install_pkgconfig_file)
     set(SSL_LIB_NAME "${arg_SSL_NAME}")
   endif()
 
+  # Requires line for product.pc.in; omit libssl when it is not built.
+  if(BUILD_LIBSSL)
+    set(PRODUCT_PC_REQUIRES "lib${SSL_LIB_NAME} lib${CRYPTO_LIB_NAME}")
+  else()
+    set(PRODUCT_PC_REQUIRES "lib${CRYPTO_LIB_NAME}")
+  endif()
+
   configure_file(pkgconfig/${arg_TEMPLATE} ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${arg_DEST} @ONLY)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${arg_DEST} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endfunction()
@@ -1777,26 +1784,26 @@ endif()
 
 install_pkgconfig_file(TEMPLATE product.pc.in DEST aws-lc.pc)
 install_pkgconfig_file(TEMPLATE libcrypto.pc.in DEST lib${CRYPTO_LIB_NAME}.pc)
-install_pkgconfig_file(TEMPLATE libssl.pc.in DEST lib${SSL_LIB_NAME}.pc)
+if(BUILD_LIBSSL)
+  install_pkgconfig_file(TEMPLATE libssl.pc.in DEST lib${SSL_LIB_NAME}.pc)
+endif()
 
 if(INSTALL_OPENSSL_SHIM)
-  # OpenSSL installs three pkg-config files: openssl.pc, libcrypto.pc and
-  # libssl.pc. pkg-config resolves packages by filename, and third-party .pc
-  # files commonly declare 'Requires.private: libcrypto' (libssh2, among
-  # others), so a drop-in replacement must provide all three names. When the
-  # libraries carry the -awslc suffix, install compat files under the OpenSSL
-  # names. They mirror genuine OpenSSL semantics: includedir is the plain
-  # include/ directory (where the include/openssl symlink lives), not the
-  # cohabitant include/aws-lc directory, so the cohabitant path does not leak
-  # into consumers. libssl.pc requires the compat libcrypto for the same
-  # reason ('pkg-config --cflags' resolves Requires.private). Libs still
-  # reference the suffixed libraries.
+  # OpenSSL installs openssl.pc, libcrypto.pc and libssl.pc, and pkg-config
+  # resolves packages by filename, so a drop-in replacement must provide all
+  # three names. When the libraries carry the -awslc suffix, install compat
+  # files under the OpenSSL names. Their includedir is the plain include/
+  # directory (home of the include/openssl symlink) so the cohabitant
+  # include/aws-lc path does not leak into consumers; Libs still references
+  # the suffixed libraries.
   if(SET_LIB_SONAME)
     install_pkgconfig_file(TEMPLATE libcrypto.pc.in DEST libcrypto.pc
                            INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
-    install_pkgconfig_file(TEMPLATE libssl.pc.in DEST libssl.pc
-                           INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}"
-                           CRYPTO_NAME crypto)
+    if(BUILD_LIBSSL)
+      install_pkgconfig_file(TEMPLATE libssl.pc.in DEST libssl.pc
+                             INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}"
+                             CRYPTO_NAME crypto)
+    endif()
   endif()
 
   # Like genuine OpenSSL, openssl.pc requires the unsuffixed package names

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1789,28 +1789,31 @@ if(BUILD_LIBSSL)
 endif()
 
 if(INSTALL_OPENSSL_SHIM)
-  # OpenSSL installs openssl.pc, libcrypto.pc and libssl.pc, and pkg-config
-  # resolves packages by filename, so a drop-in replacement must provide all
-  # three names. When the libraries carry the -awslc suffix, install compat
-  # files under the OpenSSL names. Their includedir is the plain include/
-  # directory (home of the include/openssl symlink) so the cohabitant
-  # include/aws-lc path does not leak into consumers; Libs still references
-  # the suffixed libraries.
+  # pkg-config resolves packages by filename, so a drop-in OpenSSL replacement
+  # must provide all three of OpenSSL's module names. All three describe the
+  # unsuffixed interface -- plain include/ and -lcrypto/-lssl, resolved via the
+  # compatibility symlinks below -- because consumers that only know OpenSSL's
+  # names cannot cope with a suffix. The symlinks keep suffixed SONAMEs, so
+  # cohabitation is preserved. See INCORPORATING.md. The native cohabitant
+  # modules are installed above and stay suffixed.
+  set(OPENSSL_SHIM_PC_OVERRIDES
+      INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}"
+      CRYPTO_NAME crypto
+      SSL_NAME ssl)
+
+  # Only needed when the native modules are suffixed; otherwise they already
+  # carry the OpenSSL filenames and describe the same interface.
   if(SET_LIB_SONAME)
     install_pkgconfig_file(TEMPLATE libcrypto.pc.in DEST libcrypto.pc
-                           INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+                           ${OPENSSL_SHIM_PC_OVERRIDES})
     if(BUILD_LIBSSL)
       install_pkgconfig_file(TEMPLATE libssl.pc.in DEST libssl.pc
-                             INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}"
-                             CRYPTO_NAME crypto)
+                             ${OPENSSL_SHIM_PC_OVERRIDES})
     endif()
   endif()
 
-  # Like genuine OpenSSL, openssl.pc requires the unsuffixed package names
-  # and reports the plain include directory.
   install_pkgconfig_file(TEMPLATE product.pc.in DEST openssl.pc
-                         INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}"
-                         CRYPTO_NAME crypto SSL_NAME ssl)
+                         ${OPENSSL_SHIM_PC_OVERRIDES})
 
   # Create OpenSSL compatibility symlinks
   if(BUILD_SHARED_LIBS)
@@ -1819,9 +1822,13 @@ if(INSTALL_OPENSSL_SHIM)
       install(CODE "
         execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
           lib${CRYPTO_LIB_NAME}.so \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libcrypto.so\")
-        execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
-          lib${SSL_LIB_NAME}.so \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libssl.so\")
       ")
+      if(BUILD_LIBSSL)
+        install(CODE "
+          execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
+            lib${SSL_LIB_NAME}.so \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libssl.so\")
+        ")
+      endif()
     endif()
   else()
     if(SET_LIB_SONAME)
@@ -1829,9 +1836,13 @@ if(INSTALL_OPENSSL_SHIM)
       install(CODE "
         execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
           lib${CRYPTO_LIB_NAME}.a \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libcrypto.a\")
-        execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
-          lib${SSL_LIB_NAME}.a \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libssl.a\")
       " COMPONENT Development)
+      if(BUILD_LIBSSL)
+        install(CODE "
+          execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink
+            lib${SSL_LIB_NAME}.a \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libssl.a\")
+        " COMPONENT Development)
+      endif()
     endif()
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1740,14 +1740,27 @@ include(cmake/JoinPaths.cmake)
 join_paths(LIBDIR_FOR_PC_FILE "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
 join_paths(INCLUDEDIR_FOR_PC_FILE "\${prefix}" "${AWSLC_INSTALL_INCLUDEDIR}")
 
+# Generates a pkg-config file from a template and installs it. The optional
+# INCLUDEDIR, CRYPTO_NAME and SSL_NAME arguments override the corresponding
+# template substitution variables for this one file.
 function(install_pkgconfig_file)
   set(options "")
-  set(oneValueArgs TEMPLATE DEST)
+  set(oneValueArgs TEMPLATE DEST INCLUDEDIR CRYPTO_NAME SSL_NAME)
   set(multiValueArgs)
   if(CMAKE_VERSION VERSION_LESS "3.7")
     cmake_parse_arguments(arg "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   else()
     cmake_parse_arguments(PARSE_ARGV 0 arg "${options}" "${oneValueArgs}" "${multiValueArgs}")
+  endif()
+
+  if(DEFINED arg_INCLUDEDIR)
+    join_paths(INCLUDEDIR_FOR_PC_FILE "\${prefix}" "${arg_INCLUDEDIR}")
+  endif()
+  if(DEFINED arg_CRYPTO_NAME)
+    set(CRYPTO_LIB_NAME "${arg_CRYPTO_NAME}")
+  endif()
+  if(DEFINED arg_SSL_NAME)
+    set(SSL_LIB_NAME "${arg_SSL_NAME}")
   endif()
 
   configure_file(pkgconfig/${arg_TEMPLATE} ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${arg_DEST} @ONLY)
@@ -1767,7 +1780,30 @@ install_pkgconfig_file(TEMPLATE libcrypto.pc.in DEST lib${CRYPTO_LIB_NAME}.pc)
 install_pkgconfig_file(TEMPLATE libssl.pc.in DEST lib${SSL_LIB_NAME}.pc)
 
 if(INSTALL_OPENSSL_SHIM)
-  install_pkgconfig_file(TEMPLATE product.pc.in DEST openssl.pc)
+  # OpenSSL installs three pkg-config files: openssl.pc, libcrypto.pc and
+  # libssl.pc. pkg-config resolves packages by filename, and third-party .pc
+  # files commonly declare 'Requires.private: libcrypto' (libssh2, among
+  # others), so a drop-in replacement must provide all three names. When the
+  # libraries carry the -awslc suffix, install compat files under the OpenSSL
+  # names. They mirror genuine OpenSSL semantics: includedir is the plain
+  # include/ directory (where the include/openssl symlink lives), not the
+  # cohabitant include/aws-lc directory, so the cohabitant path does not leak
+  # into consumers. libssl.pc requires the compat libcrypto for the same
+  # reason ('pkg-config --cflags' resolves Requires.private). Libs still
+  # reference the suffixed libraries.
+  if(SET_LIB_SONAME)
+    install_pkgconfig_file(TEMPLATE libcrypto.pc.in DEST libcrypto.pc
+                           INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+    install_pkgconfig_file(TEMPLATE libssl.pc.in DEST libssl.pc
+                           INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}"
+                           CRYPTO_NAME crypto)
+  endif()
+
+  # Like genuine OpenSSL, openssl.pc requires the unsuffixed package names
+  # and reports the plain include directory.
+  install_pkgconfig_file(TEMPLATE product.pc.in DEST openssl.pc
+                         INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}"
+                         CRYPTO_NAME crypto SSL_NAME ssl)
 
   # Create OpenSSL compatibility symlinks
   if(BUILD_SHARED_LIBS)

--- a/INCORPORATING.md
+++ b/INCORPORATING.md
@@ -63,7 +63,7 @@ This produces, under `${AWS_LC_INSTALL}`:
 * `include/openssl/*.h` -- the public headers.
 * `lib/libcrypto.*` and `lib/libssl.*` -- static (`.a`) and/or shared
   (`.so`/`.dylib`) libraries, depending on `BUILD_SHARED_LIBS`.
-* `lib/pkgconfig/{libcrypto,libssl,aws-lc}.pc` -- pkg-config files.
+* `lib/pkgconfig/{libcrypto,libssl,aws-lc,openssl}.pc` -- pkg-config files.
 
 `-DCMAKE_INSTALL_LIBDIR=lib` is optional but keeps the library directory named
 `lib` on distributions that would otherwise use `lib64`; adjust the paths below
@@ -220,13 +220,9 @@ the plain build described above. The differences that affect consumers are:
 * **Headers move under an `aws-lc/` subdirectory**: they install to
   `<prefix>/include/aws-lc/openssl/` rather than `<prefix>/include/openssl/`.
   Add `-I<prefix>/include/aws-lc` so that `#include <openssl/ssl.h>` resolves.
-* **pkg-config modules are renamed to match**: use `libcrypto-awslc` and
-  `libssl-awslc` (there is also an `aws-lc` module). The unsuffixed `libcrypto`
-  and `libssl` pkg-config modules are *never* installed in this mode -- only the
-  `-awslc`-suffixed ones. Enabling the OpenSSL compatibility shim
-  (`-DENABLE_DIST_PKG_OPENSSL_SHIM=ON`) adds an `openssl` pkg-config module (and
-  unsuffixed `libcrypto.so`/`libssl.so` and `include/<...>/openssl` symlinks),
-  but it does not add unsuffixed `libcrypto`/`libssl` pkg-config modules.
+* **pkg-config modules are renamed to match**: the native modules are
+  `libcrypto-awslc` and `libssl-awslc` (there is also an `aws-lc` module). They
+  report the suffixed library names and the `include/aws-lc` header directory.
 
 Putting the first three together, a manual build against a dist-package install
 looks like:
@@ -241,6 +237,58 @@ export PKG_CONFIG_PATH="${AWS_LC_INSTALL}/lib/pkgconfig"
 cc $(pkg-config --cflags libssl-awslc) app.c \
    $(pkg-config --libs libssl-awslc libcrypto-awslc) -o app
 ```
+
+#### The OpenSSL compatibility shim
+
+Enabling the shim (`-DENABLE_DIST_PKG_OPENSSL_SHIM=ON`) adds a second,
+*unsuffixed* interface on top of the native one, for consumers that only know
+OpenSSL's names. It installs unsuffixed `libcrypto.so`/`libssl.so` (or `.a`)
+symlinks, an `include/openssl` symlink, and three more pkg-config modules:
+
+| module | Cflags | Libs |
+| --- | --- | --- |
+| `libcrypto` | `-I<prefix>/include` | `-L<prefix>/lib -lcrypto` |
+| `libssl` | `-I<prefix>/include` | `-L<prefix>/lib -lssl` |
+| `openssl` | via `Requires: libssl libcrypto` | via `Requires` |
+
+So with the shim enabled the install carries two distinct sets of pkg-config
+metadata, and both remain valid:
+
+```text
+libcrypto-awslc.pc  libssl-awslc.pc  aws-lc.pc   # native, suffixed
+libcrypto.pc        libssl.pc        openssl.pc  # shim, unsuffixed
+```
+
+The shim modules deliberately describe the unsuffixed interface throughout:
+they report `include/` rather than the cohabitant `include/aws-lc`, and they
+emit `-lcrypto`/`-lssl` rather than the suffixed names. Both matter in practice:
+
+* Emitting the cohabitant include path from `libcrypto` leaks it transitively
+  into every consumer, which breaks toolchains that treat a package's include
+  directory as single-valued (Cargo's `links` metadata is last-wins).
+* Emitting a suffixed `-l` name breaks consumers that only recognize `crypto`
+  and `ssl`. CMake's `FindOpenSSL` is the notable one: it treats any other name
+  from `openssl.pc` as an extra dependency and re-emits it as a bare `-l` flag
+  with no `-L` path, so the final link fails with `cannot find -lcrypto-awslc`.
+
+Because `-lcrypto`/`-lssl` resolve the shim symlinks, and those symlinks point
+at libraries whose SONAMEs keep the `-awslc` suffix, a shared consumer linked
+this way still records the suffixed SONAME at runtime. Cohabitation with a
+system OpenSSL is preserved.
+
+With the shim enabled you can therefore use AWS-LC as a drop-in OpenSSL:
+
+```bash
+export PKG_CONFIG_PATH="${AWS_LC_INSTALL}/lib/pkgconfig"
+cc $(pkg-config --cflags libssl) app.c \
+   $(pkg-config --libs libssl libcrypto) -o app
+
+# ... or through CMake's standard OpenSSL discovery
+cmake -B build -DOPENSSL_ROOT_DIR="${AWS_LC_INSTALL}" ...   # find_package(OpenSSL)
+```
+
+When AWS-LC is built without libssl (`-DBUILD_LIBSSL=OFF`), no `libssl` module
+is installed under either name, and `openssl.pc` requires only `libcrypto`.
 
 #### Symbol versioning
 

--- a/pkgconfig/product.pc.in
+++ b/pkgconfig/product.pc.in
@@ -6,5 +6,5 @@ Name: AWS-LC
 Description: AWS-LC (@SOFTWARE_VERSION@)
 URL: https://github.com/aws/aws-lc
 Version: @REPORTED_PKGCONFIG_VERSION@
-Requires: lib@SSL_LIB_NAME@ lib@CRYPTO_LIB_NAME@
+Requires: @PRODUCT_PC_REQUIRES@
 

--- a/tests/ci/pkgconfig_test_helpers.sh
+++ b/tests/ci/pkgconfig_test_helpers.sh
@@ -13,6 +13,16 @@
 #
 # Sourcing scripts must define a fail() function before calling these.
 
+# Detect library directory (lib or lib64)
+function get_lib_dir() {
+    local INSTALL_DIR=$1
+    if [[ -d "${INSTALL_DIR}/lib64" ]]; then
+        echo "lib64"
+    else
+        echo "lib"
+    fi
+}
+
 # Derive the product suffix (e.g. "-awslc") from the installed native filenames
 # rather than hardcoding it, so these assertions still hold if SOFTWARE_NAME
 # changes. Prints the empty string when the native modules are unsuffixed.
@@ -51,8 +61,11 @@ function pc_dependency_tokens() {
 function has_exact_token() {
     local HAYSTACK=$1
     local NEEDLE=$2
+    local -a TOKENS
     local TOKEN
-    for TOKEN in ${HAYSTACK}; do
+    # read -ra splits on whitespace without pathname expansion.
+    read -ra TOKENS <<< "${HAYSTACK}"
+    for TOKEN in "${TOKENS[@]}"; do
         if [[ "${TOKEN}" == "${NEEDLE}" ]]; then
             return 0
         fi

--- a/tests/ci/pkgconfig_test_helpers.sh
+++ b/tests/ci/pkgconfig_test_helpers.sh
@@ -23,6 +23,14 @@ function get_lib_dir() {
     fi
 }
 
+# Run a command with LIBRARY_DIR prepended to LD_LIBRARY_PATH without changing
+# the caller's environment.
+function run_with_library_path() {
+    local LIBRARY_DIR=$1
+    shift
+    LD_LIBRARY_PATH="${LIBRARY_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" "$@"
+}
+
 # Derive the product suffix (e.g. "-awslc") from the installed native filenames
 # rather than hardcoding it, so these assertions still hold if SOFTWARE_NAME
 # changes. Prints the empty string when the native modules are unsuffixed.
@@ -37,6 +45,16 @@ function get_product_suffix() {
         fi
     done
     echo ""
+}
+
+function require_product_suffix() {
+    local PC_DIR=$1
+    local SUFFIX
+    SUFFIX=$(get_product_suffix "${PC_DIR}")
+    if [[ -z "${SUFFIX}" ]]; then
+        fail "could not derive the product suffix from the native pc files in ${PC_DIR}" >&2
+    fi
+    echo "${SUFFIX}"
 }
 
 # Print every whitespace-delimited token of a .pc file's Requires,
@@ -61,15 +79,12 @@ function pc_dependency_tokens() {
 function has_exact_token() {
     local HAYSTACK=$1
     local NEEDLE=$2
-    local -a TOKENS
     local TOKEN
-    # read -ra splits on whitespace without pathname expansion.
-    read -ra TOKENS <<< "${HAYSTACK}"
-    for TOKEN in "${TOKENS[@]}"; do
+    while read -r TOKEN; do
         if [[ "${TOKEN}" == "${NEEDLE}" ]]; then
             return 0
         fi
-    done
+    done < <(tr '[:space:]' '\n' <<< "${HAYSTACK}")
     return 1
 }
 

--- a/tests/ci/pkgconfig_test_helpers.sh
+++ b/tests/ci/pkgconfig_test_helpers.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+# Shared assertions for the installed pkg-config metadata. With the OpenSSL
+# shim enabled and suffixed libraries, AWS-LC installs two interfaces:
+#
+#   native cohabitant:  libcrypto-<product>.pc  libssl-<product>.pc  aws-lc.pc
+#   OpenSSL shim:       libcrypto.pc            libssl.pc            openssl.pc
+#
+# The native modules stay suffixed; every shim-facing module must describe the
+# unsuffixed OpenSSL interface. See INCORPORATING.md for why.
+#
+# Sourcing scripts must define a fail() function before calling these.
+
+# Derive the product suffix (e.g. "-awslc") from the installed native filenames
+# rather than hardcoding it, so these assertions still hold if SOFTWARE_NAME
+# changes. Prints the empty string when the native modules are unsuffixed.
+function get_product_suffix() {
+    local PC_DIR=$1
+    local NATIVE_PC
+    for NATIVE_PC in "${PC_DIR}"/libcrypto-*.pc; do
+        if [[ -f "${NATIVE_PC}" ]]; then
+            NATIVE_PC=$(basename "${NATIVE_PC}" .pc)
+            echo "${NATIVE_PC#libcrypto}"
+            return 0
+        fi
+    done
+    echo ""
+}
+
+# Print every whitespace-delimited token of a .pc file's Requires,
+# Requires.private, Libs and Libs.private fields, one per line. Deliberately
+# skips includedir, -L paths, Name and Cflags, which legitimately mention the
+# product name.
+function pc_dependency_tokens() {
+    local PC_PATH=$1
+    awk '
+        /^[[:space:]]*(Requires|Libs)(\.private)?[[:space:]]*:/ {
+            sub(/^[^:]*:/, "")
+            n = split($0, tokens, /[[:space:]]+/)
+            for (i = 1; i <= n; i++) {
+                if (tokens[i] != "") print tokens[i]
+            }
+        }
+    ' "${PC_PATH}"
+}
+
+# Exact whitespace-delimited token match: unlike a substring test, this does
+# not accept "-lcrypto-awslc" when looking for "-lcrypto".
+function has_exact_token() {
+    local HAYSTACK=$1
+    local NEEDLE=$2
+    local TOKEN
+    for TOKEN in ${HAYSTACK}; do
+        if [[ "${TOKEN}" == "${NEEDLE}" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+function assert_exact_token() {
+    local HAYSTACK=$1
+    local NEEDLE=$2
+    local DESCRIPTION=$3
+    if ! has_exact_token "${HAYSTACK}" "${NEEDLE}"; then
+        fail "${DESCRIPTION}: expected exact token '${NEEDLE}' in '${HAYSTACK}'"
+    fi
+}
+
+function assert_no_exact_token() {
+    local HAYSTACK=$1
+    local NEEDLE=$2
+    local DESCRIPTION=$3
+    if has_exact_token "${HAYSTACK}" "${NEEDLE}"; then
+        fail "${DESCRIPTION}: unexpected exact token '${NEEDLE}' in '${HAYSTACK}'"
+    fi
+}
+
+# No dependency field of a shim-facing .pc file may name a suffixed crypto/ssl
+# module or library. Suffix-agnostic on purpose: this also catches a product
+# suffix other than -awslc, and a failure to derive the suffix at all.
+function assert_no_suffixed_openssl_tokens() {
+    local PC_PATH=$1
+    local TOKEN
+    while read -r TOKEN; do
+        case "${TOKEN}" in
+            -lcrypto-*|-lssl-*|libcrypto-*|libssl-*)
+                fail "$(basename "${PC_PATH}") names suffixed OpenSSL token '${TOKEN}' in a Requires/Libs field"
+                ;;
+        esac
+    done < <(pc_dependency_tokens "${PC_PATH}")
+}
+
+# Assert a pkg-config query emits an exact token. FLAG is a pkg-config option
+# such as --libs, --print-requires or --print-requires-private. The caller must
+# set PKG_CONFIG_PATH.
+function assert_pkgconfig_token() {
+    local PC_NAME=$1
+    local FLAG=$2
+    local EXPECTED=$3
+    local OUTPUT
+    OUTPUT=$(pkg-config ${FLAG} "${PC_NAME}")
+    assert_exact_token "${OUTPUT}" "${EXPECTED}" "pkg-config ${FLAG} ${PC_NAME}"
+}
+
+function assert_no_pkgconfig_token() {
+    local PC_NAME=$1
+    local FLAG=$2
+    local UNEXPECTED=$3
+    local OUTPUT
+    OUTPUT=$(pkg-config ${FLAG} "${PC_NAME}")
+    assert_no_exact_token "${OUTPUT}" "${UNEXPECTED}" "pkg-config ${FLAG} ${PC_NAME}"
+}

--- a/tests/ci/run_dist_pkg_install_tests.sh
+++ b/tests/ci/run_dist_pkg_install_tests.sh
@@ -171,6 +171,19 @@ function verify_dist_pkg_structure() {
         if [[ ! -f "${INSTALL_DIR}/${LIB_DIR}/pkgconfig/openssl.pc" ]]; then
             fail "openssl.pc not found in ${LIB_DIR}/pkgconfig/ (OpenSSL shim enabled)"
         fi
+
+        # OpenSSL compat pkg-config files must exist and must not reference
+        # the cohabitant include directory.
+        local PC_FILE
+        for PC_FILE in libcrypto.pc libssl.pc; do
+            local PC_PATH="${INSTALL_DIR}/${LIB_DIR}/pkgconfig/${PC_FILE}"
+            if [[ ! -f "${PC_PATH}" ]]; then
+                fail "${PC_FILE} not found in ${LIB_DIR}/pkgconfig/ (OpenSSL shim enabled)"
+            fi
+            if grep -q "include/aws-lc" "${PC_PATH}"; then
+                fail "${PC_FILE} references the cohabitant include directory"
+            fi
+        done
     else
         # When OpenSSL shim is disabled, symlinks should NOT exist
         if [[ -e "${INSTALL_DIR}/include/openssl" ]]; then
@@ -192,6 +205,14 @@ function verify_dist_pkg_structure() {
                 fail "libssl.a should not exist in ${LIB_DIR}/ when OpenSSL shim is disabled"
             fi
         fi
+
+        # OpenSSL compat pkg-config files should NOT exist either
+        local PC_FILE
+        for PC_FILE in openssl.pc libcrypto.pc libssl.pc; do
+            if [[ -e "${INSTALL_DIR}/${LIB_DIR}/pkgconfig/${PC_FILE}" ]]; then
+                fail "${PC_FILE} should not exist when OpenSSL shim is disabled"
+            fi
+        done
     fi
 
     echo "Installation structure verified successfully!"
@@ -347,6 +368,75 @@ EOF
     echo "pkg-config test passed for ${PC_NAME}!"
 }
 
+# Verify the OpenSSL compat pkg-config files behave like genuine OpenSSL's:
+# all three names resolve, the cohabitant include directory does not leak,
+# and a pc file declaring 'Requires.private: libcrypto' (the pattern shipped
+# by libssh2 and others) resolves.
+function test_openssl_compat_pkg_config() {
+    local INSTALL_NAME=$1
+    local INSTALL_DIR=${SCRATCH_DIR}/${INSTALL_NAME}
+
+    # Detect library directory (lib or lib64)
+    local LIB_DIR
+    LIB_DIR=$(get_lib_dir "${INSTALL_DIR}")
+
+    echo ""
+    echo "=============================================="
+    echo "Testing OpenSSL compat pkg-config files for: ${INSTALL_NAME}"
+    echo "=============================================="
+
+    export PKG_CONFIG_PATH="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+
+    local PC_NAME
+    for PC_NAME in openssl libcrypto libssl; do
+        if ! pkg-config --exists "${PC_NAME}"; then
+            fail "pkg-config cannot find package: ${PC_NAME}"
+        fi
+        local CFLAGS
+        CFLAGS=$(pkg-config --cflags "${PC_NAME}")
+        echo "${PC_NAME} CFLAGS: ${CFLAGS}"
+        if [[ "${CFLAGS}" == *"include/aws-lc"* ]]; then
+            fail "cohabitant include directory leaked into '${PC_NAME}' Cflags: ${CFLAGS}"
+        fi
+    done
+
+    # The compat files must still link the suffixed libraries.
+    local LIBS
+    LIBS=$(pkg-config --libs libcrypto)
+    if [[ "${LIBS}" != *"-lcrypto-awslc"* ]]; then
+        fail "compat libcrypto.pc does not link libcrypto-awslc: ${LIBS}"
+    fi
+    LIBS=$(pkg-config --libs libssl)
+    if [[ "${LIBS}" != *"-lssl-awslc"* ]]; then
+        fail "compat libssl.pc does not link libssl-awslc: ${LIBS}"
+    fi
+
+    # Reproduce the third-party consumer pattern: pkg-config resolves
+    # Requires.private to compute Cflags, so this fails unless libcrypto.pc
+    # exists under that exact filename.
+    local CONSUMER_DIR=${SCRATCH_DIR}/pkgconfig-consumer
+    rm -rf "${CONSUMER_DIR:?}"
+    mkdir -p ${CONSUMER_DIR}
+    cat <<EOF > ${CONSUMER_DIR}/shimconsumer.pc
+prefix=/nonexistent
+Name: shimconsumer
+Description: Synthetic consumer of OpenSSL via pkg-config
+Version: 1.0
+Requires.private: libcrypto
+Libs: -L\${prefix}/lib -lshimconsumer
+Cflags: -I\${prefix}/include
+EOF
+
+    export PKG_CONFIG_PATH="${CONSUMER_DIR}:${PKG_CONFIG_PATH}"
+    if ! pkg-config --cflags --libs shimconsumer > /dev/null; then
+        fail "pkg-config failed to resolve 'Requires.private: libcrypto' for a consumer package"
+    fi
+
+    unset PKG_CONFIG_PATH
+
+    echo "OpenSSL compat pkg-config tests passed!"
+}
+
 # Main test execution
 
 echo ""
@@ -382,6 +472,8 @@ verify_dist_pkg_structure install-dist-pkg-shim-shared .so ON
 test_cmake_find_package install-dist-pkg-shim-shared ON
 test_pkg_config install-dist-pkg-shim-shared aws-lc OFF
 test_pkg_config install-dist-pkg-shim-shared openssl OFF
+test_pkg_config install-dist-pkg-shim-shared libcrypto OFF
+test_openssl_compat_pkg_config install-dist-pkg-shim-shared
 
 # Test 3: ENABLE_DIST_PKG only (static libs)
 echo ""
@@ -403,6 +495,8 @@ verify_dist_pkg_structure install-dist-pkg-shim-static .a ON
 test_cmake_find_package install-dist-pkg-shim-static OFF
 test_pkg_config install-dist-pkg-shim-static aws-lc ON
 test_pkg_config install-dist-pkg-shim-static openssl ON
+test_pkg_config install-dist-pkg-shim-static libcrypto ON
+test_openssl_compat_pkg_config install-dist-pkg-shim-static
 
 echo ""
 echo "############################################"

--- a/tests/ci/run_dist_pkg_install_tests.sh
+++ b/tests/ci/run_dist_pkg_install_tests.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 source tests/ci/common_posix_setup.sh
+source tests/ci/pkgconfig_test_helpers.sh
 
 export CMAKE_BUILD_PARALLEL_LEVEL=${NUM_CPU_THREADS}
 
@@ -21,6 +22,7 @@ export CMAKE_BUILD_PARALLEL_LEVEL=${NUM_CPU_THREADS}
 #    - install-dist-pkg-shim-shared
 #    - install-dist-pkg-static
 #    - install-dist-pkg-shim-static
+#    - install-dist-pkg-shim-nossl
 #    - MYAPP_SRC
 
 # Assumes script is executed from the root of aws-lc directory
@@ -51,6 +53,7 @@ function install_aws_lc_dist_pkg() {
     local INSTALL_DIR=${SCRATCH_DIR}/$1
     local BUILD_SHARED_LIBS=$2  # "BUILD_SHARED_LIBS=ON" or "BUILD_SHARED_LIBS=OFF"
     local OPENSSL_SHIM=$3       # "ON" or "OFF"
+    local BUILD_LIBSSL=${4:-ON} # "ON" or "OFF"
 
     local BUILD_DIR=${SCRATCH_DIR}/build
     rm -rf "${BUILD_DIR:?}"
@@ -64,10 +67,16 @@ function install_aws_lc_dist_pkg() {
         "-DBUILD_TESTING=OFF"
         "-DENABLE_DIST_PKG=ON"
         "-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
+        "-DBUILD_LIBSSL=${BUILD_LIBSSL}"
     )
 
     if [[ "${OPENSSL_SHIM}" == "ON" ]]; then
         CMAKE_FLAGS+=("-DENABLE_DIST_PKG_OPENSSL_SHIM=ON")
+    fi
+
+    if [[ "${BUILD_LIBSSL}" == "OFF" ]]; then
+        # The bssl tool needs libssl.
+        CMAKE_FLAGS+=("-DBUILD_TOOL=OFF")
     fi
 
     ${CMAKE_COMMAND} "${CMAKE_FLAGS[@]}"
@@ -172,8 +181,7 @@ function verify_dist_pkg_structure() {
             fail "openssl.pc not found in ${LIB_DIR}/pkgconfig/ (OpenSSL shim enabled)"
         fi
 
-        # OpenSSL compat pkg-config files must exist and must not reference
-        # the cohabitant include directory.
+        # Shim pc files must exist and must not name the cohabitant include dir.
         local PC_FILE
         for PC_FILE in libcrypto.pc libssl.pc; do
             local PC_PATH="${INSTALL_DIR}/${LIB_DIR}/pkgconfig/${PC_FILE}"
@@ -206,7 +214,7 @@ function verify_dist_pkg_structure() {
             fi
         fi
 
-        # OpenSSL compat pkg-config files should NOT exist either
+        # Nor should the shim pc files exist
         local PC_FILE
         for PC_FILE in openssl.pc libcrypto.pc libssl.pc; do
             if [[ -e "${INSTALL_DIR}/${LIB_DIR}/pkgconfig/${PC_FILE}" ]]; then
@@ -253,6 +261,163 @@ target_link_libraries(mylib PRIVATE AWS::ssl AWS::crypto)
 add_executable(myapp myapp.c)
 target_link_libraries(myapp PRIVATE mylib)
 EOF
+}
+
+# Setup an isolated consumer that uses CMake's *standard* OpenSSL discovery --
+# find_package(OpenSSL) and the OpenSSL::Crypto/OpenSSL::SSL imported targets,
+# not AWS-LC's own find_package(ssl)/AWS::crypto package. This is the path that
+# exposed the suffixed-Libs bug; see the regression guard below.
+function setup_openssl_consumer_app() {
+    local SRC_DIR=${SCRATCH_DIR}/openssl-consumer-src
+    rm -rf "${SRC_DIR:?}"
+    mkdir -p ${SRC_DIR}
+    sync
+
+    cat <<EOF > ${SRC_DIR}/main.c
+#include <openssl/crypto.h>
+#include <stdio.h>
+#ifdef CONSUMER_USE_SSL
+#include <openssl/ssl.h>
+#endif
+
+int main(void) {
+#ifdef CONSUMER_USE_SSL
+    OPENSSL_init_ssl(0, NULL);
+#endif
+    printf("find_package(OpenSSL) consumer linked against: %s\\n",
+           OpenSSL_version(OPENSSL_VERSION));
+    return 0;
+}
+EOF
+
+    cat <<'EOF' > ${SRC_DIR}/CMakeLists.txt
+cmake_minimum_required(VERSION 3.5)
+project(opensslconsumer C)
+
+# Standard OpenSSL discovery, exactly as a third-party project would do it.
+find_package(OpenSSL REQUIRED)
+
+if(NOT EXPECTED_PREFIX)
+  message(FATAL_ERROR "EXPECTED_PREFIX must be set to the install prefix under test")
+endif()
+get_filename_component(EXPECTED_PREFIX_REAL "${EXPECTED_PREFIX}" REALPATH)
+
+# Fail if CMake selected a system OpenSSL rather than the install under test.
+function(assert_within_prefix var_name path)
+  if("${path}" STREQUAL "")
+    return()
+  endif()
+  get_filename_component(_resolved "${path}" REALPATH)
+  string(FIND "${_resolved}" "${EXPECTED_PREFIX_REAL}/" _idx)
+  if(NOT _idx EQUAL 0)
+    message(FATAL_ERROR
+      "find_package(OpenSSL) resolved ${var_name} to '${path}' (real path "
+      "'${_resolved}'), which is outside the install prefix under test "
+      "'${EXPECTED_PREFIX_REAL}'. A system OpenSSL was selected.")
+  endif()
+endfunction()
+
+assert_within_prefix(OPENSSL_INCLUDE_DIR "${OPENSSL_INCLUDE_DIR}")
+assert_within_prefix(OPENSSL_CRYPTO_LIBRARY "${OPENSSL_CRYPTO_LIBRARY}")
+if(WITH_SSL)
+  assert_within_prefix(OPENSSL_SSL_LIBRARY "${OPENSSL_SSL_LIBRARY}")
+endif()
+
+# Regression guard for the suffixed-Libs bug. FindOpenSSL resolves openssl.pc
+# through pkg_check_modules and recognizes only the exact library names
+# 'ssl'/'crypto' (plus 'dl'/'z'). It appends anything else to the imported
+# targets' INTERFACE_LINK_LIBRARIES verbatim, as a bare name with no -L path,
+# so the link fails with "cannot find -lcrypto-<product>".
+foreach(_target OpenSSL::Crypto OpenSSL::SSL)
+  if(TARGET ${_target})
+    get_target_property(_iface ${_target} INTERFACE_LINK_LIBRARIES)
+    if(_iface)
+      foreach(_lib IN LISTS _iface)
+        if(_lib MATCHES "^(-l)?(lib)?(ssl|crypto)-")
+          message(FATAL_ERROR
+            "FindOpenSSL treated '${_lib}' as a bare extra dependency of "
+            "${_target} (INTERFACE_LINK_LIBRARIES: ${_iface}). The shim "
+            "pkg-config modules must report unsuffixed OpenSSL library names.")
+        endif()
+      endforeach()
+    endif()
+  endif()
+endforeach()
+
+message(STATUS "OPENSSL_VERSION: ${OPENSSL_VERSION}")
+message(STATUS "OPENSSL_INCLUDE_DIR: ${OPENSSL_INCLUDE_DIR}")
+message(STATUS "OPENSSL_CRYPTO_LIBRARY: ${OPENSSL_CRYPTO_LIBRARY}")
+message(STATUS "OPENSSL_SSL_LIBRARY: ${OPENSSL_SSL_LIBRARY}")
+
+add_executable(opensslconsumer main.c)
+target_link_libraries(opensslconsumer PRIVATE OpenSSL::Crypto)
+
+if(WITH_SSL)
+  if(NOT TARGET OpenSSL::SSL)
+    message(FATAL_ERROR "OpenSSL::SSL target was not created")
+  endif()
+  target_link_libraries(opensslconsumer PRIVATE OpenSSL::SSL)
+  target_compile_definitions(opensslconsumer PRIVATE CONSUMER_USE_SSL)
+endif()
+EOF
+}
+
+# Configure, build and run the standard-CMake OpenSSL consumer. Building it
+# matters: the failure only surfaces in the final link command.
+function test_cmake_find_package_openssl() {
+    local INSTALL_NAME=$1
+    local IS_STATIC=$2      # "ON" for static, "OFF" for shared
+    local WITH_SSL=${3:-ON}
+    local INSTALL_DIR=${SCRATCH_DIR}/${INSTALL_NAME}
+
+    local LIB_DIR
+    LIB_DIR=$(get_lib_dir "${INSTALL_DIR}")
+
+    echo ""
+    echo "=============================================="
+    echo "Testing standard CMake find_package(OpenSSL) for: ${INSTALL_NAME}"
+    echo "Static: ${IS_STATIC}  WITH_SSL: ${WITH_SSL}"
+    echo "=============================================="
+
+    local BUILD_DIR=${SCRATCH_DIR}/build-openssl-consumer
+    rm -rf "${BUILD_DIR:?}"
+    sync
+
+    local CMAKE_FLAGS=(
+        "-H${SCRATCH_DIR}/openssl-consumer-src"
+        "-B${BUILD_DIR}"
+        "-GNinja"
+        "-DEXPECTED_PREFIX=${INSTALL_DIR}"
+        "-DWITH_SSL=${WITH_SSL}"
+        # FindOpenSSL hints come from OPENSSL_ROOT_DIR and pkg-config, so point
+        # both at the prefix under test; a system OpenSSL must not win.
+        "-DOPENSSL_ROOT_DIR=${INSTALL_DIR}"
+    )
+    if [[ "${IS_STATIC}" == "ON" ]]; then
+        # Makes FindOpenSSL use --static, resolving Requires.private.
+        CMAKE_FLAGS+=("-DOPENSSL_USE_STATIC_LIBS=TRUE")
+    fi
+
+    local ORIG_PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}"
+    export PKG_CONFIG_PATH="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+
+    ${CMAKE_COMMAND} "${CMAKE_FLAGS[@]}"
+    ${CMAKE_COMMAND} --build "${BUILD_DIR}"
+
+    if [[ -n "${ORIG_PKG_CONFIG_PATH}" ]]; then
+        export PKG_CONFIG_PATH="${ORIG_PKG_CONFIG_PATH}"
+    else
+        unset PKG_CONFIG_PATH
+    fi
+
+    local ORIG_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    export LD_LIBRARY_PATH="${INSTALL_DIR}/${LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
+    ${BUILD_DIR}/opensslconsumer || fail "find_package(OpenSSL) consumer failed to run"
+
+    export LD_LIBRARY_PATH="${ORIG_LD_LIBRARY_PATH}"
+
+    echo "Standard CMake find_package(OpenSSL) test passed!"
 }
 
 # Build and run test app using CMake find_package
@@ -368,52 +533,142 @@ EOF
     echo "pkg-config test passed for ${PC_NAME}!"
 }
 
-# Verify the OpenSSL compat pkg-config files behave like genuine OpenSSL's:
-# all three names resolve, the cohabitant include directory does not leak,
-# and a pc file declaring 'Requires.private: libcrypto' (the pattern shipped
-# by libssh2 and others) resolves.
+# Verify the shim-facing modules describe the unsuffixed OpenSSL interface:
+# all three names resolve, the cohabitant include dir does not leak, and the
+# module and linker names they reference are unsuffixed.
 function test_openssl_compat_pkg_config() {
     local INSTALL_NAME=$1
+    local IS_STATIC=$2  # "ON" for static, "OFF" for shared
     local INSTALL_DIR=${SCRATCH_DIR}/${INSTALL_NAME}
 
     # Detect library directory (lib or lib64)
     local LIB_DIR
     LIB_DIR=$(get_lib_dir "${INSTALL_DIR}")
+    local PC_DIR="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+
+    local PKG_CONFIG_STATIC_FLAG=""
+    if [[ "${IS_STATIC}" == "ON" ]]; then
+        PKG_CONFIG_STATIC_FLAG="--static"
+    fi
+
+    local SUFFIX
+    SUFFIX=$(get_product_suffix "${PC_DIR}")
 
     echo ""
     echo "=============================================="
-    echo "Testing OpenSSL compat pkg-config files for: ${INSTALL_NAME}"
+    echo "Testing OpenSSL shim pkg-config modules for: ${INSTALL_NAME}"
+    echo "Static: ${IS_STATIC}"
+    echo "Product suffix: '${SUFFIX}'"
     echo "=============================================="
 
-    export PKG_CONFIG_PATH="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+    if [[ -z "${SUFFIX}" ]]; then
+        fail "could not derive the product suffix from the native pc files in ${PC_DIR}"
+    fi
 
+    export PKG_CONFIG_PATH="${PC_DIR}"
+
+    # All three OpenSSL module names must resolve from the install prefix.
     local PC_NAME
     for PC_NAME in openssl libcrypto libssl; do
         if ! pkg-config --exists "${PC_NAME}"; then
             fail "pkg-config cannot find package: ${PC_NAME}"
         fi
+
+        # The shim includedir is the plain include/ directory, where the shim
+        # installs its include/openssl symlink. Emitting include/aws-lc here
+        # would leak it into every consumer of libcrypto.
+        local RESOLVED_INCLUDEDIR
+        RESOLVED_INCLUDEDIR=$(pkg-config --variable=includedir "${PC_NAME}")
+        if [[ "${RESOLVED_INCLUDEDIR}" != "${INSTALL_DIR}/include" ]]; then
+            fail "'${PC_NAME}' includedir is '${RESOLVED_INCLUDEDIR}', expected '${INSTALL_DIR}/include'"
+        fi
+
         local CFLAGS
         CFLAGS=$(pkg-config --cflags "${PC_NAME}")
         echo "${PC_NAME} CFLAGS: ${CFLAGS}"
-        if [[ "${CFLAGS}" == *"include/aws-lc"* ]]; then
-            fail "cohabitant include directory leaked into '${PC_NAME}' Cflags: ${CFLAGS}"
-        fi
+        assert_exact_token "${CFLAGS}" "-I${INSTALL_DIR}/include" "'${PC_NAME}' Cflags"
+        assert_no_exact_token "${CFLAGS}" "-I${INSTALL_DIR}/include/aws-lc" "'${PC_NAME}' Cflags"
+
+        # No dependency field of a shim-facing file may name a suffixed token.
+        assert_no_suffixed_openssl_tokens "${PC_DIR}/${PC_NAME}.pc"
     done
 
-    # The compat files must still link the suffixed libraries.
+    # Unsuffixed linker names, as exact tokens, with the -L path that resolves
+    # them.
     local LIBS
-    LIBS=$(pkg-config --libs libcrypto)
-    if [[ "${LIBS}" != *"-lcrypto-awslc"* ]]; then
-        fail "compat libcrypto.pc does not link libcrypto-awslc: ${LIBS}"
-    fi
-    LIBS=$(pkg-config --libs libssl)
-    if [[ "${LIBS}" != *"-lssl-awslc"* ]]; then
-        fail "compat libssl.pc does not link libssl-awslc: ${LIBS}"
-    fi
+    for PC_NAME in libcrypto openssl; do
+        LIBS=$(pkg-config ${PKG_CONFIG_STATIC_FLAG} --libs "${PC_NAME}")
+        echo "${PC_NAME} LIBS: ${LIBS}"
+        assert_exact_token "${LIBS}" "-L${INSTALL_DIR}/${LIB_DIR}" "'${PC_NAME}' Libs"
+        assert_exact_token "${LIBS}" "-lcrypto" "'${PC_NAME}' Libs"
+        assert_no_exact_token "${LIBS}" "-lcrypto${SUFFIX}" "'${PC_NAME}' Libs"
+        assert_no_exact_token "${LIBS}" "-lssl${SUFFIX}" "'${PC_NAME}' Libs"
+    done
 
-    # Reproduce the third-party consumer pattern: pkg-config resolves
-    # Requires.private to compute Cflags, so this fails unless libcrypto.pc
-    # exists under that exact filename.
+    for PC_NAME in libssl openssl; do
+        LIBS=$(pkg-config ${PKG_CONFIG_STATIC_FLAG} --libs "${PC_NAME}")
+        assert_exact_token "${LIBS}" "-lssl" "'${PC_NAME}' Libs"
+    done
+
+    # --static additionally resolves Requires.private/Libs.private.
+    LIBS=$(pkg-config --static --libs libssl)
+    echo "libssl static LIBS: ${LIBS}"
+    assert_exact_token "${LIBS}" "-lssl" "'libssl' static Libs"
+    assert_exact_token "${LIBS}" "-lcrypto" "'libssl' static Libs"
+    assert_no_exact_token "${LIBS}" "-lcrypto${SUFFIX}" "'libssl' static Libs"
+
+    local SSL_REQUIRES
+    SSL_REQUIRES=$(pkg-config --print-requires-private libssl)
+    assert_exact_token "${SSL_REQUIRES}" "libcrypto" "'libssl' Requires.private"
+    assert_no_exact_token "${SSL_REQUIRES}" "libcrypto${SUFFIX}" "'libssl' Requires.private"
+
+    local OPENSSL_REQUIRES
+    OPENSSL_REQUIRES=$(pkg-config --print-requires openssl)
+    echo "openssl Requires: ${OPENSSL_REQUIRES}"
+    assert_exact_token "${OPENSSL_REQUIRES}" "libcrypto" "'openssl' Requires"
+    assert_exact_token "${OPENSSL_REQUIRES}" "libssl" "'openssl' Requires"
+    assert_no_exact_token "${OPENSSL_REQUIRES}" "libcrypto${SUFFIX}" "'openssl' Requires"
+    assert_no_exact_token "${OPENSSL_REQUIRES}" "libssl${SUFFIX}" "'openssl' Requires"
+
+    # End-to-end: an SSL consumer must compile, link and run through the shim
+    # modules alone, proving -lssl/-lcrypto resolve the shim symlinks.
+    local SSL_TEST_DIR=${SCRATCH_DIR}/pkgconfig-ssl-test
+    rm -rf "${SSL_TEST_DIR:?}"
+    mkdir -p ${SSL_TEST_DIR}
+    cat <<EOF > ${SSL_TEST_DIR}/test.c
+#include <openssl/crypto.h>
+#include <openssl/ssl.h>
+#include <stdio.h>
+int main(void) {
+    const SSL_METHOD *method = TLS_method();
+    SSL_CTX *ctx = SSL_CTX_new(method);
+    if (ctx == NULL) {
+        return 1;
+    }
+    SSL_CTX_free(ctx);
+    printf("shim libssl+libcrypto consumer ok: %s\\n",
+           OpenSSL_version(OPENSSL_VERSION));
+    return 0;
+}
+EOF
+
+    local SSL_CFLAGS SSL_LIBS
+    SSL_CFLAGS=$(pkg-config --cflags libssl libcrypto)
+    SSL_LIBS=$(pkg-config ${PKG_CONFIG_STATIC_FLAG} --libs libssl libcrypto)
+    echo "ssl consumer CFLAGS: ${SSL_CFLAGS}"
+    echo "ssl consumer LIBS: ${SSL_LIBS}"
+    assert_exact_token "${SSL_LIBS}" "-lssl" "'libssl libcrypto' Libs"
+    assert_exact_token "${SSL_LIBS}" "-lcrypto" "'libssl libcrypto' Libs"
+
+    ${CC:-cc} ${SSL_TEST_DIR}/test.c ${SSL_CFLAGS} ${SSL_LIBS} -o ${SSL_TEST_DIR}/test
+
+    local ORIG_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    export LD_LIBRARY_PATH="${INSTALL_DIR}/${LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    ${SSL_TEST_DIR}/test || fail "shim libssl+libcrypto consumer failed to run"
+    export LD_LIBRARY_PATH="${ORIG_LD_LIBRARY_PATH}"
+
+    # The libssh2 pattern: pkg-config resolves Requires.private to compute
+    # Cflags, so this fails unless libcrypto.pc exists under that exact name.
     local CONSUMER_DIR=${SCRATCH_DIR}/pkgconfig-consumer
     rm -rf "${CONSUMER_DIR:?}"
     mkdir -p ${CONSUMER_DIR}
@@ -434,16 +689,179 @@ EOF
 
     unset PKG_CONFIG_PATH
 
-    echo "OpenSSL compat pkg-config tests passed!"
+    echo "OpenSSL shim pkg-config tests passed!"
+}
+
+# The shim must leave the native cohabitant modules untouched: suffixed module
+# and linker names, and the cohabitant include directory.
+function test_native_pkg_config_unchanged() {
+    local INSTALL_NAME=$1
+    local IS_STATIC=$2  # "ON" for static, "OFF" for shared
+    local INSTALL_DIR=${SCRATCH_DIR}/${INSTALL_NAME}
+
+    local LIB_DIR
+    LIB_DIR=$(get_lib_dir "${INSTALL_DIR}")
+    local PC_DIR="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+
+    local PKG_CONFIG_STATIC_FLAG=""
+    if [[ "${IS_STATIC}" == "ON" ]]; then
+        PKG_CONFIG_STATIC_FLAG="--static"
+    fi
+
+    local SUFFIX
+    SUFFIX=$(get_product_suffix "${PC_DIR}")
+
+    echo ""
+    echo "=============================================="
+    echo "Testing native cohabitant pkg-config modules for: ${INSTALL_NAME}"
+    echo "Product suffix: '${SUFFIX}'"
+    echo "=============================================="
+
+    if [[ -z "${SUFFIX}" ]]; then
+        fail "could not derive the product suffix from the native pc files in ${PC_DIR}"
+    fi
+
+    export PKG_CONFIG_PATH="${PC_DIR}"
+
+    local PC_NAME
+    for PC_NAME in "aws-lc" "libcrypto${SUFFIX}" "libssl${SUFFIX}"; do
+        if ! pkg-config --exists "${PC_NAME}"; then
+            fail "pkg-config cannot find native package: ${PC_NAME}"
+        fi
+        local RESOLVED_INCLUDEDIR
+        RESOLVED_INCLUDEDIR=$(pkg-config --variable=includedir "${PC_NAME}")
+        if [[ "${RESOLVED_INCLUDEDIR}" != "${INSTALL_DIR}/include/aws-lc" ]]; then
+            fail "native '${PC_NAME}' includedir is '${RESOLVED_INCLUDEDIR}', expected '${INSTALL_DIR}/include/aws-lc'"
+        fi
+    done
+
+    local LIBS
+    LIBS=$(pkg-config ${PKG_CONFIG_STATIC_FLAG} --libs "libcrypto${SUFFIX}")
+    echo "libcrypto${SUFFIX} LIBS: ${LIBS}"
+    assert_exact_token "${LIBS}" "-lcrypto${SUFFIX}" "native 'libcrypto${SUFFIX}' Libs"
+    assert_no_exact_token "${LIBS}" "-lcrypto" "native 'libcrypto${SUFFIX}' Libs"
+
+    LIBS=$(pkg-config ${PKG_CONFIG_STATIC_FLAG} --libs "libssl${SUFFIX}")
+    echo "libssl${SUFFIX} LIBS: ${LIBS}"
+    assert_exact_token "${LIBS}" "-lssl${SUFFIX}" "native 'libssl${SUFFIX}' Libs"
+    assert_no_exact_token "${LIBS}" "-lssl" "native 'libssl${SUFFIX}' Libs"
+
+    local REQUIRES
+    REQUIRES=$(pkg-config --print-requires "aws-lc")
+    echo "aws-lc Requires: ${REQUIRES}"
+    assert_exact_token "${REQUIRES}" "libcrypto${SUFFIX}" "native 'aws-lc' Requires"
+    assert_exact_token "${REQUIRES}" "libssl${SUFFIX}" "native 'aws-lc' Requires"
+    assert_no_exact_token "${REQUIRES}" "libcrypto" "native 'aws-lc' Requires"
+    assert_no_exact_token "${REQUIRES}" "libssl" "native 'aws-lc' Requires"
+
+    REQUIRES=$(pkg-config --print-requires-private "libssl${SUFFIX}")
+    assert_exact_token "${REQUIRES}" "libcrypto${SUFFIX}" "native 'libssl${SUFFIX}' Requires.private"
+    assert_no_exact_token "${REQUIRES}" "libcrypto" "native 'libssl${SUFFIX}' Requires.private"
+
+    unset PKG_CONFIG_PATH
+
+    echo "Native cohabitant pkg-config tests passed!"
+}
+
+# BUILD_LIBSSL=OFF: no libssl module under either name, and openssl.pc must not
+# require one -- a dangling requirement makes 'pkg-config --exists' fail.
+function test_pkg_config_no_libssl() {
+    local INSTALL_NAME=$1
+    local INSTALL_DIR=${SCRATCH_DIR}/${INSTALL_NAME}
+
+    local LIB_DIR
+    LIB_DIR=$(get_lib_dir "${INSTALL_DIR}")
+    local PC_DIR="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+
+    local SUFFIX
+    SUFFIX=$(get_product_suffix "${PC_DIR}")
+
+    echo ""
+    echo "=============================================="
+    echo "Testing BUILD_LIBSSL=OFF pkg-config modules for: ${INSTALL_NAME}"
+    echo "Product suffix: '${SUFFIX}'"
+    echo "=============================================="
+
+    if [[ -z "${SUFFIX}" ]]; then
+        fail "could not derive the product suffix from the native pc files in ${PC_DIR}"
+    fi
+
+    local PC_FILE
+    for PC_FILE in "libssl.pc" "libssl${SUFFIX}.pc"; do
+        if [[ -e "${PC_DIR}/${PC_FILE}" ]]; then
+            fail "${PC_FILE} should not be installed when BUILD_LIBSSL=OFF"
+        fi
+    done
+
+    # Nor a dangling libssl symlink: -e follows symlinks, so a dangling one is
+    # caught by -L without -e.
+    local LIB_FILE
+    for LIB_FILE in "libssl.so" "libssl.a" "libssl${SUFFIX}.so" "libssl${SUFFIX}.a"; do
+        if [[ -e "${INSTALL_DIR}/${LIB_DIR}/${LIB_FILE}" ]]; then
+            fail "${LIB_FILE} should not be installed when BUILD_LIBSSL=OFF"
+        fi
+        if [[ -L "${INSTALL_DIR}/${LIB_DIR}/${LIB_FILE}" ]]; then
+            fail "${LIB_FILE} is a dangling symlink; it should not be installed when BUILD_LIBSSL=OFF"
+        fi
+    done
+
+    for PC_FILE in "aws-lc.pc" "openssl.pc" "libcrypto.pc" "libcrypto${SUFFIX}.pc"; do
+        if [[ ! -f "${PC_DIR}/${PC_FILE}" ]]; then
+            fail "${PC_FILE} not found in ${PC_DIR} (BUILD_LIBSSL=OFF)"
+        fi
+    done
+
+    export PKG_CONFIG_PATH="${PC_DIR}"
+
+    if pkg-config --exists libssl; then
+        fail "pkg-config resolved 'libssl' when BUILD_LIBSSL=OFF"
+    fi
+    if pkg-config --exists "libssl${SUFFIX}"; then
+        fail "pkg-config resolved 'libssl${SUFFIX}' when BUILD_LIBSSL=OFF"
+    fi
+
+    # These would fail if the Requires line still named a missing libssl.
+    local PC_NAME
+    for PC_NAME in openssl libcrypto "aws-lc" "libcrypto${SUFFIX}"; do
+        if ! pkg-config --exists "${PC_NAME}"; then
+            fail "pkg-config cannot find package '${PC_NAME}' (BUILD_LIBSSL=OFF); it likely still requires a missing libssl"
+        fi
+    done
+
+    local REQUIRES
+    REQUIRES=$(pkg-config --print-requires openssl)
+    echo "openssl Requires: ${REQUIRES}"
+    assert_exact_token "${REQUIRES}" "libcrypto" "'openssl' Requires (BUILD_LIBSSL=OFF)"
+    assert_no_exact_token "${REQUIRES}" "libssl" "'openssl' Requires (BUILD_LIBSSL=OFF)"
+    assert_no_exact_token "${REQUIRES}" "libssl${SUFFIX}" "'openssl' Requires (BUILD_LIBSSL=OFF)"
+
+    REQUIRES=$(pkg-config --print-requires "aws-lc")
+    echo "aws-lc Requires: ${REQUIRES}"
+    assert_exact_token "${REQUIRES}" "libcrypto${SUFFIX}" "native 'aws-lc' Requires (BUILD_LIBSSL=OFF)"
+    assert_no_exact_token "${REQUIRES}" "libssl${SUFFIX}" "native 'aws-lc' Requires (BUILD_LIBSSL=OFF)"
+
+    # The shim libcrypto module is still fully unsuffixed.
+    local LIBS
+    LIBS=$(pkg-config --libs libcrypto)
+    echo "libcrypto LIBS: ${LIBS}"
+    assert_exact_token "${LIBS}" "-lcrypto" "'libcrypto' Libs (BUILD_LIBSSL=OFF)"
+    assert_no_exact_token "${LIBS}" "-lcrypto${SUFFIX}" "'libcrypto' Libs (BUILD_LIBSSL=OFF)"
+    assert_no_suffixed_openssl_tokens "${PC_DIR}/libcrypto.pc"
+    assert_no_suffixed_openssl_tokens "${PC_DIR}/openssl.pc"
+
+    unset PKG_CONFIG_PATH
+
+    echo "BUILD_LIBSSL=OFF pkg-config tests passed!"
 }
 
 # Main test execution
 
 echo ""
 echo "=============================================="
-echo "Setting up test application"
+echo "Setting up test applications"
 echo "=============================================="
 setup_test_app
+setup_openssl_consumer_app
 
 # Test 1: ENABLE_DIST_PKG only (shared libs)
 echo ""
@@ -473,7 +891,9 @@ test_cmake_find_package install-dist-pkg-shim-shared ON
 test_pkg_config install-dist-pkg-shim-shared aws-lc OFF
 test_pkg_config install-dist-pkg-shim-shared openssl OFF
 test_pkg_config install-dist-pkg-shim-shared libcrypto OFF
-test_openssl_compat_pkg_config install-dist-pkg-shim-shared
+test_openssl_compat_pkg_config install-dist-pkg-shim-shared OFF
+test_native_pkg_config_unchanged install-dist-pkg-shim-shared OFF
+test_cmake_find_package_openssl install-dist-pkg-shim-shared OFF ON
 
 # Test 3: ENABLE_DIST_PKG only (static libs)
 echo ""
@@ -496,7 +916,22 @@ test_cmake_find_package install-dist-pkg-shim-static OFF
 test_pkg_config install-dist-pkg-shim-static aws-lc ON
 test_pkg_config install-dist-pkg-shim-static openssl ON
 test_pkg_config install-dist-pkg-shim-static libcrypto ON
-test_openssl_compat_pkg_config install-dist-pkg-shim-static
+test_openssl_compat_pkg_config install-dist-pkg-shim-static ON
+test_native_pkg_config_unchanged install-dist-pkg-shim-static ON
+# The static install reproduces the original FindOpenSSL failure: its
+# extra-dependency path only runs when the library it found is a static archive.
+test_cmake_find_package_openssl install-dist-pkg-shim-static ON ON
+
+# Test 5: ENABLE_DIST_PKG + OPENSSL_SHIM, BUILD_LIBSSL=OFF
+echo ""
+echo "############################################"
+echo "# Test 5: SHIM + BUILD_LIBSSL=OFF          #"
+echo "############################################"
+install_aws_lc_dist_pkg install-dist-pkg-shim-nossl ON ON OFF
+test_pkg_config_no_libssl install-dist-pkg-shim-nossl
+test_pkg_config install-dist-pkg-shim-nossl openssl OFF
+test_pkg_config install-dist-pkg-shim-nossl libcrypto OFF
+test_cmake_find_package_openssl install-dist-pkg-shim-nossl OFF OFF
 
 echo ""
 echo "############################################"

--- a/tests/ci/run_dist_pkg_install_tests.sh
+++ b/tests/ci/run_dist_pkg_install_tests.sh
@@ -39,16 +39,6 @@ function fail() {
     exit 1
 }
 
-# Detect library directory (lib or lib64)
-function get_lib_dir() {
-    local INSTALL_DIR=$1
-    if [[ -d "${INSTALL_DIR}/lib64" ]]; then
-        echo "lib64"
-    else
-        echo "lib"
-    fi
-}
-
 function install_aws_lc_dist_pkg() {
     local INSTALL_DIR=${SCRATCH_DIR}/$1
     local BUILD_SHARED_LIBS=$2  # "BUILD_SHARED_LIBS=ON" or "BUILD_SHARED_LIBS=OFF"
@@ -890,9 +880,10 @@ verify_dist_pkg_structure install-dist-pkg-shim-shared .so ON
 test_cmake_find_package install-dist-pkg-shim-shared ON
 test_pkg_config install-dist-pkg-shim-shared aws-lc OFF
 test_pkg_config install-dist-pkg-shim-shared openssl OFF
-test_pkg_config install-dist-pkg-shim-shared libcrypto OFF
+# test_openssl_compat_pkg_config subsumes a standalone libcrypto compile: it
+# token-checks all three OpenSSL module names and compiles/runs a consumer
+# against 'libssl libcrypto'.
 test_openssl_compat_pkg_config install-dist-pkg-shim-shared OFF
-test_native_pkg_config_unchanged install-dist-pkg-shim-shared OFF
 test_cmake_find_package_openssl install-dist-pkg-shim-shared OFF ON
 
 # Test 3: ENABLE_DIST_PKG only (static libs)
@@ -915,8 +906,10 @@ verify_dist_pkg_structure install-dist-pkg-shim-static .a ON
 test_cmake_find_package install-dist-pkg-shim-static OFF
 test_pkg_config install-dist-pkg-shim-static aws-lc ON
 test_pkg_config install-dist-pkg-shim-static openssl ON
-test_pkg_config install-dist-pkg-shim-static libcrypto ON
 test_openssl_compat_pkg_config install-dist-pkg-shim-static ON
+# The native pc files are identical across the shared and static shim
+# installs, so they are checked once, here, where --static also resolves the
+# Requires.private/Libs.private fields.
 test_native_pkg_config_unchanged install-dist-pkg-shim-static ON
 # The static install reproduces the original FindOpenSSL failure: its
 # extra-dependency path only runs when the library it found is a static archive.
@@ -930,6 +923,8 @@ echo "############################################"
 install_aws_lc_dist_pkg install-dist-pkg-shim-nossl ON ON OFF
 test_pkg_config_no_libssl install-dist-pkg-shim-nossl
 test_pkg_config install-dist-pkg-shim-nossl openssl OFF
+# Unlike the shim-shared/shim-static configs, this is the only compile/run
+# against the shim modules here, so the libcrypto smoke test stays.
 test_pkg_config install-dist-pkg-shim-nossl libcrypto OFF
 test_cmake_find_package_openssl install-dist-pkg-shim-nossl OFF OFF
 

--- a/tests/ci/run_dist_pkg_install_tests.sh
+++ b/tests/ci/run_dist_pkg_install_tests.sh
@@ -388,24 +388,14 @@ function test_cmake_find_package_openssl() {
         CMAKE_FLAGS+=("-DOPENSSL_USE_STATIC_LIBS=TRUE")
     fi
 
-    local ORIG_PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}"
-    export PKG_CONFIG_PATH="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+    local PKG_CONFIG_PATH="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+    export PKG_CONFIG_PATH
 
     ${CMAKE_COMMAND} "${CMAKE_FLAGS[@]}"
     ${CMAKE_COMMAND} --build "${BUILD_DIR}"
 
-    if [[ -n "${ORIG_PKG_CONFIG_PATH}" ]]; then
-        export PKG_CONFIG_PATH="${ORIG_PKG_CONFIG_PATH}"
-    else
-        unset PKG_CONFIG_PATH
-    fi
-
-    local ORIG_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    export LD_LIBRARY_PATH="${INSTALL_DIR}/${LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-
-    ${BUILD_DIR}/opensslconsumer || fail "find_package(OpenSSL) consumer failed to run"
-
-    export LD_LIBRARY_PATH="${ORIG_LD_LIBRARY_PATH}"
+    run_with_library_path "${INSTALL_DIR}/${LIB_DIR}" \
+        "${BUILD_DIR}/opensslconsumer" || fail "find_package(OpenSSL) consumer failed to run"
 
     echo "Standard CMake find_package(OpenSSL) test passed!"
 }
@@ -440,14 +430,9 @@ function test_cmake_find_package() {
 
     ${CMAKE_COMMAND} --build ${BUILD_DIR}
 
-    # Set library path for running
-    local ORIG_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    export LD_LIBRARY_PATH="${INSTALL_DIR}/${LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-
-    # Run the application
-    ${BUILD_DIR}/myapp || fail "Test application failed to run"
-
-    export LD_LIBRARY_PATH="${ORIG_LD_LIBRARY_PATH}"
+    # Run the application with the installed shared libraries.
+    run_with_library_path "${INSTALL_DIR}/${LIB_DIR}" \
+        "${BUILD_DIR}/myapp" || fail "Test application failed to run"
 
     echo "CMake find_package test passed!"
 }
@@ -477,7 +462,8 @@ function test_pkg_config() {
     echo "Static: ${IS_STATIC}"
     echo "=============================================="
 
-    export PKG_CONFIG_PATH="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+    local PKG_CONFIG_PATH="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+    export PKG_CONFIG_PATH
 
     # Check if package exists
     if ! pkg-config --exists "${PC_NAME}"; then
@@ -511,14 +497,8 @@ EOF
     # Compile using pkg-config flags
     ${CC:-cc} ${TEST_DIR}/test.c ${CFLAGS} ${LIBS} -o ${TEST_DIR}/test
 
-    # Run
-    local ORIG_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    export LD_LIBRARY_PATH="${INSTALL_DIR}/${LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-
-    ${TEST_DIR}/test || fail "pkg-config test application failed to run"
-
-    export LD_LIBRARY_PATH="${ORIG_LD_LIBRARY_PATH}"
-    unset PKG_CONFIG_PATH
+    run_with_library_path "${INSTALL_DIR}/${LIB_DIR}" \
+        "${TEST_DIR}/test" || fail "pkg-config test application failed to run"
 
     echo "pkg-config test passed for ${PC_NAME}!"
 }
@@ -542,7 +522,7 @@ function test_openssl_compat_pkg_config() {
     fi
 
     local SUFFIX
-    SUFFIX=$(get_product_suffix "${PC_DIR}")
+    SUFFIX=$(require_product_suffix "${PC_DIR}")
 
     echo ""
     echo "=============================================="
@@ -551,11 +531,8 @@ function test_openssl_compat_pkg_config() {
     echo "Product suffix: '${SUFFIX}'"
     echo "=============================================="
 
-    if [[ -z "${SUFFIX}" ]]; then
-        fail "could not derive the product suffix from the native pc files in ${PC_DIR}"
-    fi
-
-    export PKG_CONFIG_PATH="${PC_DIR}"
+    local PKG_CONFIG_PATH="${PC_DIR}"
+    export PKG_CONFIG_PATH
 
     # All three OpenSSL module names must resolve from the install prefix.
     local PC_NAME
@@ -652,10 +629,8 @@ EOF
 
     ${CC:-cc} ${SSL_TEST_DIR}/test.c ${SSL_CFLAGS} ${SSL_LIBS} -o ${SSL_TEST_DIR}/test
 
-    local ORIG_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-    export LD_LIBRARY_PATH="${INSTALL_DIR}/${LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-    ${SSL_TEST_DIR}/test || fail "shim libssl+libcrypto consumer failed to run"
-    export LD_LIBRARY_PATH="${ORIG_LD_LIBRARY_PATH}"
+    run_with_library_path "${INSTALL_DIR}/${LIB_DIR}" \
+        "${SSL_TEST_DIR}/test" || fail "shim libssl+libcrypto consumer failed to run"
 
     # The libssh2 pattern: pkg-config resolves Requires.private to compute
     # Cflags, so this fails unless libcrypto.pc exists under that exact name.
@@ -672,12 +647,10 @@ Libs: -L\${prefix}/lib -lshimconsumer
 Cflags: -I\${prefix}/include
 EOF
 
-    export PKG_CONFIG_PATH="${CONSUMER_DIR}:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="${CONSUMER_DIR}:${PKG_CONFIG_PATH}"
     if ! pkg-config --cflags --libs shimconsumer > /dev/null; then
         fail "pkg-config failed to resolve 'Requires.private: libcrypto' for a consumer package"
     fi
-
-    unset PKG_CONFIG_PATH
 
     echo "OpenSSL shim pkg-config tests passed!"
 }
@@ -699,7 +672,7 @@ function test_native_pkg_config_unchanged() {
     fi
 
     local SUFFIX
-    SUFFIX=$(get_product_suffix "${PC_DIR}")
+    SUFFIX=$(require_product_suffix "${PC_DIR}")
 
     echo ""
     echo "=============================================="
@@ -707,11 +680,8 @@ function test_native_pkg_config_unchanged() {
     echo "Product suffix: '${SUFFIX}'"
     echo "=============================================="
 
-    if [[ -z "${SUFFIX}" ]]; then
-        fail "could not derive the product suffix from the native pc files in ${PC_DIR}"
-    fi
-
-    export PKG_CONFIG_PATH="${PC_DIR}"
+    local PKG_CONFIG_PATH="${PC_DIR}"
+    export PKG_CONFIG_PATH
 
     local PC_NAME
     for PC_NAME in "aws-lc" "libcrypto${SUFFIX}" "libssl${SUFFIX}"; do
@@ -748,8 +718,6 @@ function test_native_pkg_config_unchanged() {
     assert_exact_token "${REQUIRES}" "libcrypto${SUFFIX}" "native 'libssl${SUFFIX}' Requires.private"
     assert_no_exact_token "${REQUIRES}" "libcrypto" "native 'libssl${SUFFIX}' Requires.private"
 
-    unset PKG_CONFIG_PATH
-
     echo "Native cohabitant pkg-config tests passed!"
 }
 
@@ -764,17 +732,13 @@ function test_pkg_config_no_libssl() {
     local PC_DIR="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
 
     local SUFFIX
-    SUFFIX=$(get_product_suffix "${PC_DIR}")
+    SUFFIX=$(require_product_suffix "${PC_DIR}")
 
     echo ""
     echo "=============================================="
     echo "Testing BUILD_LIBSSL=OFF pkg-config modules for: ${INSTALL_NAME}"
     echo "Product suffix: '${SUFFIX}'"
     echo "=============================================="
-
-    if [[ -z "${SUFFIX}" ]]; then
-        fail "could not derive the product suffix from the native pc files in ${PC_DIR}"
-    fi
 
     local PC_FILE
     for PC_FILE in "libssl.pc" "libssl${SUFFIX}.pc"; do
@@ -801,7 +765,8 @@ function test_pkg_config_no_libssl() {
         fi
     done
 
-    export PKG_CONFIG_PATH="${PC_DIR}"
+    local PKG_CONFIG_PATH="${PC_DIR}"
+    export PKG_CONFIG_PATH
 
     if pkg-config --exists libssl; then
         fail "pkg-config resolved 'libssl' when BUILD_LIBSSL=OFF"
@@ -838,8 +803,6 @@ function test_pkg_config_no_libssl() {
     assert_no_exact_token "${LIBS}" "-lcrypto${SUFFIX}" "'libcrypto' Libs (BUILD_LIBSSL=OFF)"
     assert_no_suffixed_openssl_tokens "${PC_DIR}/libcrypto.pc"
     assert_no_suffixed_openssl_tokens "${PC_DIR}/openssl.pc"
-
-    unset PKG_CONFIG_PATH
 
     echo "BUILD_LIBSSL=OFF pkg-config tests passed!"
 }

--- a/tests/ci/run_dist_pkg_install_tests.sh
+++ b/tests/ci/run_dist_pkg_install_tests.sh
@@ -765,8 +765,11 @@ function test_pkg_config_no_libssl() {
         fi
     done
 
-    local PKG_CONFIG_PATH="${PC_DIR}"
-    export PKG_CONFIG_PATH
+    # Restrict pkg-config to this install. PKG_CONFIG_PATH alone still searches
+    # the host's built-in directories, which may contain a system libssl.pc.
+    local PKG_CONFIG_PATH=""
+    local PKG_CONFIG_LIBDIR="${PC_DIR}"
+    export PKG_CONFIG_PATH PKG_CONFIG_LIBDIR
 
     if pkg-config --exists libssl; then
         fail "pkg-config resolved 'libssl' when BUILD_LIBSSL=OFF"

--- a/tests/ci/run_install_shared_and_static.sh
+++ b/tests/ci/run_install_shared_and_static.sh
@@ -5,6 +5,7 @@
 set -exo pipefail
 
 source tests/ci/common_posix_setup.sh
+source tests/ci/pkgconfig_test_helpers.sh
 
 export CMAKE_BUILD_PARALLEL_LEVEL=1
 
@@ -20,6 +21,7 @@ export CMAKE_BUILD_PARALLEL_LEVEL=1
 #    - install-shared
 #    - install-static
 #    - install-both
+#    - install-soname-shared
 #    - MYAPP_SRC
 
 # Assumes script is executed from the root of aws-lc directory
@@ -37,16 +39,18 @@ function fail() {
 }
 
 function install_aws_lc() {
-    local INSTALL_DIR=${SCRATCH_DIR}/$1
+    local INSTALL_NAME=$1
+    local INSTALL_DIR=${SCRATCH_DIR}/${INSTALL_NAME}
     local BUILD_SHARED_LIBS=$2
+    shift 2
 
     local BUILD_DIR=${SCRATCH_DIR}/build
     rm -rf "${BUILD_DIR:?}"
     sync
 
-    ${CMAKE_COMMAND} --fresh -H${AWS_LC_DIR} -B${BUILD_DIR} -GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF -D${BUILD_SHARED_LIBS}
+    ${CMAKE_COMMAND} --fresh -H${AWS_LC_DIR} -B${BUILD_DIR} -GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF -D${BUILD_SHARED_LIBS} "$@"
     ${CMAKE_COMMAND} --build ${BUILD_DIR} --target install
-    cp ${BUILD_DIR}/check-linkage.sh "${SCRATCH_DIR}/${1}-check-linkage.sh"
+    cp ${BUILD_DIR}/check-linkage.sh "${SCRATCH_DIR}/${INSTALL_NAME}-check-linkage.sh"
 }
 
 # create installation with shared libssl.so/libcrypto.so
@@ -59,14 +63,18 @@ install_aws_lc install-static BUILD_SHARED_LIBS=OFF
 install_aws_lc install-both BUILD_SHARED_LIBS=OFF
 install_aws_lc install-both BUILD_SHARED_LIBS=ON
 
-# Verify the pkg-config files installed by a default (non-dist-pkg) build.
-# Default Linux builds enable the OpenSSL shim, so the OpenSSL package names
-# (openssl, libcrypto, libssl) must always resolve. Shared builds use -awslc
-# suffixed libraries plus OpenSSL-named compat pc files; static builds
-# install the OpenSSL names directly.
+# create installation with SONAME'd, suffixed shared libraries. This is the only
+# non-dist-pkg configuration that installs the shim pc files alongside suffixed
+# native ones, and unlike dist-pkg mode the headers are not cohabitant.
+install_aws_lc install-soname-shared BUILD_SHARED_LIBS=ON -DENABLE_PRE_SONAME_BUILD=OFF
+
+# Verify the pkg-config files installed by default (non-dist-pkg) builds. These
+# enable the OpenSSL shim, so the OpenSSL module names must always resolve and
+# always describe the unsuffixed interface, whether or not the native libraries
+# carry a product suffix. The suffix is derived, not assumed.
 verify_pkgconfig_files() {
     local INSTALL_DIR=${SCRATCH_DIR}/$1
-    local LIB_SUFFIX=$2 # "-awslc" when libraries are suffixed, "" otherwise
+    local EXPECT_SUFFIXED=$2 # "ON" when native libraries should be suffixed
 
     local LIB_DIR=lib
     if [[ -d "${INSTALL_DIR}/lib64" ]]; then
@@ -74,22 +82,53 @@ verify_pkgconfig_files() {
     fi
     local PC_DIR="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
 
+    local SUFFIX
+    SUFFIX=$(get_product_suffix "${PC_DIR}")
+    echo "verify_pkgconfig_files ${1}: derived product suffix '${SUFFIX}'"
+
+    if [[ "${EXPECT_SUFFIXED}" == "ON" && -z "${SUFFIX}" ]]; then
+        fail "${1}: expected suffixed native pc files in ${PC_DIR}, found none"
+    fi
+    if [[ "${EXPECT_SUFFIXED}" != "ON" && -n "${SUFFIX}" ]]; then
+        fail "${1}: expected unsuffixed native pc files in ${PC_DIR}, found suffix '${SUFFIX}'"
+    fi
+
+    # aws-lc.pc plus the native and OpenSSL-named modules. When the native
+    # modules are unsuffixed these names collapse onto the same three files.
     local PC_FILE
-    for PC_FILE in aws-lc.pc openssl.pc libcrypto${LIB_SUFFIX}.pc libssl${LIB_SUFFIX}.pc libcrypto.pc libssl.pc; do
+    for PC_FILE in aws-lc.pc openssl.pc "libcrypto${SUFFIX}.pc" "libssl${SUFFIX}.pc" libcrypto.pc libssl.pc; do
         if [[ ! -f "${PC_DIR}/${PC_FILE}" ]]; then
             fail "${PC_FILE} not found in ${PC_DIR}"
         fi
     done
 
-    # The OpenSSL-named files must reference the real library names and the
-    # unsuffixed package names.
-    grep -q -- "-lcrypto${LIB_SUFFIX}" "${PC_DIR}/libcrypto.pc" || fail "libcrypto.pc does not link -lcrypto${LIB_SUFFIX}"
-    grep -q -- "-lssl${LIB_SUFFIX}" "${PC_DIR}/libssl.pc" || fail "libssl.pc does not link -lssl${LIB_SUFFIX}"
-    grep -q "Requires: libssl libcrypto" "${PC_DIR}/openssl.pc" || fail "openssl.pc does not require libssl libcrypto"
+    export PKG_CONFIG_PATH="${PC_DIR}"
+
+    # The OpenSSL-named modules describe the unsuffixed interface, whatever the
+    # native libraries are called.
+    assert_pkgconfig_token libcrypto --libs -lcrypto
+    assert_pkgconfig_token libssl --libs -lssl
+    assert_pkgconfig_token openssl --print-requires libcrypto
+    assert_pkgconfig_token openssl --print-requires libssl
+    assert_pkgconfig_token libssl --print-requires-private libcrypto
+
+    # The native modules keep whatever names this configuration gives them.
+    assert_pkgconfig_token "libcrypto${SUFFIX}" --libs "-lcrypto${SUFFIX}"
+    assert_pkgconfig_token "libssl${SUFFIX}" --libs "-lssl${SUFFIX}"
+    assert_pkgconfig_token aws-lc --print-requires "libcrypto${SUFFIX}"
+    assert_pkgconfig_token aws-lc --print-requires "libssl${SUFFIX}"
+
+    # No shim-facing Requires/Libs field may name a suffixed crypto/ssl token.
+    for PC_FILE in openssl.pc libcrypto.pc libssl.pc; do
+        assert_no_suffixed_openssl_tokens "${PC_DIR}/${PC_FILE}"
+    done
+
+    unset PKG_CONFIG_PATH
 }
 
-verify_pkgconfig_files install-shared -awslc
-verify_pkgconfig_files install-static ""
+verify_pkgconfig_files install-shared OFF
+verify_pkgconfig_files install-static OFF
+verify_pkgconfig_files install-soname-shared ON
 
 # write out source of a small cmake project, containing:
 # - mylib: a library that uses AWS-LC

--- a/tests/ci/run_install_shared_and_static.sh
+++ b/tests/ci/run_install_shared_and_static.sh
@@ -76,10 +76,8 @@ verify_pkgconfig_files() {
     local INSTALL_DIR=${SCRATCH_DIR}/$1
     local EXPECT_SUFFIXED=$2 # "ON" when native libraries should be suffixed
 
-    local LIB_DIR=lib
-    if [[ -d "${INSTALL_DIR}/lib64" ]]; then
-        LIB_DIR=lib64
-    fi
+    local LIB_DIR
+    LIB_DIR=$(get_lib_dir "${INSTALL_DIR}")
     local PC_DIR="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
 
     local SUFFIX
@@ -126,8 +124,9 @@ verify_pkgconfig_files() {
     unset PKG_CONFIG_PATH
 }
 
+# The pc files do not vary with BUILD_SHARED_LIBS, so one unsuffixed install
+# covers install-shared and install-static alike.
 verify_pkgconfig_files install-shared OFF
-verify_pkgconfig_files install-static OFF
 verify_pkgconfig_files install-soname-shared ON
 
 # write out source of a small cmake project, containing:

--- a/tests/ci/run_install_shared_and_static.sh
+++ b/tests/ci/run_install_shared_and_static.sh
@@ -59,6 +59,38 @@ install_aws_lc install-static BUILD_SHARED_LIBS=OFF
 install_aws_lc install-both BUILD_SHARED_LIBS=OFF
 install_aws_lc install-both BUILD_SHARED_LIBS=ON
 
+# Verify the pkg-config files installed by a default (non-dist-pkg) build.
+# Default Linux builds enable the OpenSSL shim, so the OpenSSL package names
+# (openssl, libcrypto, libssl) must always resolve. Shared builds use -awslc
+# suffixed libraries plus OpenSSL-named compat pc files; static builds
+# install the OpenSSL names directly.
+verify_pkgconfig_files() {
+    local INSTALL_DIR=${SCRATCH_DIR}/$1
+    local LIB_SUFFIX=$2 # "-awslc" when libraries are suffixed, "" otherwise
+
+    local LIB_DIR=lib
+    if [[ -d "${INSTALL_DIR}/lib64" ]]; then
+        LIB_DIR=lib64
+    fi
+    local PC_DIR="${INSTALL_DIR}/${LIB_DIR}/pkgconfig"
+
+    local PC_FILE
+    for PC_FILE in aws-lc.pc openssl.pc libcrypto${LIB_SUFFIX}.pc libssl${LIB_SUFFIX}.pc libcrypto.pc libssl.pc; do
+        if [[ ! -f "${PC_DIR}/${PC_FILE}" ]]; then
+            fail "${PC_FILE} not found in ${PC_DIR}"
+        fi
+    done
+
+    # The OpenSSL-named files must reference the real library names and the
+    # unsuffixed package names.
+    grep -q -- "-lcrypto${LIB_SUFFIX}" "${PC_DIR}/libcrypto.pc" || fail "libcrypto.pc does not link -lcrypto${LIB_SUFFIX}"
+    grep -q -- "-lssl${LIB_SUFFIX}" "${PC_DIR}/libssl.pc" || fail "libssl.pc does not link -lssl${LIB_SUFFIX}"
+    grep -q "Requires: libssl libcrypto" "${PC_DIR}/openssl.pc" || fail "openssl.pc does not require libssl libcrypto"
+}
+
+verify_pkgconfig_files install-shared -awslc
+verify_pkgconfig_files install-static ""
+
 # write out source of a small cmake project, containing:
 # - mylib: a library that uses AWS-LC
 # - myapp: executable that uses mylib


### PR DESCRIPTION
### Context and motivation

The OpenSSL shim installs compatible headers and library symlinks, but its pkg-config interface is incomplete. It provides only `openssl.pc`, so consumers that require `libcrypto` or `libssl` by package name cannot resolve the shim. Its metadata can also expose suffixed library names that CMake's `FindOpenSSL` treats as unresolvable extra dependencies.

### Description of changes

Install `openssl.pc`, `libcrypto.pc`, and `libssl.pc` for the shim, with metadata describing the unsuffixed OpenSSL interface: the plain `include` directory, unsuffixed package dependencies, and `-lcrypto`/`-lssl`. These names resolve through the shim symlinks, while the native AWS-LC pkg-config modules remain suffixed for cohabitation.

When `BUILD_LIBSSL=OFF`, omit the native and compatibility `libssl.pc` files, the `libssl` shim symlink, and `libssl` package dependencies. Update `INCORPORATING.md` to document both pkg-config interfaces.

### Testing

Extended the installation tests across shared, static, shim-disabled, and `BUILD_LIBSSL=OFF` configurations. They validate the installed modules and exact pkg-config metadata, compile and run consumers through the shim, cover a `Requires.private: libcrypto` dependency, exercise CMake's standard `find_package(OpenSSL)`, and confirm that the native suffixed interface is unchanged.

### Review considerations

This does not change the public C API or ABI. The compatibility modules emit unsuffixed linker names, but those names resolve to libraries retaining their suffixed SONAMEs, so runtime cohabitation with a system OpenSSL is preserved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
