### PR TITLE
Add brainpool EC_group symbols; make public API symbol registration self-service

### DIFF
--- a/.github/docker_images/symbol_check/check_symbols.sh
+++ b/.github/docker_images/symbol_check/check_symbols.sh
@@ -210,8 +210,12 @@ elif [[ "${MODE}" == "baseline" ]]; then
     echo "${unregistered}" | head -20
     [[ ${unregistered_count} -gt 20 ]] && echo "... and $((unregistered_count - 20)) more"
     echo ""
-    echo "🛑 New symbols are not in the registry."
-    echo "   Run: util/update_symbol_version.sh <version>"
+    echo "🛑 New symbols are not in the registry. Unregistered symbols are hidden"
+    echo "   by the version script, so applications cannot link against them."
+    echo "   Register them in the current version node:"
+    echo "     ./util/update_symbol_version.sh --current"
+    echo "   then commit the updated .txt and .map files together."
+    echo "   See docs/SymbolVersioning.md for when to open a new node instead."
     exit 1
   fi
 

--- a/crypto/libcrypto.map
+++ b/crypto/libcrypto.map
@@ -914,6 +914,11 @@ AWS_LC_1.0 {
     EC_curve_nid2nist;
     EC_curve_nist2nid;
     EC_get_builtin_curves;
+    EC_group_brainpoolP224r1;
+    EC_group_brainpoolP256r1;
+    EC_group_brainpoolP320r1;
+    EC_group_brainpoolP384r1;
+    EC_group_brainpoolP512r1;
     EC_group_p224;
     EC_group_p256;
     EC_group_p384;

--- a/crypto/libcrypto.txt
+++ b/crypto/libcrypto.txt
@@ -907,6 +907,11 @@ EC_POINT_set_to_infinity AWS_LC_1.0 PUBLIC
 EC_curve_nid2nist AWS_LC_1.0 PUBLIC
 EC_curve_nist2nid AWS_LC_1.0 PUBLIC
 EC_get_builtin_curves AWS_LC_1.0 PUBLIC
+EC_group_brainpoolP224r1 AWS_LC_1.0 PUBLIC
+EC_group_brainpoolP256r1 AWS_LC_1.0 PUBLIC
+EC_group_brainpoolP320r1 AWS_LC_1.0 PUBLIC
+EC_group_brainpoolP384r1 AWS_LC_1.0 PUBLIC
+EC_group_brainpoolP512r1 AWS_LC_1.0 PUBLIC
 EC_group_p224 AWS_LC_1.0 PUBLIC
 EC_group_p256 AWS_LC_1.0 PUBLIC
 EC_group_p384 AWS_LC_1.0 PUBLIC

--- a/docs/SymbolVersioning.md
+++ b/docs/SymbolVersioning.md
@@ -128,7 +128,7 @@ The registry and version scripts are managed by Go tools and shell wrappers in `
 | [`util/read_public_symbols`](../util/read_public_symbols) | Extracts exported symbols from headers and classifies visibility (PUBLIC / PRIVATE / PRIVATE_CXX). |
 | [`util/generate_version_script`](../util/generate_version_script) | Generates a `.map` version script from a registry `.txt`. Deterministic. |
 | [`util/generate_initial_version_scripts.sh`](../util/generate_initial_version_scripts.sh) | Bootstraps both registries and `.map` files from scratch (used once to establish the baseline). |
-| [`util/update_symbol_version.sh`](../util/update_symbol_version.sh) | Adds newly introduced API to a new version node and regenerates the `.map` files. |
+| [`util/update_symbol_version.sh`](../util/update_symbol_version.sh) | Registers newly introduced API and regenerates the `.map` files. `--current` adds to the open node (the common case); passing a version opens a new node. |
 
 ### Version Script Format
 
@@ -157,23 +157,50 @@ emits this inheritance automatically; only the oldest (base) node carries the
 
 ### Adding New Symbols
 
-When new public APIs are added, the new symbols must be assigned to a new version
-node. Use `update_symbol_version.sh` rather than editing the registry or `.map`
-files by hand:
+New public API is registered in the **open** version node -- the newest node in
+the registry, which is currently `AWS_LC_1.0`. Adding to it is the normal case
+and does not require a new node:
 
 ```bash
 # Build so the new OPENSSL_EXPORT symbols exist in the headers, then:
-./util/update_symbol_version.sh AWS_LC_1.1
+./util/update_symbol_version.sh --current
 ```
 
 This extracts the current symbol set from the headers, identifies symbols not yet
-in the registry, appends them to the registry under the given node with their
-visibility, re-sorts the registry, and regenerates `crypto/libcrypto.map` and
-`ssl/libssl.map`. Commit the updated `.txt` and `.map` files together.
+in the registry, appends them to the open node with their visibility, re-sorts the
+registry, and regenerates `crypto/libcrypto.map` and `ssl/libssl.map`. Commit the
+updated `.txt` and `.map` files together.
 
-> While a version series is unreleased, newly added symbols may simply be folded
-> into the existing baseline node (`AWS_LC_1.0`) by regenerating the registry;
-> once a version has shipped, its node is frozen and new API goes into a new node.
+Always use `update_symbol_version.sh` rather than editing the registry or `.map`
+files by hand. A symbol that is missing from the registry is hidden by
+`local: *;`, which means it is compiled into the library but applications cannot
+link against it -- see [Silently dropped symbols](#silently-dropped-symbols).
+
+The version node is always an explicit argument; the script has no default. This
+is deliberate, so that adding to the open node and opening a new one are both
+conscious choices.
+
+### Opening a New Version Node
+
+Opening a node **closes** the previous one: once a node is closed, no further API
+may be added to it, because packaging metadata derived from it (see
+[Package Management](#package-management)) would otherwise be unable to
+distinguish a library that has the new API from one that does not.
+
+Closing a node is a release-level decision, not something an individual
+API-adding PR does. Don't open a node just because the current one has shipped;
+raise it with maintainers first. When it is the right call:
+
+```bash
+./util/update_symbol_version.sh AWS_LC_1.1
+```
+
+The script refuses a version that already exists in the registry, and points at
+`--current` instead -- so a mistyped version number cannot silently land API in
+the wrong node.
+
+> Note: nothing currently enforces that a closed node stays closed; it is a
+> convention. `--current` always resolves to the newest node in the registry.
 
 ### Version Naming Convention
 
@@ -209,11 +236,13 @@ absolutely necessary:
 ## CI Integration
 
 AWS-LC CI monitors the symbol registry and version scripts on every PR via
-`.github/workflows/abidiff.yml`.
+`.github/workflows/abidiff.yml`, and validates the built libraries in the
+`dist-pkg-install-tests-*` jobs of
+`.github/workflows/linux-multi-arch-omnibus.yml`.
 
 ### Symbol Check Jobs
 
-Six jobs run:
+Six registry jobs run. None of them build a library, so they are fast:
 
 1. **libcrypto symbol check (incremental)** — compares the registry between the PR base and head; flags additions (warning) and PUBLIC removals (error).
 2. **libssl symbol check (incremental)** — same for libssl.
@@ -226,13 +255,31 @@ These are implemented by
 [`.github/docker_images/symbol_check/check_symbols.sh`](../.github/docker_images/symbol_check/check_symbols.sh)
 in `incremental`, `baseline`, and `mapcheck` modes.
 
+### Built-Library Check
+
+The six jobs above all derive their view of the world from
+`util/read_public_symbols`. If that extractor ever missed an `OPENSSL_EXPORT`
+symbol, the symbol would be absent from the registry *and* hidden by the version
+script, and every registry-based check would still pass -- because none of them
+look at what the compiler actually exported.
+
+[`tests/ci/run_symbol_version_test.sh`](../tests/ci/run_symbol_version_test.sh),
+run by the `dist-pkg-install-tests-*` jobs, closes that hole: it builds the same
+sources a second time *without* `ENABLE_DIST_PKG` (so no version script is
+applied) and diffs the exported symbol sets of the two libraries. Anything
+exported by the unversioned build but missing from the versioned one was hidden
+by `local: *;`. This is the backstop, not the first line of defense -- it costs two
+full shared builds, so the cheap registry checks above should catch problems
+first.
+
 ### CI Policy
 
 - **Symbol additions**: ⚠️ Warning (allowed, but verify intentional)
 - **PUBLIC symbol removals**: ❌ Error (blocks the build — ABI break)
 - **PRIVATE / PRIVATE_CXX removals**: ⚠️ Warning (allowed)
-- **Unregistered new API (baseline)**: ❌ Error (run `update_symbol_version.sh`)
+- **Unregistered new API (baseline)**: ❌ Error (run `update_symbol_version.sh --current`)
 - **`.map` out of sync with registry (drift)**: ❌ Error (regenerate the `.map`)
+- **Exported symbol hidden by the version script**: ❌ Error (register the symbol)
 
 ### When CI Fails
 
@@ -242,11 +289,36 @@ in `incremental`, `baseline`, and `mapcheck` modes.
 ❌ UNREGISTERED SYMBOLS (1):
 CRYPTO_tls13_hkdf_expand_label
 
-🛑 New symbols are not in the registry.
-   Run: util/update_symbol_version.sh <version>
+🛑 New symbols are not in the registry. Unregistered symbols are hidden
+   by the version script, so applications cannot link against them.
+   Register them in the current version node:
+     ./util/update_symbol_version.sh --current
 ```
 
-**Action**: run `./util/update_symbol_version.sh <version>` and commit the updated `.txt`/`.map`.
+**Action**: run `./util/update_symbol_version.sh --current` and commit the updated `.txt`/`.map`.
+
+#### Silently dropped symbols
+
+Reported by the `dist-pkg-install-tests-*` jobs:
+
+```
+✗ FAIL: libcrypto: 5 exported symbol(s) silently hidden by the version script
+INFO: These are exported by the compiler but missing from the registry/.map:
+  EC_group_brainpoolP224r1
+  ...
+```
+
+This is the same root cause as an unregistered-symbol failure, seen from the
+built library instead of the headers: the listed functions are compiled into
+`libcrypto` but demoted to local symbols, so an application linking against a
+`ENABLE_DIST_PKG` build fails with an undefined reference. Confirm with:
+
+```bash
+nm -D --defined-only build/crypto/libcrypto-awslc.so | grep <symbol>  # absent
+nm              build/crypto/libcrypto-awslc.so | grep <symbol>  # present, as 't'
+```
+
+**Action**: run `./util/update_symbol_version.sh --current` and commit the updated `.txt`/`.map`. Expect the baseline check to be failing for the same reason.
 
 #### PUBLIC symbol removal (incremental check)
 
@@ -277,18 +349,27 @@ No action needed. Symbol versioning is transparent.
 
 ### Adding New Public APIs
 
-1. Add new `OPENSSL_EXPORT` functions to headers.
+1. Add new `OPENSSL_EXPORT` functions to headers and implement them.
 2. Register the new symbols and regenerate the version scripts:
    ```bash
-   ./util/update_symbol_version.sh AWS_LC_1.1
+   ./util/update_symbol_version.sh --current
    ```
-3. Optionally verify against a build:
+3. Verify the symbols are actually exported and versioned:
    ```bash
    cmake -GNinja -B build -DBUILD_SHARED_LIBS=ON -DENABLE_DIST_PKG=ON
    ninja -C build
-   nm -D build/crypto/libcrypto-awslc.so | grep @AWS_LC_1.1 | head
+   nm -D --defined-only build/crypto/libcrypto-awslc.so | grep MyNewFunction
+   # expect: T MyNewFunction@@AWS_LC_1.0
    ```
-4. Commit the updated registry (`crypto/libcrypto.txt`, `ssl/libssl.txt`) and version scripts (`crypto/libcrypto.map`, `ssl/libssl.map`) together.
+   A symbol that shows up as `t` under plain `nm`, and not at all under `nm -D`,
+   was not registered in step 2.
+4. Commit the updated registry (`crypto/libcrypto.txt`, `ssl/libssl.txt`) and version scripts (`crypto/libcrypto.map`, `ssl/libssl.map`) together with the header change.
+
+Step 2 is not optional. Skipping it produces a library that compiles, installs
+cleanly, and passes the whole test suite, but whose new API cannot be called by
+any application linking against the shared library. The tests do not catch it
+because the version script is only applied when `ENABLE_DIST_PKG` is set, and
+those builds are configured with `-DBUILD_TESTING=OFF`.
 
 ### Regenerating from Scratch
 

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -225,23 +225,31 @@ that these registries remain accurate:
   `util/read_public_symbols.go` and compare against the registry. No library
   build required.
   - ❌ **Symbols in headers but not in registry**: Error — new public API
-    must be registered with `util/update_symbol_version.sh <version>`
+    must be registered with `util/update_symbol_version.sh --current`
   - ⚠️ **Symbols in registry but not in headers**: Warning — may be
     platform-specific (FIPS-only, ARM-specific) or unimplemented declarations
 
 Symbol checks run using Docker containers in `.github/docker_images/symbol_check/`.
+The `dist-pkg-install-tests-*` jobs additionally verify against built libraries
+that no exported symbol is hidden by the version script.
 See [docs/SymbolVersioning.md](../../docs/SymbolVersioning.md) for full details.
 
 #### Registering New Public API
 
-When new `OPENSSL_EXPORT` symbols are added to public headers:
+When new `OPENSSL_EXPORT` symbols are added to public headers, they must also be
+registered, or the version script will hide them and applications will not be
+able to link against them:
 
 ```bash
-# Assign them to a new version node and regenerate the map files
-./util/update_symbol_version.sh AWS_LC_1.0
+# Add them to the current version node and regenerate the map files
+./util/update_symbol_version.sh --current
 
 # Commit the updated registry and map files
 git add crypto/libcrypto.txt ssl/libssl.txt
 git add crypto/libcrypto.map ssl/libssl.map
-git commit -m "Register new public API symbols in AWS_LC_1.0"
+git commit -m "Register new public API symbols"
 ```
+
+Opening a new version node instead (`./util/update_symbol_version.sh AWS_LC_1.1`)
+closes the current one and is a release-level decision -- see
+[docs/SymbolVersioning.md](../../docs/SymbolVersioning.md).

--- a/tests/ci/run_symbol_version_test.sh
+++ b/tests/ci/run_symbol_version_test.sh
@@ -403,6 +403,12 @@ check_dropped_symbols() {
     print_info "These are exported by the compiler but missing from the registry/.map:"
     echo "${dropped}" | head -10 | sed 's/^/  /'
     [[ ${dropped_count} -gt 10 ]] && print_info "... and $((dropped_count - 10)) more"
+    echo ""
+    print_info "These symbols are compiled into the library but demoted to local by"
+    print_info "'local: *;', so applications cannot link against them. Register them:"
+    print_info "  ./util/update_symbol_version.sh --current"
+    print_info "then commit the updated crypto/libcrypto.{txt,map} and ssl/libssl.{txt,map}."
+    print_info "See docs/SymbolVersioning.md for when to open a new node instead."
   fi
 }
 

--- a/util/generate_initial_version_scripts.sh
+++ b/util/generate_initial_version_scripts.sh
@@ -38,9 +38,10 @@ done
 
 # The baseline version node for a from-scratch bootstrap. This is intentionally
 # fixed: this script only ever establishes the initial node. Later additions go
-# through update_symbol_version.sh <version>, which takes the node as an argument
-# rather than hardcoding it. The major component corresponds to ABI_VERSION in
-# CMakeLists.txt (bumped only on an ABI break).
+# through update_symbol_version.sh, which takes the node explicitly (--current to
+# add to the open node, or a version to open a new one) rather than hardcoding it.
+# The major component corresponds to ABI_VERSION in CMakeLists.txt (bumped only
+# on an ABI break).
 INITIAL_VERSION="AWS_LC_1.0"
 CRYPTO_REGISTRY="${SOURCE_ROOT}/crypto/libcrypto.txt"
 SSL_REGISTRY="${SOURCE_ROOT}/ssl/libssl.txt"

--- a/util/update_symbol_version.sh
+++ b/util/update_symbol_version.sh
@@ -2,36 +2,52 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
-# Assigns newly added public and internal API symbols to a new version node
-# and regenerates the version scripts.
+# Assigns newly added public and internal API symbols to a version node and
+# regenerates the version scripts.
 #
 # When new OPENSSL_EXPORT symbols are added to public or internal headers,
 # this script:
 #   1. Extracts the current full symbol set from headers (public + internal)
 #   2. Identifies symbols not yet in the registry (new API)
-#   3. Appends them to the registry with the given version node and visibility
+#   3. Appends them to the registry with the chosen version node and visibility
 #   4. Re-sorts the registry and regenerates the map files
 #
-# Usage: ./util/update_symbol_version.sh <version>
-# Example: ./util/update_symbol_version.sh AWS_LC_1.0
+# Usage: ./util/update_symbol_version.sh --current
+#        ./util/update_symbol_version.sh <version>
+#
+#   --current   Add the new symbols to the current (newest) node already in the
+#               registry. This is the common case: while a node is still open,
+#               new API accumulates in it.
+#   <version>   Open a NEW node (e.g. AWS_LC_1.1) and add the new symbols to it.
+#               Opening a node closes the current one, so this is a release-level
+#               decision: use it when the current node has been closed to further
+#               additions, or when starting a new ABI series.
+#
+# Exactly one of the two must be given: the node is always an explicit choice,
+# never a default.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+usage() {
+  echo "Usage: $0 --current      # add new symbols to the current (newest) node"
+  echo "       $0 <version>     # open a new node, e.g. AWS_LC_1.1"
+  echo ""
+  echo "Exactly one argument is required; the version node is always explicit."
+}
+
 if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 <version>"
