### PR TITLE
Decouple symbol versioning from distribution packaging mode

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -202,6 +202,11 @@ the symbol list on the fly (by building without prefixing, using
 `read_symbols.go` to construct a symbol list, and then building again with
 prefixing).
 
+Prefixing cannot be combined with symbol versioning (the version scripts
+reference the unprefixed names); configuring both is rejected. To distinguish
+libraries that must keep identical symbol names, use a symbol version
+namespace instead (see [docs/SymbolVersioning.md](docs/SymbolVersioning.md)).
+
 This mechanism is under development and may change over time. Please contact the
 BoringSSL maintainers if making use of it.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -106,8 +106,25 @@ This mode enables:
   crypto libraries without conflicts
 
 Symbol versioning ensures backward compatibility and enables multiple AWS-LC versions to
-coexist on the same system. See [docs/SymbolVersioning.md](docs/SymbolVersioning.md) for
-detailed information about symbol versioning, version evolution, and CI integration.
+coexist on the same system. It is on by default in this mode but is an independent
+option, so it can also be enabled on its own:
+
+```bash
+cmake -GNinja -B build \
+  -DBUILD_SHARED_LIBS=ON \
+  -DENABLE_PRE_SONAME_BUILD=OFF \
+  -DENABLE_SYMBOL_VERSIONING=ON \
+  -DCMAKE_BUILD_TYPE=Release
+```
+
+That produces versioned symbols with a standard SONAME while leaving headers in
+`include/openssl` and the `bssl` tool unrenamed. `-DENABLE_PRE_SONAME_BUILD=OFF`
+is what provides the SONAME outside of distribution packaging mode; the
+deprecation warning it prints is expected. `-DSYMBOL_VERSION_NAMESPACE=<prefix>`
+replaces the `AWS_LC` node prefix, which is only appropriate for a privately
+distributed libcrypto. See [docs/SymbolVersioning.md](docs/SymbolVersioning.md)
+for detailed information about symbol versioning, version evolution, and CI
+integration.
 
 ### Other Build Options
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,14 +128,75 @@ endif()
 
 enable_language(C)
 
-# Enable symbol versioning for shared libraries in distribution packaging mode
-# on UNIX platforms (excluding Apple).
+# ELF symbol versioning for shared libraries. Deliberately independent of the
+# rest of distribution packaging: versioned symbols can be adopted without
+# relocating headers into include/aws-lc (COHABITANT_HEADERS) or renaming the
+# bssl tool (COHABITANT_BINARIES). ENABLE_DIST_PKG only supplies the default.
+#
 # Version scripts are derived from the symbol registry files and have stable
 # filenames (crypto/libcrypto.map, ssl/libssl.map). The version node names are
 # recorded in the registry (crypto/libcrypto.txt, ssl/libssl.txt).
-if(ENABLE_DIST_PKG AND BUILD_SHARED_LIBS AND UNIX AND NOT APPLE)
-  set(ENABLE_SYMBOL_VERSIONING TRUE)
-  message(STATUS "Symbol versioning enabled")
+#
+# Not declared with option(): that would bake the first configure's default into
+# the cache, so a later -DENABLE_DIST_PKG=ON would leave versioning stuck off.
+# Testing DEFINED lets an explicit -D win (it stays in the cache, so it stays
+# DEFINED) while an unset value keeps tracking ENABLE_DIST_PKG.
+if(DEFINED ENABLE_SYMBOL_VERSIONING)
+  set(SYMBOL_VERSIONING_REQUESTED_EXPLICITLY TRUE)
+else()
+  set(SYMBOL_VERSIONING_REQUESTED_EXPLICITLY FALSE)
+  set(ENABLE_SYMBOL_VERSIONING "${ENABLE_DIST_PKG}")
+endif()
+
+# Version-node prefix. A non-default value yields symbol versions that do not
+# interoperate with a stock AWS-LC build, so it is only appropriate for a
+# privately distributed libcrypto (see docs/SymbolVersioning.md).
+set(SYMBOL_VERSION_NAMESPACE "${AWSLC_DEFAULT_SYMBOL_VERSION_NAMESPACE}" CACHE STRING
+    "Prefix for ELF symbol version nodes (e.g. AWS_LC yields AWS_LC_1.0)")
+
+if(NOT "${SYMBOL_VERSION_NAMESPACE}" MATCHES "${AWSLC_SYMBOL_VERSION_NAMESPACE_REGEX}")
+  message(FATAL_ERROR "SYMBOL_VERSION_NAMESPACE must match ${AWSLC_SYMBOL_VERSION_NAMESPACE_REGEX}, got: ${SYMBOL_VERSION_NAMESPACE}")
+endif()
+
+# A version script is a link-time input that only the ELF linker understands: a
+# static build has no link step to attach it to, and Mach-O and PE have no
+# equivalent. Fail loudly when versioning was requested explicitly; when merely
+# inherited from ENABLE_DIST_PKG, leave it off so a static dist-pkg build still
+# configures.
+if(ENABLE_SYMBOL_VERSIONING AND (NOT BUILD_SHARED_LIBS OR NOT UNIX OR APPLE))
+  if(SYMBOL_VERSIONING_REQUESTED_EXPLICITLY)
+    message(FATAL_ERROR "ENABLE_SYMBOL_VERSIONING requires a shared library build (-DBUILD_SHARED_LIBS=ON) on a non-Apple UNIX platform.")
+  endif()
+  set(ENABLE_SYMBOL_VERSIONING OFF)
+endif()
+unset(SYMBOL_VERSIONING_REQUESTED_EXPLICITLY)
+
+# Canonicalize: an inherited value carries ENABLE_DIST_PKG's literal spelling, so
+# -DENABLE_DIST_PKG=1 would otherwise report "1" here rather than "ON".
+if(ENABLE_SYMBOL_VERSIONING)
+  set(ENABLE_SYMBOL_VERSIONING ON)
+else()
+  set(ENABLE_SYMBOL_VERSIONING OFF)
+endif()
+
+message(STATUS "ENABLE_SYMBOL_VERSIONING: ${ENABLE_SYMBOL_VERSIONING}")
+
+# The namespace only reaches the linker through a version script, and unlike
+# ENABLE_SYMBOL_VERSIONING it has no inherited default, so setting one without
+# versioning is always a mistake. Refuse it, as ENABLE_DIST_PKG_OPENSSL_SHIM
+# without ENABLE_DIST_PKG is refused.
+if(NOT ENABLE_SYMBOL_VERSIONING AND
+   NOT "${SYMBOL_VERSION_NAMESPACE}" STREQUAL "${AWSLC_DEFAULT_SYMBOL_VERSION_NAMESPACE}")
+  message(FATAL_ERROR
+    "SYMBOL_VERSION_NAMESPACE is set to '${SYMBOL_VERSION_NAMESPACE}' but symbol "
+    "versioning is disabled, so the namespace cannot take effect. Enable "
+    "versioning with -DENABLE_SYMBOL_VERSIONING=ON (requires "
+    "-DBUILD_SHARED_LIBS=ON on a non-Apple UNIX platform), or clear the "
+    "namespace with -USYMBOL_VERSION_NAMESPACE.")
+endif()
+
+if(ENABLE_SYMBOL_VERSIONING)
+  message(STATUS "SYMBOL_VERSION_NAMESPACE: ${SYMBOL_VERSION_NAMESPACE}")
 
   # lld treats undefined symbols in version scripts as errors by default.
   # The --undefined-version flag downgrades them to warnings, matching GNU ld.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,18 @@ if(NOT ENABLE_SYMBOL_VERSIONING AND
     "namespace with -USYMBOL_VERSION_NAMESPACE.")
 endif()
 
