### PR TITLE
Add tests for RSASSA-PSS with SHA-3 digest and MGF1

### DIFF
--- a/crypto/evp_extra/evp_tests.txt
+++ b/crypto/evp_extra/evp_tests.txt
@@ -719,6 +719,55 @@ Digest = SHA256
 Input = "0123456789ABCDEF0123456789ABCDEF"
 Output = 4065b284b0a6e98d4c41a8427007f878d8dd61599c87764fa79b8bf03f030c48127a4b1a5af5a6e0cf9055e57a1f47e5b0c0d8c600e78369cf1c39374899fac91a812692aa2216ba10900ce85a5cf7fddcafb726e4b83479c5bb7b3b84b08ffe183b4c2973aa3193ec7b7d4ea73bf1b579c6657b78ad7800e1975a4838c28ffe353fafef96be27b5c69677760a71b6f4df65ba6fe6b3565580a536f966928294c6e9ece807a90c1477779bcbfa3a250e98d685097c162c1c8c56ab02bd2e16eec7a019b51c067bdba7fa8cd5460796e22c607a8b6d12e1deb9be51c6943c46590f416800c48bb4cbb8c409d316573e59eadf7d3b9e6e5c2d0e570692e511e139
 
+# RSA-PSS with SHA-3 as both the message digest and the MGF1 hash. The salt
+# length matches the digest length (-1). Signing is non-deterministic with a
+# non-zero salt, so these are checked by round-tripping through verification.
+# The |Input| is the pre-computed message digest, so its length matches the
+# digest size (32, 48, and 64 bytes for SHA3-256/384/512 respectively).
+Sign = RSA-2048
+RSAPadding = PSS
+PSSSaltLength = -1
+Digest = SHA3-256
+MGF1Digest = SHA3-256
+Input = "0123456789ABCDEF0123456789ABCDEF"
+CheckVerify
+
+Sign = RSA-2048
+RSAPadding = PSS
+PSSSaltLength = -1
+Digest = SHA3-384
+MGF1Digest = SHA3-384
+Input = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+CheckVerify
+
+Sign = RSA-2048
+RSAPadding = PSS
+PSSSaltLength = -1
+Digest = SHA3-512
+MGF1Digest = SHA3-512
+Input = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+CheckVerify
+
+# Zero salt length makes SHA-3 PSS deterministic; still checked by round-trip.
+Sign = RSA-2048
+RSAPadding = PSS
+PSSSaltLength = 0
+Digest = SHA3-256
+MGF1Digest = SHA3-256
+Input = "0123456789ABCDEF0123456789ABCDEF"
+CheckVerify
+
+# The message digest and the MGF1 digest are selected independently: SHA3-256
+# for the message hash and SHA3-512 for the mask. This proves the MGF1 hash is
+# not forced to equal the message digest.
+Sign = RSA-2048
+RSAPadding = PSS
+PSSSaltLength = -1
+Digest = SHA3-256
+MGF1Digest = SHA3-512
+Input = "0123456789ABCDEF0123456789ABCDEF"
+CheckVerify
+
 
 # RSA decrypt
 

--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -1648,15 +1648,15 @@ TEST(RSATest, LargeE) {
   EXPECT_FALSE(RSA_new_public_key_large_e(n, bad_e.get()));
 }
 
