### PR TITLE
delocate: Drop redundant `-dI` flag (test)

### DIFF
--- a/util/fipstools/delocate/delocate.go
+++ b/util/fipstools/delocate/delocate.go
@@ -2686,9 +2686,6 @@ func main() {
 
 		// -E requests only preprocessing.
 		cppCommand = append(cppCommand, "-E")
-
-		// Output ‘#include’ directives in addition to the result of preprocessing.
-		cppCommand = append(cppCommand, "-dI")
 	}
 
 	if err := parseInputs(inputs, cppCommand); err != nil {


### PR DESCRIPTION
Test PR to check CI behavior (mirror of #3384). Drops the redundant `-dI` flag from the delocator's preprocessor command. Verified libcrypto.a byte-identical with/without on x86_64 and aarch64 FIPS builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.