### PR TITLE
Move network-dependent s_client tests into integration_test

### DIFF
--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -70,20 +70,27 @@ if(ENABLE_SYMBOL_VERSIONING)
 endif()
 
 if(BUILD_TESTING)
-  # ocsp_integration_test.cc does integration tests with the Amazon Trust
-  # Services OCSP responder. This is ran as its own test executable because
-  # internal sandbox builds cannot properly connect with the host.
-  # Since the integration test relies on libssl functionalities to retrieve
-  # the certification chain from a host, this integration test dimension is
-  # built with libssl and libcrypto.
+  # Tests that connect to a live, remote host. Kept as its own executable, and
+  # deliberately out of util/all_tests.json, so the default test run stays
+  # hermetic; environments without outbound access (e.g. internal sandbox
+  # builds) simply do not run it. Built against libssl and libcrypto because
+  # these tests use libssl to retrieve a certificate chain from a host.
   # Skip on Generic systems (e.g., WASI) which don't have BSD sockets.
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "Generic")
     add_executable(
       ${INTEGRATION_TEST_EXEC}
 
       ../crypto/ocsp/ocsp_integration_test.cc
-      ../tool/transport_common.cc
+      ../tool-openssl/s_client_integration_test.cc
+
+      # Link closure for SClientTool.
+      ../tool-openssl/ordered_args.cc
+      ../tool-openssl/s_client.cc
+      ../tool/args.cc
+      ../tool/client.cc
       ../tool/fd.cc
+      ../tool/file.cc
+      ../tool/transport_common.cc
 
       $<TARGET_OBJECTS:crypto_test_data>
     )

--- a/tool-openssl/README.md
+++ b/tool-openssl/README.md
@@ -9,4 +9,5 @@ Current status:
   * md5 options: N/A (md5.cc)
 * Unit, integration, and OpenSSL comparison tests (x509_test.cc, rsa_test.cc, md5_test.cc)
   * OpenSSL comparison tests require environment variables for both AWS-LC ("AWSLC_TOOL_PATH") and OpenSSL ("OPENSSL_TOOL_PATH") tools
+  * Tests that connect to a live, remote host (s_client_integration_test.cc) are built into the `integration_test` executable, not `tool_openssl_test`
 

--- a/tool-openssl/s_client_integration_test.cc
+++ b/tool-openssl/s_client_integration_test.cc
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <gtest/gtest.h>
+#include <openssl/ssl.h>
+#include "internal.h"
+
+// These tests connect to a live, remote host, so they are built into the
+// integration_test executable rather than tool_openssl_test. See
+// ssl/CMakeLists.txt.
+
+// Test -connect
+TEST(SClientIntegrationTest, Connect) {
+  args_list_t args = {"-connect", "amazon.com:443"};
+  bool result = SClientTool(args);
+  ASSERT_TRUE(result);
+}
+
+// Test -connect, -verify, -showcerts
+TEST(SClientIntegrationTest, ConnectVerifyShowcerts) {
+  args_list_t args = {"-connect", "amazon.com:443", "-verify", "99", "-showcerts"};
+  bool result = SClientTool(args);
+  ASSERT_TRUE(result);
+}
+
+// Test -cipher
+TEST(SClientIntegrationTest, Cipher) {
+  // Pin to TLS 1.2 so the -cipher list is actually enforced. Without a version
+  // pin the handshake can negotiate TLS 1.3, whose cipher suites are configured
+  // separately, leaving -cipher effectively ignored.
+  args_list_t args = {"-connect", "amazon.com:443", "-cipher",
+                      "ECDHE-RSA-AES128-GCM-SHA256", "-tls1_2"};
+  bool result = SClientTool(args);
+  ASSERT_TRUE(result);
+}
+
+// Test -tls1_1
+TEST(SClientIntegrationTest, Tls1_1) {
+  args_list_t args = {"-connect", "amazon.com:443", "-tls1_1"};
+  bool result = SClientTool(args);
+  ASSERT_TRUE(result);
+}
+
+// Test -cipher and -tls1_1 together
+TEST(SClientIntegrationTest, CipherAndTls1_1) {
+  // TLS 1.1 has no AEAD/SHA-256 suites, so this stays on a CBC-SHA1 cipher, but
+  // prefer the forward-secret ECDHE variant over static-RSA AES128-SHA.
+  args_list_t args = {"-connect", "amazon.com:443", "-cipher",
+                      "ECDHE-RSA-AES128-SHA", "-tls1_1"};
+  bool result = SClientTool(args);
+  ASSERT_TRUE(result);
+}

