### PR TITLE
Rename autofix reasoning role to AwsLcGitHubActionsBedrockRole

### DIFF
--- a/.github/workflows/autofix_integration_failures.yml
+++ b/.github/workflows/autofix_integration_failures.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: ./.github/actions/configure-aws-credentials
         with:
           oidcRole: AwsLcGitHubActionsAutofixOidcRole
-          roleName: AwsLcGitHubActionAutofixReasoningRole
+          roleName: AwsLcGitHubActionsBedrockRole
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code@2
       - name: Install Bash sandbox deps

--- a/tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py
@@ -116,9 +116,9 @@ class AwsLcGitHubOidcStack(Stack):
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
         )
 
-        self.autofix_reasoning_role = create_autofix_reasoning_role(
-            self, "AwsLcGitHubActionAutofixReasoningRole", env, self.autofix_oidc_role)
-        self.autofix_reasoning_role.grant_assume_role(self.autofix_oidc_role)
+        self.bedrock_role = create_bedrock_role(
+            self, "AwsLcGitHubActionsBedrockRole", env, self.autofix_oidc_role)
+        self.bedrock_role.grant_assume_role(self.autofix_oidc_role)
 
         self.autofix_upload_role = create_autofix_upload_role(
             self, "AwsLcGitHubActionAutofixUploadRole", self.autofix_oidc_role,
@@ -332,9 +332,9 @@ def create_standard_github_actions_role(scope: Construct, id: str,
     return role
 
 
-def create_autofix_reasoning_role(scope: Construct, id: str,
-                                       env: typing.Union[Environment, typing.Dict[str, typing.Any]],
-                                       principal: iam.IPrincipal) -> iam.Role:
+def create_bedrock_role(scope: Construct, id: str,
+                        env: typing.Union[Environment, typing.Dict[str, typing.Any]],
+                        principal: iam.IPrincipal) -> iam.Role:
     return iam.Role(scope, id, role_name=id,
                     assumed_by=iam.SessionTagsPrincipal(principal),
                     inline_policies={


### PR DESCRIPTION
### Description of changes:
Renames the autofix Bedrock role `AwsLcGitHubActionAutofixReasoningRole` → `AwsLcGitHubActionsBedrockRole` (and the factory `create_autofix_reasoning_role` → `create_bedrock_role`), plus the `reason` job's `roleName`. The role grants generic `bedrock:InvokeModel` on `anthropic.*`, so naming it by capability lets other AI-CI share it; also normalizes `Action` → `Actions`. Name-only, trust policy and permissions unchanged.

Note: renaming replaces the IAM role (CDK derives `role_name` from the construct id), so the CDK deploy should land before/with the workflow change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
