### PR TITLE
Add Neoverse-V3 (Graviton5) detection and dispatch

### DIFF
--- a/.github/workflows/linux_arm_omnibus.yml
+++ b/.github/workflows/linux_arm_omnibus.yml
@@ -75,6 +75,37 @@ jobs:
             source /opt/compiler-env/setup-clang-19.sh
             ${{ matrix.run }}
 
+  graviton5:
+    name: graviton5-${{ matrix.name }}
+    runs-on:
+      - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
+        image:arm-3.0
+        fleet:linux-graviton5-c9g-2xlarge
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: asan-tests
+            options: --privileged
+            run: ./tests/ci/run_posix_sanitizers.sh
+          - name: fips-tests
+            run: ./tests/ci/run_fips_tests.sh
+    steps:
+      - uses: actions/checkout@v7
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - uses: ./.github/actions/codebuild-docker-run
+        name: Run Container
+        with:
+          image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/amazonlinux:2023
+          options: ${{ matrix.options || '' }}
+          env: |
+            AWS_LC_GO_TEST_TIMEOUT=60m
+          run: |
+            source /opt/compiler-env/setup-clang-19.sh
+            ${{ matrix.run }}
+
 
   # BoringSSL has 7k+ ssl runner tests, and the total number of the runner tests keep increasing.
   # When ASAN enabled, the tests take more than 1 hour to finish. The cause relates to https://github.com/google/sanitizers/issues/1331,

--- a/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
+++ b/crypto/fipsmodule/cpucap/cpu_aarch64_linux.c
@@ -86,6 +86,11 @@ void OPENSSL_cpuid_setup(void) {
       // CPU capabilities of N1 are a subset of CPU capabilities of V2
       OPENSSL_armcap_P |= ARMV8_NEOVERSE_N1;
     }
+    if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V3)) {
+      OPENSSL_armcap_P |= ARMV8_NEOVERSE_V3;
+      // CPU capabilities of N1 are a subset of CPU capabilities of V3
+      OPENSSL_armcap_P |= ARMV8_NEOVERSE_N1;
+    }
   }
 
   static const unsigned long kDIT = 1 << 24;

--- a/crypto/fipsmodule/cpucap/cpucap.c
+++ b/crypto/fipsmodule/cpucap/cpucap.c
@@ -77,6 +77,9 @@ HIDDEN uint32_t OPENSSL_armcap_P =
 #if defined(OPENSSL_STATIC_ARMCAP_NEOVERSE_V2) || defined(__ARM_FEATURE_NEOVERSE_V2)
     ARMV8_NEOVERSE_V2 |
 #endif
+#if defined(OPENSSL_STATIC_ARMCAP_NEOVERSE_V3) || defined(__ARM_FEATURE_NEOVERSE_V3)
+    ARMV8_NEOVERSE_V3 |
+#endif
     0;
 
 #else

