### PR TITLE
Fix thread-local destructors with MSYS2 clang64

### DIFF
--- a/crypto/thread_win.c
+++ b/crypto/thread_win.c
@@ -180,6 +180,8 @@ __pragma(comment(
 // reference to this variable with a linker /INCLUDE:symbol pragma to ensure
 // that.) If this variable is discarded, the OnThreadExit function will never
 // be called.
+#if defined(_MSC_VER)
+
 #ifdef _WIN64
 
 // .CRT section is merged with .rdata on x64 so it must be constant data.
@@ -199,6 +201,23 @@ PIMAGE_TLS_CALLBACK p_thread_callback_boringssl = thread_local_destructor;
 #pragma data_seg()
 
 #endif  // _WIN64
+
+#else  // !_MSC_VER
+
+// MinGW compilers do not reliably implement the MSVC section pragmas above;
+// use the GCC section attribute instead ('used' prevents discarding).
+extern const PIMAGE_TLS_CALLBACK p_thread_callback_boringssl;
+__attribute__((section(".CRT$XLC"), used))
+const PIMAGE_TLS_CALLBACK p_thread_callback_boringssl = thread_local_destructor;
+
+// The callback array is only walked if the image has a TLS directory, which
+// requires the CRT's _tls_used symbol. MSVC forces it with /INCLUDE above;
+// on MinGW, create a reference so the linker pulls it in.
+extern const IMAGE_TLS_DIRECTORY _tls_used;
+__attribute__((used))
+static const IMAGE_TLS_DIRECTORY *tls_used_reference_boringssl = &_tls_used;
+
+#endif  // _MSC_VER
 
 static void **get_thread_locals(void) {
   // |TlsGetValue| clears the last error even on success, so that callers may


### PR DESCRIPTION
### Description of changes:

The MSYS2 clang64 CI jobs began failing `ThreadTest.ThreadLocal` after updating to LLVM 22 because the linked test executable no longer contained the Thread Local Storage (TLS) directory needed to register thread-exit callbacks. The existing callback registration relies on MSVC-specific section and linker pragmas that are not reliable when Clang targets MinGW.

This change preserves the existing MSVC path and adds a MinGW-compatible path that places the callback in `.CRT$XLC` using GCC-style attributes. It also retains a reference to the MinGW CRT's `_tls_used` symbol so the linker emits the Thread Local Storage directory required for the Windows loader to invoke the callback.

### Call-outs:

The explicit `_tls_used` reference is necessary because LLVM 22's LLD no longer pulls in the MinGW TLS support object by default.

### Testing:

- Reproduced the `ThreadTest.ThreadLocal` failure on `main` using Windows Server 2022 with MSYS2 clang64 and Clang/LLD 22.1.8.
- Verified that `ThreadTest.ThreadLocal` passes with this change.
- Verified that the full `crypto_test` suite passes (2715 tests).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.