### PR TITLE
[FIPS 4.0] Avoid /usr/bin/env dependency in FIPS compiler wrapper

### DIFF
--- a/util/compiler_wrapper/CompilerWrapper.cmake
+++ b/util/compiler_wrapper/CompilerWrapper.cmake
@@ -119,12 +119,23 @@ function(setup_compiler_wrapper)
     message(FATAL_ERROR "Failed to generate compiler wrapper script")
   endif()
 
+  # Launch via an explicit interpreter rather than the shebang or executable bit,
+  # neither of which survives every environment this tree is vendored into.
+  # /bin/sh is no new dependency; Make and Ninja already run recipes through it.
+  if(COMPILER_WRAPPER_BAT AND WRAPPER_SCRIPT STREQUAL "${COMPILER_WRAPPER_BAT}")
+    set(WRAPPER_LAUNCHER "${WRAPPER_SCRIPT}")
+  else()
+    set(WRAPPER_LAUNCHER "/bin/sh" "${WRAPPER_SCRIPT}")
+  endif()
+
   # Store wrapper information in cache for use by other functions
   set(COMPILER_WRAPPER_SCRIPT "${WRAPPER_SCRIPT}" CACHE INTERNAL "Path to generated compiler wrapper script")
+  set(COMPILER_WRAPPER_LAUNCHER "${WRAPPER_LAUNCHER}" CACHE INTERNAL "Command used to launch the compiler wrapper")
   set(COMPILER_WRAPPER_REAL_COMPILER "${REAL_COMPILER}" CACHE INTERNAL "Real compiler being wrapped")
   set(COMPILER_WRAPPER_AVAILABLE TRUE CACHE INTERNAL "Whether compiler wrapper is available")
 
   message(STATUS "Compiler wrapper ready: ${WRAPPER_SCRIPT}")
+  message(STATUS "Compiler wrapper launch command: ${WRAPPER_LAUNCHER}")
 endfunction()
 
 # Apply the compiler wrapper to a specific target
@@ -143,7 +154,7 @@ function(use_compiler_wrapper_for_target target_name)
 
   # Set the compiler launcher to use our wrapper
   set_target_properties(${target_name} PROPERTIES
-        C_COMPILER_LAUNCHER "${COMPILER_WRAPPER_SCRIPT}"
+        C_COMPILER_LAUNCHER "${COMPILER_WRAPPER_LAUNCHER}"
     )
 
   message(STATUS "Applied compiler wrapper to target: ${target_name}")

--- a/util/compiler_wrapper/compiler_wrapper_template.sh.in
+++ b/util/compiler_wrapper/compiler_wrapper_template.sh.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 


### PR DESCRIPTION

Same as: 
* #3411

----
The generated compiler wrapper used `#!/usr/bin/env sh`, which fails in build sandboxes that do not provide /usr/bin/env (reported for Nix in aws/aws-lc-rs#1204). Because the wrapper is generated by CMake at build time, tooling that rewrites shebangs across a source tree cannot fix it up.

Switch the template to `#!/bin/sh`, and invoke the wrapper through an explicit interpreter via C_COMPILER_LAUNCHER so that neither the shebang line nor the executable bit is relied upon at all. The executable bit matters because configure_file() copies the template's permissions, which may not survive being vendored into the aws-lc-fips-sys crate and re-extracted elsewhere.

Depending on /bin/sh introduces no new requirement, since both Make and Ninja already run every build recipe through it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