--- a/crypto/fipsmodule/cpucap/internal.h
+++ b/crypto/fipsmodule/cpucap/internal.h
@@ -243,12 +243,14 @@ OPENSSL_INLINE int CRYPTO_is_ARMv8_GCM_8x_capable(void) {
   return (CRYPTO_is_ARMv8_SHA3_capable() &&
           ((OPENSSL_armcap_P & ARMV8_NEOVERSE_V1) != 0 ||
            (OPENSSL_armcap_P & ARMV8_NEOVERSE_V2) != 0 ||
+           (OPENSSL_armcap_P & ARMV8_NEOVERSE_V3) != 0 ||
            (OPENSSL_armcap_P & ARMV8_APPLE_M) != 0));
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_wide_multiplier_capable(void) {
   return (OPENSSL_armcap_P & ARMV8_NEOVERSE_V1) != 0 ||
            (OPENSSL_armcap_P & ARMV8_NEOVERSE_V2) != 0 ||
+           (OPENSSL_armcap_P & ARMV8_NEOVERSE_V3) != 0 ||
            (OPENSSL_armcap_P & ARMV8_APPLE_M) != 0;
 }
 
@@ -263,9 +265,10 @@ OPENSSL_INLINE int CRYPTO_is_ARMv8_RNDR_capable(void) {
 
 OPENSSL_INLINE int CRYPTO_is_Neoverse_N1(void) {
   // It is Neoverse N1 if only ARMV8_NEOVERSE_N1 = 1 and
-  // ARMV8_NEOVERSE_<V1|V2> = 0.
+  // ARMV8_NEOVERSE_<V1|V2|V3> = 0.
   return ((OPENSSL_armcap_P & ARMV8_NEOVERSE_N1) != 0 &&
-          (OPENSSL_armcap_P & (ARMV8_NEOVERSE_V1 | ARMV8_NEOVERSE_V2)) == 0);
+          (OPENSSL_armcap_P &
+           (ARMV8_NEOVERSE_V1 | ARMV8_NEOVERSE_V2 | ARMV8_NEOVERSE_V3)) == 0);
 }
 
 OPENSSL_INLINE int CRYPTO_is_Neoverse_V1(void) {
@@ -274,6 +277,10 @@ OPENSSL_INLINE int CRYPTO_is_Neoverse_V1(void) {
 
 OPENSSL_INLINE int CRYPTO_is_Neoverse_V2(void) {
   return (OPENSSL_armcap_P & ARMV8_NEOVERSE_V2) != 0;
+}
+
+OPENSSL_INLINE int CRYPTO_is_Neoverse_V3(void) {
+  return (OPENSSL_armcap_P & ARMV8_NEOVERSE_V3) != 0;
 }
 
 OPENSSL_INLINE int CRYPTO_is_ARMv8_Apple_M(void) {

--- a/crypto/fipsmodule/sha/keccak1600.c
+++ b/crypto/fipsmodule/sha/keccak1600.c
@@ -359,7 +359,8 @@ void KeccakF1600(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS]) {
     // implementation.
 #if defined(OPENSSL_AARCH64)
 #if defined(KECCAK1600_S2N_BIGNUM_ASM)
-    if (CRYPTO_is_Neoverse_N1() || CRYPTO_is_Neoverse_V1() || CRYPTO_is_Neoverse_V2()) {
+    if (CRYPTO_is_Neoverse_N1() || CRYPTO_is_Neoverse_V1() || CRYPTO_is_Neoverse_V2() ||
+        CRYPTO_is_Neoverse_V3()) {
         keccak_log_dispatch(10); // kFlag_sha3_keccak_f1600
         sha3_keccak_f1600((uint64_t *)A, iotas);
         return;
@@ -440,7 +441,7 @@ static void Keccak1600_x4(uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS]) {
     }
 
 #if defined(MY_ASSEMBLER_SUPPORTS_NEON_SHA3_EXTENSION)
-    if (CRYPTO_is_Neoverse_V1() || CRYPTO_is_Neoverse_V2()) {
+    if (CRYPTO_is_Neoverse_V1() || CRYPTO_is_Neoverse_V2() || CRYPTO_is_Neoverse_V3()) {
         keccak_log_dispatch(14); // kFlag_sha3_keccak4_f1600_alt2
         sha3_keccak4_f1600_alt2((uint64_t *)A, iotas);
         return;

--- a/crypto/fipsmodule/sha/keccak1600.c
+++ b/crypto/fipsmodule/sha/keccak1600.c
@@ -340,7 +340,7 @@ void KeccakF1600(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS]) {
     //
     // 1. If ASM is disabled, we use the C implementation.
     // 2. If ASM is enabled:
-    //   - For Neoverse N1, V1, V2, we use scalar Keccak assembly from s2n-bignum
+    //   - For Neoverse N1, V1, V2, V3, we use scalar Keccak assembly from s2n-bignum
     //     (`sha3_keccak_f1600()`)
     //     leveraging lazy rotations from https://eprint.iacr.org/2022/1243.
     //   - Otherwise, if the Neon SHA3 extension is supported, we use the Neon
@@ -350,7 +350,7 @@ void KeccakF1600(uint64_t A[KECCAK1600_ROWS][KECCAK1600_ROWS]) {
     //     (`Keccak1600_hw()`), not using lazy rotations.
     //
     // Lazy rotations improve performance by up to 10% on CPUs with free
-    // Barrel shifting, which includes Neoverse N1, V1, and V2. Not all
+    // Barrel shifting, which includes Neoverse N1, V1, V2, and V3. Not all
     // CPUs have free Barrel shifting (e.g. Apple M1 or Cortex-A72), so we
     // don't use it by default.
     //
@@ -425,9 +425,11 @@ static void Keccak1600_x4(uint64_t A[4][KECCAK1600_ROWS][KECCAK1600_ROWS]) {
     // - For Neoverse N1, we use scalar batched hybrid Keccak assembly from s2n-bignum
     //   (`sha3_keccak4_f1600_alt()`) leveraging Neon and scalar assembly with
     //   lazy rotations.
-    // - For Neoverse V1, V2, we use SIMD batched hybrid Keccak assembly from s2n-bignum
+    // - For Neoverse V1, V2, V3, we use SIMD batched hybrid Keccak assembly from s2n-bignum
     //   (`sha3_keccak4_f1600_alt2()`) leveraging Neon, Neon SHA3 extension,
-    //   and scalar assembly with lazy rotations.
+    //   and scalar assembly with lazy rotations. On V3 the SHA3-extension-only
+    //   path (`sha3_keccak2_f1600()`, below) is much faster than on V1/V2, but
+    //   this SIMD path is still measurably faster, so V3 is grouped here.
     // - Otherwise, if the Neon SHA3 extension is supported, we use the 2-fold
     //   Keccak assembly from s2n-bignum (`sha3_keccak2_f1600()`) twice,
     //   which is a straightforward implementation using the SHA3 extension.

--- a/crypto/impl_dispatch_test.cc
+++ b/crypto/impl_dispatch_test.cc
@@ -80,6 +80,7 @@ class ImplDispatchTest : public ::testing::Test {
     neoverse_n1_ = CRYPTO_is_Neoverse_N1();
     neoverse_v1_ = CRYPTO_is_Neoverse_V1();
     neoverse_v2_ = CRYPTO_is_Neoverse_V2();
+    neoverse_v3_ = CRYPTO_is_Neoverse_V3();
 
     assembler_has_neon_sha3_extension_ =
 #if defined(MY_ASSEMBLER_SUPPORTS_NEON_SHA3_EXTENSION)
@@ -140,6 +141,7 @@ class ImplDispatchTest : public ::testing::Test {
   bool neoverse_n1_ = false;
   bool neoverse_v1_ = false;
   bool neoverse_v2_ = false;
+  bool neoverse_v3_ = false;
   bool assembler_has_neon_sha3_extension_ = false;
 #endif
 
@@ -273,7 +275,7 @@ TEST_F(ImplDispatchTest, SHA512) {
 
 TEST_F(ImplDispatchTest, SHA3_512) {
   // Assembly dispatch logic for Keccak-x1 on AArch64:
-  // - For Neoverse N1, V1, V2, we use scalar Keccak assembly from s2n-bignum
+  // - For Neoverse N1, V1, V2, V3, we use scalar Keccak assembly from s2n-bignum
   //   (`sha3_keccak_f1600()`)
   //   leveraging lazy rotations from https://eprint.iacr.org/2022/1243.
   // - Otherwise, if the Neon SHA3 extension is supported, we use the Neon
@@ -285,15 +287,15 @@ TEST_F(ImplDispatchTest, SHA3_512) {
       {
           {kFlag_sha3_keccak_f1600,
            have_s2n_bignum_asm_ &&
-           (neoverse_n1_ || neoverse_v1_ || neoverse_v2_) },
+           (neoverse_n1_ || neoverse_v1_ || neoverse_v2_ || neoverse_v3_) },
           {kFlag_sha3_keccak_f1600_alt,
            have_s2n_bignum_asm_ &&
-           !(neoverse_n1_ || neoverse_v1_ || neoverse_v2_) &&
+           !(neoverse_n1_ || neoverse_v1_ || neoverse_v2_ || neoverse_v3_) &&
            (assembler_has_neon_sha3_extension_ && sha3_ext_) },
           {kFlag_KeccakF1600_hw,
            !have_s2n_bignum_asm_ ||
            (
-             !(neoverse_n1_ || neoverse_v1_ || neoverse_v2_) &&
+             !(neoverse_n1_ || neoverse_v1_ || neoverse_v2_ || neoverse_v3_) &&
              !(assembler_has_neon_sha3_extension_ && sha3_ext_)
            ) },
       },
@@ -325,7 +327,7 @@ TEST_F(ImplDispatchTest, SHAKE256_Batched) {
   // - For Neoverse N1, we use scalar batched hybrid Keccak assembly from s2n-bignum
   //   (`sha3_keccak4_f1600_alt()`) leveraging Neon and scalar assembly with
   //   lazy rotations.
-  // - For Neoverse V1, V2, we use SIMD batched hybrid Keccak assembly from s2n-bignum
+  // - For Neoverse V1, V2, V3, we use SIMD batched hybrid Keccak assembly from s2n-bignum
   //   (`sha3_keccak4_f1600_alt2()`) leveraging Neon, Neon SHA3 extension,
   //   and scalar assembly with lazy rotations.
   // - Otherwise, if the Neon SHA3 extension is supported, we use the 2-fold
@@ -339,28 +341,28 @@ TEST_F(ImplDispatchTest, SHAKE256_Batched) {
            have_s2n_bignum_asm_ && neoverse_n1_},
           {kFlag_sha3_keccak4_f1600_alt2,
            have_s2n_bignum_asm_ &&
-           (neoverse_v1_ || neoverse_v2_) &&
+           (neoverse_v1_ || neoverse_v2_ || neoverse_v3_) &&
            assembler_has_neon_sha3_extension_},
           {kFlag_sha3_keccak2_f1600,
            have_s2n_bignum_asm_ &&
-           !(neoverse_n1_ || neoverse_v1_ || neoverse_v2_) &&
+           !(neoverse_n1_ || neoverse_v1_ || neoverse_v2_ || neoverse_v3_) &&
            (assembler_has_neon_sha3_extension_ && sha3_ext_)},
           // If we don't have assembly batched Keccak available,
           // we fall back to the dispatch logic in KeccakF1600().
           // Under the assumption that no batched Keccak assembly
           // was chosen, this simplifies as follows:
-          // 1. If we run on Neoverse-V1 and Neoverse-V2 and there is
+          // 1. If we run on Neoverse-V1, Neoverse-V2, or Neoverse-V3 and there is
           //    no compiler support for SHA3 (otherwise, we would have
           //    have chosen the batched hybrid with SHA3 extension),
           //    we use the scalar assembly with lazy rotation.
           // 2. Otherwise, we fall back to the OpenSSL assembly.
           {kFlag_sha3_keccak_f1600,
-           have_s2n_bignum_asm_ && (neoverse_v1_ || neoverse_v2_) &&
+           have_s2n_bignum_asm_ && (neoverse_v1_ || neoverse_v2_ || neoverse_v3_) &&
            !(assembler_has_neon_sha3_extension_ && sha3_ext_) },
           {kFlag_KeccakF1600_hw,
            !have_s2n_bignum_asm_ ||
            (
-	       !neoverse_n1_ && !neoverse_v1_ && !neoverse_v2_ &&
+	       !neoverse_n1_ && !neoverse_v1_ && !neoverse_v2_ && !neoverse_v3_ &&
 	       !(assembler_has_neon_sha3_extension_ && sha3_ext_)
 	   ) },
       },

--- a/include/openssl/arm_arch.h
+++ b/include/openssl/arm_arch.h
@@ -38,17 +38,18 @@
 // "Test algorithm dispatch without CPU indicator or Neon extension capability bits"
 // in util/all_tests.json
 
-// The Neoverse N1, V1, V2, and Apple M1 micro-architectures are detected to
+// The Neoverse N1, V1, V2, V3, and Apple M1 micro-architectures are detected to
 // allow selecting the fasted implementations for SHA3/SHAKE and AES-GCM.
-// Combination of all CPU indicator bits: 0x7080
+// Combination of all CPU indicator bits: 0x47080
 // NOTE: If you add further CPU indicator bits, adjust
 // "Test algorithm dispatch without CPU indicator bits" in util/all_tests.json.
 #define ARMV8_NEOVERSE_N1 (1 << 7)
 #define ARMV8_NEOVERSE_V1 (1 << 12)
 #define ARMV8_APPLE_M (1 << 13)
 #define ARMV8_NEOVERSE_V2 (1 << 14)
+#define ARMV8_NEOVERSE_V3 (1 << 18)
 
-// Combination of CPU indicator bits and Armv8 Neon extension bits: 0x78fc
+// Combination of CPU indicator bits and Armv8 Neon extension bits: 0x478fc
 
 // ARMV8_DIT indicates support for the Data-Independent Timing (DIT) flag.
 #define ARMV8_DIT (1 << 15)
@@ -77,6 +78,7 @@
 # define ARM_CPU_PART_N1           0xD0C
 # define ARM_CPU_PART_V1           0xD40
 # define ARM_CPU_PART_V2           0xD4F
+# define ARM_CPU_PART_V3           0xD84
 
 # define MIDR_PARTNUM_SHIFT       4
 # define MIDR_PARTNUM_MASK        (0xfffUL << MIDR_PARTNUM_SHIFT)

--- a/tests/ci/cdk/config/codebuild-fleets.yaml
+++ b/tests/ci/cdk/config/codebuild-fleets.yaml
@@ -18,6 +18,14 @@ fleets:
     scalingConfiguration:
       enabled: true
       utilizationRate: 70
+  # 8 vCPUs, 16 GB (Graviton5 / Neoverse-V3)
+  - name: linux-graviton5-c9g-2xlarge
+    baseCapacity: 1
+    environmentType: ARM_CONTAINER
+    customInstanceType: c9g.2xlarge
+    scalingConfiguration:
+      enabled: true
+      utilizationRate: 70
   # 8 vCPUs, 16 GB
   - name: windows-image-build-large
     baseCapacity: 1

--- a/util/all_tests.json
+++ b/util/all_tests.json
@@ -37,7 +37,7 @@
   {
     "comment": "Test algorithm dispatch without CPU indicator bits",
     "cmd": ["crypto/crypto_test"],
-    "env": ["OPENSSL_armcap=~0x7080"],
+    "env": ["OPENSSL_armcap=~0x47080"],
     "target_arch": "arm",
     "skip_valgrind": true,
     "shard": true
@@ -45,7 +45,7 @@
   {
     "comment": "Test algorithm dispatch without CPU indicator or Neon extension capability bits",
     "cmd": ["crypto/crypto_test"],
-    "env": ["OPENSSL_armcap=~0x78fc"],
+    "env": ["OPENSSL_armcap=~0x478fc"],
     "target_arch": "arm",
     "skip_valgrind": true,
     "shard": true


### PR DESCRIPTION
### Issues
N/A 

### Description of Changes

Add runtime and static detection of the Neoverse-V3 microarchitecture (Graviton5, MIDR part `0xD84`) and group it with Neoverse-V1/V2 for selecting AWS-LC's fastest AArch64 implementations.

#### Why

AWS-LC gates several of its fastest AArch64 code paths on a microarchitecture allowlist (Neoverse-V1/V2, Apple-M). Neoverse-V3 was not on that list, so on Graviton5 the library silently fell through to
slower fallbacks. Measured on a c9g (Neoverse-V3) instance, with every dispatch path trap-verified at the object-code level:

| Workload | Before (fallback) | After (V-core path) | Delta |
|---|---|---|---|
| AES-128-GCM, 16 KB | 6135 MB/s (4x kernel) | 8854 MB/s (8x-EOR3) | +44% |
| RSA-2048 sign | 1227 ops/s (s2n-bignum) | 2025 ops/s (generic) | +65% |
| RSA-2048 verify | 49986 ops/s | 77819 ops/s | +56% |
| SHAKE256-x4, 16 KB | Neon-SHA3 keccak2 (413 MB/s) | V-core alt2 (448 MB/s) | +8% |

#### Changes

- **`arm_arch.h`**: add `ARMV8_NEOVERSE_V3` (bit `1<<18`) and `ARM_CPU_PART_V3` (`0xD84`); update the CPU-indicator-bit mask comments (`0x7080`→`0x47080`, `0x78fc`→`0x478fc`).
- **`cpu_aarch64_linux.c`**: detect the V3 MIDR at runtime; set the V3 bit and the N1-subset bit (matching the existing V1/V2 pattern).
- **`cpucap.c`**: static-armcap support via `OPENSSL_STATIC_ARMCAP_NEOVERSE_V3` / `__ARM_FEATURE_NEOVERSE_V3`.
- **`internal.h`**: add V3 to the AES-GCM-8x and wide-multiplier gates; add `CRYPTO_is_Neoverse_V3()`; **exclude V3 from `CRYPTO_is_Neoverse_N1()`** (since detection also sets the N1-subset bit, V3 must be excluded here or it would be mis-classified as N1 and mis-route Keccak).
- **`keccak1600.c`**: group V3 with V1/V2 at both dispatch sites.
- **`all_tests.json`**: update the CPU-indicator armcap masks used by the "dispatch without CPU indicator bits" tests to include the V3 bit.
- **CI**: add a `linux-graviton5-c9g-2xlarge` CodeBuild fleet and a`graviton5` job in `linux_arm_omnibus.yml` (mirrors the graviton4 job).

### Testing

- Built and ran `crypto_test` on a Neoverse-V3 (c9g) instance; all tests pass and the FIPS module links cleanly.
- Each dispatch decision (GCM 8x, generic Montgomery, Keccak alt2) was trap-verified on hardware to confirm the intended kernel executes.
- Benchmarks above collected on c9g with warmup + averaged repeated runs.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