-// PSSWithSHA3 proves that RSASSA-PSS supports SHA-3 as both the message digest
-// and the MGF1 hash. It exercises the low-level padding functions
-// (|RSA_padding_add_PKCS1_PSS_mgf1| / |RSA_verify_PKCS1_PSS_mgf1|) and the
-// higher-level sign/verify functions (|RSA_sign_pss_mgf1| /
-// |RSA_verify_pss_mgf1|), including a case where the message digest and the
-// MGF1 digest differ.
-TEST(RSATest, PSSWithSHA3) {
-  // A 2048-bit key so that even SHA3-512 with a digest-length salt fits within
-  // the modulus (64-byte hash + 64-byte salt + overhead).
+// PSSWithVariousDigests proves that RSASSA-PSS works with a range of digest
+// and MGF1 hash functions (currently the SHA-2 and SHA-3 families). It
+// exercises the low-level padding functions (|RSA_padding_add_PKCS1_PSS_mgf1| /
+// |RSA_verify_PKCS1_PSS_mgf1|) and the higher-level sign/verify functions
+// (|RSA_sign_pss_mgf1| / |RSA_verify_pss_mgf1|), including cases where the
+// message digest and the MGF1 digest differ.
+TEST(RSATest, PSSWithVariousDigests) {
+  // A 2048-bit key so that even SHA-512 / SHA3-512 with a digest-length salt
+  // fits within the modulus (64-byte hash + 64-byte salt + overhead).
   bssl::UniquePtr<RSA> key(RSA_new());
   ASSERT_TRUE(key);
   bssl::UniquePtr<BIGNUM> e(BN_new());
@@ -1668,10 +1668,17 @@ TEST(RSATest, PSSWithSHA3) {
     const EVP_MD *md;
     const EVP_MD *mgf1_md;
   } kTests[] = {
+      // SHA-2 family, message digest == MGF1 digest.
+      {EVP_sha224(), EVP_sha224()},
+      {EVP_sha256(), EVP_sha256()},
+      {EVP_sha384(), EVP_sha384()},
+      {EVP_sha512(), EVP_sha512()},
+      // SHA-3 family, message digest == MGF1 digest.
       {EVP_sha3_256(), EVP_sha3_256()},
       {EVP_sha3_384(), EVP_sha3_384()},
       {EVP_sha3_512(), EVP_sha3_512()},
       // The message digest and MGF1 digest are independent.
+      {EVP_sha256(), EVP_sha512()},
       {EVP_sha3_256(), EVP_sha3_512()},
   };
 

--- a/crypto/rsa_extra/rsa_test.cc
+++ b/crypto/rsa_extra/rsa_test.cc
@@ -1648,6 +1648,75 @@ TEST(RSATest, LargeE) {
   EXPECT_FALSE(RSA_new_public_key_large_e(n, bad_e.get()));
 }
 
+// PSSWithSHA3 proves that RSASSA-PSS supports SHA-3 as both the message digest
+// and the MGF1 hash. It exercises the low-level padding functions
+// (|RSA_padding_add_PKCS1_PSS_mgf1| / |RSA_verify_PKCS1_PSS_mgf1|) and the
+// higher-level sign/verify functions (|RSA_sign_pss_mgf1| /
+// |RSA_verify_pss_mgf1|), including a case where the message digest and the
+// MGF1 digest differ.
+TEST(RSATest, PSSWithSHA3) {
+  // A 2048-bit key so that even SHA3-512 with a digest-length salt fits within
+  // the modulus (64-byte hash + 64-byte salt + overhead).
+  bssl::UniquePtr<RSA> key(RSA_new());
+  ASSERT_TRUE(key);
+  bssl::UniquePtr<BIGNUM> e(BN_new());
+  ASSERT_TRUE(e);
+  ASSERT_TRUE(BN_set_word(e.get(), RSA_F4));
+  ASSERT_TRUE(RSA_generate_key_ex(key.get(), 2048, e.get(), nullptr));
+
+  struct {
+    const EVP_MD *md;
+    const EVP_MD *mgf1_md;
+  } kTests[] = {
+      {EVP_sha3_256(), EVP_sha3_256()},
+      {EVP_sha3_384(), EVP_sha3_384()},
+      {EVP_sha3_512(), EVP_sha3_512()},
+      // The message digest and MGF1 digest are independent.
+      {EVP_sha3_256(), EVP_sha3_512()},
+  };
+
+  static const uint8_t kMsg[] = "RSASSA-PSS with SHA-3";
+  for (const auto &t : kTests) {
+    SCOPED_TRACE(EVP_MD_type(t.md));
+    SCOPED_TRACE(EVP_MD_type(t.mgf1_md));
+
+    // Hash the message with the message digest.
+    uint8_t digest[EVP_MAX_MD_SIZE];
+    unsigned digest_len;
+    ASSERT_TRUE(EVP_Digest(kMsg, sizeof(kMsg), digest, &digest_len, t.md,
+                           /*impl=*/nullptr));
+    ASSERT_EQ(digest_len, EVP_MD_size(t.md));
+
+    // Low-level padding round-trips: add the PSS padding, then verify it.
+    std::vector<uint8_t> em(RSA_size(key.get()));
+    ASSERT_TRUE(RSA_padding_add_PKCS1_PSS_mgf1(key.get(), em.data(), digest,
+                                               t.md, t.mgf1_md,
+                                               RSA_PSS_SALTLEN_DIGEST));
+    EXPECT_TRUE(RSA_verify_PKCS1_PSS_mgf1(key.get(), digest, t.md, t.mgf1_md,
+                                          em.data(), RSA_PSS_SALTLEN_DIGEST));
+
+    // High-level sign/verify round-trips.
+    std::vector<uint8_t> sig(RSA_size(key.get()));
+    size_t sig_len;
+    ASSERT_TRUE(RSA_sign_pss_mgf1(key.get(), &sig_len, sig.data(), sig.size(),
+                                  digest, digest_len, t.md, t.mgf1_md,
+                                  RSA_PSS_SALTLEN_DIGEST));
+    sig.resize(sig_len);
+    EXPECT_TRUE(RSA_verify_pss_mgf1(key.get(), digest, digest_len, t.md,
+                                    t.mgf1_md, RSA_PSS_SALTLEN_DIGEST,
+                                    sig.data(), sig.size()));
+
+    // A signature over a different digest must not verify.
+    uint8_t bad_digest[EVP_MAX_MD_SIZE];
+    OPENSSL_memcpy(bad_digest, digest, digest_len);
+    bad_digest[0] ^= 0xff;
+    EXPECT_FALSE(RSA_verify_pss_mgf1(key.get(), bad_digest, digest_len, t.md,
+                                     t.mgf1_md, RSA_PSS_SALTLEN_DIGEST,
+                                     sig.data(), sig.size()));
+    ERR_clear_error();
+  }
+}
+
 #if !defined(BORINGSSL_SHARED_LIBRARY)
 TEST(RSATest, SqrtTwo) {
   bssl::UniquePtr<BIGNUM> sqrt(BN_new()), pow2(BN_new());


### PR DESCRIPTION
### What

Adds test coverage proving RSASSA-PSS supports SHA-3 and all SHA-2 variants as both the message digest and the MGF1 hash. No library code changes -- this capability already works because the PSS padding, sign, and verify paths drive the digest through the abstract `EVP_MD` interface with no digest allowlist.

### Testing

- `crypto/rsa_extra/rsa_test.cc` -- new test covers the low-level padding functions (`RSA_padding_add_PKCS1_PSS_mgf1` / `RSA_verify_PKCS1_PSS_mgf1`) and sign/verify (`RSA_sign_pss_mgf1` / `RSA_verify_pss_mgf1`) with SHA3-256/384/512, plus a mismatched message-digest/MGF1-digest case (SHA3-256 hash with SHA3-512 mask) and a negative control.
- `crypto/evp_extra/evp_tests.txt` -- file-driven vectors covering the EVP layer (`EVP_PKEY_sign`/`verify` with `EVP_PKEY_CTX_set_rsa_mgf1_md`), round-tripped via `CheckVerify`.


### Note

The one place SHA-3 is not accepted for PSS is the ASN.1 parameter allowlist in `crypto/rsa_extra/rsassa_pss_asn1.c` (SHA1/224/256/384/512 only), which is exercised only for restricted `EVP_PKEY_RSA_PSS` keys. These tests deliberately use plain RSA keys and the direct APIs, which are unaffected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.