### PR TITLE
Fix flaky s_client cipher tests by using better ciphers

### DIFF
--- a/tool-openssl/s_client_test.cc
+++ b/tool-openssl/s_client_test.cc
@@ -35,7 +35,11 @@ TEST(SClientTest, ConnectVerifyShowcerts) {
 
 // Test -cipher
 TEST(SClientTest, Cipher) {
-  args_list_t args = {"-connect", "amazon.com:443", "-cipher", "AES128-SHA"};
+  // Pin to TLS 1.2 so the -cipher list is actually enforced. Without a version
+  // pin the handshake can negotiate TLS 1.3, whose cipher suites are configured
+  // separately, leaving -cipher effectively ignored.
+  args_list_t args = {"-connect", "amazon.com:443", "-cipher",
+                      "ECDHE-RSA-AES128-GCM-SHA256", "-tls1_2"};
   bool result = SClientTool(args);
   ASSERT_TRUE(result);
 }

--- a/tool-openssl/s_client_test.cc
+++ b/tool-openssl/s_client_test.cc
@@ -53,8 +53,10 @@ TEST(SClientTest, Tls1_1) {
 
 // Test -cipher and -tls1_1 together
 TEST(SClientTest, CipherAndTls1_1) {
-  args_list_t args = {"-connect", "amazon.com:443", "-cipher", "AES128-SHA",
-                      "-tls1_1"};
+  // TLS 1.1 has no AEAD/SHA-256 suites, so this stays on a CBC-SHA1 cipher, but
+  // prefer the forward-secret ECDHE variant over static-RSA AES128-SHA.
+  args_list_t args = {"-connect", "amazon.com:443", "-cipher",
+                      "ECDHE-RSA-AES128-SHA", "-tls1_1"};
   bool result = SClientTool(args);
   ASSERT_TRUE(result);
 }


### PR DESCRIPTION
### Motivation:
`SClientTest.Cipher` [intermittently](https://github.com/aws/aws-lc/actions/runs/30038682932/job/89315456912?pr=3371#step:4:8381) [fails](https://github.com/aws/aws-lc/actions/runs/30038683037/job/89312971345?pr=3371#step:4:9236) in CI.
```
  [ RUN      ] SClientTest.Connect
  Error while connecting: peer closed connection
  CONNECTED(00000003)
  /codebuild/output/src2402885012/src/actions-runner/_work/aws-lc/aws-lc/tool-openssl/s_client_test.cc:12: Failure
  Value of: result
    Actual: false
  Expected: true
  [  FAILED  ] SClientTest.Connect (17311 ms)
```

### Description of changes:
`SClientTest.Cipher` intermittently failed because it forced the legacy `AES128-SHA` (static-RSA, CBC, SHA-1) suite, which the server it connects to might not reliably accept. This switches it to the modern forward-secret `ECDHE-RSA-AES128-GCM-SHA256` and pins the connection to `-tls1_2`.

While here, `SClientTest.CipherAndTls1_1` is moved from static-RSA `AES128-SHA` to the forward-secret `ECDHE-RSA-AES128-SHA` for the same reason.

### Call-outs:
The `-tls1_2` pin on `SClientTest.Cipher` is the non-obvious part. `-cipher` only configures the TLS 1.2-and-below cipher list, and TLS 1.3 suites are configured separately and always offered. Since the client defaults to a TLS 1.3 max version, without the pin the handshake could negotiate TLS 1.3 and never exercise the `-cipher` value.

`CipherAndTls1_1` stays on a CBC/SHA-1 suite because TLS 1.1 has no AEAD or SHA-256 suites; the improvement there is moving from static-RSA to forward-secret ECDHE key exchange.

### Testing:
Built `tool_openssl_test` and ran both `SClientTest.Cipher` and `SClientTest.CipherAndTls1_1` repeatedly; each passed every iteration.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
