### PR TITLE
Add CPython 3.15 integration test

### DIFF
--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -505,6 +505,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+          - "3.15"
         buildFIPS: [0, 1]
         crtUseSystemCrypto: [0, 1]
         include:

--- a/tests/ci/integration/python_patch/3.15/aws-lc-cpython.patch
+++ b/tests/ci/integration/python_patch/3.15/aws-lc-cpython.patch
@@ -1,0 +1,21 @@
+diff --git a/Modules/Setup b/Modules/Setup
+index cd1cf24..53bcc4c 100644
+--- a/Modules/Setup
++++ b/Modules/Setup
+@@ -208,11 +208,11 @@ PYTHONPATH=$(COREPYTHONPATH)
+ #_hashlib _hashopenssl.c $(OPENSSL_INCLUDES) $(OPENSSL_LDFLAGS) -lcrypto
+
+ # To statically link OpenSSL:
+-# _ssl _ssl.c $(OPENSSL_INCLUDES) $(OPENSSL_LDFLAGS) \
+-#     -l:libssl.a -Wl,--exclude-libs,libssl.a \
+-#     -l:libcrypto.a -Wl,--exclude-libs,libcrypto.a
+-# _hashlib _hashopenssl.c $(OPENSSL_INCLUDES) $(OPENSSL_LDFLAGS) \
+-#     -l:libcrypto.a -Wl,--exclude-libs,libcrypto.a
++_ssl _ssl.c $(OPENSSL_INCLUDES) $(OPENSSL_LDFLAGS) \
++    -l:libssl.a -Wl,--exclude-libs,libssl.a \
++    -l:libcrypto.a -Wl,--exclude-libs,libcrypto.a
++_hashlib _hashopenssl.c $(OPENSSL_INCLUDES) $(OPENSSL_LDFLAGS) \
++    -l:libcrypto.a -Wl,--exclude-libs,libcrypto.a
+
+ # The _tkinter module.
+ #


### PR DESCRIPTION
## Summary

- Adds `tests/ci/integration/python_patch/3.15/aws-lc-cpython.patch` for the CPython 3.15 release branch
- Adds `3.15` to the `python` job matrix in `integration_omnibus.yml`
- The patch is intentionally minimal: only the `Modules/Setup` static linking config, since the test and `_ssl.c` fixes present in patches for older versions have already been incorporated upstream into CPython 3.15

## Tests

- CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.