-  echo "  version: version node for new symbols (e.g. AWS_LC_1.0)"
+  usage
   exit 1
 fi
 
-NEW_VERSION="$1"
+MODE_ARG="$1"
 
-# Validate version format
-if ! [[ "${NEW_VERSION}" =~ ^AWS_LC_[0-9]+\.[0-9]+$ ]]; then
-  echo "Error: version must match AWS_LC_X.Y (e.g. AWS_LC_1.0), got: ${NEW_VERSION}"
-  exit 1
+if [[ "${MODE_ARG}" == "-h" || "${MODE_ARG}" == "--help" ]]; then
+  usage
+  exit 0
 fi
 
 CRYPTO_REGISTRY="${SOURCE_ROOT}/crypto/libcrypto.txt"
@@ -47,16 +63,67 @@ for f in "${CRYPTO_REGISTRY}" "${SSL_REGISTRY}"; do
   fi
 done
 
-# Verify the new version is not already present in the registry (check field 2).
-# Use -F so the '.' in the version (e.g. AWS_LC_1.0) is matched literally rather
-# than as a regex wildcard.
-if awk '{print $2}' "${CRYPTO_REGISTRY}" | grep -Fqx "${NEW_VERSION}" 2>/dev/null || \
-   awk '{print $2}' "${SSL_REGISTRY}" | grep -Fqx "${NEW_VERSION}" 2>/dev/null; then
-  echo "Error: ${NEW_VERSION} already exists in the registry."
-  exit 1
+# Print the newest version node in a registry. Nodes are AWS_LC_<major>.<minor>,
+# so sort numerically on each component rather than lexically: that keeps
+# AWS_LC_1.10 after AWS_LC_1.9 instead of before it.
+newest_node() {
+  awk 'NF { print $2 }' "$1" | sort -u | sed 's/^AWS_LC_//' | \
+    sort -t. -k1,1n -k2,2n | tail -1 | sed 's/^/AWS_LC_/'
+}
+
+if [[ "${MODE_ARG}" == "--current" ]]; then
+  # libcrypto and libssl share one symbol version namespace, so their newest
+  # nodes must agree; if they have diverged, "current" is ambiguous and the
+  # caller has to say which node they mean.
+  CRYPTO_CURRENT=$(newest_node "${CRYPTO_REGISTRY}")
+  SSL_CURRENT=$(newest_node "${SSL_REGISTRY}")
+
+  if [[ -z "${CRYPTO_CURRENT}" || -z "${SSL_CURRENT}" ]]; then
+    echo "Error: could not determine the current version node from the registry."
+    echo "Run util/generate_initial_version_scripts.sh first."
+    exit 1
+  fi
+
+  if [[ "${CRYPTO_CURRENT}" != "${SSL_CURRENT}" ]]; then
+    echo "Error: registries disagree on the current version node:"
+    echo "  ${CRYPTO_REGISTRY}: ${CRYPTO_CURRENT}"
+    echo "  ${SSL_REGISTRY}: ${SSL_CURRENT}"
+    echo "libcrypto and libssl share one version namespace. Pass the node"
+    echo "explicitly instead of --current."
+    exit 1
+  fi
+
+  NEW_VERSION="${CRYPTO_CURRENT}"
+  echo "Adding to current version node: ${NEW_VERSION}"
+else
+  NEW_VERSION="${MODE_ARG}"
+
+  # Validate version format
+  if ! [[ "${NEW_VERSION}" =~ ^AWS_LC_[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: version must match AWS_LC_X.Y (e.g. AWS_LC_1.1), got: ${NEW_VERSION}"
+    echo ""
+    usage
+    exit 1
+  fi
+
+  # A new node must actually be new. Reusing an existing node is a valid
+  # operation, but it has to be requested as such via --current so the choice
+  # is deliberate rather than a typo in a version number.
+  # Use -F so the '.' in the version (e.g. AWS_LC_1.0) is matched literally
+  # rather than as a regex wildcard.
+  if awk '{print $2}' "${CRYPTO_REGISTRY}" | grep -Fqx "${NEW_VERSION}" 2>/dev/null || \
+     awk '{print $2}' "${SSL_REGISTRY}" | grep -Fqx "${NEW_VERSION}" 2>/dev/null; then
+    echo "Error: ${NEW_VERSION} already exists in the registry."
+    echo ""
+    echo "To add the new symbols to the current node, run:"
+    echo "  $0 --current"
+    echo "To open a different new node, pass a version that does not exist yet."
+    exit 1
+  fi
+
+  echo "Opening new version node: ${NEW_VERSION}"
 fi
 
-echo "New version: ${NEW_VERSION}"
 echo ""
 
 TMPDIR=$(mktemp -d)
@@ -100,8 +167,10 @@ comm -23 \
   "${TMPDIR}/registered_ssl.txt" \
   > "${TMPDIR}/new_ssl_names.txt"
 
-NEW_CRYPTO=$(wc -l < "${TMPDIR}/new_crypto_names.txt")
-NEW_SSL=$(wc -l < "${TMPDIR}/new_ssl_names.txt")
+# wc -l pads its output, which would render as "(       5)" in the summary
+# below; strip the padding so the counts read cleanly.
+NEW_CRYPTO=$(wc -l < "${TMPDIR}/new_crypto_names.txt" | tr -d '[:space:]')
+NEW_SSL=$(wc -l < "${TMPDIR}/new_ssl_names.txt" | tr -d '[:space:]')
 
 if [[ ${NEW_CRYPTO} -eq 0 && ${NEW_SSL} -eq 0 ]]; then
   echo "No unregistered symbols found. Nothing to do."
@@ -117,12 +186,18 @@ echo ""
 
 # Append new symbols to registries with version and visibility, then re-sort.
 # Look up each new symbol's visibility from the header output.
+#
+# The re-sort runs under LC_ALL=C so the registry stays in byte order. That is
+# the order generate_version_script emits symbols in, and the order the
+# committed registries are already in; sorting under a UTF-8 locale instead
+# would silently rewrite the whole file and bury the real change in a
+# thousands-line reordering diff.
 if [[ ${NEW_CRYPTO} -gt 0 ]]; then
   while IFS= read -r sym; do
     vis=$(awk -v s="${sym}" '$1 == s { print $2 }' "${TMPDIR}/all_crypto.txt")
     echo "${sym} ${NEW_VERSION} ${vis}"
   done < "${TMPDIR}/new_crypto_names.txt" >> "${CRYPTO_REGISTRY}"
-  sort -o "${CRYPTO_REGISTRY}" "${CRYPTO_REGISTRY}"
+  LC_ALL=C sort -o "${CRYPTO_REGISTRY}" "${CRYPTO_REGISTRY}"
 fi
 
 if [[ ${NEW_SSL} -gt 0 ]]; then
@@ -130,7 +205,7 @@ if [[ ${NEW_SSL} -gt 0 ]]; then
     vis=$(awk -v s="${sym}" '$1 == s { print $2 }' "${TMPDIR}/all_ssl.txt")
     echo "${sym} ${NEW_VERSION} ${vis}"
   done < "${TMPDIR}/new_ssl_names.txt" >> "${SSL_REGISTRY}"
-  sort -o "${SSL_REGISTRY}" "${SSL_REGISTRY}"
+  LC_ALL=C sort -o "${SSL_REGISTRY}" "${SSL_REGISTRY}"
 fi
 
 # Regenerate version scripts
@@ -144,7 +219,7 @@ go run "${SOURCE_ROOT}/util/generate_version_script" \
   -out "${SSL_MAP}" 2>&1
 
 echo ""
-echo "Done. Commit these files:"
+echo "Symbols added to ${NEW_VERSION}. Commit these files together:"
 echo "  ${CRYPTO_REGISTRY}"
 echo "  ${SSL_REGISTRY}"
 echo "  ${CRYPTO_MAP}"


### PR DESCRIPTION
### Context/Motivation

The five `EC_group_brainpoolP*r1()` functions added in #3286 were never registered. 
* New `OPENSSL_EXPORT` symbols that are not added to the symbol registry are compiled into shared libraries but hidden by the version script, preventing applications from linking against them. 

### Description of changes:

This PR registers the Brainpool EC group APIs in `AWS_LC_1.0` and makes the registration path when updating the current node explicit with `./util/update_symbol_version.sh --current`.

The symbol-versioning tool now distinguishes adding API to the current open node from opening a new node, rejects accidental reuse of an existing version node, and uses a deterministic byte-order sort. Documentation and CI failure messages now explain the impact of unregistered symbols and how to remediate them.

### Call-outs:

Opening a new symbol-version node is now documented and treated as a release-level decision. Most API additions should use `--current`; providing a version creates a new node and closes the current one by convention.

### Testing:

- `git diff --check`
- Full build and CI tests not run locally.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.