### PR TITLE
Enable mtr retries in MariaDB CI integration

### DIFF
--- a/tests/ci/integration/run_mariadb_integration.sh
+++ b/tests/ci/integration/run_mariadb_integration.sh
@@ -64,7 +64,9 @@ main.plugin_load : This test generates a warning in Codebuild. Skip over since t
 main.desc_index_min_max : This test is flaky and unrelated to aws-lc.
 main.socket_conflict : mariadbd refuses to run as root in CI container; not relevant to AWS-LC.
 "> skiplist
-  ./mtr --suite=main --force --parallel=auto --skip-test-list=${MARIADB_BUILD_FOLDER}/mysql-test/skiplist --retry-failure=2
+  # mtr's --retry defaults to 1, meaning no retries at all, so --retry-failure
+  # (which only caps retries) does nothing on its own.
+  ./mtr --suite=main --force --parallel=auto --skip-test-list=${MARIADB_BUILD_FOLDER}/mysql-test/skiplist --retry=2 --retry-failure=2
   popd
 }
 


### PR DESCRIPTION
### Description of changes:

`run_mariadb_integration.sh` passes `--retry-failure=2` but never sets `--retry`, which defaults to `1` ("no retries") in `mariadb-test-run.pl`. The retry branch is therefore unreachable and `--retry-failure`, which only *caps* retries, has nothing to cap -- so the flag we already had was a no-op, and any single flaky test failed the whole job. `--force` doesn't enable retries either. This sets `--retry=2` so a failed test gets one retry, plus a short comment so the pairing doesn't look redundant to a future reader.

### Call-outs:

Retrying beats skipping more tests here because a retried attempt is *guaranteed* a clean server, not merely a likely-clean one: `mtr` dispatches the retry back to the same worker that just failed, and that worker has already run `stop_all_servers()` via `report_failure_and_restart()`, so its next `run_testcase()` hits `clean_datadir()` and reinstalls from scratch. That covers the order-dependent failures this suite produces, where one test leaks server state into a later one on the same worker -- the recent case being `ps_change_master.test` ending in `CHANGE MASTER TO MASTER_HOST=...` rather than `RESET SLAVE ALL`, leaving `mysqld` configured as a replica so a later `main.start_slave_until` never got its expected `ER_BAD_SLAVE`. Whether it trips depends on `--parallel=auto` worker fan-out, which is why aarch64 failed while x86-64 passed in the same run.

`--retry-failure=2` is now unreachable in practice, since the cap is only consulted after a second failure and `--retry=2` never allows one. Keeping it anyway: it's already the documented default and it bounds things explicitly if `--retry` is ever raised.

This doesn't fix the upstream isolation bug, only stops it failing our CI. Reporting that separately.

### Testing:

Existing CI -- the `mariadb-x86_64` and `mariadb-aarch64` jobs exercise this directly, though a green run won't demonstrate the retry itself since the behavior only appears when a test fails. Locally: `bash -n`, plus traced the retry, shutdown, and datadir-cleanup paths in `mariadb-test-run.pl` at `MariaDB/server@main`, the revision this job shallow-clones.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
