### PR TITLE
Add backport apply command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ symbols.txt
 awslcTestTmpFile*
 /pages-output
 util/backport/.backport-runs/
+util/backport/.backport-worktrees/

--- a/util/backport/README.md
+++ b/util/backport/README.md
@@ -1,6 +1,7 @@
-# AWS-LC Backport Analysis
+# AWS-LC Backport
 
-Works out which supported release branches still need a fix, before it merges.
+Works out which supported release branches still need a fix, before it merges, and
+cherry-picks it onto the ones that do.
 
 ## What This Tool Does
 
@@ -19,7 +20,9 @@ passes:
 It also says when a fix reaches inside the validated FIPS module, which is a
 certification question rather than a code one.
 
-Nothing is cherry-picked, pushed, or committed. The tool only reports.
+`apply` then cherry-picks the fix onto one local branch per affected branch.
+
+Nothing is pushed and no pull request is opened. The branches are yours to review.
 
 ## Prerequisites
 
@@ -143,6 +146,57 @@ sure nobody finds out later. The same line is carried into every pull request `p
 opens and into the summary it posts, so it survives being read by someone who never ran
 `analyze`.
 
+### Cherry-pick onto the affected branches
+
+```bash
+util/backport/backport apply
+```
+
+Reads the last `analyze` run and cherry-picks the fix onto one local branch per
+affected branch, named `backport-<release branch>-<fix>`. Branches `analyze` could not
+settle are left out, since picking onto one of those would be a guess. `--branch` does
+a single branch, including one that was cleared, and `--yes` skips the confirm.
+
+Each pick happens in its own worktree under `.backport-worktrees/`, so the branch you
+have checked out never moves and a half-finished cherry-pick can never strand your own
+working tree mid-merge. Each branch is cut from the same remote-tracking release branch
+`analyze` judged, so the backport is never built on a base the analysis never saw.
+
+**Example Output:**
+
+```
+Fix ac3aee3104, analyzed 2026-08-04 14:36:20
+Backporting onto 7 branch(es): fips-2026-06-26-snapshot, fips-2025-09-12-lts, ...
+Create these local branches? [Y/N] y
+  fips-2026-06-26-snapshot: applied, on backport-fips-2026-06-26-snapshot-ac3aee3104
+  fips-2025-09-12-lts: applied, on backport-fips-2025-09-12-lts-ac3aee3104
+  fips-2022-11-02: CONFLICT in 4 file(s)
+      crypto/dh_extra/dh_test.cc
+      crypto/fipsmodule/dh/check.c
+      resolve in util/backport/.backport-worktrees/backport-fips-2022-11-02-ac3aee3104
+
+2 of 7 applied cleanly
+Resolve each conflict in the worktree named above, then 'git cherry-pick --continue' there.
+Nothing was pushed. Review each branch before you open a pull request.
+```
+
+A clean pick leaves just the branch and removes its worktree. A conflict keeps the
+worktree, stopped mid-cherry-pick, so you can resolve it in place. Conflicts are
+normal on the older branches, where the surrounding code has moved on.
+
+**Results:**
+
+| Result | Meaning |
+| --- | --- |
+| `applied` | cherry-picked cleanly, the branch is left behind and its worktree removed |
+| `CONFLICT` | the worktree is kept, stopped mid-cherry-pick, for you to resolve |
+| `skipped` | that backport branch already exists, so nothing was touched |
+| `nothing to do` | the change is already on the branch, so the pick came out empty |
+
+`skipped` is what makes a second run safe: re-running after resolving one conflict
+leaves the branches you already have alone. The command exits non-zero if any branch
+conflicted, so a script can tell whether anything needs a human.
+
 ## Configuration
 
 ### Model settings
@@ -241,7 +295,8 @@ util/backport/
 ├── src/
 │   ├── main.py                   # argument parsing
 │   ├── commands/
-│   │   └── analyze.py            # the analyze command
+│   │   ├── analyze.py            # the analyze command
+│   │   └── apply.py              # the apply command
 │   ├── engine/
 │   │   ├── inspect_fix.py        # which lines the fix deletes, who wrote them
 │   │   ├── discover_branches.py  # which release branches to check
@@ -258,6 +313,7 @@ util/backport/
 │   ├── fixes.txt                 # 39 real fixes to replay
 │   └── answer_key.txt            # which branches each one should flag
 └── .backport-runs/               # the last analyze result, not checked in
+    .backport-worktrees/          # where a conflicted pick waits, not checked in
 ```
 
 ## Testing
