### PR TITLE
ci: use preinstalled Rust in pyopenssl integration

### DIFF
--- a/tests/ci/integration/run_pyopenssl_integration.sh
+++ b/tests/ci/integration/run_pyopenssl_integration.sh
@@ -54,10 +54,7 @@ function pyopenssl_run_tests() {
     # Upgrade pip and install build dependencies.
     python -m pip install --upgrade pip setuptools wheel
 
-    # Install the Rust and the bindgen-cli, needed by cryptography when building
-    # against AWS-LC.
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
-    . "$HOME/.cargo/env"
+    # Install bindgen-cli, needed by cryptography when building against AWS-LC.
     cargo install bindgen-cli
 
     # Build cryptography from source so it links against AWS-LC via OPENSSL_DIR.


### PR DESCRIPTION
### Issues:
None.

### Description of changes:
The Ubuntu CI image now provides Rust and Cargo under the configured `CARGO_HOME`. The pyOpenSSL integration job nevertheless reinstalled Rust and then sourced `$HOME/.cargo/env`, which does not exist when `CARGO_HOME=/.cargo`.

Use the image-provided Cargo toolchain and retain the `bindgen-cli` installation required to build cryptography against AWS-LC.

### Call-outs:
The pyOpenSSL integration job runs on the Ubuntu 22.04 image, which installs and verifies Rust during image construction.

### Testing:
- `bash -n tests/ci/integration/run_pyopenssl_integration.sh`
- `git diff --check`

https://github.com/aws/aws-lc/actions/runs/32286373459/job/96176755526?pr=3430

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.