### PR TITLE
delocate: Drop redundant `-dI` flag

### DIFF
--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -2686,9 +2686,6 @@ func main() {
 
 		// -E requests only preprocessing.
 		cppCommand = append(cppCommand, "-E")
-
-		// Output ‘#include’ directives in addition to the result of preprocessing.
-		cppCommand = append(cppCommand, "-dI")
 	}
 
 	if err := parseInputs(inputs, cppCommand); err != nil {


### PR DESCRIPTION
Commit 40cbc25b9a40 ("Modify prefixing behavior on aarch64 to allow delocator to handle OPENSSL_armcap_P correctly (#1342)") added -dI while moving the AArch64 preprocessing into the delocator.

That fix required the assembly to be delocated before symbol prefixing. It achieved this by excluding the generated prefix headers from the delocator's include path. It also passed the three required headers, arm_arch.h, asm_base.h, and target.h, as explicit arguments. The delocator re-emits these headers for the final preprocessing pass, where the symbol prefixes are applied. Retaining the source include directives was not needed for this. The upstream BoringSSL delocator likewise does not use -dI.

This commit drops -dI. The flag only carries the already-expanded source includes into bcm-delocated.S, causing them to be processed a second time. Removing the flag drops those directives and line markers while leaving bcm-delocated.S.o and libcrypto.a byte-identical in FIPS builds on AArch64 and x86_64, both with and without symbol prefixing.

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
