### PR TITLE
Pin librelp to a release, wrap `SSL_get_shutdown` for failing integration test

### DIFF
--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -210,13 +210,22 @@ jobs:
             credentials: true
             run: ./tests/ci/integration/run_monit_integration.sh
 
-          # librelp Integration Tests
+          # librelp (pinned to a release - required)
           - name: librelp
             arch: x86_64
             size: small
             image: ubuntu:22.04
             compiler: gcc-12
-            run: ./tests/ci/integration/run_librelp_integration.sh
+            allow_failure: false
+            run: ./tests/ci/integration/run_librelp_integration.sh v1.13
+          # librelp (tracking upstream master - informational, allowed to fail)
+          - name: librelp-master
+            arch: x86_64
+            size: small
+            image: ubuntu:22.04
+            compiler: gcc-12
+            allow_failure: true
+            run: ./tests/ci/integration/run_librelp_integration.sh master
 
           # HAProxy Integration Tests
           - name: haproxy

--- a/tests/ci/integration/librelp_patch/aws-lc-librelp.patch
+++ b/tests/ci/integration/librelp_patch/aws-lc-librelp.patch
@@ -66,6 +66,44 @@ index 18cffda..110fcd0 100644
  	BIO_set_callback_ex(conn, BIO_debug_callback_ex);
  #else
  	BIO_set_callback(conn, BIO_debug_callback);
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 45ef7e1..59a534b 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -13,7 +13,7 @@ else
+ check_PROGRAMS+=tls_ossl_retry_state
+ tls_ossl_retry_state_SOURCES=tls-ossl-retry-state.c
+ tls_ossl_retry_state_LDADD=../src/.libs/librelp.a $(GNUTLS_LIBS) $(OPENSSL_LIBS) $(rt_libs) $(socket_libs) $(pthread_libs)
+-tls_ossl_retry_state_LDFLAGS=-Wl,--wrap=SSL_write -Wl,--wrap=SSL_read -Wl,--wrap=SSL_get_error
++tls_ossl_retry_state_LDFLAGS=-Wl,--wrap=SSL_write -Wl,--wrap=SSL_read -Wl,--wrap=SSL_get_error -Wl,--wrap=SSL_get_shutdown
+ tls_ossl_retry_state_CFLAGS=$(AM_CFLAGS) -I${top_srcdir}/src $(WARN_CFLAGS)
+ endif
+ endif
+diff --git a/tests/tls-ossl-retry-state.c b/tests/tls-ossl-retry-state.c
+index ccc04ca..7bb38ef 100644
+--- a/tests/tls-ossl-retry-state.c
++++ b/tests/tls-ossl-retry-state.c
+@@ -31,6 +31,7 @@ static enum operation current_operation;
+ int __wrap_SSL_write(SSL *ssl, const void *buf, int num);
+ int __wrap_SSL_read(SSL *ssl, void *buf, int num);
+ int __wrap_SSL_get_error(const SSL *ssl, int ret);
++int __wrap_SSL_get_shutdown(const SSL *ssl);
+ 
+ int
+ __wrap_SSL_write(SSL *const ssl __attribute__((unused)), const void *const buf __attribute__((unused)), const int num)
+@@ -54,6 +55,12 @@ __wrap_SSL_get_error(const SSL *const ssl __attribute__((unused)), const int ret
+ 	return current_operation == OP_SEND_WANT ? SSL_ERROR_WANT_WRITE : SSL_ERROR_WANT_READ;
+ }
+ 
++int
++__wrap_SSL_get_shutdown(const SSL *const ssl __attribute__((unused)))
++{
++	return 0;
++}
++
+ static void
+ discard_debug(char *const fmt __attribute__((unused)), ...)
+ {
 diff --git a/tests/tls-basic-anon.sh b/tests/tls-basic-anon.sh
 index 32b6682..fa1f327 100755
 --- a/tests/tls-basic-anon.sh

--- a/tests/ci/integration/run_librelp_integration.sh
+++ b/tests/ci/integration/run_librelp_integration.sh
@@ -6,6 +6,9 @@ set -exu
 
 source tests/ci/common_posix_setup.sh
 
+# Optional librelp git ref (tag or branch), defaults to librelp's "master" branch.
+LIBRELP_REF="${1:-}"
+
 # Set up environment.
 
 # SYS_ROOT
@@ -47,7 +50,12 @@ mkdir -p ${SCRATCH_FOLDER}
 rm -rf ${SCRATCH_FOLDER}/*
 cd ${SCRATCH_FOLDER}
 
-git clone https://github.com/rsyslog/librelp.git ${LIBRELP_SRC_FOLDER} --depth 1
+# Clone the given ref (e.g. a release tag), or librelp's "master" branch when unset.
+if [[ -n "${LIBRELP_REF}" ]]; then
+  git clone --depth 1 --branch "${LIBRELP_REF}" https://github.com/rsyslog/librelp.git ${LIBRELP_SRC_FOLDER}
+else
+  git clone --depth 1 https://github.com/rsyslog/librelp.git ${LIBRELP_SRC_FOLDER}
+fi
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${LIBRELP_BUILD_FOLDER}
 ls
 


### PR DESCRIPTION
Fixes failing CI job `integration-omnibus / librelp-x86_64`

### Description of changes: 

The librelp integration was previously running on the latest tip of main ("master" branch on librelp), causing integration failures with AWS-LC when a new incompatible test was added upstream. We now add a required release tag to track in our integration tests, and a non-required job to continue tracking integration against the latest tip of main, similiar to https://github.com/aws/aws-lc/pull/3343

librelp also added a [new test](https://github.com/rsyslog/librelp/commit/cfd92093), in their new release, `tls-ossl retry-state`, that wraps `SSL_write`/`SSL_read`/`SSL_get_error` with `ld --wrap`. 

But [`relpTcpSend_ossl`](https://github.com/rsyslog/librelp/blob/v1.13/src/tcp.c#L3420) also calls `SSL_get_shutdown`, which isn't wrapped. That unwrapped call  dereferences `ssl->s3` on the fake `SSL` token and segfaults, failing the `librelp-x86_64` job. This PR extends  `aws-lc-librelp.patch` to also `--wrap=SSL_get_shutdown`.

### Callouts: 
 The test uses a fake SSL object to simulate `WANT_READ` and `WANT_WRITE`, which mean the TLS operation should be retried because the connection is still open. `SSL_get_shutdown` returns 0 because no shutdown flags should be set as returning `SSL_RECEIVED_SHUTDOWN` would make librelp treat the connection as closed and abort instead of testing the retry path.

### Testing:
- `patch -p1 --dry-run -d "$LIBRELP_SRC" < "$SRC_ROOT/tests/ci/integration/librelp_patch/aws-lc-librelp.patch`  
- `git diff --check`
- Ran ` ./tests/ci/integration/run_librelp_integration.sh` on a throwaway instance to verify
- https://github.com/aws/aws-lc/actions/runs/32400252222/job/96526464696?pr=3431

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
