### PR TITLE
ci: pin openssh required job

### DIFF
--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -68,34 +68,44 @@ jobs:
             run: ./tests/ci/integration/run_libgit2_integration.sh main
 
           # OpenSSH Integration Tests
-          - name: openssh-master
+          - name: openssh-10.4p1
             arch: x86_64
             size: small
             image: amazonlinux:2023
             compiler: clang-15
-            openssh_branch: master
-            run: ./tests/ci/integration/run_openssh_integration.sh
+            run: ./tests/ci/integration/run_openssh_integration.sh V_10_4_P1
           - name: openssh-v8.9
             arch: x86_64
             size: small
             image: amazonlinux:2023
             compiler: clang-15
-            openssh_branch: V_8_9
-            run: ./tests/ci/integration/run_openssh_integration.sh
+            run: ./tests/ci/integration/run_openssh_integration.sh V_8_9
           - name: openssh-master
+            arch: x86_64
+            size: small
+            image: amazonlinux:2023
+            compiler: clang-15
+            allow_failure: true
+            run: ./tests/ci/integration/run_openssh_integration.sh master
+          - name: openssh-10.4p1
             arch: aarch64
             size: 2xlarge
             image: amazonlinux:2023
             compiler: clang-15
-            openssh_branch: master
-            run: ./tests/ci/integration/run_openssh_integration.sh
+            run: ./tests/ci/integration/run_openssh_integration.sh V_10_4_P1
           - name: openssh-v8.9
             arch: aarch64
             size: 2xlarge
             image: amazonlinux:2023
             compiler: clang-15
-            openssh_branch: V_8_9
-            run: ./tests/ci/integration/run_openssh_integration.sh
+            run: ./tests/ci/integration/run_openssh_integration.sh V_8_9
+          - name: openssh-master
+            arch: aarch64
+            size: 2xlarge
+            image: amazonlinux:2023
+            compiler: clang-15
+            allow_failure: true
+            run: ./tests/ci/integration/run_openssh_integration.sh master
 
           # PostgreSQL Integration Tests
           - name: postgresql
@@ -429,7 +439,6 @@ jobs:
             compiler: gcc-12
             run: ./tests/ci/integration/run_pyopenssl_integration.sh '25.3.0'
     env:
-      OPENSSH_BRANCH: ${{ matrix.openssh_branch || '' }}
       ACCP_FIPS: ${{ matrix.accp_fips || '' }}
     steps:
       - uses: actions/checkout@v7
@@ -442,7 +451,6 @@ jobs:
         with:
           image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/${{ matrix.image }}
           env: |
-            OPENSSH_BRANCH
             ACCP_FIPS
           options: ${{ matrix.options || '' }}
           user: ${{ matrix.user || '' }}

--- a/tests/ci/integration/run_openssh_integration.sh
+++ b/tests/ci/integration/run_openssh_integration.sh
@@ -26,6 +26,8 @@ AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
 OPENSSH_WORKSPACE_FOLDER="${SCRATCH_FOLDER}/openssh-portable"
 OPENSSH_INSTALL_FOLDER="${SCRATCH_FOLDER}/openssh-install"
 
+OPENSSH_REF="${1:-master}"
+
 NINJA_COMMAND=ninja
 if ! ${NINJA_COMMAND} --version; then
   NINJA_COMMAND=ninja-build
@@ -50,7 +52,7 @@ function openssh_build() {
   pushd "${OPENSSH_WORKSPACE_FOLDER}"
   autoreconf
 
-  if [ "$OPENSSH_BRANCH" == "master" ]; then
+  if [ "${OPENSSH_REF}" == "master" ] || [[ "${OPENSSH_REF}" == V_10_* ]]; then
     ./configure --with-ssl-dir="${AWS_LC_INSTALL_FOLDER}" --prefix="${OPENSSH_INSTALL_FOLDER}"
   else
     # The RSA_meth_XXX functions are not implemented by AWS-LC, and the implementation provided by OpenSSH also doesn't compile for us.
@@ -63,13 +65,6 @@ function openssh_build() {
   make -j "$NUM_CPU_THREADS"
   make install
   ls -R "${OPENSSH_INSTALL_FOLDER}"
-  popd
-}
-
-function checkout_openssh_branch() {
-  pushd "${OPENSSH_WORKSPACE_FOLDER}"
-  git clean -f -d
-  git checkout --track origin/"$1"
   popd
 }
 
@@ -86,22 +81,18 @@ function openssh_run_tests() {
 
 mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${OPENSSH_INSTALL_FOLDER}"
 
-# Get latest OpenSSH version.
-git clone https://github.com/openssh/openssh-portable.git "${OPENSSH_WORKSPACE_FOLDER}"
+# Get OpenSSH at the requested ref.
+git clone --depth 1 --branch "${OPENSSH_REF}" https://github.com/openssh/openssh-portable.git "${OPENSSH_WORKSPACE_FOLDER}"
 ls
 
 # Build AWS-LC as a shared library
 aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=1
 install_aws_lc
 
-if [ "$OPENSSH_BRANCH" != "master" ]; then
-  checkout_openssh_branch "$OPENSSH_BRANCH"
-fi
-
 openssh_build
 
 CODEBUILD_SKIPPED_TESTS="agent-subprocess forwarding multiplex channel-timeout forward-control agent-restrict connection-timeout"
-if [ "$OPENSSH_BRANCH" == "V_8_9" ]; then
+if [ "${OPENSSH_REF}" == "V_8_9" ]; then
     # In v8.9, the "percent" test requires the 'openssl' cli command
     openssh_run_tests "percent ${CODEBUILD_SKIPPED_TESTS}"
 else


### PR DESCRIPTION
## Summary

openssh-portable commit [`ddbcd8f`](https://github.com/openssh/openssh-portable/commit/ddbcd8ffdabeeb04955ea187739904a52f09c8c9) added `mlkem768brainpoolp256r1-sha256` to master. AWS-LC defines `NID_brainpoolP256r1` in `nid.h` but does not implement the Brainpool P-256 curve in its EC backend, so `EC_KEY_new_by_curve_name(NID_brainpoolP256r1)` returns NULL at runtime. The `rekey.sh` regression test builds its KEX list via `ssh -Q kex`, which now includes the new algorithm, causing cascading failures across all AEAD ciphers.

The `mlkem768nistp256-sha256` algorithm added in the same upstream batch [`786cb6a`](https://github.com/openssh/openssh-portable/commit/786cb6a14cede4c1bfcf7a1989b53c9a28c8bee4) works correctly since P-256 is fully implemented in AWS-LC.

Follows the pattern established for grpc (#3331) and libssh2 (#3343):
- Pin the blocking required jobs to `V_10_4_P1` (last known-good release)
- Add `openssh-master` jobs back with `allow_failure: true` to keep tracking upstream without blocking PRs

Also simplifies `run_openssh_integration.sh`:
- Accept the ref as `$1` (defaulting to `master`)
- Remove the `checkout_openssh_branch` helper and `OPENSSH_BRANCH` env wiring that are no longer needed

*Related* https://github.com/aws/aws-lc/pull/3286

## Branch protection changes

The required checks for `openssh-master-x86_64` and `openssh-master-aarch64` were dropped, and `openssh-10.4p1-x86_64` and `openssh-10.4p1-aarch64` were marked required.

## Testing

- [X] `openssh-10.4p1` x86_64 and aarch64 jobs pass
- [X] `openssh-v8.9` x86_64 and aarch64 jobs pass
- [X] `openssh-master` x86_64 and aarch64 jobs are non-blocking (allowed to fail)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.