### PR TITLE
Fix Windows OPENSSL_SMALL Debug builds with NASM 2.16.01

### DIFF
--- a/.github/workflows/openssl-small.yml
+++ b/.github/workflows/openssl-small.yml
@@ -181,12 +181,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "perlasm",              disable_perl: "OFF", disable_avx: "OFF" }
-          - { name: "pre-generated",        disable_perl: "ON",  disable_avx: "OFF" }
-          - { name: "perlasm, AVX disabled", disable_perl: "OFF", disable_avx: "ON" }
+          - { name: "perlasm",               build_type: "Release", disable_perl: "OFF", disable_avx: "OFF" }
+          - { name: "pre-generated, Debug",  build_type: "Debug",   disable_perl: "ON",  disable_avx: "OFF" }
+          - { name: "perlasm, AVX disabled", build_type: "Release", disable_perl: "OFF", disable_avx: "ON" }
     steps:
       - name: Install NASM
         uses: ilammy/setup-nasm@v1.5.1
+        with:
+          version: "2.16.01"
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -208,7 +210,7 @@ jobs:
           options: |
             CMAKE_SYSTEM_NAME=Windows
             CMAKE_SYSTEM_PROCESSOR=x86_64
-            CMAKE_BUILD_TYPE=Release
+            CMAKE_BUILD_TYPE=${{ matrix.build_type }}
             OPENSSL_SMALL=ON
             DISABLE_PERL=${{ matrix.disable_perl }}
             MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=${{ matrix.disable_avx }}

--- a/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
+++ b/crypto/fipsmodule/aes/asm/aesni-xts-avx512.pl
@@ -1456,10 +1456,9 @@ ___
 
   my $rndsuffix = &random_string();
 
-  # The .text directive is deliberately emitted outside the #ifndef guard:
-  # when MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX elides the body, some NASM
-  # versions reject an object with no sections (nasm.us bug 3392738), which
-  # would otherwise break win64 builds that assemble this file (#3355).
+  # Keep the disabled output non-empty. Some NASM versions reject an object
+  # with no sections (nasm.us bug 3392738), and NASM 2.16.01 crashes while
+  # generating CodeView debug information for an empty section.
   $code .= <<___;
 .text
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -3111,6 +3110,9 @@ ___
     .byte  0xff, 0xff, 0xff, 0xff, 0xff
 
 .text
+#endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte 0
 #endif
 ___
 } else {

--- a/crypto/fipsmodule/bn/asm/rsaz-2k-avx512.pl
+++ b/crypto/fipsmodule/bn/asm/rsaz-2k-avx512.pl
@@ -281,10 +281,9 @@ $code.=<<___;
 ___
 }
 
