### PR TITLE
[Cherry-pick 2024] Fix CMake Compatability CI jobs (#2953, #3068)

### DIFF
--- a/.github/docker_images/cmake_build_versions/cmake_build.sh
+++ b/.github/docker_images/cmake_build_versions/cmake_build.sh
@@ -9,8 +9,21 @@ echo "Building CMake Version: ${CMAKE_VERSION:-unknown}"
 
 NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 
-# At the moment this works fine for all versions, in the future build logic can be modified to
-# look at it ${CMAKE_VERSION}.
-./configure --prefix=/opt/cmake --system-curl --system-libarchive
+# CMake versions before 4.0 have compatibility issues with newer system curl libraries.
+# The curl headers define CURL_NETRC_* as long int values, but older CMake code expects
+# them to be CURL_NETRC_OPTION enum values, causing compilation errors.
+# For older versions, we use CMake's bundled curl instead of the system curl.
+CONFIGURE_OPTS="--prefix=/opt/cmake --system-libarchive"
+
+if [[ "${CMAKE_VERSION}" =~ ^[0-3]\. ]]; then
+    # CMake versions 3.x and earlier: use bundled curl to avoid compatibility issues
+    echo "Using bundled curl for CMake ${CMAKE_VERSION}"
+else
+    # CMake 4.0 and later: safe to use system curl
+    echo "Using system curl for CMake ${CMAKE_VERSION}"
+    CONFIGURE_OPTS="${CONFIGURE_OPTS} --system-curl"
+fi
+
+./configure ${CONFIGURE_OPTS}
 make -j"${NUM_CPU_THREADS}"
 make install

--- a/.github/docker_images/cmake_build_versions/cmake_build.sh
+++ b/.github/docker_images/cmake_build_versions/cmake_build.sh
@@ -15,14 +15,7 @@ NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 # For older versions, we use CMake's bundled curl instead of the system curl.
 CONFIGURE_OPTS="--prefix=/opt/cmake --system-libarchive"
 
-if [[ "${CMAKE_VERSION}" =~ ^[0-3]\. ]]; then
-    # CMake versions 3.x and earlier: use bundled curl to avoid compatibility issues
-    echo "Using bundled curl for CMake ${CMAKE_VERSION}"
-else
-    # CMake 4.0 and later: safe to use system curl
-    echo "Using system curl for CMake ${CMAKE_VERSION}"
-    CONFIGURE_OPTS="${CONFIGURE_OPTS} --system-curl"
-fi
+echo "Using bundled curl for CMake ${CMAKE_VERSION}"
 
 ./configure ${CONFIGURE_OPTS}
 make -j"${NUM_CPU_THREADS}"


### PR DESCRIPTION
### Issues:
N/A

### Description of changes:
Backports the CMake CI fixes from [#2953](https://github.com/aws/aws-lc/pull/2953) and [#3068](https://github.com/aws/aws-lc/pull/3068) to the `fips-2024-09-27` branch, fixing the long-standing "CMake Compatability" workflow failures on this branch.

The `cmake_build_versions` Docker image builds CMake from source with `./configure --system-curl`. Newer system curl headers define the `CURL_NETRC_*` / proxy-type constants as `long int` rather than as enum values, which older CMake sources reject:

```
/cmake/source/Source/CTest/cmCTestCurl.cxx:262:29: error: invalid conversion from 'long int' to 'curl_proxytype' [-fpermissive]
make: *** [Makefile:161: all] Error 2
```

This fails during the "Build Docker Image" step, so every downstream build/test step in the job is skipped. Because this branch only exercises CMake 3.5 and 3.28 (both pre-4.0), all four CMake 3.5 jobs fail. The fix drops `--system-curl` so CMake builds against its own bundled curl.

After these two cherry-picks, `cmake_build.sh` is byte-identical to the version on `main`.

### Call-outs:
- This is a CI-only change; no library, header, or test code is touched.
- Both upstream commits were cherry-picked (rather than hand-editing the script) to preserve authorship and history. #2953 introduced version-conditional logic and #3068 simplified it to always use the bundled curl; the net end state is what `main` runs today.
- This failure is pre-existing and unrelated to any in-flight change: the "CMake Compatability" workflow has failed on every push to `fips-2024-09-27` since at least 2026-05-27. It surfaced while investigating CI on [#3394](https://github.com/aws/aws-lc/pull/3394), which is unaffected by it.

### Testing:
Reproduced the failure and verified the fix locally with Docker (`linux/amd64`):

- **Pre-fix** (script as it exists on `fips-2024-09-27`): the CMake 3.5.0 image build fails with exactly the CI error, the same `invalid conversion from 'long int' to 'curl_proxytype'` at `cmCTestCurl.cxx:262/267/271/275`.
- **Post-fix**: the CMake 3.5.0 image builds successfully and `cmake --version` in the image reports 3.5.0.
- Ran the full CI invocation against the fixed image (`-G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DFIPS=1`): CMake 3.5.0 configures and compiles AWS-LC successfully, and `crypto_test` reports 2029/2031 passing. The 2 failures are the ChaCha20-Poly1305 / XChaCha20-Poly1305 assembly `PerAEADTest.ABI` checks, which fail under x86-64 QEMU emulation on an arm64 host and are unrelated to this change; CI runs these natively.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
