### PR TITLE
Avoid /usr/bin/env dependency in FIPS compiler wrapper

### DIFF
--- a/util/compiler_wrapper/CompilerWrapper.cmake
+++ b/util/compiler_wrapper/CompilerWrapper.cmake
@@ -119,12 +119,23 @@ function(setup_compiler_wrapper)
     message(FATAL_ERROR "Failed to generate compiler wrapper script")
   endif()
 
+  # Launch via an explicit interpreter rather than the shebang or executable bit,
+  # neither of which survives every environment this tree is vendored into.
+  # /bin/sh is no new dependency; Make and Ninja already run recipes through it.
+  if(COMPILER_WRAPPER_BAT AND WRAPPER_SCRIPT STREQUAL "${COMPILER_WRAPPER_BAT}")
+    set(WRAPPER_LAUNCHER "${WRAPPER_SCRIPT}")
+  else()
+    set(WRAPPER_LAUNCHER "/bin/sh" "${WRAPPER_SCRIPT}")
+  endif()
+
   # Store wrapper information in cache for use by other functions
   set(COMPILER_WRAPPER_SCRIPT "${WRAPPER_SCRIPT}" CACHE INTERNAL "Path to generated compiler wrapper script")
+  set(COMPILER_WRAPPER_LAUNCHER "${WRAPPER_LAUNCHER}" CACHE INTERNAL "Command used to launch the compiler wrapper")
   set(COMPILER_WRAPPER_REAL_COMPILER "${REAL_COMPILER}" CACHE INTERNAL "Real compiler being wrapped")
   set(COMPILER_WRAPPER_AVAILABLE TRUE CACHE INTERNAL "Whether compiler wrapper is available")
 
   message(STATUS "Compiler wrapper ready: ${WRAPPER_SCRIPT}")
+  message(STATUS "Compiler wrapper launch command: ${WRAPPER_LAUNCHER}")
 endfunction()
 
 # Apply the compiler wrapper to a specific target
@@ -143,7 +154,7 @@ function(use_compiler_wrapper_for_target target_name)
 
   # Set the compiler launcher to use our wrapper
   set_target_properties(${target_name} PROPERTIES
-        C_COMPILER_LAUNCHER "${COMPILER_WRAPPER_SCRIPT}"
+        C_COMPILER_LAUNCHER "${COMPILER_WRAPPER_LAUNCHER}"
     )
 
   message(STATUS "Applied compiler wrapper to target: ${target_name}")

--- a/util/compiler_wrapper/compiler_wrapper_template.sh.in
+++ b/util/compiler_wrapper/compiler_wrapper_template.sh.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 


### PR DESCRIPTION
### Issues:
Addresses aws/aws-lc-rs#1204

### Description of changes:
The generated FIPS compiler wrapper used `#!/usr/bin/env sh`, which fails in build sandboxes that don't provide `/usr/bin/env` (Nix, per the linked issue). The template now uses `#!/bin/sh`, and we invoke the wrapper through an explicit `/bin/sh` in `C_COMPILER_LAUNCHER` so that neither the shebang nor the executable bit is relied on at all.

### Call-outs:
- `#!/usr/bin/env sh` buys nothing for `sh` specifically, and `/bin/sh` is not a new dependency: Make and Ninja already run every build recipe through it. Worth noting the wrapper is generated at build time, so shebang-rewriting tooling like nixpkgs `patchShebangs` cannot fix it up in the source tree.
- The launcher change means the exec bit no longer matters either, which is relevant because `configure_file()` copies the template's permissions and those may not survive being vendored into the `aws-lc-fips-sys` crate and re-extracted elsewhere.
- Needs a cherry-pick onto `fips-2025-09-12-lts`, which still carries the old shebang. I confirmed the patch applies cleanly there, even though that branch predates #3269 and its `util/compiler_wrapper/` differs from mainline.

### Testing:
Full FIPS static build (`-DFIPS=1 -DBUILD_SHARED_LIBS=0`) on CMake 3.5.0, our declared floor, through `bcm_c_generated_asm`, delocate, and `libcrypto.a`. The `/bin/sh;<wrapper>` launcher form was separately confirmed on CMake 3.5.0 and 3.28.3 with both Ninja and Unix Makefiles.

Hostile check for the actual bug: after configure I rewrote the generated wrapper's shebang to `#!/nonexistent/interpreter sh` and chmod'd it to 644, so it cannot be executed directly. The build still completed and the wrapper still stripped `-c`, which is what shows both failure modes are gone rather than relocated.

One caveat: the CMake compatibility workflow does not currently cover this path. Its configure args are silently dropped, so `-DFIPS=1` never reaches CMake and the wrapper is never exercised. Tracked separately; the testing above was done by hand in that job's container image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.