@@ -383,6 +439,18 @@ of its own, so analyze what it brought in instead.
 ```bash
 util/backport/backport analyze --commit <sha>^..<sha>
 ```
+
+### No saved analyze run
+
+`apply` acts on what `analyze` decided, so `analyze` has to have run first:
+
+```bash
+util/backport/backport analyze
+```
+
+The same error appears if the run names a fix this checkout no longer has, which
+happens when a range was analyzed and git has since collected the squashed commit.
+Re-running `analyze` fixes both.
 
 ### Wrong or empty results from a subdirectory
 

--- a/util/backport/src/commands/apply.py
+++ b/util/backport/src/commands/apply.py
@@ -1,0 +1,174 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+"""
+The apply command: cherry-picks the fix onto one local branch per affected branch
+Nothing is pushed and no pull request is opened, the branches are yours to review
+"""
+
+from util.config import (
+    AFFECTED,
+    BACKPORT_BRANCH_PREFIX,
+    RUN_FILE,
+    UNSURE,
+    BackportError,
+)
+from util.git import (
+    WORKTREE_ROOT,
+    abort_cherry_pick,
+    add_worktree,
+    branch_exists,
+    branch_ref,
+    cherry_pick,
+    cherry_pick_was_empty,
+    commit_exists,
+    remove_worktree,
+)
+from util.render import ask_yn
+
+import json
+from typing import Dict, List, Optional, Tuple
+
+# How one branch turned out
+APPLIED = "applied"
+CONFLICT = "conflict"
+ALREADY_THERE = "already there"
+BRANCH_EXISTS = "branch exists"
+
+
+def load_run() -> dict:
+    """
+    The run analyze saved, as {generated_at, fix, base, branches, verdicts}
+    Written by save_run in util/config.py, where the fields are spelled out
+
+    Raises rather than returning a partial answer, in all three cases where acting on
+    the run would mean guessing: there is no run, the file cannot be read, or the fix
+    it names is no longer in this checkout
+    """
+    try:
+        run = json.loads(RUN_FILE.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise BackportError(
+            "no saved analyze run to apply.\n  Run 'backport analyze' first."
+        )
+    except json.JSONDecodeError as exc:
+        raise BackportError(f"{RUN_FILE} is not valid JSON: {exc}")
+
+    # These two are the whole input: which commit to pick, and onto which branches
+    for key in ("fix", "verdicts"):
+        if key not in run:
+            raise BackportError(f"{RUN_FILE} has no '{key}'. Re-run analyze.")
+
+    # Analyzing a range squashes it into a commit nothing points at, so git can collect
+    # it between analyze and apply
+    if not commit_exists(run["fix"]):
+        raise BackportError(
+            f"the analyzed fix {run['fix'][:10]} is not in this checkout any more.\n"
+            "  Re-run analyze."
+        )
+    return run
+
+
+def backport_branch_name(fix: str, release: str) -> str:
+    """What the local branch holding a backport is called"""
+    return f"{BACKPORT_BRANCH_PREFIX}{release}-{fix[:10]}"
+
+
+def branches_to_backport(verdicts: Dict[str, str], only: Optional[str]) -> List[str]:
+    """
+    Which release branches to cherry-pick onto
+    Returns the affected ones, or just the named branch. Unsure branches are left
+    out: analyze could not settle them, so a cherry-pick would be a guess
+    """
+    if only:
+        if only not in verdicts:
+            known = ", ".join(sorted(verdicts))
+            raise BackportError(f"'{only}' was not in the analyze run.\n  Had: {known}")
+        return [only]
+    return [b for b, state in verdicts.items() if state == AFFECTED]
+
+
+def cherry_pick_onto(fix: str, release: str) -> Tuple[str, List[str]]:
+    """
+    Cherry-picks the fix onto one release branch, in a worktree of its own
+    Returns (outcome, conflicting files) where outcome is one of the four above
+
+    The worktree is what makes this safe to run while you are working: your own
+    checkout never moves. It is removed once the pick is settled either way, and kept
+    only when there is a conflict, because that is where you resolve it
+
+    The pick starts from the same remote-tracking ref analyze judged, not from origin.
+    A fork is often behind on the release branches, and starting from a stale one would
+    build the backport on the wrong base
+    """
+    local_branch = backport_branch_name(fix, release)
+    if branch_exists(local_branch):
+        return BRANCH_EXISTS, []
+
+    worktree = WORKTREE_ROOT / local_branch
+    add_worktree(worktree, local_branch, branch_ref(release))
+    picked, conflicts = cherry_pick(worktree, fix)
+
+    if picked:
+        remove_worktree(worktree)
+        return APPLIED, []
+    if not conflicts and cherry_pick_was_empty(worktree):
+        # The pick came out empty, so this branch already has the change
+        abort_cherry_pick(worktree)
+        remove_worktree(worktree)
+        return ALREADY_THERE, []
+    return CONFLICT, conflicts
+
+
+def cmd_apply(args) -> int:
+    """
+    Cherry-picks the analyzed fix onto every affected branch
+    Returns 0 when every branch applied cleanly or was skipped, 1 when any conflicted
+    """
+    run = load_run()
+    fix, verdicts = run["fix"], run["verdicts"]
+    releases = branches_to_backport(verdicts, args.branch)
+
+    if not releases:
+        print("No affected branches in the last analyze run, nothing to apply.")
+        return 0
+
+    unsure = [b for b, state in verdicts.items() if state == UNSURE]
+    print(f"Fix {fix[:10]}, analyzed {run.get('generated_at', 'at an unknown time')}")
+    print(f"Backporting onto {len(releases)} branch(es): {', '.join(releases)}")
+    if unsure:
+        print(
+            f"Leaving out {len(unsure)} branch(es) analyze could not settle: "
+            f"{', '.join(unsure)}"
+        )
+    if not args.yes and not ask_yn("Create these local branches?"):
+        print("Aborted. Nothing was created.")
+        return 0
+
+    outcomes = {}
+    for release in releases:
+        outcome, conflicts = cherry_pick_onto(fix, release)
+        outcomes[release] = (outcome, conflicts)
+        local_branch = backport_branch_name(fix, release)
+        if outcome == APPLIED:
+            print(f"  {release}: applied, on {local_branch}")
+        elif outcome == BRANCH_EXISTS:
+            print(f"  {release}: skipped, {local_branch} already exists")
+        elif outcome == ALREADY_THERE:
+            print(f"  {release}: nothing to do, the change is already there")
+        else:
+            print(f"  {release}: CONFLICT in {len(conflicts)} file(s)")
+            for name in conflicts:
+                print(f"      {name}")
+            print(f"      resolve in {WORKTREE_ROOT / local_branch}")
+
+    conflicted = [b for b, (o, _) in outcomes.items() if o == CONFLICT]
+    print()
+    print(f"{len(outcomes) - len(conflicted)} of {len(outcomes)} applied cleanly")
+    if conflicted:
+        print(
+            "Resolve each conflict in the worktree named above, then "
+            "'git cherry-pick --continue' there."
+        )
+    print("Nothing was pushed. Review each branch before you open a pull request.")
+    return 1 if conflicted else 0

--- a/util/backport/src/main.py
+++ b/util/backport/src/main.py
@@ -7,6 +7,7 @@ Calls upon actions based on command-line arguments
 """
 
 from commands.analyze import cmd_analyze
+from commands.apply import cmd_apply
 from util.config import BackportError
 
 import argparse
@@ -33,10 +34,29 @@ def add_analyze(subparsers) -> None:
     p.set_defaults(func=cmd_analyze)
 
 
+def add_apply(subparsers) -> None:
+    """
+    Cherry-picks the analyzed fix onto a local branch per affected release branch
+    Reads the run analyze saved, so analyze has to have run first
+    """
+    p = subparsers.add_parser(
+        "apply", help="cherry-picks the fix onto a branch per affected branch"
+    )
+    p.add_argument(
+        "--branch", help="only this release branch, instead of every affected one"
+    )
+    p.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skips the confirm. Useful for test scripts",
+    )
+    p.set_defaults(func=cmd_apply)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """
     Build parser for args
-    Returns the parser, with the analyze subcommand on it
+    Returns the parser, with the analyze and apply subcommands on it
     """
     ap = argparse.ArgumentParser(
         prog="backport",
@@ -44,6 +64,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     subparsers = ap.add_subparsers(dest="cmd", required=True)
     add_analyze(subparsers)
+    add_apply(subparsers)
     return ap
 
 

--- a/util/backport/src/util/config.py
+++ b/util/backport/src/util/config.py
@@ -221,6 +221,10 @@ SUPPORTED_BRANCH_PREFIXES = ("fips-", "AWS-LC-FIPS-", "NetOS")
 # release branches, or missing them entirely, so guessing origin is not safe
 RELEASE_REMOTE = os.environ.get("BACKPORT_REMOTE", "").strip()
 
+# What every local branch holding a backport is named after. Kept here so the code that
+# builds the name and the code that later has to recognize it cannot drift apart
+BACKPORT_BRANCH_PREFIX = "backport-"
+
 
 # --- The Saved Run ---
 # analyze writes its result here so apply can pick it up. Kept next to the tool,

--- a/util/backport/src/util/git.py
+++ b/util/backport/src/util/git.py
@@ -375,3 +375,68 @@ def resolve_on_branch(
             if older != file_path and file_on_branch(branch_ref, older):
                 return older
     return None
+
+
+# --- Backporting ---
+
+# Cherry-picks happen in a worktree under here, never in the tree you are sitting in
+WORKTREE_ROOT = TOOL_ROOT / ".backport-worktrees"
+
+
+def commit_exists(sha: str) -> bool:
+    """True when this checkout still has that commit"""
+    return git("cat-file", "-e", f"{sha}^{{commit}}", check=False).returncode == 0
+
+
+def branch_exists(name: str) -> bool:
+    """True when that local branch already exists"""
+    ref = f"refs/heads/{name}"
+    return git("show-ref", "--verify", "--quiet", ref, check=False).returncode == 0
+
+
+def add_worktree(path, branch: str, start_point: str) -> None:
+    """
+    Checks start_point out at path on a new branch
+    A worktree is used so apply never moves the branch you have checked out, and an
+    unfinished cherry-pick can never strand your own working tree mid-merge
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    git("worktree", "add", "-q", "-b", branch, str(path), start_point)
+
+
+def remove_worktree(path) -> None:
+    """Drops the worktree but keeps the branch it built"""
+    git("worktree", "remove", "--force", str(path), check=False)
+
+
+def cherry_pick(path, sha: str) -> Tuple[bool, List[str]]:
+    """
+    Cherry-picks sha in the worktree at path
+    Returns (applied, conflicted files). The user's own name lands on the commit
+    because git is left to read their config, so the result is theirs to push
+
+    -x is what writes the "cherry picked from commit" line into the message, which is
+    one of the three signals analyze uses to spot a branch that already has the fix.
+    Without it the tool could not recognise its own backports on the next run
+    """
+    picked = git("-C", str(path), "cherry-pick", "-x", sha, check=False)
+    if picked.returncode == 0:
+        return True, []
+    unmerged = git(
+        "-C", str(path), "diff", "--name-only", "--diff-filter=U", check=False
+    )
+    return False, [f for f in unmerged.stdout.splitlines() if f.strip()]
+
+
+def cherry_pick_was_empty(path) -> bool:
+    """
+    True when the cherry-pick stopped because the change is already there
+    git calls this an empty commit, which means the branch did not need the fix
+    """
+    state = git("-C", str(path), "status", "--porcelain", check=False)
+    return not state.stdout.strip()
+
+
+def abort_cherry_pick(path) -> None:
+    """Backs a stopped cherry-pick out, leaving the worktree on its branch"""
+    git("-C", str(path), "cherry-pick", "--abort", check=False)

--- a/util/backport/testing/test_engine.py
+++ b/util/backport/testing/test_engine.py
@@ -9,9 +9,11 @@ Run from util/backport:
     python3 -m unittest testing.test_engine
 """
 
+import argparse
 import datetime
 import io
 import json
+import re
 import subprocess
 import sys
 import unittest
@@ -22,6 +24,7 @@ from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
+from commands import apply as apply_cmd
 from engine import (
     classify_branches,
     consult_ai,
@@ -30,6 +33,8 @@ from engine import (
     prompts,
 )
 from util import config, git
+
+import main
 
 
 class NormalizeSpaces(unittest.TestCase):
@@ -1371,6 +1376,205 @@ class AnUnreadableManifestWarns(unittest.TestCase):
             self.assertEqual(config.load_supported_versions(), {})
         self.assertIn("could not read", said.getvalue())
         self.assertIn("out of support", said.getvalue())
+
+
+class BackportBranchName(unittest.TestCase):
+    def test_names_carry_the_branch_and_the_fix(self):
+        got = apply_cmd.backport_branch_name("ac3aee3104ff", "fips-2024-09-27")
+        self.assertEqual(got, "backport-fips-2024-09-27-ac3aee3104")
+
+    def test_two_fixes_on_one_branch_do_not_collide(self):
+        first = apply_cmd.backport_branch_name("aaaaaaaaaaaa", "fips-2024-09-27")
+        second = apply_cmd.backport_branch_name("bbbbbbbbbbbb", "fips-2024-09-27")
+        self.assertNotEqual(first, second)
+
+
+# One of each verdict, so a target picker has to filter rather than pass them through
+APPLY_VERDICTS = {
+    "fips-2024-09-27": config.AFFECTED,
+    "fips-2022-11-02": config.UNSURE,
+    "fips-2021-10-20": config.NOT_AFFECTED,
+    "fips-NetOS-2024-06-11": config.ALREADY_PATCHED,
+}
+
+
+class BranchesToBackport(unittest.TestCase):
+    # Cherry-picking a branch analyze could not settle would be a guess, so unsure
+    # branches are left out and only affected ones are acted on
+
+    def test_only_affected_branches_by_default(self):
+        self.assertEqual(
+            apply_cmd.branches_to_backport(APPLY_VERDICTS, None), ["fips-2024-09-27"]
+        )
+
+    def test_a_named_branch_is_used_even_when_not_affected(self):
+        # An explicit --branch is the user overriding the verdict on purpose
+        got = apply_cmd.branches_to_backport(APPLY_VERDICTS, "fips-2021-10-20")
+        self.assertEqual(got, ["fips-2021-10-20"])
+
+    def test_a_branch_that_was_not_analyzed_is_an_error(self):
+        with self.assertRaises(config.BackportError) as caught:
+            apply_cmd.branches_to_backport(APPLY_VERDICTS, "fips-1999-01-01")
+        self.assertIn("fips-1999-01-01", str(caught.exception))
+
+    def test_nothing_affected_gives_no_targets(self):
+        cleared = {"fips-2024-09-27": config.NOT_AFFECTED}
+        self.assertEqual(apply_cmd.branches_to_backport(cleared, None), [])
+
+
+class LoadRun(unittest.TestCase):
+    # apply acts on what analyze decided, so a run it cannot trust has to stop it
+    # rather than cherry-pick against the wrong fix
+
+    def load(self, text, commit_there=True):
+        """load_run reading canned run file contents"""
+
+        class FakePath:
+            def read_text(self, encoding=None):
+                if text is None:
+                    raise FileNotFoundError
+                return text
+
+        with mock.patch.multiple(
+            apply_cmd, RUN_FILE=FakePath(), commit_exists=lambda sha: commit_there
+        ):
+            return apply_cmd.load_run()
+
+    def test_a_good_run_comes_back_parsed(self):
+        run = self.load(
+            '{"fix": "abc123", "verdicts": {"fips-2024-09-27": "affected"}}'
+        )
+        self.assertEqual(run["fix"], "abc123")
+
+    def test_no_run_at_all_says_to_analyze_first(self):
+        with self.assertRaises(config.BackportError) as caught:
+            self.load(None)
+        self.assertIn("analyze", str(caught.exception))
+
+    def test_unreadable_json_is_an_error(self):
+        with self.assertRaises(config.BackportError):
+            self.load("{not json")
+
+    def test_a_run_without_verdicts_is_an_error(self):
+        with self.assertRaises(config.BackportError) as caught:
+            self.load('{"fix": "abc123"}')
+        self.assertIn("verdicts", str(caught.exception))
+
+    def test_a_fix_gc_took_is_an_error(self):
+        # A range analyze squashes into a commit nothing references, so it can vanish
+        with self.assertRaises(config.BackportError) as caught:
+            self.load('{"fix": "abc123", "verdicts": {}}', commit_there=False)
+        self.assertIn("abc123", str(caught.exception))
+
+
+class CherryPickOnto(unittest.TestCase):
+    # A clean pick leaves only the branch behind; a conflict has to leave the worktree
+    # in place, since that is where the user resolves it
+
+    def run_one(self, exists=False, applied=True, conflicts=(), empty=False):
+        """cherry_pick_onto with every git call faked, as (outcome, found, calls)"""
+        calls = []
+        with mock.patch.multiple(
+            apply_cmd,
+            branch_exists=lambda name: exists,
+            branch_ref=lambda branch: f"upstream/{branch}",
+            add_worktree=lambda path, branch, start: calls.append(("add", start)),
+            cherry_pick=lambda path, sha: (applied, list(conflicts)),
+            cherry_pick_was_empty=lambda path: empty,
+            abort_cherry_pick=lambda path: calls.append(("abort", None)),
+            remove_worktree=lambda path: calls.append(("remove", None)),
+        ):
+            outcome, found = apply_cmd.cherry_pick_onto("abc1234567", "fips-2024-09-27")
+        return outcome, found, calls
+
+    def test_a_clean_pick_keeps_the_branch_and_drops_the_worktree(self):
+        outcome, _, calls = self.run_one(applied=True)
+        self.assertEqual(outcome, apply_cmd.APPLIED)
+        self.assertIn(("remove", None), calls)
+
+    def test_a_conflict_keeps_the_worktree(self):
+        outcome, found, calls = self.run_one(applied=False, conflicts=["crypto/x.c"])
+        self.assertEqual(outcome, apply_cmd.CONFLICT)
+        self.assertEqual(found, ["crypto/x.c"])
+        self.assertNotIn(("remove", None), calls)
+
+    def test_an_existing_branch_is_left_alone(self):
+        outcome, _, calls = self.run_one(exists=True)
+        self.assertEqual(outcome, apply_cmd.BRANCH_EXISTS)
+        self.assertEqual(calls, [])
+
+    def test_a_change_already_there_is_not_a_conflict(self):
+        outcome, _, calls = self.run_one(applied=False, conflicts=[], empty=True)
+        self.assertEqual(outcome, apply_cmd.ALREADY_THERE)
+        self.assertIn(("abort", None), calls)
+        self.assertIn(("remove", None), calls)
+
+    def test_the_worktree_starts_from_the_release_branch(self):
+        # From the remote analyze read, not from origin. A fork is often behind on the
+        # release branches, and a stale base would make the backport wrong
+        _, _, calls = self.run_one()
+        self.assertIn(("add", "upstream/fips-2024-09-27"), calls)
+
+
+class ReadmeMatchesTheCode(unittest.TestCase):
+    # The README is the only description of the CLI, so drift is a real bug. These
+    # fail when a command, a flag or a file is added without documenting it
+
+    README = Path(__file__).resolve().parent.parent / "README.md"
+    TOOL = README.parent
+
+    def readme(self) -> str:
+        return self.README.read_text(encoding="utf-8")
+
+    def subcommands(self):
+        """Every subcommand the parser accepts, and its flags, from the parser itself"""
+        parser = main.build_parser()
+        # _actions is the only way to walk the subparsers, and it stays in step with main
+        subs = next(
+            a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
+        )
+        found = {}
+        for name, sub in subs.choices.items():
+            flags = set()
+            for action in sub._actions:
+                flags.update(f for f in action.option_strings if f.startswith("--"))
+            flags.discard("--help")
+            found[name] = flags
+        return found
+
+    def test_every_subcommand_is_documented(self):
+        text = self.readme()
+        for name in self.subcommands():
+            # assertTrue, not assertIn, so a failure does not dump the whole README
+            self.assertTrue(
+                f"backport {name}" in text, f"'{name}' is not shown in the README"
+            )
+
+    def test_every_flag_is_documented(self):
+        text = self.readme()
+        for name, flags in self.subcommands().items():
+            for flag in sorted(flags):
+                self.assertTrue(
+                    flag in text, f"{name} takes {flag}, the README omits it"
+                )
+
+    def test_the_structure_listing_matches_what_ships(self):
+        # Anything a reader would look for by name, so no __init__.py and nothing
+        # generated or gitignored
+        skip_dirs = ("__pycache__", "qa", ".backport-runs", ".backport-worktrees")
+        shipped = {
+            p.name
+            for p in self.TOOL.rglob("*")
+            if p.is_file()
+            and p.suffix in (".py", ".json", ".txt")
+            and p.name != "__init__.py"
+            and not any(part in skip_dirs for part in p.parts)
+        }
+        listed = set(re.findall(r"([\w.-]+\.(?:py|json|txt))\s+#", self.readme()))
+        self.assertEqual(
+            shipped - listed, set(), "these ship but are not in the README listing"
+        )
+        self.assertEqual(listed - shipped, set(), "these are listed but do not exist")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Issues:
Addresses `P425131803`

### Description of changes:
`analyze` only reports which branches are affected. Acting on that still means cherry-picking the fix onto each branch by hand, which for a fix that hits seven branches is seven rounds of the same work.

This pull request adds `apply`, which **cherry-picks the fix onto one local branch per affected branch**, named `backport-<release branch>-<fix>`.

**Stacked on #3389.** The base here is `backport-stack/analyze`, a scaffolding branch holding that PR's commits, so this diff is only the 7 files this change touches. I will retarget it to `main` once #3389 merges. Please don't merge it into the scaffolding branch.

### Call-outs:
- Each pick runs in **its own worktree**, so the branch you have checked out never moves and a half-finished cherry-pick can't strand your working tree mid-merge.

- A clean pick leaves the branch and removes its worktree. A conflict **keeps** the worktree, stopped mid-cherry-pick, so you can fix it in place.

- Branches that `analyze` could not settle are left out. Cherry-picking onto one of those would be a guess.

- Cherry-picks pass `-x` so the commit carries the "cherry picked from commit" line. That's one of the three signals `analyze` uses to spot a branch that already has the fix, so **without it the tool couldn't recognise its own backports** on a later run.

- Each branch is cut from **the same remote-tracking release branch `analyze` judged**, not from `origin`. Locally `origin` is usually a fork that is behind on the release branches, and a backport built on a base the analysis never saw can cherry-pick cleanly and still be the wrong change.

- **Nothing is pushed and no pull request is opened.** That's the next one.

### Testing:
**Unit tests** - 19 new, 141 total:
```
python3 -m unittest testing.test_engine
```
They cover the branch naming, which branches get picked, the run file it reads, that the worktree starts from the ref `analyze` judged rather than `origin`, and that a clean pick removes its worktree while a conflict keeps it.

**Real fix** - ran `apply` for `ac3aee310` across all 7 release branches: 2 applied cleanly and 5 conflicted. Confirmed the conflicted worktrees were left mid-cherry-pick with `UU` markers, the clean picks produced commits on top of the release branch with the original subject kept, and the `-x` trailer is written and found by `branch_mentions_cherry_pick`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.