+# BORINGSSL_PREFIX renames every exported symbol, but the version scripts
+# reference the unprefixed names, so a prefixed+versioned build would hide
+# every symbol behind "local: *". Reject the combination rather than produce
+# an empty library; docs/SymbolVersioning.md contrasts the two mechanisms.
+if(ENABLE_SYMBOL_VERSIONING AND BORINGSSL_PREFIX)
+  message(FATAL_ERROR
+    "BORINGSSL_PREFIX cannot be combined with symbol versioning: the version "
+    "scripts reference unprefixed symbol names, so the build would export no "
+    "symbols. Configure with -DENABLE_SYMBOL_VERSIONING=OFF (needed even with "
+    "-DENABLE_DIST_PKG=ON, which enables versioning by default).")
+endif()
+
 if(ENABLE_SYMBOL_VERSIONING)
   message(STATUS "SYMBOL_VERSION_NAMESPACE: ${SYMBOL_VERSION_NAMESPACE}")
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ and BSD systems. When built with `-DENABLE_DIST_PKG=1`, AWS-LC enables:
 
 Symbol versioning assigns every public API symbol to a named version node. New symbols
 introduced in future releases get new version nodes that inherit from their predecessors,
-enabling fine-grained compatibility tracking. See [docs/SymbolVersioning.md](docs/SymbolVersioning.md)
-for details.
+enabling fine-grained compatibility tracking. It defaults to on in this mode but is an
+independent option (`-DENABLE_SYMBOL_VERSIONING`), so versioned symbols can be adopted
+without the header relocation and binary renaming. See
+[docs/SymbolVersioning.md](docs/SymbolVersioning.md) for details.
 
 ## Platform Support
 

--- a/cmake/GenerateVersionScript.cmake
+++ b/cmake/GenerateVersionScript.cmake
@@ -14,7 +14,9 @@
 # Version-node prefix in the checked-in registries and .map files: their nodes
 # are named AWS_LC_<major>.<minor>. -DSYMBOL_VERSION_NAMESPACE=<prefix> rewrites
 # them into the build tree instead of using the script verbatim; see
-# docs/SymbolVersioning.md for when that is appropriate.
+# docs/SymbolVersioning.md for when that is appropriate. Unrelated to
+# BORINGSSL_PREFIX: only node names change, never symbols, and the two are
+# mutually exclusive (enforced in the top-level CMakeLists.txt).
 set(AWSLC_DEFAULT_SYMBOL_VERSION_NAMESPACE "AWS_LC")
 
 # A node name is "<namespace>_<major>.<minor>", so the namespace must be a valid

--- a/cmake/GenerateVersionScript.cmake
+++ b/cmake/GenerateVersionScript.cmake
@@ -11,6 +11,79 @@
 #   util/generate_initial_version_scripts.sh   (initial population)
 #   util/update_symbol_version.sh <version>    (adding new symbols)
 
+# Version-node prefix in the checked-in registries and .map files: their nodes
+# are named AWS_LC_<major>.<minor>. -DSYMBOL_VERSION_NAMESPACE=<prefix> rewrites
+# them into the build tree instead of using the script verbatim; see
+# docs/SymbolVersioning.md for when that is appropriate.
+set(AWSLC_DEFAULT_SYMBOL_VERSION_NAMESPACE "AWS_LC")
+
+# A node name is "<namespace>_<major>.<minor>", so the namespace must be a valid
+# linker identifier.
+set(AWSLC_SYMBOL_VERSION_NAMESPACE_REGEX "^[A-Za-z_][A-Za-z0-9_]*$")
+
+# _awslc_write_namespaced_version_script(<in_file> <namespace> <out_file>)
+#
+# Rewrites version-node names to a different namespace; symbol names are never
+# touched. Done textually here rather than by invoking
+# util/generate_version_script -namespace (which performs the same rename)
+# because the checked-in .map files exist so that a build never has to run the
+# generator, notably with -DDISABLE_GO=ON. run_symbol_version_test.sh diffs the
+# two implementations against each other.
+function(_awslc_write_namespaced_version_script in_file namespace out_file)
+  set(default_ns "${AWSLC_DEFAULT_SYMBOL_VERSION_NAMESPACE}")
+
+  file(READ "${in_file}" contents)
+
+  # Node names appear only at the start of a line, as "AWS_LC_1.0 {" (the
+  # declaration) and "} AWS_LC_1.0;" (the predecessor of an inheriting node).
+  # CMake regexes have no multiline mode, hence the explicit "(^|\n)" anchor;
+  # matching the line start is also what protects indented symbol names.
+  string(REGEX REPLACE
+    "(^|\n)${default_ns}_([0-9]+\\.[0-9]+)[ \t]*\\{"
+    "\\1${namespace}_\\2 {"
+    contents "${contents}")
+  string(REGEX REPLACE
+    "(^|\n)\\}[ \t]*${default_ns}_([0-9]+\\.[0-9]+)[ \t]*;"
+    "\\1} ${namespace}_\\2;"
+    contents "${contents}")
+
+  # Never link a script that was not fully renamed. This check is unanchored so
+  # it also catches a node name the rewrites could not reach (indented, or split
+  # across lines): "<ns>_<digits>.<digits>" cannot occur in a symbol name ('.' is
+  # invalid in an identifier) nor in an already-renamed node (AWS_LC_PRIVATE_1.0
+  # has no digit directly after "AWS_LC_").
+  if(contents MATCHES "${default_ns}_[0-9]+\\.[0-9]+")
+    message(FATAL_ERROR
+      "apply_version_script: failed to apply namespace '${namespace}' to "
+      "${in_file}: one or more ${default_ns}_<major>.<minor> node names remain. "
+      "Regenerate the version script with util/generate_initial_version_scripts.sh.")
+  endif()
+  # No node in the requested namespace means the input was not a version script.
+  if(NOT contents MATCHES "(^|\n)${namespace}_[0-9]+\\.[0-9]+[ \t]*\\{")
+    message(FATAL_ERROR
+      "apply_version_script: no version node found in ${in_file}; expected at "
+      "least one node named ${default_ns}_<major>.<minor> to rename to "
+      "'${namespace}_<major>.<minor>'.")
+  endif()
+
+  # Write only on change: an unconditional write would bump the timestamp on
+  # every configure and force a needless relink.
+  set(write_needed TRUE)
+  if(EXISTS "${out_file}")
+    file(READ "${out_file}" existing)
+    if(existing STREQUAL contents)
+      set(write_needed FALSE)
+    endif()
+  endif()
+  if(write_needed)
+    file(WRITE "${out_file}" "${contents}")
+  endif()
+
+  # The rewrite happens at configure time, so re-run configure when the source
+  # script changes (for example after regenerating it from the registry).
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${in_file}")
+endfunction()
+
 # apply_version_script()
 #
 # Applies a GNU ld version script to a library target for symbol versioning.
@@ -18,10 +91,13 @@
 # Parameters:
 #   TARGET         - Library target name (e.g., crypto, ssl)
 #   VERSION_SCRIPT - Path to version script file (e.g., ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto.map)
+#   NAMESPACE      - Optional version-node prefix. Defaults to "AWS_LC", which uses
+#                    VERSION_SCRIPT as-is; any other value rewrites the node names
+#                    into a copy under the target's binary directory.
 
 function(apply_version_script)
   set(options "")
