### PR TITLE
Run the backport bot in CI

### DIFF
--- a/.github/workflows/backport-bot.yml
+++ b/.github/workflows/backport-bot.yml
@@ -1,0 +1,120 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+#
+# Backport bot. When a pull request labelled needs-backport merges, work out which
+# supported release branches still need the fix and open one pull request each.
+#
+# Two jobs. analyze is the only job that talks to the model and has no write access.
+# publish is the only job that can write and never talks to the model, so repository
+# content is never handled by a job holding a token that could change the repository.
+#
+# The OIDC role is pinned to this file by job_workflow_ref in
+# tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py, so renaming this file breaks the trust
+# policy until the CDK stack is redeployed. The general OIDC role excludes this file by
+# the same claim, so these jobs cannot take the general route into CI instead.
+name: backport-bot
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: analyze
+    # Only merged pull requests, and only when somebody asked for a backport. Reading
+    # the label here keeps the decision with the reviewers
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'needs-backport')
+    permissions:
+      id-token: write # to assume the Bedrock role
+      contents: read
+    runs-on:
+      - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
+        image:linux-5.0
+        instance-size:small
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The merge commit, not the pull request head, so no untrusted code runs
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          # Brings every branch, which is how the tool sees the release branches, and
+          # the whole history, which it needs to compare them
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Load shared Bedrock settings
+        # For configure-aws-credentials, which takes no region input and reads
+        # AWS_REGION from the environment. No model id is set here: the tool reads
+        # the same shared file itself
+        run: |
+          jq -r '"AWS_REGION=\(.aws_region)"' \
+            .github/workflows/ai-config.json >> "$GITHUB_ENV"
+      - uses: ./.github/actions/configure-aws-credentials
+        with:
+          oidcRole: AwsLcGitHubActionsBackportOidcRole
+          roleName: AwsLcGitHubActionsBedrockRole
+      - name: Install the AI client
+        run: pip3 install --user anthropic boto3
+      - name: Work out which branches need the fix
+        # The SHA goes through the environment rather than into the script, so nothing
+        # from the event is expanded by the shell. GitHub's script injection guidance:
+        # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks
+        env:
+          FIX_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          util/backport/backport analyze --commit "$FIX_SHA" --skip
+      - name: Keep the verdict for the publish job
+        uses: actions/upload-artifact@v4
+        with:
+          name: backport-run
+          path: util/backport/.backport-runs/last-run.json
+          if-no-files-found: error
+
+  publish:
+    name: publish
+    needs: analyze
+    permissions:
+      contents: read # the app token does the writing, not this job's token
+    runs-on:
+      - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
+        image:linux-5.0
+        instance-size:small
+    steps:
+      # GITHUB_TOKEN cannot open a pull request unless the repository allows every
+      # workflow to, and pull requests it opens do not start CI. An app token has
+      # neither limit, and its write scope is the app's rather than the repository's
+      - name: Mint a token for the backport app
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BACKPORT_BOT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_BOT_PRIVATE_KEY }}
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          # The app token, since it is the checkout's credentials that push the
+          # backport branches
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Take the verdict from the analyze job
+        uses: actions/download-artifact@v4
+        with:
+          name: backport-run
+          path: util/backport/.backport-runs
+      - name: Cherry-pick and open the pull requests
+        # PR_NUMBER through the environment, not inlined into the script, same as in
+        # analyze above
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # cherry-pick needs an author, and a runner has no git identity
+          git config user.name "aws-lc-backport-bot"
+          git config user.email "backport-bot@users.noreply.github.com"
+          # --push-to-aws-lc because in CI the checkout is aws/aws-lc itself,
+          # so the backport branches have nowhere else to go
+          util/backport/backport apply --yes
+          util/backport/backport publish \
+            --pr "$PR_NUMBER" --push-to-aws-lc --yes

--- a/tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py
@@ -57,14 +57,21 @@ class AwsLcGitHubOidcStack(Stack):
                                                   )
                                               },
                                               "StringNotLike": {
-                                                  "token.actions.githubusercontent.com:job_workflow_ref":
-                                                      "{}/{}/.github/workflows/autofix_integration_failures.yml@*".format(
+                                                  # A workflow with a pinned OIDC role of its own must not be able to
+                                                  # assume this general one instead and reach the rest of CI
+                                                  "token.actions.githubusercontent.com:job_workflow_ref": [
+                                                      "{}/{}/.github/workflows/{}@*".format(
                                                           GITHUB_REPO_OWNER, (
                                                               STAGING_GITHUB_REPO_NAME
                                                               if (env.account == PRE_PROD_ACCOUNT)
                                                               else GITHUB_REPO_NAME
-                                                          )
+                                                          ), workflow
                                                       )
+                                                      for workflow in (
+                                                          "autofix_integration_failures.yml",
+                                                          "backport-bot.yml",
+                                                      )
+                                                  ]
                                               },
                                           }))
 
@@ -93,6 +100,35 @@ class AwsLcGitHubOidcStack(Stack):
                                               },
                                           }))
 
+        # The backport bot gets its own OIDC entry role, pinned to its own workflow file
+        # the same way autofix's is above, and that role chains into the shared Bedrock
+        # role below. Keeping the entry role per-workflow is what stops sharing Bedrock
+        # from sharing everything else an entry role can reach
+        backport_oidc_role_name = "AwsLcGitHubActionsBackportOidcRole"
+        self.backport_oidc_role = iam.Role(self, id=backport_oidc_role_name, role_name=backport_oidc_role_name,
+                                           assumed_by=iam.WebIdentityPrincipal(self.oidc_provider.attr_arn, {
+                                               "StringEquals": {
+                                                   "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                                               },
+                                               "StringLike": {
+                                                   "token.actions.githubusercontent.com:sub": "repo:{}/{}:*".format(
+                                                       GITHUB_REPO_OWNER, (
+                                                           STAGING_GITHUB_REPO_NAME
+                                                           if (env.account == PRE_PROD_ACCOUNT)
+                                                           else GITHUB_REPO_NAME
+                                                       )
+                                                   ),
+                                                   "token.actions.githubusercontent.com:job_workflow_ref":
+                                                       "{}/{}/.github/workflows/backport-bot.yml@*".format(
+                                                           GITHUB_REPO_OWNER, (
+                                                               STAGING_GITHUB_REPO_NAME
+                                                               if (env.account == PRE_PROD_ACCOUNT)
+                                                               else GITHUB_REPO_NAME
+                                                           )
+                                                       ),
+                                               },
+                                           }))
+
         ecr_repos = [ecr.Repository.from_repository_name(self, x.replace('/', '-'), repository_name=x)
                      for x in ECR_REPOS]
 
@@ -116,9 +152,14 @@ class AwsLcGitHubOidcStack(Stack):
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
         )
 
+        # The shared Bedrock role. Autofix and the backport bot both assume it, each
+        # through its own pinned OIDC role, so neither can borrow the other's. Only the
+        # trust policy grows here, there is no second Bedrock role
         self.bedrock_role = create_bedrock_role(
-            self, "AwsLcGitHubActionsBedrockRole", env, self.autofix_oidc_role)
+            self, "AwsLcGitHubActionsBedrockRole", env,
+            [self.autofix_oidc_role, self.backport_oidc_role])
         self.bedrock_role.grant_assume_role(self.autofix_oidc_role)
