### PR TITLE
Add MinGW shared-library Windows CI coverage

### DIFF
--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -47,6 +47,54 @@ jobs:
         run: cmake --build "path has spaces/build" --target all
       - name: Run tests
         run: cmake --build "path has spaces/build" --target run_tests
+  mingw-shared:
+    # MinGW + BUILD_SHARED_LIBS had no coverage, and GNU ld is stricter than the
+    # MSVC-ABI linkers used by the other shared jobs in two ways:
+    #  - It will not resolve __imp_ references against definitions in the same
+    #    image, so only MinGW catches a missing BORINGSSL_IMPLEMENTATION on a
+    #    target whose objects are linked into libcrypto itself.
+    #  - __attribute__((visibility("default"))) is a no-op on PE, so a symbol
+    #    only decorated for export under _MSC_VER never leaves the DLL, and
+    #    consumers fail to link against it.
+    if: github.repository_owner == 'aws'
+    runs-on: windows-latest
+    steps:
+      - name: Install NASM
+        uses: ilammy/setup-nasm@v1.5.1
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup MinGW
+        uses: egor-tensin/setup-mingw@v3
+        id: setup_mingw
+      - name: Setup CMake
+        uses: threeal/cmake-action@v2.1.0
+        with:
+          generator: Ninja
+          c-compiler: ${{ steps.setup_mingw.outputs.gcc }}
+          cxx-compiler: ${{ steps.setup_mingw.outputs.gxx }}
+          options: |
+            BUILD_SHARED_LIBS=1
+            CMAKE_SYSTEM_NAME=Windows
+            CMAKE_SYSTEM_PROCESSOR=x86_64
+            CMAKE_BUILD_TYPE=Release
+      - name: Build Project
+        run: cmake --build ./build --target all
+      - name: Co-locate DLLs with the test executables
+        # Windows resolves DLLs out of System32 before it looks at PATH, and the
+        # runner image has a LibreSSL libcrypto.dll there (shipped by Windows
+        # OpenSSH). MinGW gives our libraries the same lib-prefixed names, so an
+        # executable that does not sit next to our own libcrypto.dll binds to
+        # LibreSSL instead and dies in the loader with
+        # STATUS_ENTRYPOINT_NOT_FOUND. Only the directory of the executable is
+        # searched ahead of System32, so putting the build output on PATH does
+        # not help; the DLLs have to be beside the binaries.
+        run: |
+          $build = (Resolve-Path ./build).Path
+          $dlls = Get-ChildItem $build -Recurse -Filter *.dll | Where-Object { $_.FullName -notmatch '\\CMakeFiles\\' } | Group-Object Name | ForEach-Object { $_.Group[0] }
+          $exeDirs = Get-ChildItem $build -Recurse -Filter *.exe | Where-Object { $_.FullName -notmatch '\\CMakeFiles\\' } | Select-Object -ExpandProperty DirectoryName -Unique
+          foreach ($dir in $exeDirs) { foreach ($dll in $dlls) { if ($dll.DirectoryName -ne $dir) { Copy-Item $dll.FullName $dir -Force } } }
+      - name: Run tests
+        run: cmake --build ./build --target run_tests
   clang:
     if: github.repository_owner == 'aws'
     runs-on: windows-latest

