### PR TITLE
Include <openssl/cipher.h> from <openssl/hmac.h> for OpenSSL compat

### DIFF
--- a/include/openssl/hmac.h
+++ b/include/openssl/hmac.h
@@ -13,6 +13,7 @@
 // OpenSSL exposes the EVP_MAX_*_LENGTH constants transitively through
 // <openssl/hmac.h>; in AWS-LC they live in <openssl/cipher.h>. Include it
 // so consumers that reach them this way keep building.
+// See: https://github.com/aws/aws-lc/pull/3371
 #include <openssl/cipher.h>
 
 #if defined(__cplusplus)

--- a/include/openssl/hmac.h
+++ b/include/openssl/hmac.h
@@ -10,6 +10,11 @@
 #include <openssl/sha.h>
 #include <openssl/md5.h>
 
+// OpenSSL exposes the EVP_MAX_*_LENGTH constants transitively through
+// <openssl/hmac.h>; in AWS-LC they live in <openssl/cipher.h>. Include it
+// so consumers that reach them this way keep building. (See commit message.)
+#include <openssl/cipher.h>
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/include/openssl/hmac.h
+++ b/include/openssl/hmac.h
@@ -12,7 +12,7 @@
 
 // OpenSSL exposes the EVP_MAX_*_LENGTH constants transitively through
 // <openssl/hmac.h>; in AWS-LC they live in <openssl/cipher.h>. Include it
-// so consumers that reach them this way keep building. (See commit message.)
+// so consumers that reach them this way keep building.
 #include <openssl/cipher.h>
 
 #if defined(__cplusplus)


### PR DESCRIPTION
### Description of changes:
OpenSSL's `<openssl/hmac.h>` transitively pulls in `EVP_MAX_KEY_LENGTH`, `EVP_MAX_IV_LENGTH`, and `EVP_MAX_BLOCK_LENGTH` (via `evp.h`). AWS-LC keeps those in `<openssl/cipher.h>` and `hmac.h` doesn't include it, so OpenSSL source reaching those constants through `<openssl/hmac.h>` fails to compile. This adds the `cipher.h` include so that source keeps building. `EVP_MAX_MD_SIZE` is unaffected -- it already arrives via `digest.h`.

### Call-outs:
No include cycle: `cipher.h` only pulls in `base.h`. This mirrors `evp.h`, which already includes both `cipher.h` and `hmac.h`.

### Testing:
No functional change. Verified including only `<openssl/hmac.h>` resolves all four `EVP_MAX_*` constants, and that it fails to without this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