+        self.bedrock_role.grant_assume_role(self.backport_oidc_role)
 
         self.autofix_upload_role = create_autofix_upload_role(
             self, "AwsLcGitHubActionAutofixUploadRole", self.autofix_oidc_role,
@@ -334,9 +375,10 @@ def create_standard_github_actions_role(scope: Construct, id: str,
 
 def create_bedrock_role(scope: Construct, id: str,
                         env: typing.Union[Environment, typing.Dict[str, typing.Any]],
-                        principal: iam.IPrincipal) -> iam.Role:
+                        principals: typing.List[iam.IPrincipal]) -> iam.Role:
     return iam.Role(scope, id, role_name=id,
-                    assumed_by=iam.SessionTagsPrincipal(principal),
+                    assumed_by=iam.CompositePrincipal(
+                        *[iam.SessionTagsPrincipal(p) for p in principals]),
                     inline_policies={
                         "bedrock_policy": iam.PolicyDocument(
                             statements=[

--- a/util/backport/README.md
+++ b/util/backport/README.md
@@ -20,9 +20,10 @@ passes:
 It also says when a fix reaches inside the validated FIPS module, which is a
 certification question rather than a code one.
 
-`apply` then cherry-picks the fix onto one local branch per affected branch.
+`apply` then cherry-picks the fix onto one local branch per affected branch, and
+`publish` turns those into one pull request each.
 
-Nothing is pushed and no pull request is opened. The branches are yours to review.
+Nothing is auto-merged, and nothing is ever a draft. Every pull request needs review.
 
 ## Prerequisites
 
@@ -34,6 +35,8 @@ Nothing is pushed and no pull request is opened. The branches are yours to revie
 - **anthropic + boto3**: required, not optional (`pip3 install --user anthropic boto3`).
   The AI pass is part of how a verdict is reached, so the tool imports them at startup
   even when `BACKPORT_DISABLE_AI` is set
+- **gh**: the GitHub CLI, for `publish` only. Logged in with `gh auth login`, or
+  `GH_TOKEN` set, which is how CI supplies it
 
 ### AWS Permissions
 
@@ -197,6 +200,106 @@ normal on the older branches, where the surrounding code has moved on.
 leaves the branches you already have alone. The command exits non-zero if any branch
 conflicted, so a script can tell whether anything needs a human.
 
+### Open the pull requests
+
+```bash
+util/backport/backport publish
+```
+
+Pushes each finished backport branch to your fork and opens one pull request per
+branch into the matching release branch. One command, however many branches the fix
+touched.
+
+Most of the time you never type it: `apply --open-pr` offers to run it as soon as the
+cherry-picks are done, so a normal session is `analyze` then `apply`.
+
+```bash
+util/backport/backport apply --open-pr
+```
+
+| Flag | Purpose |
+| --- | --- |
+| `--branch` | just this release branch |
+| `--pr` | source pull request number, linked in each body and given a summary comment |
+| `--remote` | fork remote the branches are pushed to, the non-`aws/aws-lc` remote by default |
+| `--base-repo` | `owner/repo` to open the pull requests against, the `aws/aws-lc` remote by default |
+| `--dry-run` | print what would be pushed and opened, touch nothing |
+| `--yes` | skip the confirm, for scripts and CI |
+
+Branches go to your fork; the pull requests are opened against `aws/aws-lc`. Pushing
+to `aws/aws-lc` is refused outright, so a stray `--remote` cannot put half-reviewed
+work on the real repository. `--base-repo` points the pull requests somewhere else, for
+a staging repo.
+
+`--dry-run` pushes nothing, opens nothing, and prints the summary comment instead of
+posting it. The source pull request belongs to whoever wrote the fix, so a dry run does
+not write to it either.
+
+**Example Output:**
+
+```
+Fix ac3aee3104
+Opening pull requests into aws/aws-lc for: fips-2025-09-12-lts, fips-2024-09-27
+Branches are pushed to 'origin'
+Go ahead? [Y/N] y
+  fips-2025-09-12-lts: opened: https://github.com/aws/aws-lc/pull/3401
+  fips-2024-09-27: unfinished: cherry-pick still open in .backport-worktrees/...
+
+1 pull request(s) opened, 1 still need attention
+  fips-2024-09-27
+  Unfinished branches: resolve the conflict in the worktree, then
+  'git cherry-pick --continue' there and run publish again.
+```
+
+**Results:**
+
+| Result | Meaning |
+| --- | --- |
+| `opened` | pushed and a pull request created |
+| `dry run` | `--dry-run` only, what a real run would have pushed and opened |
+| `already open` | a pull request for that branch exists, so nothing was done again |
+| `unfinished` | its cherry-pick is still stopped in the worktree, resolve it first |
+| `missing` | no such backport branch, run `apply` first |
+| `failed` | the push or the pull request failed, with the reason |
+
+**`--dry-run` Output:**
+
+Nothing is pushed and nothing is opened, and there is no confirm to answer. A branch
+whose cherry-pick is still stopped reports `unfinished` here too, so a dry run tells you
+what needs resolving before the real one:
+
+```
+Fix ac3aee3104
+Opening pull requests into aws/aws-lc for: fips-2025-09-12-lts, fips-2024-09-27
+Branches are pushed to 'origin'
+  fips-2025-09-12-lts: dry run: would push backport-fips-2025-09-12-lts-ac3aee3104 and open a PR into fips-2025-09-12-lts
+  fips-2024-09-27: unfinished: cherry-pick still open in .backport-worktrees/...
+
+dry run: 1 pull request(s) would be opened, 1 still need attention
+  fips-2024-09-27
+  Unfinished branches: resolve the conflict in the worktree, then
+  'git cherry-pick --continue' there and run publish again.
+
+dry run: would comment this on #3401
+### Backport report for `ac3aee3104ab`
+
+Fix the thing
+
+| Branch | Result |
+| --- | --- |
+| `fips-2025-09-12-lts` | dry run: would push ... and open a PR into fips-2025-09-12-lts |
+| `fips-2024-09-27` | unfinished: cherry-pick still open in ... |
+
+Nothing is auto-merged. Every pull request above needs review.
+```
+
+The last block is only printed when `--pr` names a source pull request. It is the
+comment that a real run would post there.
+
+Nothing is ever a draft and nothing is auto-merged. Re-running is safe: a branch that
+already has a pull request is left alone, and finishing a conflict by hand is enough
+to let the next run pick it up, with no need to run `apply` again.
+
 ## Configuration
 
 ### Model settings
@@ -296,7 +399,8 @@ util/backport/
 │   ├── main.py                   # argument parsing
 │   ├── commands/
 │   │   ├── analyze.py            # the analyze command
-│   │   └── apply.py              # the apply command
+│   │   ├── apply.py              # the apply command
+│   │   └── publish.py            # the publish command
 │   ├── engine/
 │   │   ├── inspect_fix.py        # which lines the fix deletes, who wrote them
 │   │   ├── discover_branches.py  # which release branches to check
@@ -306,6 +410,7 @@ util/backport/
 │   └── util/
 │       ├── config.py             # verdicts, settings, the FIPS boundary, the saved run
 │       ├── git.py                # everything that runs a git command
+│       ├── github.py             # everything that talks to GitHub, through gh
 │       └── render.py             # the output table and prompts
 ├── testing/
 │   ├── test_engine.py            # unit tests, no repo or credentials
@@ -451,6 +556,27 @@ util/backport/backport analyze
 The same error appears if the run names a fix this checkout no longer has, which
 happens when a range was analyzed and git has since collected the squashed commit.
 Re-running `analyze` fixes both.
+
+### No pull request can be opened
+
+`publish` needs the GitHub CLI, installed and logged in:
+
+```bash
+gh auth login
+gh auth status
+```
+
+In CI set `GH_TOKEN` instead, and give the job `contents: write` and
+`pull-requests: write`.
+
+### Refused to push to aws/aws-lc
+
+Backport branches belong on a fork; only the pull requests go to `aws/aws-lc`. Point
+`--remote` at your fork:
+
+```bash
+util/backport/backport publish --remote origin
+```
 
 ### Wrong or empty results from a subdirectory
 

--- a/util/backport/README.md
+++ b/util/backport/README.md
@@ -224,12 +224,13 @@ util/backport/backport apply --open-pr
 | `--remote` | fork remote the branches are pushed to, the non-`aws/aws-lc` remote by default |
 | `--base-repo` | `owner/repo` to open the pull requests against, the `aws/aws-lc` remote by default |
 | `--dry-run` | print what would be pushed and opened, touch nothing |
+| `--push-to-aws-lc` | let branches be pushed to `aws/aws-lc`. For CI only |
 | `--yes` | skip the confirm, for scripts and CI |
 
 Branches go to your fork; the pull requests are opened against `aws/aws-lc`. Pushing
-to `aws/aws-lc` is refused outright, so a stray `--remote` cannot put half-reviewed
-work on the real repository. `--base-repo` points the pull requests somewhere else, for
-a staging repo.
+branches to `aws/aws-lc` is refused unless `--push-to-aws-lc` asks for it, which only
+CI does, so a stray `--remote` cannot put half-reviewed work on the real repository.
+`--base-repo` points the pull requests somewhere else, for a staging repo.
 
 `--dry-run` pushes nothing, opens nothing, and prints the summary comment instead of
 posting it. The source pull request belongs to whoever wrote the fix, so a dry run does
@@ -299,6 +300,53 @@ comment that a real run would post there.
 Nothing is ever a draft and nothing is auto-merged. Re-running is safe: a branch that
 already has a pull request is left alone, and finishing a conflict by hand is enough
 to let the next run pick it up, with no need to run `apply` again.
+
+## Running In CI
+
+`.github/workflows/backport-bot.yml` does the same three steps automatically. It fires
+when a pull request labelled `needs-backport` merges, so the decision to backport stays
+with the reviewers rather than with the tool.
+
+It runs as two jobs, and the split is the point:
+
+| Job | Can reach the model | Can write to the repo |
+| --- | --- | --- |
+| `analyze` | yes, `id-token: write` for Bedrock | no, `contents: read` |
+| `publish` | no | yes, through a GitHub App token, not the job's own |
+
+The model reads repository content, so the job that reads it is never the job holding a
+token that could change it. The verdict travels between them as an artifact.
+
+Branches are pushed to `aws/aws-lc` itself, because in CI the checkout already is
+`aws/aws-lc`. That needs `--push-to-aws-lc`, which is refused everywhere else,
+and `push_branch` will only ever push a `backport-` branch, so the escape cannot reach
+anything else.
+
+The workflow assumes `AwsLcGitHubActionsBackportOidcRole`, which the OIDC stack pins to
+this exact workflow file by `job_workflow_ref`. Renaming the file breaks the trust
+policy until the CDK stack is redeployed. That role is the only thing allowed to chain
+into the shared `AwsLcGitHubActionsBedrockRole`, alongside autofix's own OIDC role.
+
+The pinning cuts both ways, following what autofix already does. The general
+`AwsLcGitHubActionsOidcRole` excludes this workflow file, so the bot cannot skip its own
+role and assume the general one to reach the rest of CI. One role the bot can assume,
+and one thing that role can do.
+
+### Before the bot can run
+
+Two things have to be true first, and neither is settled by merging this code.
+
+The role has to exist. CDK takes the role name from the construct id, so
+`tests/ci/cdk` has to be deployed before the workflow can assume it. Until then the
+`analyze` job fails at the credentials step.
+
+The app has to exist. `publish` mints a token from a GitHub App, so
+`BACKPORT_BOT_APP_ID` and `BACKPORT_BOT_PRIVATE_KEY` have to be set and the app
+installed with `contents: write` and `pull_requests: write`. `GITHUB_TOKEN` is not
+enough: it cannot open a pull request unless the repository lets every workflow do so,
+and pull requests it opens do not start CI, so the backports would arrive untested.
+The app also keeps that write scope on itself rather than on the repository. If a
+ruleset guards `backport-*` branches, the app needs to be allowed to push them.
 
 ## Configuration
 
@@ -420,6 +468,9 @@ util/backport/
 └── .backport-runs/               # the last analyze result, not checked in
     .backport-worktrees/          # where a conflicted pick waits, not checked in
 ```
+
+The CI half of the tool lives outside this folder, in
+`.github/workflows/backport-bot.yml` and `tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py`.
 
 ## Testing
 
@@ -566,8 +617,8 @@ gh auth login
 gh auth status
 ```
 
-In CI set `GH_TOKEN` instead, and give the job `contents: write` and
-`pull-requests: write`.
+In CI set `GH_TOKEN` instead, from a GitHub App token with `contents: write` and
+`pull_requests: write`.
 
 ### Refused to push to aws/aws-lc
 
@@ -577,6 +628,9 @@ Backport branches belong on a fork; only the pull requests go to `aws/aws-lc`. P
 ```bash
 util/backport/backport publish --remote origin
 ```
+
+CI is the one exception: it runs inside `aws/aws-lc` already, and passes
+`--push-to-aws-lc` to say so.
 
 ### Wrong or empty results from a subdirectory
 

--- a/util/backport/src/commands/analyze.py
+++ b/util/backport/src/commands/analyze.py
@@ -59,5 +59,5 @@ def cmd_analyze(args) -> int:
         print()
         print(f"FIPS BOUNDARY: this fix {fips_note}.")
 
-    save_run(fix_sha, base, branches, verdicts, fips_files)
+    save_run(fix_sha, base, branches, verdicts, decided_by, fips_files)
     return 0

--- a/util/backport/src/commands/apply.py
+++ b/util/backport/src/commands/apply.py
@@ -170,5 +170,14 @@ def cmd_apply(args) -> int:
             "Resolve each conflict in the worktree named above, then "
             "'git cherry-pick --continue' there."
         )
-    print("Nothing was pushed. Review each branch before you open a pull request.")
+
+    # Imported here, not at the top: publish imports this module for the run file and
+    # the branch naming, so importing it up there would be a cycle
+    from commands.publish import offer_publish
+
+    ready = [b for b, (o, _) in outcomes.items() if o in (APPLIED, ALREADY_THERE)]
+    if args.open_pr:
+        offer_publish(run, ready, args.remote)
+    else:
+        print("Nothing was pushed. Review each branch before you open a pull request.")
     return 1 if conflicted else 0

--- a/util/backport/src/commands/publish.py
+++ b/util/backport/src/commands/publish.py
@@ -1,0 +1,275 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+"""
+The publish command: pushes the branches apply built and opens one pull request each
+Run by apply after a local cherry-pick, or on its own in CI
+"""
+
+from commands.apply import backport_branch_name, branches_to_backport, load_run
+from util.config import BackportError, fips_boundary_files
+from util.git import (
+    WORKTREE_ROOT,
+    branch_exists,
+    branch_ref,
+    cherry_pick_in_progress,
+    commit_subject,
+    commits_ahead,
+    remove_worktree,
+)
+from util.github import (
+    base_repo,
+    comment_on_pr,
+    create_pr,
+    existing_pr,
+    fork_remote,
+    head_spec,
+    pr_title_and_body,
+    push_branch,
+    require_gh,
+    require_push_remote,
+    summary_lines,
+)
+from util.render import ask_yn
+
+from typing import Dict, List, Optional, Tuple
+
+# What happened to one branch
+OPENED = "opened"
+ALREADY_OPEN = "already open"
+UNFINISHED = "unfinished"
+MISSING = "missing"
+FAILED = "failed"
+DRY_RUN = "dry run"
+
+
+def fips_note_for(run: Dict) -> str:
+    """
+    The FIPS boundary line for this run, or empty when the fix stayed outside the module
+
+    run: the saved analyze run
+    Returns the same sentence analyze printed, built from the file list analyze recorded,
+    since publish never reads the diff itself
+    """
+    return fips_boundary_files(run.get("fips_files", []))[1]
+
+
+def branch_state(release: str, local_branch: str) -> str:
+    """
+    Whether one backport branch is ready to become a pull request
+    Returns MISSING when apply never made it, UNFINISHED while a cherry-pick is still
+    stopped in its worktree, and OPENED when it holds at least one commit. Resolving a
+    conflict by hand is enough to turn UNFINISHED into ready, with no need to re-run
+    apply
+
+    The commit count is measured against the same ref apply cut the branch from, so a
+    branch carrying no pick of its own cannot look ready just because the fork it was
+    compared against is behind
+    """
+    if not branch_exists(local_branch):
+        return MISSING
+    worktree = WORKTREE_ROOT / local_branch
+    if worktree.exists() and cherry_pick_in_progress(worktree):
+        return UNFINISHED
+    if commits_ahead(branch_ref(release), local_branch) < 1:
+        return MISSING
+    return OPENED
+
+
+def publish_branch(
+    release: str,
+    fix: str,
+    subject: str,
+    basis: str,
+    source_pr: Optional[str],
+    remote: str,
+    push_slug: str,
+    repo: str,
+    dry_run: bool,
+    fips_note: str = "",
+) -> Tuple[str, str]:
+    """
+    Pushes one finished backport branch and opens its pull request
+    Returns (outcome, detail) where detail is a URL, a reason, or an error
+    """
+    local_branch = backport_branch_name(fix, release)
+    state = branch_state(release, local_branch)
+    if state == MISSING:
+        return MISSING, f"no branch {local_branch}, run apply first"
+    if state == UNFINISHED:
+        return UNFINISHED, f"cherry-pick still open in {WORKTREE_ROOT / local_branch}"
+
+    head = head_spec(push_slug, repo, local_branch)
+    open_already = existing_pr(repo, head)
+    if open_already:
+        return ALREADY_OPEN, open_already
+    if dry_run:
+        return DRY_RUN, f"would push {local_branch} and open a PR into {release}"
+
+    failure = push_branch(remote, local_branch)
+    if failure:
+        return FAILED, f"push failed: {failure}"
+
+    title, body = pr_title_and_body(release, fix, subject, basis, source_pr, fips_note)
+    url = create_pr(repo, release, head, title, body)
+    if url.startswith("error:"):
+        return FAILED, url
+    # The worktree only survives a resolved conflict, and it is finished with now
+    remove_worktree(WORKTREE_ROOT / local_branch)
+    return OPENED, url
+
+
+def run_publish(
+    run: Dict,
+    branches: List[str],
+    remote: str,
+    push_slug: str,
+    repo: str,
+    source_pr: Optional[str],
+    dry_run: bool,
+) -> List[Tuple[str, str, str]]:
+    """
+    Publishes every named branch
+
+    repo: owner/repo the pull requests are opened against
+    Returns (branch, outcome, detail) per branch, in the order given. The caller has
+    already checked gh and the remote, so nothing here can fail on setup
+    """
+    fix = run["fix"]
+    subject = commit_subject(fix)
+    decided = run.get("decided_by", {})
+    # From the saved run, since publish never reads the diff itself
+    fips_note = fips_note_for(run)
+
+    outcomes = []
+    for release in branches:
+        outcome, detail = publish_branch(
+            release=release,
+            fix=fix,
+            subject=subject,
+            basis=decided.get(release, ""),
+            source_pr=source_pr,
+            remote=remote,
+            push_slug=push_slug,
+            repo=repo,
+            dry_run=dry_run,
+            fips_note=fips_note,
+        )
+        outcomes.append((release, outcome, detail))
+        print(f"  {release}: {outcome}: {detail}")
+    return outcomes
+
+
+def report(
+    run: Dict,
+    outcomes: List[Tuple[str, str, str]],
+    source_pr: Optional[str],
+    repo: str,
+    dry_run: bool = False,
+) -> None:
+    """
+    Prints the tally and, when a source PR was named, comments the table on it
+    A dry run prints the comment instead of posting it. Writing to a real pull request
+    is the one thing a dry run must not do, and the source PR is somebody else's
+    """
+    opened = sum(1 for _, o, _ in outcomes if o == OPENED)
+    would_open = sum(1 for _, o, _ in outcomes if o == DRY_RUN)
+    stuck = [b for b, o, _ in outcomes if o in (UNFINISHED, MISSING, FAILED)]
+    print()
+    if would_open:
+        # Otherwise a dry run reports "0 pull request(s) opened", which reads as
+        # nothing to do
+        print(
+            f"dry run: {would_open} pull request(s) would be opened, "
+            f"{len(stuck)} still need attention"
+        )
+    else:
+        print(f"{opened} pull request(s) opened, {len(stuck)} still need attention")
+    if stuck:
+        print(f"  {', '.join(stuck)}")
+        # The advice has to match the cause, or it sends people to the wrong place
+        kinds = {o for _, o, _ in outcomes}
+        if MISSING in kinds:
+            print("  Missing branches: run 'backport apply' first.")
+        if UNFINISHED in kinds:
+            print(
+                "  Unfinished branches: resolve the conflict in the worktree, then\n"
+                "  'git cherry-pick --continue' there and run publish again."
+            )
+        if FAILED in kinds:
+            print("  Failed branches: see the reason above.")
+    if source_pr:
+        table = summary_lines(
+            run["fix"],
+            commit_subject(run["fix"]),
+            outcomes,
+            fips_note_for(run),
+        )
+        if dry_run:
+            print()
+            print(f"dry run: would comment this on #{source_pr}")
+            print(table)
+            return
+        failure = comment_on_pr(repo, source_pr, table)
+        if failure:
+            print(f"could not comment on #{source_pr}: {failure}")
+
+
+def cmd_publish(args) -> int:
+    """
+    Opens a backport pull request for every affected branch
+    Returns 0 when every branch was published or already had a pull request, 1 when
+    any branch still needs attention
+    """
+    run = load_run()
+    branches = branches_to_backport(run["verdicts"], args.branch)
+    if not branches:
+        print("No affected branches in the last analyze run, nothing to publish.")
+        return 0
+
+    # Checked before anything is printed, so nobody confirms a run that cannot work
+    require_gh()
+    remote = args.remote or fork_remote()
+    push_slug = require_push_remote(remote)
+
+    repo = base_repo(args.base_repo)
+    print(f"Fix {run['fix'][:10]}")
+    print(f"Opening pull requests into {repo} for: {', '.join(branches)}")
+    print(f"Branches are pushed to '{remote}'")
+    if not args.yes and not args.dry_run and not ask_yn("Go ahead?"):
+        print("Aborted. Nothing was pushed.")
+        return 0
+
+    outcomes = run_publish(
+        run, branches, remote, push_slug, repo, args.pr, args.dry_run
+    )
+    report(run, outcomes, args.pr, repo, args.dry_run)
+    return 1 if any(o in (UNFINISHED, MISSING, FAILED) for _, o, _ in outcomes) else 0
+
+
+def offer_publish(run: Dict, branches: List[str], remote: Optional[str]) -> None:
+    """
+    Asks whether to open the pull requests, straight after apply cherry-picked
+    Only the branches that applied cleanly are offered, so a conflict is never
+    published half-done
+    """
+    if not branches:
+        return
+    print()
+    # Checked before the question, so a missing gh is not discovered after a yes
+    try:
+        require_gh()
+        remote = remote or fork_remote()
+        push_slug = require_push_remote(remote)
+    except BackportError as exc:
+        print(f"Cannot open pull requests: {exc}")
+        print("The branches are here. Fix that and run 'backport publish'.")
+        return
+    if not ask_yn(f"Open pull requests for {len(branches)} branch(es)?"):
+        print("Left as local branches. Run 'backport publish' when you are ready.")
+        return
+    repo = base_repo()
+    outcomes = run_publish(
+        run, branches, remote, push_slug, repo, source_pr=None, dry_run=False
+    )
+    report(run, outcomes, None, repo)

--- a/util/backport/src/commands/publish.py
+++ b/util/backport/src/commands/publish.py
@@ -230,7 +230,7 @@ def cmd_publish(args) -> int:
     # Checked before anything is printed, so nobody confirms a run that cannot work
     require_gh()
     remote = args.remote or fork_remote()
-    push_slug = require_push_remote(remote)
+    push_slug = require_push_remote(remote, args.push_to_aws_lc)
 
     repo = base_repo(args.base_repo)
     print(f"Fix {run['fix'][:10]}")

--- a/util/backport/src/main.py
+++ b/util/backport/src/main.py
@@ -87,6 +87,11 @@ def add_publish(subparsers) -> None:
         help="say what would be pushed and opened, without doing it",
     )
     p.add_argument(
+        "--push-to-aws-lc",
+        action="store_true",
+        help="let branches be pushed to aws/aws-lc. For CI, which runs there already",
+    )
+    p.add_argument(
         "--yes",
         action="store_true",
         help="Skips the confirm. Useful for test scripts",

--- a/util/backport/src/main.py
+++ b/util/backport/src/main.py
@@ -8,6 +8,7 @@ Calls upon actions based on command-line arguments
 
 from commands.analyze import cmd_analyze
 from commands.apply import cmd_apply
+from commands.publish import cmd_publish
 from util.config import BackportError
 
 import argparse
@@ -50,13 +51,53 @@ def add_apply(subparsers) -> None:
         action="store_true",
         help="Skips the confirm. Useful for test scripts",
     )
+    p.add_argument(
+        "--open-pr",
+        action="store_true",
+        help="offer to open the pull requests once the cherry-picks are done",
+    )
+    p.add_argument(
+        "--remote",
+        help="fork remote the branches are pushed to (default the non-aws/aws-lc remote)",
+    )
     p.set_defaults(func=cmd_apply)
+
+
+def add_publish(subparsers) -> None:
+    """
+    Pushes the branches apply built and opens one pull request each
+    Reads the same saved run, so analyze and apply have to have run first
+    """
+    p = subparsers.add_parser(
+        "publish", help="opens a backport pull request for every affected branch"
+    )
+    p.add_argument("--branch", help="only this release branch")
+    p.add_argument("--pr", help="source pull request number, to link and report on")
+    p.add_argument(
+        "--remote",
+        help="fork remote the branches are pushed to (default the non-aws/aws-lc remote)",
+    )
+    p.add_argument(
+        "--base-repo",
+        help="owner/repo to open the pull requests against (default the aws/aws-lc remote)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="say what would be pushed and opened, without doing it",
+    )
+    p.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skips the confirm. Useful for test scripts",
+    )
+    p.set_defaults(func=cmd_publish)
 
 
 def build_parser() -> argparse.ArgumentParser:
     """
     Build parser for args
-    Returns the parser, with the analyze and apply subcommands on it
+    Returns the parser, with the analyze, apply and publish subcommands on it
     """
     ap = argparse.ArgumentParser(
         prog="backport",
@@ -65,6 +106,7 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = ap.add_subparsers(dest="cmd", required=True)
     add_analyze(subparsers)
     add_apply(subparsers)
+    add_publish(subparsers)
     return ap
 
 

--- a/util/backport/src/util/config.py
+++ b/util/backport/src/util/config.py
@@ -238,6 +238,7 @@ def save_run(
     base: str,
     branches: Sequence[str],
     verdicts: Dict[str, str],
+    decided_by: Optional[Dict[str, str]] = None,
     fips_files: Optional[Sequence[str]] = None,
 ) -> None:
     """
@@ -249,6 +250,7 @@ def save_run(
         base          what the fix was compared against
         branches      every release branch that was looked at
         verdicts      one of the four verdicts per branch, the part apply acts on
+        decided_by    what settled each branch, quoted in the pull request body
         fips_files    the files inside the validated FIPS module, so publish can carry
                       the warning into every pull request it opens
     """
@@ -261,6 +263,7 @@ def save_run(
                 "base": base,
                 "branches": list(branches),
                 "verdicts": verdicts,
+                "decided_by": decided_by or {},
                 "fips_files": list(fips_files or []),
             },
             indent=2,

--- a/util/backport/src/util/git.py
+++ b/util/backport/src/util/git.py
@@ -440,3 +440,29 @@ def cherry_pick_was_empty(path) -> bool:
 def abort_cherry_pick(path) -> None:
     """Backs a stopped cherry-pick out, leaving the worktree on its branch"""
     git("-C", str(path), "cherry-pick", "--abort", check=False)
+
+
+def cherry_pick_in_progress(path) -> bool:
+    """
+    True while a cherry-pick in that worktree is still stopped part way
+    This is what tells a resolved conflict from an open one, so publish can pick up a
+    branch the user finished by hand without apply having to run again
+    """
+    head = git(
+        "-C", str(path), "rev-parse", "-q", "--verify", "CHERRY_PICK_HEAD", check=False
+    )
+    return head.returncode == 0
+
+
+def commits_ahead(base_ref: str, branch: str) -> int:
+    """How many commits branch has that base_ref does not. 0 when git cannot tell"""
+    counted = git("rev-list", "--count", f"{base_ref}..{branch}", check=False)
+    if counted.returncode != 0:
+        return 0
+    return int(counted.stdout.strip() or 0)
+
+
+def commit_subject(commit: str) -> str:
+    """The one-line subject of a commit, or an empty string when git cannot read it"""
+    subject = git("log", "-1", "--format=%s", commit, check=False)
+    return subject.stdout.strip() if subject.returncode == 0 else ""

--- a/util/backport/src/util/github.py
+++ b/util/backport/src/util/github.py
@@ -1,0 +1,258 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+"""
+Everything that talks to GitHub, through the gh CLI
+Kept in one place so no command can grow a second, slightly different PR opener
+"""
+
+from util.config import BackportError
+from util.git import git, release_remote, run
+
+import re
+import shutil
+from functools import lru_cache
+from typing import List, Optional, Tuple
+
+# The repo backports are reviewed in. Branches are never pushed here, only PRs opened
+AWS_LC_REPO = "aws/aws-lc"
+
+_SLUG = re.compile(r"github\.com[:/]+([^/]+)/([^/]+?)(?:\.git)?/?$")
+
+
+# --- The gh CLI ---
+
+
+def gh(*args: str, check: bool = False):
+    """
+    Runs the GitHub CLI in this repo
+    Returns the finished process. gh finds its own credentials: GH_TOKEN or
+    GITHUB_TOKEN from the environment in CI, its stored login on a laptop, so
+    nothing here has to know which one is in play
+    """
+    return run(["gh", *args], check=check)
+
+
+def require_gh() -> None:
+    """Raises unless the gh CLI is installed and logged in"""
+    if shutil.which("gh") is None:
+        raise BackportError(
+            "the GitHub CLI (gh) is not installed, so no pull request can be opened.\n"
+            "  Install it, or run without --open-pr and open them by hand."
+        )
+    if gh("auth", "status").returncode != 0:
+        raise BackportError(
+            "the GitHub CLI is not logged in.\n"
+            "  Run 'gh auth login', or set GH_TOKEN."
+        )
+
+
+# --- Which Repo Is Which ---
+
+
+def remote_slug(remote: str) -> Optional[str]:
+    """
+    The owner/repo a remote points at, or None when the URL cannot be read
+    """
+    url = git("remote", "get-url", remote, check=False)
+    if url.returncode != 0:
+        return None
+    found = _SLUG.search(url.stdout.strip())
+    return f"{found.group(1)}/{found.group(2)}" if found else None
+
+
+def require_push_remote(remote: str) -> str:
+    """
+    Checks a remote is somewhere we are allowed to push branches
+    Returns its owner/repo. aws/aws-lc is refused: backport branches belong on a fork,
+    and pushing them there would put half-reviewed work on the real repository
+    """
+    slug = remote_slug(remote)
+    if slug is None:
+        raise BackportError(f"no remote called '{remote}' in this checkout.")
+    if slug.lower() == AWS_LC_REPO:
+        raise BackportError(
+            f"remote '{remote}' is {slug}, which is where the pull requests go, not\n"
+            "  where the branches go. Push to your fork instead, with --remote."
+        )
+    return slug
+
+
+@lru_cache(maxsize=1)
+def fork_remote() -> str:
+    """
+    The remote backport branches are pushed to
+
+    Returns the first remote that is not aws/aws-lc, preferring origin, else origin.
+    A maintainer's origin is often aws/aws-lc itself, and that is never a push target
+    """
+    listed = git("remote", check=False)
+    if listed.returncode != 0:
+        return "origin"
+    forks = [
+        name
+        for name in listed.stdout.split()
+        if (remote_slug(name) or "").lower() != AWS_LC_REPO
+    ]
+    if "origin" in forks:
+        return "origin"
+    return forks[0] if forks else "origin"
+
+
+def base_repo(override: Optional[str] = None) -> str:
+    """
+    Which repo the pull requests are opened against
+
+    override: owner/repo from --base-repo, when given
+    Returns the override, else the repo the release-branch remote points at, else
+    aws/aws-lc. Read from the remote rather than a fixed name, so a staging repo and a
+    checkout that calls it something other than upstream both work
+    """
+    return override or remote_slug(release_remote()) or AWS_LC_REPO
+
+
+def head_spec(push_slug: str, base_slug: str, branch: str) -> str:
+    """
+    How to name the branch to GitHub, as owner:branch across repos or plain within one
+    This is the only difference between a laptop pushing to a fork and CI pushing to
+    the repo it is already running in
+    """
+    if push_slug.split("/")[0] == base_slug.split("/")[0]:
+        return branch
+    return f"{push_slug.split('/')[0]}:{branch}"
+
+
+# --- Branches And Pull Requests ---
+
+
+def push_branch(remote: str, branch: str) -> Optional[str]:
+    """
+    Pushes one local branch to the remote
+    Returns None on success or the git error, so one bad branch cannot stop the rest
+    """
+    pushed = git(
+        "push", "--force-with-lease", remote, f"{branch}:{branch}", check=False
+    )
+    if pushed.returncode != 0:
+        return (pushed.stderr or pushed.stdout).strip()
+    return None
+
+
+def existing_pr(repo: str, head: str) -> Optional[str]:
+    """
+    The URL of an open pull request already using this head branch, or None
+    Checked before opening one so a second run does not file a duplicate
+    """
+    found = gh(
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--head",
+        head,
+        "--state",
+        "open",
+        "--json",
+        "url",
+        "--jq",
+        ".[0].url // empty",
+    )
+    if found.returncode != 0:
+        return None
+    return found.stdout.strip() or None
+
+
+def create_pr(repo: str, base: str, head: str, title: str, body: str) -> str:
+    """
+    Opens a pull request and returns its URL, or a string starting with 'error:'
+    Never a draft: a backport nobody notices is the same as no backport
+    """
+    made = gh(
+        "pr",
+        "create",
+        "--repo",
+        repo,
+        "--base",
+        base,
+        "--head",
+        head,
+        "--title",
+        title,
+        "--body",
+        body,
+    )
+    if made.returncode != 0:
+        return f"error: {(made.stderr or made.stdout).strip()}"
+    return made.stdout.strip()
+
+
+def comment_on_pr(repo: str, number: str, body: str) -> Optional[str]:
+    """Leaves a comment on a pull request. Returns the error text, or None"""
+    posted = gh("pr", "comment", str(number), "--repo", repo, "--body", body)
+    if posted.returncode != 0:
+        return (posted.stderr or posted.stdout).strip()
+    return None
+
+
+def pr_title_and_body(
+    branch: str,
+    fix: str,
+    subject: str,
+    basis: str,
+    source_pr: Optional[str],
+    fips_note: str = "",
+) -> Tuple[str, str]:
+    """
+    The title and body for one backport pull request, as (title, body)
+    fips_note, when the fix reaches inside the validated module, is put above everything
+    else. A reviewer who reads one line of this has to read that one
+    """
+    title = f"[backport {branch}] {subject}"
+    link = f" of #{source_pr}" if source_pr else ""
+    warning = (
+        f"> [!WARNING]\n> **FIPS boundary:** this fix {fips_note}.\n\n"
+        if fips_note
+        else ""
+    )
+    body = (
+        f"{warning}"
+        f"Backport{link} of `{fix[:12]}` onto `{branch}`.\n\n"
+        f"- Verdict: **affected** ({basis or 'git history'}).\n"
+        "- Cherry-picked as-is, with no changes beyond conflict resolution.\n"
+        "- **Not** auto-merged. Please review before merging.\n"
+        + ("- Needs FIPS review before merging.\n" if fips_note else "")
+        + "\n_Opened by the AWS-LC backport tool._"
+    )
+    return title, body
+
+
+def summary_lines(
+    fix: str,
+    subject: str,
+    results: List[Tuple[str, str, str]],
+    fips_note: str = "",
+) -> str:
+    """
+    A markdown table of what happened to each branch, for a comment on the source PR
+    results is (branch, outcome, detail)
+    Carries the same FIPS boundary warning as the pull request bodies, since this comment
+    is what the author of the fix actually reads
+    """
+    lines = [
+        f"### Backport report for `{fix[:12]}`",
+        "",
+        f"{subject}",
+        "",
+    ]
+    if fips_note:
+        lines += [f"> [!WARNING]\n> **FIPS boundary:** this fix {fips_note}.", ""]
+    lines += [
+        "| Branch | Result |",
+        "| --- | --- |",
+    ]
+    for branch, outcome, detail in results:
+        lines.append(f"| `{branch}` | {outcome}: {detail} |")
+    lines += ["", "Nothing is auto-merged. Every pull request above needs review."]
+    if fips_note:
+        lines.append("Every branch above also needs FIPS review before it merges.")
+    return "\n".join(lines)

--- a/util/backport/src/util/github.py
+++ b/util/backport/src/util/github.py
@@ -6,7 +6,7 @@ Everything that talks to GitHub, through the gh CLI
 Kept in one place so no command can grow a second, slightly different PR opener
 """
 
-from util.config import BackportError
+from util.config import BACKPORT_BRANCH_PREFIX, BackportError
 from util.git import git, release_remote, run
 
 import re
@@ -14,7 +14,7 @@ import shutil
 from functools import lru_cache
 from typing import List, Optional, Tuple
 
-# The repo backports are reviewed in. Branches are never pushed here, only PRs opened
+# Where the pull requests are opened. Branches only go here when CI says so
 AWS_LC_REPO = "aws/aws-lc"
 
 _SLUG = re.compile(r"github\.com[:/]+([^/]+)/([^/]+?)(?:\.git)?/?$")
@@ -61,16 +61,18 @@ def remote_slug(remote: str) -> Optional[str]:
     return f"{found.group(1)}/{found.group(2)}" if found else None
 
 
-def require_push_remote(remote: str) -> str:
+def require_push_remote(remote: str, allow_aws_lc: bool = False) -> str:
     """
     Checks a remote is somewhere we are allowed to push branches
-    Returns its owner/repo. aws/aws-lc is refused: backport branches belong on a fork,
-    and pushing them there would put half-reviewed work on the real repository
+    Returns its owner/repo. aws/aws-lc is refused unless allow_aws_lc is set, which
+    only CI does: running there, the checkout already is aws/aws-lc, so the branches
+    have nowhere else to go. Locally the refusal stands, so a stray --remote cannot
+    put half-reviewed work on the real repository
     """
     slug = remote_slug(remote)
     if slug is None:
         raise BackportError(f"no remote called '{remote}' in this checkout.")
-    if slug.lower() == AWS_LC_REPO:
+    if slug.lower() == AWS_LC_REPO and not allow_aws_lc:
         raise BackportError(
             f"remote '{remote}' is {slug}, which is where the pull requests go, not\n"
             "  where the branches go. Push to your fork instead, with --remote."
@@ -129,7 +131,11 @@ def push_branch(remote: str, branch: str) -> Optional[str]:
     """
     Pushes one local branch to the remote
     Returns None on success or the git error, so one bad branch cannot stop the rest
+    Anything not named backport- is refused, so even the CI run that is allowed to
+    push to aws/aws-lc can only push branches this tool built
     """
+    if not branch.startswith(BACKPORT_BRANCH_PREFIX):
+        raise BackportError(f"refusing to push '{branch}': not a backport branch.")
     pushed = git(
         "push", "--force-with-lease", remote, f"{branch}:{branch}", check=False
     )

--- a/util/backport/testing/test_engine.py
+++ b/util/backport/testing/test_engine.py
@@ -17,7 +17,7 @@ import re
 import subprocess
 import sys
 import unittest
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Sequence
 from unittest import mock
@@ -25,6 +25,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from commands import apply as apply_cmd
+from commands import publish
 from engine import (
     classify_branches,
     consult_ai,
@@ -32,7 +33,7 @@ from engine import (
     inspect_fix,
     prompts,
 )
-from util import config, git
+from util import config, git, github
 
 import main
 
@@ -1575,6 +1576,364 @@ class ReadmeMatchesTheCode(unittest.TestCase):
             shipped - listed, set(), "these ship but are not in the README listing"
         )
         self.assertEqual(listed - shipped, set(), "these are listed but do not exist")
+
+
+class FakeWorktreeRoot:
+    """Stands in for WORKTREE_ROOT, so a test can say whether the worktree is there"""
+
+    def __init__(self, present: bool) -> None:
+        self.present = present
+
+    def __truediv__(self, name):
+        return mock.Mock(exists=lambda: self.present)
+
+
+class RemoteSlug(unittest.TestCase):
+    # The push target decides whether a PR head needs an owner prefix, so reading a
+    # remote URL wrong sends the pull request at the wrong repo
+
+    def slug(self, url):
+        with mock.patch.object(
+            github, "git", lambda *a, **k: completed(stdout=url + "\n")
+        ):
+            return github.remote_slug("origin")
+
+    def test_https_with_git_suffix(self):
+        self.assertEqual(
+            self.slug("https://github.com/tianyiy-tim/aws-lc.git"), "tianyiy-tim/aws-lc"
+        )
+
+    def test_https_without_suffix(self):
+        self.assertEqual(self.slug("https://github.com/aws/aws-lc"), "aws/aws-lc")
+
+    def test_ssh_form(self):
+        self.assertEqual(self.slug("git@github.com:aws/aws-lc.git"), "aws/aws-lc")
+
+    def test_a_url_we_cannot_parse_is_none(self):
+        self.assertIsNone(self.slug("/some/local/path"))
+
+    def test_a_missing_remote_is_none(self):
+        with mock.patch.object(
+            github, "git", lambda *a, **k: completed(returncode=2, stdout="")
+        ):
+            self.assertIsNone(github.remote_slug("nope"))
+
+
+class RequirePushRemote(unittest.TestCase):
+    # Pushing backport branches at aws/aws-lc would put half-reviewed work on the real
+    # repository, so it is refused outright rather than just discouraged
+
+    def test_pushing_to_aws_lc_is_refused(self):
+        with mock.patch.object(
+            github, "remote_slug", lambda r: "aws/aws-lc"
+        ), self.assertRaises(config.BackportError) as caught:
+            github.require_push_remote("upstream")
+        self.assertIn("aws/aws-lc", str(caught.exception))
+
+    def test_the_check_ignores_case(self):
+        with mock.patch.object(
+            github, "remote_slug", lambda r: "AWS/AWS-LC"
+        ), self.assertRaises(config.BackportError):
+            github.require_push_remote("upstream")
+
+    def test_a_fork_is_allowed(self):
+        with mock.patch.object(github, "remote_slug", lambda r: "tianyiy-tim/aws-lc"):
+            self.assertEqual(github.require_push_remote("origin"), "tianyiy-tim/aws-lc")
+
+    def test_an_unknown_remote_is_an_error(self):
+        with mock.patch.object(
+            github, "remote_slug", lambda r: None
+        ), self.assertRaises(config.BackportError):
+            github.require_push_remote("nope")
+
+
+class ForkRemote(unittest.TestCase):
+    # A maintainer's origin is often aws/aws-lc itself, so the push target cannot be a
+    # fixed name
+
+    def pick(self, names, slugs):
+        github.fork_remote.cache_clear()
+        with mock.patch.object(
+            github, "git", lambda *a, **k: completed(stdout="\n".join(names) + "\n")
+        ), mock.patch.object(github, "remote_slug", lambda r: slugs.get(r)):
+            return github.fork_remote()
+
+    def tearDown(self):
+        github.fork_remote.cache_clear()
+
+    def test_origin_is_preferred_when_it_is_a_fork(self):
+        got = self.pick(
+            ["origin", "upstream"],
+            {"origin": "tianyiy-tim/aws-lc", "upstream": "aws/aws-lc"},
+        )
+        self.assertEqual(got, "origin")
+
+    def test_an_origin_that_is_aws_lc_is_skipped(self):
+        got = self.pick(
+            ["origin", "fork"], {"origin": "aws/aws-lc", "fork": "tianyiy-tim/aws-lc"}
+        )
+        self.assertEqual(got, "fork")
+
+    def test_the_check_ignores_case(self):
+        got = self.pick(
+            ["origin", "fork"], {"origin": "AWS/AWS-LC", "fork": "tianyiy-tim/aws-lc"}
+        )
+        self.assertEqual(got, "fork")
+
+    def test_a_checkout_with_only_aws_lc_falls_back_to_origin(self):
+        # require_push_remote is what reports it, so this only has to not invent a name
+        got = self.pick(["origin"], {"origin": "aws/aws-lc"})
+        self.assertEqual(got, "origin")
+
+
+class BaseRepo(unittest.TestCase):
+    # Where the pull requests are opened. Read from the remote, so a checkout that does
+    # not call it upstream still works
+
+    def test_an_override_wins(self):
+        self.assertEqual(github.base_repo("aws/aws-lc-staging"), "aws/aws-lc-staging")
+
+    def test_otherwise_the_release_remote_decides(self):
+        with mock.patch.object(
+            github, "release_remote", lambda: "upstream"
+        ), mock.patch.object(
+            github, "remote_slug", lambda r: "aws/aws-lc" if r == "upstream" else None
+        ):
+            self.assertEqual(github.base_repo(), "aws/aws-lc")
+
+    def test_an_unreadable_remote_falls_back_to_aws_lc(self):
+        with mock.patch.object(
+            github, "release_remote", lambda: "nope"
+        ), mock.patch.object(github, "remote_slug", lambda r: None):
+            self.assertEqual(github.base_repo(), "aws/aws-lc")
+
+
+class HeadSpec(unittest.TestCase):
+    # The one difference between a laptop pushing to a fork and CI pushing to the repo
+    # it already runs in
+
+    def test_across_repos_the_owner_is_prefixed(self):
+        got = github.head_spec("tianyiy-tim/aws-lc", "aws/aws-lc", "backport-x")
+        self.assertEqual(got, "tianyiy-tim:backport-x")
+
+    def test_within_one_repo_the_branch_stands_alone(self):
+        got = github.head_spec("aws/aws-lc", "aws/aws-lc", "backport-x")
+        self.assertEqual(got, "backport-x")
+
+
+class PrBody(unittest.TestCase):
+    def test_the_body_says_it_is_not_auto_merged(self):
+        title, body = github.pr_title_and_body(
+            "fips-2024-09-27", "abc1234567890", "Fix a thing", "git history", "3301"
+        )
+        self.assertEqual(title, "[backport fips-2024-09-27] Fix a thing")
+        self.assertIn("#3301", body)
+        self.assertIn("Not** auto-merged", body)
+
+    def test_without_a_source_pr_there_is_no_dangling_link(self):
+        _, body = github.pr_title_and_body(
+            "fips-2024-09-27", "abc1234567890", "Fix a thing", "", None
+        )
+        self.assertNotIn("of #", body)
+
+
+class BranchState(unittest.TestCase):
+    # A branch is only publishable once its cherry-pick is finished. Resolving a
+    # conflict by hand has to be enough, without apply running again
+
+    def state(self, exists=True, worktree=False, in_progress=False, ahead=1):
+        """branch_state with git and the worktree directory faked out"""
+        self.base = None
+
+        def commits_ahead(base, branch):
+            # Records which ref the count was taken against
+            self.base = base
+            return ahead
+
+        with mock.patch.multiple(
+            publish,
+            WORKTREE_ROOT=FakeWorktreeRoot(worktree),
+            branch_exists=lambda name: exists,
+            branch_ref=lambda branch: f"upstream/{branch}",
+            cherry_pick_in_progress=lambda path: in_progress,
+            commits_ahead=commits_ahead,
+        ):
+            return publish.branch_state("fips-2024-09-27", "backport-x")
+
+    def test_no_branch_is_missing(self):
+        self.assertEqual(self.state(exists=False), publish.MISSING)
+
+    def test_a_stopped_cherry_pick_is_unfinished(self):
+        got = self.state(worktree=True, in_progress=True)
+        self.assertEqual(got, publish.UNFINISHED)
+
+    def test_a_resolved_conflict_is_ready(self):
+        # The worktree survives a hand resolution, so its presence alone means nothing
+        got = self.state(worktree=True, in_progress=False)
+        self.assertEqual(got, publish.OPENED)
+
+    def test_a_clean_pick_with_no_worktree_is_ready(self):
+        self.assertEqual(self.state(worktree=False), publish.OPENED)
+
+    def test_a_branch_with_no_commits_of_its_own_is_missing(self):
+        self.assertEqual(self.state(ahead=0), publish.MISSING)
+
+    def test_the_count_is_taken_against_the_ref_apply_cut_the_branch_from(self):
+        # Not against origin. A fork behind on the release branches would make a branch
+        # carrying no pick of its own look ready to publish
+        self.state()
+        self.assertEqual(self.base, "upstream/fips-2024-09-27")
+
+
+class PublishBranch(unittest.TestCase):
+    def publish(self, state, existing=None, dry_run=False, push_error=None, url="ok"):
+        with mock.patch.multiple(
+            publish,
+            branch_state=lambda release, local_branch: state,
+            existing_pr=lambda repo, head: existing,
+            push_branch=lambda remote, branch: push_error,
+            create_pr=lambda *a: url,
+            remove_worktree=lambda path: None,
+        ):
+            return publish.publish_branch(
+                "fips-2024-09-27",
+                "abc1234567890",
+                "subject",
+                "basis",
+                None,
+                "origin",
+                "me/aws-lc",
+                "aws/aws-lc",
+                dry_run,
+            )
+
+    def test_a_missing_branch_says_run_apply(self):
+        outcome, detail = self.publish(publish.MISSING)
+        self.assertEqual(outcome, publish.MISSING)
+        self.assertIn("apply", detail)
+
+    def test_an_unfinished_branch_is_never_pushed(self):
+        outcome, _ = self.publish(publish.UNFINISHED)
+        self.assertEqual(outcome, publish.UNFINISHED)
+
+    def test_an_existing_pull_request_is_not_opened_twice(self):
+        outcome, detail = self.publish(publish.OPENED, existing="http://pr/1")
+        self.assertEqual(outcome, publish.ALREADY_OPEN)
+        self.assertEqual(detail, "http://pr/1")
+
+    def test_a_dry_run_pushes_nothing(self):
+        outcome, _ = self.publish(publish.OPENED, dry_run=True)
+        self.assertEqual(outcome, publish.DRY_RUN)
+
+    def test_a_failed_push_is_reported_not_raised(self):
+        outcome, detail = self.publish(publish.OPENED, push_error="denied")
+        self.assertEqual(outcome, publish.FAILED)
+        self.assertIn("denied", detail)
+
+    def test_a_failed_pr_is_reported(self):
+        outcome, detail = self.publish(publish.OPENED, url="error: no base")
+        self.assertEqual(outcome, publish.FAILED)
+        self.assertIn("no base", detail)
+
+    def test_a_good_run_returns_the_url(self):
+        outcome, detail = self.publish(publish.OPENED, url="http://pr/9")
+        self.assertEqual(outcome, publish.OPENED)
+        self.assertEqual(detail, "http://pr/9")
+
+
+class ADryRunWritesNothing(unittest.TestCase):
+    # The source pull request belongs to somebody else, and a dry run that comments on it
+    # has already done the thing it promised not to do
+
+    def report(self, dry_run):
+        """report() with the comment call recorded, as the list of posts it made"""
+        posted = []
+
+        def comment(repo, number, body):
+            posted.append((repo, number))
+
+        outcomes = [("fips-2024-09-27", publish.OPENED, "http://pr/1")]
+        with mock.patch.multiple(
+            publish,
+            comment_on_pr=comment,
+            commit_subject=lambda sha: "a subject",
+            summary_lines=lambda *a: "| table |",
+        ), redirect_stdout(io.StringIO()):
+            publish.report(
+                {"fix": "abc1234567"}, outcomes, "3105", "aws/aws-lc", dry_run
+            )
+        return posted
+
+    def test_a_real_run_comments_on_the_source_pull_request(self):
+        self.assertEqual(self.report(dry_run=False), [("aws/aws-lc", "3105")])
+
+    def test_a_dry_run_does_not(self):
+        self.assertEqual(self.report(dry_run=True), [])
+
+    def test_a_dry_run_says_what_it_would_have_opened(self):
+        # "0 pull request(s) opened" on a dry run reads as nothing to do, which is the
+        # opposite of what it means
+        printed = io.StringIO()
+        outcomes = [
+            ("fips-2024-09-27", publish.DRY_RUN, "would push and open"),
+            ("fips-2022-11-02", publish.DRY_RUN, "would push and open"),
+        ]
+        with redirect_stdout(printed):
+            publish.report({"fix": "abc1234567"}, outcomes, None, "aws/aws-lc", True)
+        said = printed.getvalue()
+        self.assertIn("2 pull request(s) would be opened", said)
+        self.assertNotIn("0 pull request(s) opened", said)
+
+
+class TheFipsWarningReachesTheReader(unittest.TestCase):
+    # analyze prints the boundary warning, but nobody reviewing a backport ran analyze.
+    # It has to travel into the pull requests and the summary, or it reaches no one
+
+    NOTE = "touches the validated FIPS module (1 file(s): crypto/fipsmodule/bn/bn.c)"
+    OUTCOMES: ClassVar[list] = [("fips-2024-09-27", "opened", "http://pr/1")]
+
+    def test_the_pull_request_body_leads_with_it(self):
+        _, body = github.pr_title_and_body(
+            "fips-2024-09-27",
+            "abc1234567890",
+            "Fix a thing",
+            "git history",
+            "3105",
+            self.NOTE,
+        )
+        self.assertTrue(body.startswith("> [!WARNING]"), body[:60])
+        self.assertIn("FIPS boundary", body)
+        self.assertIn("crypto/fipsmodule/bn/bn.c", body)
+        self.assertIn("Needs FIPS review", body)
+
+    def test_a_fix_outside_the_module_says_nothing_about_fips(self):
+        _, body = github.pr_title_and_body(
+            "fips-2024-09-27", "abc1234567890", "Fix a thing", "git history", "3105", ""
+        )
+        self.assertNotIn("FIPS", body)
+        self.assertTrue(body.startswith("Backport"), body[:40])
+
+    def test_the_summary_comment_carries_it_too(self):
+        table = github.summary_lines(
+            "abc1234567890", "Fix a thing", self.OUTCOMES, self.NOTE
+        )
+        self.assertIn("FIPS boundary", table)
+        self.assertIn("FIPS review before it merges", table)
+        # and still says what happened per branch
+        self.assertIn("fips-2024-09-27", table)
+
+    def test_the_summary_is_unchanged_without_it(self):
+        table = github.summary_lines("abc1234567890", "Fix a thing", self.OUTCOMES)
+        self.assertNotIn("FIPS", table)
+
+    def test_the_note_comes_from_the_saved_run_not_the_diff(self):
+        # publish never reads the fix, so the files analyze recorded are the only source.
+        # An older run file without the key must not crash it
+        self.assertEqual(publish.fips_note_for({}), "")
+        self.assertEqual(publish.fips_note_for({"fips_files": []}), "")
+        self.assertNotEqual(
+            publish.fips_note_for({"fips_files": ["crypto/fipsmodule/bn/bn.c"]}), ""
+        )
 
 
 if __name__ == "__main__":

--- a/util/backport/testing/test_engine.py
+++ b/util/backport/testing/test_engine.py
@@ -1936,5 +1936,58 @@ class TheFipsWarningReachesTheReader(unittest.TestCase):
         )
 
 
+class PushToAwsLcEscape(unittest.TestCase):
+    # CI runs inside aws/aws-lc, so the branches have nowhere else to go. That escape
+    # has to be explicit, and it must not weaken the local refusal
+
+    def test_ci_may_push_to_aws_lc(self):
+        with mock.patch.object(github, "remote_slug", lambda r: "aws/aws-lc"):
+            got = github.require_push_remote("origin", allow_aws_lc=True)
+        self.assertEqual(got, "aws/aws-lc")
+
+    def test_the_refusal_still_stands_by_default(self):
+        with mock.patch.object(
+            github, "remote_slug", lambda r: "aws/aws-lc"
+        ), self.assertRaises(config.BackportError):
+            github.require_push_remote("origin")
+
+    def test_a_missing_remote_is_still_an_error_even_for_ci(self):
+        with mock.patch.object(
+            github, "remote_slug", lambda r: None
+        ), self.assertRaises(config.BackportError):
+            github.require_push_remote("nope", allow_aws_lc=True)
+
+
+class PushOnlyBackportBranches(unittest.TestCase):
+    # The escape above means a bug here could push anything to the real repository, so
+    # the branch name is checked too. Two independent limits, not one
+
+    def test_a_backport_branch_is_pushed(self):
+        pushed = []
+
+        def record(*args, **kwargs):
+            # Records the call, so a silent no-push cannot pass as a success
+            pushed.append(args)
+            return completed()
+
+        with mock.patch.object(github, "git", record):
+            error = github.push_branch("origin", "backport-fips-2024-09-27-abc")
+        self.assertIsNone(error)
+        self.assertEqual(len(pushed), 1)
+
+    def test_anything_else_is_refused_before_git_runs(self):
+        with mock.patch.object(github, "git", never_called):
+            for branch in ("main", "fips-2024-09-27", "my-feature"):
+                with self.assertRaises(config.BackportError):
+                    github.push_branch("origin", branch)
+
+    def test_a_failed_push_comes_back_as_text(self):
+        with mock.patch.object(
+            github, "git", lambda *a, **k: completed(returncode=1, stdout="denied")
+        ):
+            got = github.push_branch("origin", "backport-x")
+        self.assertIn("denied", got)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Issues:
Addresses `P425131803`

### Description of changes:
`analyze`, `apply` and `publish` still need someone to run them after a fix merges.

This pull request adds `.github/workflows/backport-bot.yml`, which **runs all three automatically** when a pull request labelled `needs-backport` merges. The decision to backport stays with the reviewers who apply the label, not with the tool.

It also adds the bot's own OIDC role to the CDK stack, chaining into the shared `AwsLcGitHubActionsBedrockRole` that #3376 renamed for exactly this.

**Stacked on #3415.** The base here is `backport-stack/publish`, a scaffolding branch holding the commits below it, so this diff is only the 7 files this change touches. I will retarget it to `main` as the stack lands. Please don't merge it into the scaffolding branch.

### Call-outs:
- Two jobs, and the split is the point. `analyze` is the only job that reaches the model and it has `contents: read`. `publish` is the only job that can write and it never reaches the model. So **repository content, which the model reads, is never handled by a job holding a token that could change the repository.** The verdict moves between them as an artifact.

- The checkout is the merge commit, never the pull request head, so no untrusted code runs.

- The role is pinned by `job_workflow_ref` to this one workflow file. The bot can't borrow autofix's role and general CI can't borrow either. Renaming the file breaks the trust policy until the stack is redeployed.

- The pinning goes both ways, same as autofix: the general `AwsLcGitHubActionsOidcRole` now excludes this workflow file too, so the bot can't skip its own role and use the general one to reach the rest of CI.

- In CI the checkout already is `aws/aws-lc`, so the branches have nowhere else to go. `--push-to-aws-lc` says so out loud, is refused anywhere else, and `push_branch` only ever pushes a branch named `backport-`, so the escape has **two independent limits**.

- Two things this needs that merging it doesn't provide, and I can't do either: **the CDK stack has to be deployed** before the workflow can assume the new role, and **a pull request opened with `GITHUB_TOKEN` starts no workflow**, so the backport pull requests would arrive with no CI of their own. Getting them tested needs a token that isn't `GITHUB_TOKEN`.

- Uses #3395 (merged) for `.github/workflows/ai-config.json`, which the workflow reads for the region.

### Testing:
**Unit tests** - 6 new, 173 total:
```
python3 -m unittest testing.test_engine
```
They cover the `--push-to-aws-lc` escape, that the refusal still stands without it, and that only a `backport-` branch can be pushed.

**CDK** - synthesized the stack (no deploy) and read the rendered trust policies. The backport role is pinned to `backport-bot.yml@*`, the general role excludes both AI workflows, and the Bedrock role has one statement per OIDC role. Staging account path renders `aws-lc-staging` too.

**Workflow** - parsed it to confirm the two jobs hold the permissions above, `analyze` has no write access, `publish` has no `id-token`, the settings step runs before `configure-aws-credentials`, and the CDK pin matches this filename. I can't run the bot end to end until the role is deployed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.