--- a/tool-openssl/s_client_test.cc
+++ b/tool-openssl/s_client_test.cc
@@ -5,12 +5,8 @@
 #include <openssl/ssl.h>
 #include "internal.h"
 
-// Test -connect
-TEST(SClientTest, Connect) {
-  args_list_t args = {"-connect", "amazon.com:443"};
-  bool result = SClientTool(args);
-  ASSERT_TRUE(result);
-}
+// Tests that connect to a live, remote host are in
+// s_client_integration_test.cc, built into the integration_test executable.
 
 // Test without connect but with help
 TEST(SClientTest, NoConnect) {
@@ -26,42 +22,9 @@ TEST(SClientTest, Help) {
   ASSERT_TRUE(result);
 }
 
-// Test -connect, -verify, -showcerts
-TEST(SClientTest, ConnectVerifyShowcerts) {
-  args_list_t args = {"-connect", "amazon.com:443", "-verify", "99", "-showcerts"};
-  bool result = SClientTool(args);
-  ASSERT_TRUE(result);
-}
-
-// Test -cipher
-TEST(SClientTest, Cipher) {
-  // Pin to TLS 1.2 so the -cipher list is actually enforced. Without a version
-  // pin the handshake can negotiate TLS 1.3, whose cipher suites are configured
-  // separately, leaving -cipher effectively ignored.
-  args_list_t args = {"-connect", "amazon.com:443", "-cipher",
-                      "ECDHE-RSA-AES128-GCM-SHA256", "-tls1_2"};
-  bool result = SClientTool(args);
-  ASSERT_TRUE(result);
-}
-
-// Test -tls1_1
-TEST(SClientTest, Tls1_1) {
-  args_list_t args = {"-connect", "amazon.com:443", "-tls1_1"};
-  bool result = SClientTool(args);
-  ASSERT_TRUE(result);
-}
-
-// Test -cipher and -tls1_1 together
-TEST(SClientTest, CipherAndTls1_1) {
-  // TLS 1.1 has no AEAD/SHA-256 suites, so this stays on a CBC-SHA1 cipher, but
-  // prefer the forward-secret ECDHE variant over static-RSA AES128-SHA.
-  args_list_t args = {"-connect", "amazon.com:443", "-cipher",
-                      "ECDHE-RSA-AES128-SHA", "-tls1_1"};
-  bool result = SClientTool(args);
-  ASSERT_TRUE(result);
-}
-
-// Test that s_client returns false (not crash) for unresolvable hostname
+// Test that s_client returns false (not crash) for unresolvable hostname. This
+// only needs DNS resolution to fail, not network egress, so it stays here
+// rather than moving to s_client_integration_test.cc.
 TEST(SClientTest, UnresolvableHost) {
   args_list_t args = {"-connect", "this.host.does.not.exist.invalid:443"};
   bool result = SClientTool(args);


### PR DESCRIPTION
### Description of changes:
Five of the eight `SClientTest` cases connect to `amazon.com:443`, so they fail whenever egress is unavailable or rate limited. This moves them into a new `tool-openssl/s_client_integration_test.cc`, built into the existing `integration_test` executable alongside the OCSP responder tests, and renames them to `SClientIntegrationTest` to match `OCSPIntegrationTest`.

`integration_test` is deliberately absent from `util/all_tests.json`, so the default test run (`go run util/all_tests.go`, `ninja run_tests`) never invokes it. Environments without outbound access, such as internal sandbox builds, get a hermetic default suite without having to opt out of anything.

### Call-outs:
* The moved cases no longer run in the default suite. That is the goal, but the trade-off is that nothing exercises `s_client` against a live host unless `integration_test` is run explicitly.
* `UnresolvableHost` stays in `tool_openssl_test` even though it passes `-connect`. It only needs DNS resolution to fail, not egress, so it is hermetic. I extended its comment to say so, since otherwise it reads like it was missed during the move.
* `ssl/CMakeLists.txt` gains a few extra sources (`s_client.cc`, `ordered_args.cc`, `tool/args.cc`, `tool/client.cc`, `tool/file.cc`) purely as the link closure for `SClientTool`. No new library dependencies.

### Testing:
Existing tests, relocated rather than rewritten. `tool_openssl_test` and `integration_test` both pass locally (macOS/arm64): the 3 remaining `SClientTest` cases and all 5 moved `SClientIntegrationTest` cases. Test count balances -- 8 before, 3 + 5 after. Also ran `ssl_test` to confirm the `ssl/CMakeLists.txt` change did not disturb anything else.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