-  set(oneValueArgs TARGET VERSION_SCRIPT)
+  set(oneValueArgs TARGET VERSION_SCRIPT NAMESPACE)
   set(multiValueArgs "")
   cmake_parse_arguments(PARSE_ARGV 0 ARG "${options}" "${oneValueArgs}" "${multiValueArgs}")
 
@@ -42,15 +118,33 @@ function(apply_version_script)
     message(FATAL_ERROR "apply_version_script: Version script not found: ${ARG_VERSION_SCRIPT}")
   endif()
 
+  # An empty NAMESPACE means "unspecified", not "no prefix".
+  if("${ARG_NAMESPACE}" STREQUAL "")
+    set(ARG_NAMESPACE "${AWSLC_DEFAULT_SYMBOL_VERSION_NAMESPACE}")
+  endif()
+  if(NOT "${ARG_NAMESPACE}" MATCHES "${AWSLC_SYMBOL_VERSION_NAMESPACE_REGEX}")
+    message(FATAL_ERROR
+      "apply_version_script: invalid NAMESPACE '${ARG_NAMESPACE}': a version "
+      "node namespace must match ${AWSLC_SYMBOL_VERSION_NAMESPACE_REGEX}")
+  endif()
+
+  set(version_script "${ARG_VERSION_SCRIPT}")
+  if(NOT "${ARG_NAMESPACE}" STREQUAL "${AWSLC_DEFAULT_SYMBOL_VERSION_NAMESPACE}")
+    get_filename_component(script_name "${ARG_VERSION_SCRIPT}" NAME)
+    set(version_script "${CMAKE_CURRENT_BINARY_DIR}/${script_name}")
+    _awslc_write_namespaced_version_script(
+      "${ARG_VERSION_SCRIPT}" "${ARG_NAMESPACE}" "${version_script}")
+  endif()
+
   target_link_options(${ARG_TARGET} PRIVATE
-    "LINKER:--version-script=${ARG_VERSION_SCRIPT}"
+    "LINKER:--version-script=${version_script}"
   )
 
   # The version script is passed via a linker flag, which CMake does not parse
   # to discover a build dependency. Record it explicitly so editing the .map
   # (e.g. regenerating it from the registry) triggers a re-link.
   set_target_properties(${ARG_TARGET} PROPERTIES
-    LINK_DEPENDS "${ARG_VERSION_SCRIPT}"
+    LINK_DEPENDS "${version_script}"
   )
 
   if(LINKER_HAS_UNDEFINED_VERSION)
@@ -59,6 +153,10 @@ function(apply_version_script)
     )
   endif()
 
-  get_filename_component(VERSION_SCRIPT_NAME "${ARG_VERSION_SCRIPT}" NAME)
-  message(STATUS "Applied symbol version script to ${ARG_TARGET}: ${VERSION_SCRIPT_NAME}")
+  get_filename_component(VERSION_SCRIPT_NAME "${version_script}" NAME)
+  if("${ARG_NAMESPACE}" STREQUAL "${AWSLC_DEFAULT_SYMBOL_VERSION_NAMESPACE}")
+    message(STATUS "Applied symbol version script to ${ARG_TARGET}: ${VERSION_SCRIPT_NAME}")
+  else()
+    message(STATUS "Applied symbol version script to ${ARG_TARGET}: ${VERSION_SCRIPT_NAME} (namespace ${ARG_NAMESPACE})")
+  endif()
 endfunction()

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -648,6 +648,7 @@ function(build_libcrypto)
     apply_version_script(
       TARGET ${arg_NAME}
       VERSION_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/libcrypto.map"
+      NAMESPACE "${SYMBOL_VERSION_NAMESPACE}"
     )
   endif()
 endfunction()

--- a/docs/SymbolVersioning.md
+++ b/docs/SymbolVersioning.md
@@ -276,6 +276,28 @@ go run ./util/generate_version_script \
   -in crypto/libcrypto.txt -out /tmp/libcrypto.map -namespace MYCORP
 ```
 
+### Relationship to Symbol Prefixing (`BORINGSSL_PREFIX`)
+
+Symbol prefixing (see "Building with Prefixed Symbols" in
+[BUILDING.md](../BUILDING.md)) and a custom version node namespace both keep a
+binary from linking against the wrong library, but they rename different
+things:
+
+| | `BORINGSSL_PREFIX` | `SYMBOL_VERSION_NAMESPACE` |
+|---|--------------------|----------------------------|
+| Renames | Every exported symbol (`SSL_new` -> `awslc_SSL_new`) | Only version node names (`AWS_LC_1.0` -> `MYCORP_1.0`) |
+| Mechanism | Generated `#define` headers compiled into library and consumers | GNU ld version script, applied at link time |
+| Consumer impact | Token-level rewrite of consumer code; also hits same-named identifiers in unrelated C++ namespaces | None; consumer source is unchanged |
+| Applies to | All build types and platforms | Shared ELF libraries only |
+| Isolation via | Names differ across builds | Dynamic linker refuses to bind `SSL_new@AWS_LC_1.0` to a library defining only `SSL_new@MYCORP_1.0` |
+
+Use prefixing when renaming the symbols is acceptable; use a version namespace
+when symbol names must stay standard (drop-in OpenSSL-API consumers, `dlsym()`
+of standard names). The two are mutually exclusive: the version scripts
+reference unprefixed names, so a prefixed build would hide every symbol behind
+`local: *`. Configuring both is rejected at configure time; a prefixed
+`ENABLE_DIST_PKG` build must set `-DENABLE_SYMBOL_VERSIONING=OFF`.
+
 ### Symbol Removal (ABI Break)
 
 **Removing a PUBLIC symbol breaks ABI compatibility** and should be avoided. If

