### PR TITLE
Link header documentation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ information about required dependencies and build options. If you’re intereste
 getting involved [open an issue](https://github.com/aws/aws-lc/issues/new/choose) to discuss your plan.
 [Contributing.md](https://github.com/aws/aws-lc/blob/main/CONTRIBUTING.md) has
 info for how to specifically make the change and get it reviewed by AWS-LC maintainers.
-If you just want to use AWS-LC, see our existing documentation in the public header
+If you just want to use AWS-LC, see our [existing documentation](https://aws.github.io/aws-lc/headers.html) in the public header
 files. If you’re moving your application from OpenSSL, see the
 [porting guide](https://github.com/aws/aws-lc/blob/main/PORTING.md)
 for more information.


### PR DESCRIPTION
### What

Turns the "existing documentation" reference in the README into a hyperlink to the published header documentation at https://aws.github.io/aws-lc/headers.html, so readers who "just want to use AWS-LC" can navigate directly to the API docs.

### Details

Single-line change to `README.md`. No functional or code changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.