### PR TITLE
[FIPS 4.x BACKPORT] ci: re-enable gcc-14 + FIPS build in gcc-14-hardened job

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -251,40 +251,45 @@ jobs:
 
   gcc-14-hardened:
     if: github.repository_owner == 'aws'
-    needs: [ sanity-test-run ]
+    needs: [sanity-test-run]
+    env:
+      GOFLAGS: "-buildvcs=false"
     strategy:
       fail-fast: false
       matrix:
-        gccversion:
-          - "14"
         fips:
           - "0"
           - "1"
     runs-on: ubuntu-24.04
+    container: gcc:14.4
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
-          go-version: '>=1.18'
+          go-version: ">=1.18"
+      - name: Install build deps
+        # perl is needed for perlasm in the FIPS build; Go comes from setup-go above.
+        run: |
+          apt-get update
+          apt-get install -y cmake ninja-build perl
+          gcc --version
+          cmake --version
+          go version
+          perl --version
       - name: Setup CMake
-        uses: threeal/cmake-action@v1.3.0
+        uses: threeal/cmake-action@v2.1.0
         with:
           generator: Ninja
-          c-compiler: gcc-${{ matrix.gccversion }}
-          cxx-compiler: g++-${{ matrix.gccversion }}
+          c-compiler: gcc
+          cxx-compiler: g++
           options: FIPS=${{ matrix.fips }} CMAKE_BUILD_TYPE=Release
       - name: Build Project
-        # -Wno-error=hardened gives us warning but no errors if options implied by -fhardened are downgraded or disabledAdd commentMore actions
-        # Ubuntu sets FORTIFY_SOURCE automatically which is one of the options implemented by hardened so this warning is
-        # generated on every compiler call.
-        # TODO: Re-enable gcc-14/FIPS build once delocator updated
-        if: ${{ !( matrix.gccversion == '14' && matrix.fips == '1' ) }}
+        # Keep -Whardened config noise (e.g. jitterentropy's -O0 compiles disabling
+        # _FORTIFY_SOURCE) from becoming fatal under the project's blanket -Werror.
         run: |
-            cmake -DCMAKE_C_FLAGS='-O2 -fhardened -Wno-error=hardened' -S. -Bbuild
-            cmake --build ./build --target all
+          cmake -DCMAKE_C_FLAGS='-O2 -fhardened -Wno-error=hardened' -S. -Bbuild
+          cmake --build ./build --target all
       - name: Run tests
-        # TODO: Re-enable gcc-14/FIPS build once delocator updated
-        if: ${{ !( matrix.gccversion == '14' && matrix.fips == '1' ) }}
         run: cmake --build ./build --target run_tests
 
   pedantic-tests:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1160,6 +1160,18 @@ if(BUILD_TESTING)
     PRIVATE third_party/googletest
   )
 
+  # GCC's object-access warnings periodically produce false positives in
+  # heavily-inlined test code (e.g. x509_test.cc under GCC 14, see #3201).
+  # PUBLIC on boringssl_gtest demotes them for test targets only; library
+  # targets keep -Werror. -Wstringop-overread requires GCC >= 11.
+  if(GCC AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11")
+    target_compile_options(boringssl_gtest PUBLIC
+      -Wno-error=stringop-overflow
+      -Wno-error=stringop-overread
+      -Wno-error=array-bounds
+    )
+  endif()
+
   # Declare a dummy target to build all unit tests. Test targets should inject
   # themselves as dependencies next to the target definition.
   add_custom_target(all_tests)


### PR DESCRIPTION
### Backport of aws/aws-lc#3428

>  ## Summary

> Re-enable the `Build Project` and `Run tests` steps in the `gcc-14-hardened` CI job's `fips=1` matrix variant. These steps have been guarded off since #1622 (2024-06), pending resolution of the delocator issue tracked in #2977. That fix landed 2026-02, but the CI guards were never removed.

> ## Testing

> - [ ] This change may surface latent `-Werror=stringop-overflow` false-positives under `-fhardened` (which implies `-D_FORTIFY_SOURCE=2`); those would need the same `#pragma GCC diagnostic push / ignored / pop` pattern used in #3201.
> - [ ] If CI passes: guard removal is complete and this can be marked ready for review.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
