### PR TITLE
Define AT_HWCAP* when <sys/auxv.h> hides them

### DIFF
--- a/crypto/fipsmodule/cpucap/cpu_getauxval_linux.h
+++ b/crypto/fipsmodule/cpucap/cpu_getauxval_linux.h
@@ -14,6 +14,8 @@
 // After including this header (on Linux), OPENSSL_HAS_GETAUXVAL is defined
 // and getauxval(type) is callable -- regardless of whether <sys/auxv.h> was
 // available -- so call sites do not need to special-case the libc.
+// AT_NULL, AT_HWCAP, AT_HWCAP2, and AT_EXECFN are also defined when the
+// system header omits them (for example under `-D_XOPEN_SOURCE=700`).
 
 #if defined(OPENSSL_LINUX)
 
@@ -41,7 +43,29 @@
 
 #if defined(OPENSSL_HAS_GETAUXVAL)
 #include <sys/auxv.h>
-#else
+#endif
+
+// Auxiliary vector type constants from the Linux kernel ABI
+// (include/uapi/linux/auxvec.h). The specific values used here are stable.
+//
+// <sys/auxv.h> may exist but still hide AT_HWCAP2 when building with
+// `-D_XOPEN_SOURCE=700` and without `_GNU_SOURCE` (aws-lc-sys Linux
+// builds on manylinux 2.17). glibc also only advertised AT_HWCAP2 starting
+// in 2.18 (see #1682).
+#if !defined(AT_NULL)
+#define AT_NULL 0
+#endif
+#if !defined(AT_HWCAP)
+#define AT_HWCAP 16
+#endif
+#if !defined(AT_HWCAP2)
+#define AT_HWCAP2 26
+#endif
+#if !defined(AT_EXECFN)
+#define AT_EXECFN 31
+#endif
+
+#if !defined(OPENSSL_HAS_GETAUXVAL)
 
 // When <sys/auxv.h> is not available (e.g. older uclibc without getauxval),
 // fall back to reading /proc/self/auxv. The file contains sequential pairs of
@@ -57,21 +81,6 @@
 // (no intervening fork), so close-on-exec is not security-relevant here.
 #if !defined(O_CLOEXEC)
 #define O_CLOEXEC 0
-#endif
-
-// Auxiliary vector type constants from the Linux kernel ABI
-// (include/uapi/linux/auxvec.h). The specific values used here are stable.
-#if !defined(AT_NULL)
-#define AT_NULL 0
-#endif
-#if !defined(AT_HWCAP)
-#define AT_HWCAP 16
-#endif
-#if !defined(AT_HWCAP2)
-#define AT_HWCAP2 26
-#endif
-#if !defined(AT_EXECFN)
-#define AT_EXECFN 31
 #endif
 
 // getauxval returns the value of the auxiliary-vector entry of the given
@@ -138,7 +147,7 @@ done:
 // the fallback above.
 #define OPENSSL_HAS_GETAUXVAL
 
-#endif  // OPENSSL_HAS_GETAUXVAL
+#endif  // !defined(OPENSSL_HAS_GETAUXVAL)
 
 #endif  // OPENSSL_LINUX
 

--- a/crypto/fipsmodule/cpucap/cpu_getauxval_linux.h
+++ b/crypto/fipsmodule/cpucap/cpu_getauxval_linux.h
@@ -15,7 +15,7 @@
 // and getauxval(type) is callable -- regardless of whether <sys/auxv.h> was
 // available -- so call sites do not need to special-case the libc.
 // AT_NULL, AT_HWCAP, AT_HWCAP2, and AT_EXECFN are also defined when the
-// system header omits them (for example under `-D_XOPEN_SOURCE=700`).
+// system header omits them (for example, glibc < 2.18 lacks AT_HWCAP2).
 
 #if defined(OPENSSL_LINUX)
 
@@ -36,7 +36,7 @@
 #define OPENSSL_HAS_GETAUXVAL
 #endif
 #elif !defined(__UCLIBC__)
-// Non-glibc, non-uclibc libc (e.g. musl) — assume getauxval is available.
+// Non-glibc, non-uclibc libc (e.g. musl) -- assume getauxval is available.
 #define OPENSSL_HAS_GETAUXVAL
 #endif
 #endif  // !defined(OPENSSL_HAS_GETAUXVAL) && !defined(OPENSSL_GETAUXVAL_FORCE_PROC_FALLBACK)
@@ -48,10 +48,11 @@
 // Auxiliary vector type constants from the Linux kernel ABI
 // (include/uapi/linux/auxvec.h). The specific values used here are stable.
 //
-// <sys/auxv.h> may exist but still hide AT_HWCAP2 when building with
-// `-D_XOPEN_SOURCE=700` and without `_GNU_SOURCE` (aws-lc-sys Linux
-// builds on manylinux 2.17). glibc also only advertised AT_HWCAP2 starting
-// in 2.18 (see #1682).
+// <sys/auxv.h> may exist but still omit AT_HWCAP2: glibc only added it in
+// 2.18 (see #1682), so sysroots built from vanilla glibc <= 2.17 lack it
+// (observed in aws-lc-sys manylinux 2.17 builds for ppc64le; CentOS 7's
+// glibc 2.17 carries a backport of it, so stock manylinux2014 images are
+// unaffected).
 #if !defined(AT_NULL)
 #define AT_NULL 0
 #endif


### PR DESCRIPTION
### Issues:
Regressed by #3250. Observed downstream when aws-lc-sys 0.44 built AWS-LC on manylinux 2.17 for powerpc64le:
https://github.com/astral-sh/uv/actions/runs/31985144822/job/95258879338

#3250 removed the `#if defined(AT_HWCAP2)` guard from `cpu_ppc64le.c` because the new helper header defines `AT_HWCAP2` on the `/proc/self/auxv` fallback path, and assumed `<sys/auxv.h>` always defines it otherwise.

That assumption is false: glibc only advertised `AT_HWCAP2` starting in 2.18 (#1682), and even later headers can hide it under `-D_XOPEN_SOURCE=700` without `_GNU_SOURCE`. aws-lc-sys Linux builds use exactly those flags, so `cpu_ppc64le.c` fails to compile on manylinux 2.17:

    cpu_ppc64le.c:69:38: error: 'AT_HWCAP2' undeclared

### Description of changes:

Provide the Linux UAPI values (`include/uapi/linux/auxvec.h`) whenever the system header omits them, for both the libc `getauxval` path and the `/proc/self/auxv` fallback.

### Call-outs:
None

### Testing:
* `gcc -std=c99 -D_XOPEN_SOURCE=700` compiles a TU that includes `cpu_getauxval_linux.h` and calls `getauxval(AT_HWCAP2)`.
* Same compile with `-DOPENSSL_GETAUXVAL_FORCE_PROC_FALLBACK`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