--- a/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
+++ b/crypto/fipsmodule/rand/entropy/tree_drbg_jitter_entropy.c
@@ -409,6 +409,14 @@ void tree_jitter_free_thread_drbg(struct entropy_source_t *entropy_source) {
 // extra work to use random data (from the OS source) ensures that even if some
 // output were to escape from the randomness generation, it will still be sound
 // practically.
+//
+// Windows shared builds take the zeros option: there this runs from a libcrypto
+// global destructor on |DLL_PROCESS_DETACH|, after |ExitProcess|, where
+// |CRYPTO_sysrand| faults on bcryptprimitives.dll (loaded on demand, so not
+// kept alive by libcrypto's dependency graph). Static builds run it from the
+// executable's |atexit| and are unaffected. Zeros still override every state in
+// the tree, losing only the defence in depth above, which the write-locked
+// frontend DRBGs already cover.
 
 // tree_jitter_zeroize_drbg zeroizes the DRBG state configured in
 // |tree_jitter_drbg|.
@@ -416,7 +424,11 @@ static void tree_jitter_zeroize_drbg(
   struct tree_jitter_drbg_t *tree_jitter_drbg) {
 
   uint8_t random_data[CTR_DRBG_ENTROPY_LEN];
+#if defined(OPENSSL_WINDOWS) && defined(BORINGSSL_SHARED_LIBRARY)
+  OPENSSL_memset(random_data, 0, CTR_DRBG_ENTROPY_LEN);
+#else
   CRYPTO_sysrand_if_available(random_data, CTR_DRBG_ENTROPY_LEN);
+#endif
 
   if (CTR_DRBG_reseed(&(tree_jitter_drbg->drbg), random_data, NULL, 0) != 1) {
     abort();

--- a/third_party/jitterentropy/CMakeLists.txt
+++ b/third_party/jitterentropy/CMakeLists.txt
@@ -63,5 +63,10 @@ set(JITTER_COMPILE_FLAGS "${JITTER_COMPILE_FLAGS} ${JITTER_ENETROPY_PREFIX_INCLU
 set_source_files_properties(${JITTER_SOURCES} PROPERTIES COMPILE_FLAGS "${JITTER_COMPILE_FLAGS}")
 add_library(jitterentropy OBJECT ${JITTER_SOURCES})
 
+# These objects are linked into libcrypto itself, so this code is part of the
+# implementation, not a consumer: without this, a shared build decorates the
+# AWS-LC functions it calls as dllimport and MinGW's ld fails on __imp_ refs.
+target_compile_definitions(jitterentropy PRIVATE BORINGSSL_IMPLEMENTATION)
+
 target_include_directories(jitterentropy BEFORE PRIVATE "${PROJECT_SOURCE_DIR}/third_party/jitterentropy/jitterentropy-library")
 target_add_awslc_include_paths(TARGET jitterentropy SCOPE PRIVATE)

--- a/third_party/jitterentropy/README.md
+++ b/third_party/jitterentropy/README.md
@@ -8,6 +8,12 @@ https://github.com/smuellerDD/jitterentropy-library.
 The following changes were made to the original source code to integrate
 the library with AWS-LC:
 * `asm volatile` was changed to `__asm__volatile`
+* In `jitterentropy.h`, the `JENT_PRIVATE_STATIC` export decoration was
+  widened from `_MSC_VER` to `_WIN32`. On PE targets
+  `__attribute__((visibility("default")))` is a no-op, so under MinGW the
+  `jent_*` symbols were never exported from `libcrypto.dll` and consumers of a
+  shared build failed to link against them. Submitted upstream as
+  https://github.com/smuellerDD/jitterentropy-library/pull/212.
 
 The original README.md file starts below.
 

--- a/third_party/jitterentropy/jitterentropy-library/jitterentropy.h
+++ b/third_party/jitterentropy/jitterentropy-library/jitterentropy.h
@@ -412,7 +412,7 @@ struct rand_data
 #ifdef JENT_PRIVATE_COMPILE
 # define JENT_PRIVATE_STATIC static
 #else /* JENT_PRIVATE_COMPILE */
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #define JENT_PRIVATE_STATIC __declspec(dllexport)
 #else
 #define JENT_PRIVATE_STATIC __attribute__((visibility("default")))


### PR DESCRIPTION
### Description of changes:

Add a Windows MinGW shared-library CI job. This exposes and fixes shared-build issues in:
* jitterentropy -- missing `BORINGSSL_IMPLEMENTATION` definitions, unavailable `jent_*` DLL exports (fix is [submitted and accepted upstream](https://github.com/smuellerDD/jitterentropy-library/pull/212)), and 
* entropy collection during DLL teardown.

### Testing:

The new CI job builds a shared AWS-LC library with MinGW and runs `run_tests`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