-# The .text directive is deliberately emitted outside the #ifndef guard:
-# when MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX elides the body, some NASM
-# versions reject an object with no sections (nasm.us bug 3392738), which
-# would otherwise break win64 builds that assemble this file (#3355).
+# Keep the disabled output non-empty. Some NASM versions reject an object
+# with no sections (nasm.us bug 3392738), and NASM 2.16.01 crashes while
+# generating CodeView debug information for an empty section.
 $code.=<<___;
 .text
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -676,9 +675,17 @@ rsaz_def_handler:
     .rva    .Lrsaz_amm52x20_x2_ifma256_body,.Lrsaz_amm52x20_x2_ifma256_epilogue
 
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte 0
+#endif
 ___
 } else {
-$code.="#endif";
+$code.=<<___;
+#endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte 0
+#endif
+___
 }
 
 }}} else {{{                # fallback for old assembler

--- a/crypto/fipsmodule/bn/asm/rsaz-3k-avx512.pl
+++ b/crypto/fipsmodule/bn/asm/rsaz-3k-avx512.pl
@@ -345,10 +345,9 @@ $code.=<<___;
 ___
 }
 
-# The .text directive is deliberately emitted outside the #ifndef guard:
-# when MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX elides the body, some NASM
-# versions reject an object with no sections (nasm.us bug 3392738), which
-# would otherwise break win64 builds that assemble this file (#3355).
+# Keep the disabled output non-empty. Some NASM versions reject an object
+# with no sections (nasm.us bug 3392738), and NASM 2.16.01 crashes while
+# generating CodeView debug information for an empty section.
 $code.=<<___;
 .text
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -831,9 +830,17 @@ rsaz_avx_handler:
     .rva    .Lrsaz_amm52x30_x2_ifma256_body,.Lrsaz_amm52x30_x2_ifma256_epilogue
 
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte 0
+#endif
 ___
 } else {
-$code.="#endif";
+$code.=<<___;
+#endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte 0
+#endif
+___
 }
 
 }}} else {{{                # fallback for old assembler

--- a/crypto/fipsmodule/bn/asm/rsaz-4k-avx512.pl
+++ b/crypto/fipsmodule/bn/asm/rsaz-4k-avx512.pl
@@ -386,10 +386,9 @@ $code.=<<___;
 ___
 }
 
-# The .text directive is deliberately emitted outside the #ifndef guard:
-# when MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX elides the body, some NASM
-# versions reject an object with no sections (nasm.us bug 3392738), which
-# would otherwise break win64 builds that assemble this file (#3355).
+# Keep the disabled output non-empty. Some NASM versions reject an object
+# with no sections (nasm.us bug 3392738), and NASM 2.16.01 crashes while
+# generating CodeView debug information for an empty section.
 $code.=<<___;
 .text
 #ifndef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
@@ -892,9 +891,17 @@ rsaz_avx_handler:
     .rva    .Lrsaz_amm52x40_x2_ifma256_body,.Lrsaz_amm52x40_x2_ifma256_epilogue
 
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte 0
+#endif
 ___
 } else {
-$code.="#endif";
+$code.=<<___;
+#endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte 0
+#endif
+___
 }
 
 }}} else {{{                # fallback for old assembler

--- a/generated-src/linux-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
@@ -5227,4 +5227,7 @@ shufb_15_7:
 
 .text	
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte	0
+#endif
 #endif

--- a/generated-src/linux-x86_64/crypto/fipsmodule/rsaz-2k-avx512.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/rsaz-2k-avx512.S
@@ -894,4 +894,7 @@ extract_multiplier_2x20_win5:
 .quad	0,0,0,0
 .text	
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte	0
+#endif
 #endif

--- a/generated-src/linux-x86_64/crypto/fipsmodule/rsaz-3k-avx512.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/rsaz-3k-avx512.S
@@ -1321,4 +1321,7 @@ extract_multiplier_2x30_win5:
 .quad	0,0,0,0
 .text	
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte	0
+#endif
 #endif

--- a/generated-src/linux-x86_64/crypto/fipsmodule/rsaz-4k-avx512.S
+++ b/generated-src/linux-x86_64/crypto/fipsmodule/rsaz-4k-avx512.S
@@ -1364,4 +1364,7 @@ extract_multiplier_2x40_win5:
 .quad	0,0,0,0
 .text	
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte	0
+#endif
 #endif

--- a/generated-src/mac-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/aesni-xts-avx512.S
@@ -5227,4 +5227,7 @@ shufb_15_7:
 
 .text	
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte	0
+#endif
 #endif

--- a/generated-src/mac-x86_64/crypto/fipsmodule/rsaz-2k-avx512.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/rsaz-2k-avx512.S
@@ -882,4 +882,7 @@ L$zeros:
 .quad	0,0,0,0
 .text	
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte	0
+#endif
 #endif

--- a/generated-src/mac-x86_64/crypto/fipsmodule/rsaz-3k-avx512.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/rsaz-3k-avx512.S
@@ -1309,4 +1309,7 @@ L$zeros:
 .quad	0,0,0,0
 .text	
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte	0
+#endif
 #endif

--- a/generated-src/mac-x86_64/crypto/fipsmodule/rsaz-4k-avx512.S
+++ b/generated-src/mac-x86_64/crypto/fipsmodule/rsaz-4k-avx512.S
@@ -1352,4 +1352,7 @@ L$zeros:
 .quad	0,0,0,0
 .text	
 #endif
+#ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+.byte	0
+#endif
 #endif

--- a/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/aesni-xts-avx512.asm
@@ -5314,6 +5314,9 @@ shufb_15_7:
 section	.text
 
 %endif
+%ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+	DB	0
+%endif
 %else
 ; Work around https://bugzilla.nasm.us/show_bug.cgi?id=3392738
 ret

--- a/generated-src/win-x86_64/crypto/fipsmodule/rsaz-2k-avx512.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/rsaz-2k-avx512.asm
@@ -1025,6 +1025,9 @@ $L$SEH_info_rsaz_amm52x20_x2_ifma256:
 	DD	$L$rsaz_amm52x20_x2_ifma256_body wrt ..imagebase,$L$rsaz_amm52x20_x2_ifma256_epilogue wrt ..imagebase
 
 %endif
+%ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+	DB	0
+%endif
 %else
 ; Work around https://bugzilla.nasm.us/show_bug.cgi?id=3392738
 ret

--- a/generated-src/win-x86_64/crypto/fipsmodule/rsaz-3k-avx512.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/rsaz-3k-avx512.asm
@@ -1503,6 +1503,9 @@ $L$SEH_info_rsaz_amm52x30_x2_ifma256:
 	DD	$L$rsaz_amm52x30_x2_ifma256_body wrt ..imagebase,$L$rsaz_amm52x30_x2_ifma256_epilogue wrt ..imagebase
 
 %endif
+%ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+	DB	0
+%endif
 %else
 ; Work around https://bugzilla.nasm.us/show_bug.cgi?id=3392738
 ret

--- a/generated-src/win-x86_64/crypto/fipsmodule/rsaz-4k-avx512.asm
+++ b/generated-src/win-x86_64/crypto/fipsmodule/rsaz-4k-avx512.asm
@@ -1546,6 +1546,9 @@ $L$SEH_info_rsaz_amm52x40_x2_ifma256:
 	DD	$L$rsaz_amm52x40_x2_ifma256_body wrt ..imagebase,$L$rsaz_amm52x40_x2_ifma256_epilogue wrt ..imagebase
 
 %endif
+%ifdef MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX
+	DB	0
+%endif
 %else
 ; Work around https://bugzilla.nasm.us/show_bug.cgi?id=3392738
 ret


### PR DESCRIPTION
### Description of changes:

NASM 2.16.01 can crash while generating CodeView debug information for empty text sections produced when AVX-512 assembly is disabled in `OPENSSL_SMALL` builds. Emit an unreferenced byte in the affected disabled assembly sources so the section is non-empty, and update CI to reproduce the failure using NASM 2.16.01 with a Windows Debug build.

### Call-outs:

The byte is emitted only when `MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX` disables the corresponding AVX-512 implementation.

### Testing:

- Regenerated the pre-generated assembly sources and verified the affected files assemble directly with NASM 2.16.01 and debug information enabled.
- Built and ran the C/C++ tests on Windows Server 2022 using the affected NASM version and the pre-generated `OPENSSL_SMALL` Debug configuration.
- Built and tested the change on Linux and macOS, including FIPS and blackbox SSL runner coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
