### PR TITLE
Fix docker image dependencies and update octocrab initialization

### DIFF
--- a/tests/ci/lambda/Dockerfile
+++ b/tests/ci/lambda/Dockerfile
@@ -7,7 +7,7 @@ ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-RUN yum install -y openssl openssl-devel clang pkgconfig
+RUN yum install -y clang pkgconfig
 
 ENV PATH /root/.cargo/bin:$PATH
 

--- a/tests/ci/lambda/src/bin/purge-stale-builds.rs
+++ b/tests/ci/lambda/src/bin/purge-stale-builds.rs
@@ -37,7 +37,9 @@ async fn handle(_event: LambdaEvent<Value>) -> Result<(), Error> {
     )
     .await?;
 
-    let github = octocrab::initialise(octocrab::Octocrab::builder().personal_token(github_token))
+    let github = octocrab::Octocrab::builder()
+        .personal_token(github_token)
+        .build()
         .map_err(|e| format!("failed to build github client: {e}"))?;
 
     let codebuild_client = aws_sdk_codebuild::Client::new(&config);


### PR DESCRIPTION

### Description of changes: 

Installing `openssl-devel `makes `yum` pull `openssl-libs`. The Lambda AL2 image already contains `openssl-snapsafe-libs`, so both packages provide the same OpenSSL libraries and conflict, so dependency resolution fails on the image. 

The `openssl` packages were originally required because Octocrab 0.19 used `native-tls`, which depended on `openssl` and `openssl-sys.` 

[PR #3217](https://github.com/aws/aws-lc/pull/3217) upgraded Octocrab to 0.47.1. The current dependencies are now [`hyper-rustls`](https://github.com/aws/aws-lc/blob/94735c9a3/tests/ci/lambda/Cargo.lock#L1036-L1065) and [`rustls`](https://github.com/aws/aws-lc/blob/94735c9a3/tests/ci/lambda/Cargo.lock#L1562-L1586), so OpenSSL packages are no longer required.

This change removes the stale `openssl` and `openssl-devel` installation from the `purge-stale-builds` image. It also updates Octocrab client construction for the 0.47.1 API.

### Testing:
Tested with `cargo check --locked --bin purge-stale-builds.` Verified the patch on a cloud desktop, which completed successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.