--- a/docs/SymbolVersioning.md
+++ b/docs/SymbolVersioning.md
@@ -9,7 +9,9 @@ AWS-LC uses **ELF symbol versioning** for its shared libraries on UNIX systems (
 - **Concurrent Installation**: Multiple AWS-LC versions can coexist on the same system
 - **Distribution Packaging**: Standard practice for system libraries in Linux distributions
 
-Symbol versioning is automatically enabled when building with distribution packaging mode (`-DENABLE_DIST_PKG=1`).
+Symbol versioning is enabled by default in distribution packaging mode
+(`-DENABLE_DIST_PKG=1`), but it is an independent option: see
+[Enabling Symbol Versioning](#enabling-symbol-versioning).
 
 ## How It Works
 
@@ -52,9 +54,40 @@ The `@@AWS_LC_1.0` suffix indicates your application requires the `AWS_LC_1.0` v
 - CMake 3.0+
 - Ninja or Make
 
+### Enabling Symbol Versioning
+
+Symbol versioning is controlled by `ENABLE_SYMBOL_VERSIONING`, which defaults to
+the value of `ENABLE_DIST_PKG` and can be set explicitly to override that:
+
+```bash
+# Distribution packaging: versioning on by default.
+cmake -GNinja -B build -DBUILD_SHARED_LIBS=ON -DENABLE_DIST_PKG=ON
+
+# Versioned symbols WITHOUT the rest of distribution packaging: standard SONAME,
+# headers left in include/openssl, bssl not renamed.
+cmake -GNinja -B build -DBUILD_SHARED_LIBS=ON \
+  -DENABLE_PRE_SONAME_BUILD=OFF -DENABLE_SYMBOL_VERSIONING=ON
+
+# Distribution packaging layout WITHOUT versioned symbols.
+cmake -GNinja -B build -DBUILD_SHARED_LIBS=ON \
+  -DENABLE_DIST_PKG=ON -DENABLE_SYMBOL_VERSIONING=OFF
+```
+
+Versioning is independent of the other distribution-packaging behaviors
+(`COHABITANT_HEADERS`, `COHABITANT_BINARIES`, SONAME), so it can be adopted as an
+isolated step. The second example passes `-DENABLE_PRE_SONAME_BUILD=OFF` only
+because a shared library you distribute should carry a SONAME and that flag is
+currently the sole way to get one without `ENABLE_DIST_PKG`; the deprecation
+warning it prints is expected, and versioning itself does not require a SONAME.
+
+`ENABLE_SYMBOL_VERSIONING` requires a shared library build
+(`-DBUILD_SHARED_LIBS=ON`) on a non-Apple UNIX platform. Requesting it explicitly
+elsewhere is a configure error; when merely inherited from `ENABLE_DIST_PKG` it is
+silently left off.
+
 ### Build Configuration
 
-Symbol versioning is enabled automatically with distribution packaging:
+A full distribution-packaging build, which enables versioning by default:
 
 ```bash
 cmake -GNinja -B build \
@@ -126,7 +159,7 @@ The registry and version scripts are managed by Go tools and shell wrappers in `
 | Tool | Purpose |
 |------|---------|
 | [`util/read_public_symbols`](../util/read_public_symbols) | Extracts exported symbols from headers and classifies visibility (PUBLIC / PRIVATE / PRIVATE_CXX). |
-| [`util/generate_version_script`](../util/generate_version_script) | Generates a `.map` version script from a registry `.txt`. Deterministic. |
+| [`util/generate_version_script`](../util/generate_version_script) | Generates a `.map` version script from a registry `.txt`. Deterministic. `-namespace` rewrites the version node prefix. |
 | [`util/generate_initial_version_scripts.sh`](../util/generate_initial_version_scripts.sh) | Bootstraps both registries and `.map` files from scratch (used once to establish the baseline). |
 | [`util/update_symbol_version.sh`](../util/update_symbol_version.sh) | Registers newly introduced API and regenerates the `.map` files. `--current` adds to the open node (the common case); passing a version opens a new node. |
 
@@ -211,6 +244,37 @@ the wrong node.
   - `AWS_LC_1.1` - First update with new symbols
   - `AWS_LC_1.2` - Second update with new symbols
   - `AWS_LC_2.0` - After ABI break (new SONAME)
+
+### Custom Version Node Namespace
+
+The `AWS_LC` prefix in the node name is configurable via
+`-DSYMBOL_VERSION_NAMESPACE=<prefix>`:
+
+```bash
+cmake -GNinja -B build -DBUILD_SHARED_LIBS=ON \
+  -DENABLE_SYMBOL_VERSIONING=ON -DSYMBOL_VERSION_NAMESPACE=MYCORP
+# => nodes are named MYCORP_1.0 instead of AWS_LC_1.0
+```
+
+The prefix must be a valid linker identifier (`[A-Za-z_][A-Za-z0-9_]*`), and
+setting a non-default namespace while symbol versioning is disabled is a configure
+error rather than being silently ignored. Only node names are rewritten; symbol
+names are untouched, and the checked-in `.map` files are left alone -- the renamed
+script is written into the build tree (`<build>/crypto/libcrypto.map`,
+`<build>/ssl/libssl.map`).
+
+> **This changes the ABI contract.** An application linked against a `MYCORP_1.0`
+> build records a dependency on `MYCORP_1.0` and will not resolve against a stock
+> `AWS_LC_1.0` library, or vice versa. A custom namespace is therefore only
+> appropriate for a privately distributed libcrypto. Do not use it for anything
+> published as AWS-LC.
+
+The same rename is available from the generator directly:
+
+```bash
+go run ./util/generate_version_script \
+  -in crypto/libcrypto.txt -out /tmp/libcrypto.map -namespace MYCORP
+```
 
 ### Symbol Removal (ABI Break)
 
@@ -415,7 +479,9 @@ This ensures users have a compatible AWS-LC version installed.
 - **Windows**: PE format uses DEF files for exports
 - **Static libraries**: Symbol versioning only applies to shared libraries
 
-On unsupported platforms, `ENABLE_DIST_PKG` builds libraries without symbol versioning.
+On unsupported platforms, `ENABLE_DIST_PKG` builds libraries without symbol
+versioning; requesting `-DENABLE_SYMBOL_VERSIONING=ON` explicitly there is a
+configure error.
 
 ## Troubleshooting
 

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -66,6 +66,7 @@ if(ENABLE_SYMBOL_VERSIONING)
   apply_version_script(
     TARGET ssl
     VERSION_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/libssl.map"
+    NAMESPACE "${SYMBOL_VERSION_NAMESPACE}"
   )
 endif()
 

--- a/tests/ci/run_symbol_version_test.sh
+++ b/tests/ci/run_symbol_version_test.sh
@@ -14,6 +14,7 @@
 #    independently of distribution packaging mode
 # 7. A custom namespace without symbol versioning is rejected at configure time
 # 8. The CMake and Go implementations of the namespace rewrite agree
+# 9. BORINGSSL_PREFIX with symbol versioning is rejected at configure time
 #
 # Usage: ./tests/ci/run_symbol_version_test.sh [install_dir]
 #   If install_dir is provided, uses the installed shared libraries there.
@@ -639,6 +640,77 @@ CMAKE_EOF
     else
       print_pass "Both rewrite implementations agree on a multi-node script"
     fi
+  fi
+fi
+
+# Test 12: BORINGSSL_PREFIX with symbol versioning is refused at configure time
+# (the version scripts reference unprefixed names, so the build would export
+# nothing), whether versioning is explicit or inherited from ENABLE_DIST_PKG;
+# the opt-out in the error message (-DENABLE_SYMBOL_VERSIONING=OFF) must work.
+print_test "BORINGSSL_PREFIX with symbol versioning is a configure error"
+
+PREFIX_TEST_DIR=$(mktemp -d)
+CLEANUP_DIRS+=("${PREFIX_TEST_DIR}")
+# A real symbols file, so this cannot fail for the unrelated "must specify
+# both" reason if the guard ever moves later in the configure.
+echo "SSL_new" > "${PREFIX_TEST_DIR}/symbols.txt"
+PREFIX_GUARD_ERROR="BORINGSSL_PREFIX cannot be combined with symbol versioning"
+
+PREFIX_EXPLICIT_LOG="${PREFIX_TEST_DIR}/explicit.log"
+if cmake -GNinja -B "${PREFIX_TEST_DIR}/explicit" -S "${SOURCE_ROOT}" \
+     -DBUILD_SHARED_LIBS=ON \
+     -DENABLE_SYMBOL_VERSIONING=ON \
+     -DBORINGSSL_PREFIX=SYMVER_TEST_PFX \
+     -DBORINGSSL_PREFIX_SYMBOLS="${PREFIX_TEST_DIR}/symbols.txt" \
+     -DBUILD_TESTING=OFF > "${PREFIX_EXPLICIT_LOG}" 2>&1; then
+  print_fail "Configure unexpectedly succeeded with BORINGSSL_PREFIX and explicit versioning"
+else
+  if grep -q "${PREFIX_GUARD_ERROR}" "${PREFIX_EXPLICIT_LOG}"; then
+    print_pass "Prefix with explicit versioning rejected at configure time"
+  else
+    print_fail "Configure failed, but not with the prefix/versioning error:"
+    tail -20 "${PREFIX_EXPLICIT_LOG}" | sed 's/^/  /'
+  fi
+fi
+
+# Inherited versioning (ENABLE_DIST_PKG) must be rejected the same way.
+PREFIX_INHERITED_LOG="${PREFIX_TEST_DIR}/inherited.log"
+if cmake -GNinja -B "${PREFIX_TEST_DIR}/inherited" -S "${SOURCE_ROOT}" \
+     -DBUILD_SHARED_LIBS=ON \
+     -DENABLE_DIST_PKG=ON \
+     -DBORINGSSL_PREFIX=SYMVER_TEST_PFX \
+     -DBORINGSSL_PREFIX_SYMBOLS="${PREFIX_TEST_DIR}/symbols.txt" \
+     -DBUILD_TESTING=OFF > "${PREFIX_INHERITED_LOG}" 2>&1; then
+  print_fail "Configure unexpectedly succeeded with BORINGSSL_PREFIX and ENABLE_DIST_PKG"
+else
+  if grep -q "${PREFIX_GUARD_ERROR}" "${PREFIX_INHERITED_LOG}"; then
+    print_pass "Prefix with dist-pkg-inherited versioning rejected at configure time"
+  else
+    print_fail "Configure failed, but not with the prefix/versioning error:"
+    tail -20 "${PREFIX_INHERITED_LOG}" | sed 's/^/  /'
+  fi
+fi
+
+# The opt-out check needs Go (prefix builds hard-error at configure without it).
+if ! command -v go > /dev/null 2>&1; then
+  print_warn "go not found; skipping prefix-with-versioning-off configure check"
+else
+  PREFIX_OFF_LOG="${PREFIX_TEST_DIR}/off.log"
+  if cmake -GNinja -B "${PREFIX_TEST_DIR}/off" -S "${SOURCE_ROOT}" \
+       -DBUILD_SHARED_LIBS=ON \
+       -DENABLE_DIST_PKG=ON \
+       -DENABLE_SYMBOL_VERSIONING=OFF \
+       -DBORINGSSL_PREFIX=SYMVER_TEST_PFX \
+       -DBORINGSSL_PREFIX_SYMBOLS="${PREFIX_TEST_DIR}/symbols.txt" \
+       -DBUILD_TESTING=OFF > "${PREFIX_OFF_LOG}" 2>&1; then
+    if grep -q '^-- ENABLE_SYMBOL_VERSIONING: OFF$' "${PREFIX_OFF_LOG}"; then
+      print_pass "Prefix build configures once versioning is explicitly disabled"
+    else
+      print_fail "Prefix build configured but versioning was not reported OFF"
+    fi
+  else
+    print_fail "Configure failed for prefix build with -DENABLE_SYMBOL_VERSIONING=OFF:"
+    tail -20 "${PREFIX_OFF_LOG}" | sed 's/^/  /'
   fi
 fi
 

--- a/tests/ci/run_symbol_version_test.sh
+++ b/tests/ci/run_symbol_version_test.sh
@@ -10,6 +10,10 @@
 # 3. No unversioned symbols leak
 # 4. Version definitions are present in shared libraries
 # 5. Libraries can be linked and used correctly
+# 6. Symbol versioning and its version node namespace are configurable
+#    independently of distribution packaging mode
+# 7. A custom namespace without symbol versioning is rejected at configure time
+# 8. The CMake and Go implementations of the namespace rewrite agree
 #
 # Usage: ./tests/ci/run_symbol_version_test.sh [install_dir]
 #   If install_dir is provided, uses the installed shared libraries there.
@@ -402,7 +406,12 @@ check_dropped_symbols() {
     print_fail "${name}: ${dropped_count} exported symbol(s) silently hidden by the version script"
     print_info "These are exported by the compiler but missing from the registry/.map:"
     echo "${dropped}" | head -10 | sed 's/^/  /'
-    [[ ${dropped_count} -gt 10 ]] && print_info "... and $((dropped_count - 10)) more"
+    # An explicit "if" rather than "[[ ... ]] && cmd": the latter returns non-zero
+    # when the condition is false, which under "set -e" would abort the script if
+    # it were ever the function's last command.
+    if [[ ${dropped_count} -gt 10 ]]; then
+      print_info "... and $((dropped_count - 10)) more"
+    fi
     echo ""
     print_info "These symbols are compiled into the library but demoted to local by"
     print_info "'local: *;', so applications cannot link against them. Register them:"
@@ -427,17 +436,17 @@ fi
 UNVERSIONED_BUILD=$(mktemp -d)
 CLEANUP_DIRS+=("${UNVERSIONED_BUILD}")
 
-print_info "Building unversioned reference libraries (no ENABLE_DIST_PKG)"
+print_info "Building unversioned reference libraries (no symbol versioning)"
 # Build with SONAME enabled (ENABLE_PRE_SONAME_BUILD=OFF) so the library file
 # names carry the same "-awslc" suffix as the versioned dist-pkg build, but with
-# ENABLE_DIST_PKG=OFF (set explicitly) so symbol versioning is not applied.
-# Symbol versioning is gated solely on ENABLE_DIST_PKG, so this reference is
-# guaranteed unversioned. (A bare -DBUILD_SHARED_LIBS=ON build would leave
-# ENABLE_PRE_SONAME_BUILD at its default ON, yielding SET_LIB_SONAME=0 and
-# unsuffixed libcrypto.so names.)
+# symbol versioning explicitly off so the reference is guaranteed unversioned
+# regardless of what ENABLE_SYMBOL_VERSIONING would default to. (A bare
+# -DBUILD_SHARED_LIBS=ON build would leave ENABLE_PRE_SONAME_BUILD at its default
+# ON, yielding SET_LIB_SONAME=0 and unsuffixed libcrypto.so names.)
 if ! cmake -GNinja -B "${UNVERSIONED_BUILD}" -S "${SOURCE_ROOT}" \
      -DBUILD_SHARED_LIBS=ON \
      -DENABLE_DIST_PKG=OFF \
+     -DENABLE_SYMBOL_VERSIONING=OFF \
      -DENABLE_PRE_SONAME_BUILD=OFF \
      -DCMAKE_BUILD_TYPE=RelWithDebInfo > /dev/null 2>&1 || \
    ! cmake --build "${UNVERSIONED_BUILD}" --target crypto ssl > /dev/null 2>&1; then
@@ -462,6 +471,176 @@ fi
 
 check_dropped_symbols "libcrypto" "${UV_CRYPTO}" "${LIBCRYPTO_SO}"
 check_dropped_symbols "libssl" "${UV_SSL}" "${LIBSSL_SO}"
+
+# Test 8: Symbol versioning is configurable independently of ENABLE_DIST_PKG.
+# Configure-only: the link is already covered above, so skipping the compile
+# keeps Tests 8-10 cheap.
+print_test "Symbol versioning can be enabled without ENABLE_DIST_PKG"
+
+DECOUPLED_BUILD=$(mktemp -d)
+CLEANUP_DIRS+=("${DECOUPLED_BUILD}")
+DECOUPLED_LOG="${DECOUPLED_BUILD}/configure.log"
+
+if cmake -GNinja -B "${DECOUPLED_BUILD}" -S "${SOURCE_ROOT}" \
+     -DBUILD_SHARED_LIBS=ON \
+     -DENABLE_DIST_PKG=OFF \
+     -DENABLE_PRE_SONAME_BUILD=OFF \
+     -DENABLE_SYMBOL_VERSIONING=ON \
+     -DBUILD_TESTING=OFF > "${DECOUPLED_LOG}" 2>&1; then
+  if grep -q '^-- ENABLE_SYMBOL_VERSIONING: ON$' "${DECOUPLED_LOG}"; then
+    print_pass "Symbol versioning enabled with ENABLE_DIST_PKG=OFF"
+  else
+    print_fail "ENABLE_SYMBOL_VERSIONING=ON did not take effect without ENABLE_DIST_PKG"
+  fi
+  # The point of the decoupling: no header relocation, no renamed binaries.
+  if grep -q '^-- COHABITANT_HEADERS: 0$' "${DECOUPLED_LOG}" && \
+     grep -q '^-- COHABITANT_BINARIES: 0$' "${DECOUPLED_LOG}"; then
+    print_pass "Versioning did not force header/binary cohabitation"
+  else
+    print_fail "Enabling symbol versioning unexpectedly turned on cohabitation"
+  fi
+else
+  print_fail "Configure failed with ENABLE_SYMBOL_VERSIONING=ON and ENABLE_DIST_PKG=OFF"
+  tail -20 "${DECOUPLED_LOG}" | sed 's/^/  /'
+fi
+
+# Test 9: A custom version node namespace is applied to the version scripts
+print_test "SYMBOL_VERSION_NAMESPACE renames the version nodes"
+
+NAMESPACE_BUILD=$(mktemp -d)
+CLEANUP_DIRS+=("${NAMESPACE_BUILD}")
+NAMESPACE_LOG="${NAMESPACE_BUILD}/configure.log"
+# Deliberately not prefixed with AWS_LC so the "no default node remains" grep
+# below cannot match the renamed node by accident.
+TEST_NAMESPACE="SYMVER_TEST_NS"
+
+if cmake -GNinja -B "${NAMESPACE_BUILD}" -S "${SOURCE_ROOT}" \
+     -DBUILD_SHARED_LIBS=ON \
+     -DENABLE_DIST_PKG=ON \
+     -DSYMBOL_VERSION_NAMESPACE="${TEST_NAMESPACE}" \
+     -DBUILD_TESTING=OFF > "${NAMESPACE_LOG}" 2>&1; then
+  namespace_ok=1
+  for lib in crypto ssl; do
+    generated="${NAMESPACE_BUILD}/${lib}/lib${lib}.map"
+    if [[ ! -f "${generated}" ]]; then
+      print_fail "lib${lib}: namespaced version script not generated at ${generated}"
+      namespace_ok=0
+      continue
+    fi
+    if ! grep -qE "^${TEST_NAMESPACE}_[0-9]+\.[0-9]+ \{" "${generated}"; then
+      print_fail "lib${lib}: generated script has no ${TEST_NAMESPACE}_<major>.<minor> node"
+      namespace_ok=0
+    fi
+    # No node may keep the default namespace, or the library would export a mix.
+    if grep -qE "^AWS_LC_[0-9]+\.[0-9]+ \{" "${generated}"; then
+      print_fail "lib${lib}: generated script still declares an AWS_LC_* node"
+      namespace_ok=0
+    fi
+    # The checked-in script is the source of truth and must not be rewritten.
+    if ! grep -qE "^AWS_LC_[0-9]+\.[0-9]+ \{" "${SOURCE_ROOT}/${lib}/lib${lib}.map"; then
+      print_fail "lib${lib}: checked-in ${lib}/lib${lib}.map was modified in place"
+      namespace_ok=0
+    fi
+  done
+  if [[ ${namespace_ok} -eq 1 ]]; then
+    print_pass "Version nodes renamed to ${TEST_NAMESPACE}_* in the build tree"
+  fi
+else
+  print_fail "Configure failed with SYMBOL_VERSION_NAMESPACE=${TEST_NAMESPACE}"
+  tail -20 "${NAMESPACE_LOG}" | sed 's/^/  /'
+fi
+
+# Test 10: A custom namespace without symbol versioning is refused rather than
+# silently ignored (it can only take effect through a version script, and unlike
+# ENABLE_SYMBOL_VERSIONING it has no inherited default).
+print_test "SYMBOL_VERSION_NAMESPACE without versioning is a configure error"
+
+NS_OFF_BUILD=$(mktemp -d)
+CLEANUP_DIRS+=("${NS_OFF_BUILD}")
+NS_OFF_LOG="${NS_OFF_BUILD}/configure.log"
+
+if cmake -GNinja -B "${NS_OFF_BUILD}" -S "${SOURCE_ROOT}" \
+     -DBUILD_SHARED_LIBS=ON \
+     -DENABLE_SYMBOL_VERSIONING=OFF \
+     -DSYMBOL_VERSION_NAMESPACE="${TEST_NAMESPACE}" \
+     -DBUILD_TESTING=OFF > "${NS_OFF_LOG}" 2>&1; then
+  print_fail "Configure unexpectedly succeeded with a namespace but versioning disabled"
+else
+  # Make sure it failed for the right reason, not some unrelated breakage.
+  if grep -q "SYMBOL_VERSION_NAMESPACE is set to" "${NS_OFF_LOG}"; then
+    print_pass "Namespace without versioning rejected at configure time"
+  else
+    print_fail "Configure failed, but not with the namespace/versioning error:"
+    tail -20 "${NS_OFF_LOG}" | sed 's/^/  /'
+  fi
+fi
+
+# Test 11: The namespace rewrite exists twice -- string(REGEX REPLACE) in
+# cmake/GenerateVersionScript.cmake (so a build never needs Go) and
+# applyNamespace() in util/generate_version_script -- and the two must agree. The
+# in-tree .map files have a single node, so this uses a synthetic multi-node
+# registry to also cover the "} AWS_LC_1.0;" inheritance clause. The fixture is
+# regenerated each run so a change to the generator's output format cannot
+# silently leave the CMake copy behind.
+print_test "CMake namespace rewrite matches the generator"
+
+if ! command -v go > /dev/null 2>&1; then
+  print_warn "go not found; skipping CMake/generator rewrite equivalence check"
+else
+  REWRITE_DIR=$(mktemp -d)
+  CLEANUP_DIRS+=("${REWRITE_DIR}")
+
+  cat > "${REWRITE_DIR}/registry.txt" <<'REGISTRY_EOF'
+AES_encrypt AWS_LC_1.0 PUBLIC
+EVP_thing AWS_LC_1.0 PUBLIC
+new_api AWS_LC_1.1 PUBLIC
+newer_api AWS_LC_2.0 PUBLIC
+REGISTRY_EOF
+
+  rewrite_ok=1
+  if ! (cd "${SOURCE_ROOT}" && go run ./util/generate_version_script \
+          -in "${REWRITE_DIR}/registry.txt" \
+          -out "${REWRITE_DIR}/default.map") > /dev/null 2>&1 || \
+     ! (cd "${SOURCE_ROOT}" && go run ./util/generate_version_script \
+          -in "${REWRITE_DIR}/registry.txt" \
+          -out "${REWRITE_DIR}/generator.map" \
+          -namespace "${TEST_NAMESPACE}") > /dev/null 2>&1; then
+    print_fail "Could not generate the multi-node fixture with the generator"
+    rewrite_ok=0
+  fi
+
+  # Fail rather than pass vacuously if the fixture lost its inheritance clause.
+  if [[ ${rewrite_ok} -eq 1 ]] && \
+     ! grep -qE '^\} AWS_LC_[0-9]+\.[0-9]+;' "${REWRITE_DIR}/default.map"; then
+    print_fail "Fixture has no '} AWS_LC_<major>.<minor>;' clause, so the inheritance rewrite is untested"
+    rewrite_ok=0
+  fi
+
+  if [[ ${rewrite_ok} -eq 1 ]]; then
+    # Drive the CMake helper in script mode: no project, no configure.
+    cat > "${REWRITE_DIR}/rewrite.cmake" <<CMAKE_EOF
+include("${SOURCE_ROOT}/cmake/GenerateVersionScript.cmake")
+_awslc_write_namespaced_version_script(
+  "${REWRITE_DIR}/default.map"
+  "${TEST_NAMESPACE}"
+  "${REWRITE_DIR}/cmake.map")
+CMAKE_EOF
+
+    if ! cmake -P "${REWRITE_DIR}/rewrite.cmake" > "${REWRITE_DIR}/rewrite.log" 2>&1; then
+      print_fail "CMake rewrite of the multi-node fixture failed"
+      tail -20 "${REWRITE_DIR}/rewrite.log" | sed 's/^/  /'
+    elif ! diff -u "${REWRITE_DIR}/generator.map" "${REWRITE_DIR}/cmake.map" \
+            > "${REWRITE_DIR}/rewrite.diff" 2>&1; then
+      print_fail "CMake rewrite disagrees with 'generate_version_script -namespace'"
+      print_info "--- generator.map (expected)  +++ cmake.map (actual)"
+      head -20 "${REWRITE_DIR}/rewrite.diff" | sed 's/^/  /'
+    elif ! grep -qE "^\\} ${TEST_NAMESPACE}_[0-9]+\\.[0-9]+;" "${REWRITE_DIR}/cmake.map"; then
+      print_fail "CMake rewrite left the inheritance clause un-renamed"
+    else
+      print_pass "Both rewrite implementations agree on a multi-node script"
+    fi
+  fi
+fi
 
 # Summary
 echo ""

--- a/util/generate_initial_version_scripts.sh
+++ b/util/generate_initial_version_scripts.sh
@@ -52,17 +52,16 @@ echo "Step 1: Building shared libraries for validation..."
 BUILD_DIR="$(mktemp -d)"
 rm -rf "${BUILD_DIR}"
 # This build only produces libraries to validate the extracted symbols against
-# (via read_public_symbols -validate-against); it does not need symbol
-# versioning. Crucially, building with -DENABLE_DIST_PKG=ON would require the
-# .map files to already exist (apply_version_script fatal-errors otherwise),
-# which is a chicken-and-egg problem for a script whose job is to regenerate
-# those .map files from scratch. Instead build with SONAME enabled
-# (ENABLE_PRE_SONAME_BUILD=OFF, so the libraries keep the -awslc suffix the
-# find globs below expect) but ENABLE_DIST_PKG=OFF (so no version script is
-# required or applied).
+# (via read_public_symbols -validate-against). Symbol versioning is explicitly off
+# because enabling it would require the .map files to already exist
+# (apply_version_script fatal-errors otherwise) -- a chicken-and-egg problem for a
+# script whose job is to regenerate them from scratch. SONAME stays enabled
+# (ENABLE_PRE_SONAME_BUILD=OFF) so the libraries keep the -awslc suffix the find
+# globs below expect.
 cmake -B "${BUILD_DIR}" -S "${SOURCE_ROOT}" \
   -DBUILD_SHARED_LIBS=ON \
   -DENABLE_DIST_PKG=OFF \
+  -DENABLE_SYMBOL_VERSIONING=OFF \
   -DENABLE_PRE_SONAME_BUILD=OFF \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -GNinja

--- a/util/generate_version_script/main.go
+++ b/util/generate_version_script/main.go
@@ -16,6 +16,11 @@
 // visibility. C++ symbols are emitted in an "extern C++" block with glob
 // patterns so the linker matches their demangled C++ names.
 //
+// The -namespace flag rewrites the prefix of every version node, so a registry
+// recording AWS_LC_1.0 can emit, say, MYCORP_1.0 instead. This is for consumers
+// who ship a private libcrypto; the resulting symbol versions do not interoperate
+// with a stock AWS-LC build.
+//
 // Usage:
 //
 //	go run ./util/generate_version_script -in crypto/libcrypto.txt -out crypto/libcrypto.map
@@ -27,6 +32,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -34,11 +40,22 @@ import (
 
 var inFile string
 var outFile string
+var namespace string
 
 func init() {
 	flag.StringVar(&inFile, "in", "", "Symbol registry file (one '<symbol> <version> [visibility]' per line)")
 	flag.StringVar(&outFile, "out", "", "Output GNU ld version script (.map)")
+	flag.StringVar(&namespace, "namespace", "", "Rewrite version node prefixes to this namespace (default: keep the registry's)")
 }
+
+// namespacePattern matches a version node namespace. A node name is
+// "<namespace>_<major>.<minor>", so the namespace must be a valid linker
+// identifier.
+var namespacePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// nodeNamePattern splits a node name into namespace and version, e.g.
+// "AWS_LC_1.0" -> ("AWS_LC", "1.0").
+var nodeNamePattern = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_]*)_([0-9]+\.[0-9]+)$`)
 
 // visibility classifies a symbol's linkage and export status. It is the third
 // field of a registry line. Go has no native enum; the idiom is a defined
@@ -75,11 +92,24 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
+	if namespace != "" && !namespacePattern.MatchString(namespace) {
+		fmt.Fprintf(os.Stderr, "Error: -namespace must match %s, got: %q\n",
+			namespacePattern, namespace)
+		os.Exit(1)
+	}
 
 	versionSymbols, versions, err := readRegistry(inFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading registry %s: %v\n", inFile, err)
 		os.Exit(1)
+	}
+
+	if namespace != "" {
+		versionSymbols, versions, err = applyNamespace(versionSymbols, versions, namespace)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error applying namespace %q: %v\n", namespace, err)
+			os.Exit(1)
+		}
 	}
 
 	if err := writeVersionScript(outFile, versions, versionSymbols); err != nil {
@@ -91,8 +121,40 @@ func main() {
 	for _, syms := range versionSymbols {
 		total += len(syms)
 	}
-	fmt.Fprintf(os.Stderr, "Generated %s (%d symbols across %d version(s))\n",
-		outFile, total, len(versions))
+	namespaceNote := ""
+	if namespace != "" {
+		namespaceNote = fmt.Sprintf(", namespace %s", namespace)
+	}
+	fmt.Fprintf(os.Stderr, "Generated %s (%d symbols across %d version(s)%s)\n",
+		outFile, total, len(versions), namespaceNote)
+}
+
+// applyNamespace rewrites the namespace of every version node, preserving the
+// oldest-first ordering of versions. Its parameters and results mirror
+// readRegistry's, so the two compose directly in main().
+//
+// _awslc_write_namespaced_version_script() in cmake/GenerateVersionScript.cmake
+// implements the same rename textually, so a build can apply a namespace without
+// a Go toolchain (-DDISABLE_GO=ON). The two must produce identical output;
+// tests/ci/run_symbol_version_test.sh asserts that. Keep them in step.
+func applyNamespace(versionSymbols map[string][]symbolInfo, versions []string, namespace string) (map[string][]symbolInfo, []string, error) {
+	renamedVersions := make([]string, 0, len(versions))
+	renamedSymbols := make(map[string][]symbolInfo, len(versionSymbols))
+	for _, version := range versions {
+		m := nodeNamePattern.FindStringSubmatch(version)
+		if m == nil {
+			return nil, nil, fmt.Errorf("version node %q is not of the form <namespace>_<major>.<minor>", version)
+		}
+		renamed := namespace + "_" + m[2]
+		// Distinct nodes must not collapse onto one another; that would silently
+		// drop a node's symbols.
+		if _, exists := renamedSymbols[renamed]; exists {
+			return nil, nil, fmt.Errorf("version node %q collides with another node after renaming to %q", version, renamed)
+		}
+		renamedVersions = append(renamedVersions, renamed)
+		renamedSymbols[renamed] = versionSymbols[version]
+	}
+	return renamedSymbols, renamedVersions, nil
 }
 
 // readRegistry opens a symbol registry file and parses it.

--- a/util/generate_version_script/main_test.go
+++ b/util/generate_version_script/main_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -272,6 +273,152 @@ func TestWriteVersionScriptTo_Empty(t *testing.T) {
 	}
 	if strings.Contains(output, "global:") {
 		t.Error("empty output should not contain version blocks")
+	}
+}
+
+func TestApplyNamespace(t *testing.T) {
+	tests := []struct {
+		name         string
+		versions     []string
+		namespace    string
+		wantVersions []string
+		wantErr      bool
+	}{
+		{
+			name:         "single node",
+			versions:     []string{"AWS_LC_1.0"},
+			namespace:    "MYCORP",
+			wantVersions: []string{"MYCORP_1.0"},
+		},
+		{
+			name:         "multiple nodes keep order",
+			versions:     []string{"AWS_LC_1.0", "AWS_LC_1.1", "AWS_LC_2.0"},
+			namespace:    "MYCORP",
+			wantVersions: []string{"MYCORP_1.0", "MYCORP_1.1", "MYCORP_2.0"},
+		},
+		{
+			// The namespace is everything before the trailing <major>.<minor>, so an
+			// underscore-laden prefix is replaced wholesale rather than in part.
+			name:         "namespace with underscores",
+			versions:     []string{"AWS_LC_1.0"},
+			namespace:    "MY_CORP_LIBCRYPTO",
+			wantVersions: []string{"MY_CORP_LIBCRYPTO_1.0"},
+		},
+		{
+			name:         "renaming to the same namespace is a no-op",
+			versions:     []string{"AWS_LC_1.0"},
+			namespace:    "AWS_LC",
+			wantVersions: []string{"AWS_LC_1.0"},
+		},
+		{
+			name:      "malformed node without numeric version",
+			versions:  []string{"AWS_LC_ONE"},
+			namespace: "MYCORP",
+			wantErr:   true,
+		},
+		{
+			name:      "malformed node without a namespace",
+			versions:  []string{"1.0"},
+			namespace: "MYCORP",
+			wantErr:   true,
+		},
+		{
+			// Two namespaces sharing a numeric version would collapse onto one node
+			// and silently lose one node's symbols.
+			name:      "colliding nodes",
+			versions:  []string{"AWS_LC_1.0", "OTHER_1.0"},
+			namespace: "MYCORP",
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			versionSymbols := make(map[string][]symbolInfo, len(tt.versions))
+			for i, v := range tt.versions {
+				versionSymbols[v] = []symbolInfo{
+					{name: fmt.Sprintf("sym%d", i), visibility: visPublic},
+				}
+			}
+
+			gotSymbols, gotVersions, err := applyNamespace(versionSymbols, tt.versions, tt.namespace)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(gotVersions) != len(tt.wantVersions) {
+				t.Fatalf("versions = %v, want %v", gotVersions, tt.wantVersions)
+			}
+			for i, v := range gotVersions {
+				if v != tt.wantVersions[i] {
+					t.Errorf("version[%d] = %q, want %q", i, v, tt.wantVersions[i])
+				}
+			}
+			// Every renamed node must carry the symbols of the node it came from.
+			for i, want := range tt.wantVersions {
+				syms := gotSymbols[want]
+				if len(syms) != 1 {
+					t.Fatalf("node %q has %d symbols, want 1", want, len(syms))
+				}
+				if expected := fmt.Sprintf("sym%d", i); syms[0].name != expected {
+					t.Errorf("node %q has symbol %q, want %q", want, syms[0].name, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestNamespacePattern(t *testing.T) {
+	valid := []string{"AWS_LC", "MYCORP", "_private", "a", "My_Corp_1"}
+	for _, ns := range valid {
+		if !namespacePattern.MatchString(ns) {
+			t.Errorf("namespace %q should be valid", ns)
+		}
+	}
+	// A namespace has to be a bare linker identifier: anything that would make the
+	// resulting node name unparseable, or let a metacharacter into a version
+	// script, must be rejected.
+	invalid := []string{"", "1CORP", "MY CORP", "MY-CORP", "MY.CORP", "MY_CORP;", "MY_CORP*", "MY\nCORP"}
+	for _, ns := range invalid {
+		if namespacePattern.MatchString(ns) {
+			t.Errorf("namespace %q should be invalid", ns)
+		}
+	}
+}
+
+func TestApplyNamespaceEndToEnd(t *testing.T) {
+	registry := "AES_encrypt AWS_LC_1.0 PUBLIC\nnew_api AWS_LC_1.1 PUBLIC\n"
+	versionSymbols, versions, err := readRegistryFrom(strings.NewReader(registry))
+	if err != nil {
+		t.Fatal(err)
+	}
+	versionSymbols, versions, err = applyNamespace(versionSymbols, versions, "MYCORP")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := writeVersionScriptTo(&buf, versions, versionSymbols); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	if !strings.Contains(output, "MYCORP_1.0 {") {
+		t.Error("missing renamed base node")
+	}
+	if !strings.Contains(output, "MYCORP_1.1 {") {
+		t.Error("missing renamed derived node")
+	}
+	// Inheritance must reference the renamed predecessor, not the original.
+	if !strings.Contains(output, "} MYCORP_1.0;") {
+		t.Error("derived node does not inherit from the renamed base node")
+	}
+	if strings.Contains(output, "AWS_LC_") {
+		t.Error("output still references the original namespace")
 	}
 }
 


### PR DESCRIPTION
### Description of changes:
Symbol versioning was previously enabled only through `ENABLE_DIST_PKG`, which also relocates headers and renames binaries. This change adds an independent `ENABLE_SYMBOL_VERSIONING` setting that defaults to `ENABLE_DIST_PKG`, preserving existing behavior while allowing consumers to adopt versioned ELF symbols without the other distribution packaging changes. Explicit requests are rejected for unsupported static, Apple, and Windows builds, while inherited settings remain disabled without breaking existing static distribution package configurations.

This also adds `SYMBOL_VERSION_NAMESPACE` for private distributions that need version nodes other than `AWS_LC_*`. Custom version scripts are generated in the build tree without modifying the checked-in `.map` files, and the standalone version script generator supports the same namespace override.

Documentation is updated to describe the independent configuration, platform restrictions, and ABI implications of custom namespaces.

### Call-outs:
- `ENABLE_SYMBOL_VERSIONING` intentionally does not use CMake's `option()` because doing so would cache its initial default and prevent an unset value from continuing to track `ENABLE_DIST_PKG` across reconfiguration.
- A custom `SYMBOL_VERSION_NAMESPACE` changes the ABI contract and is only appropriate for privately distributed libraries. It is rejected when symbol versioning is disabled.
- Namespace rewriting exists in both CMake and the Go generator so builds can continue using checked-in version scripts with `DISABLE_GO=ON`. The tests verify that both implementations produce identical output.

### Testing:
- Added Go unit coverage for valid and invalid namespaces, single-node and multi-node rewrites, namespace collisions, inheritance preservation, and end-to-end version script generation.
- Extended `run_symbol_version_test.sh` to verify that symbol versioning can be enabled without distribution packaging, does not enable header or binary cohabitation, writes namespaced scripts only into the build tree, rejects namespaces when versioning is disabled, and keeps the CMake and Go rewrite implementations equivalent.
- Existing integration coverage continues to verify version definitions, versioned exports, linking, and detection of unversioned or silently dropped symbols.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
