### PR TITLE
Fix ML-DSA externalMu JSON tags

### DIFF
--- a/util/fipstools/acvp/acvptool/subprocess/ml_dsa.go
+++ b/util/fipstools/acvp/acvptool/subprocess/ml_dsa.go
@@ -100,7 +100,7 @@ type mlDsaSigGenTestGroup struct {
 	ParameterSet       string `json:"parameterSet"`
 	Deterministic      bool   `json:"deterministic"`
 	SignatureInterface string `json:"signatureInterface"`
-	ExternalMu         *bool  `json:"externalMu`
+	ExternalMu         *bool  `json:"externalMu"`
 	Tests              []struct {
 		ID      uint64               `json:"tcId"`
 		Message hexEncodedByteString `json:"message"`
@@ -177,7 +177,7 @@ type mlDsaSigVerTestGroup struct {
 	ParameterSet       string `json:"parameterSet"`
 	Deterministic      bool   `json:"deterministic"`
 	SignatureInterface string `json:"signatureInterface"`
-	ExternalMu         *bool  `json:"externalMu`
+	ExternalMu         *bool  `json:"externalMu"`
 	Tests              []struct {
 		ID        uint64               `json:"tcId"`
 		PK        hexEncodedByteString `json:"pk"`

--- a/util/fipstools/acvp/acvptool/subprocess/ml_dsa_test.go
+++ b/util/fipstools/acvp/acvptool/subprocess/ml_dsa_test.go
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+package subprocess
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMlDsaExternalMuJSONTags(t *testing.T) {
+	for _, group := range []any{
+		mlDsaSigGenTestGroup{},
+		mlDsaSigVerTestGroup{},
+	} {
+		field, ok := reflect.TypeOf(group).FieldByName("ExternalMu")
+		if !ok {
+			t.Fatalf("%T has no ExternalMu field", group)
+		}
+		if got, want := field.Tag.Get("json"), "externalMu"; got != want {
+			t.Errorf("%T ExternalMu JSON tag = %q, want %q", group, got, want)
+		}
+	}
+}


### PR DESCRIPTION
### Context and motivation

The ML-DSA sigGen and sigVer test-group structures contain malformed `externalMu` JSON tags. The package still compiles because `encoding/json` can fall back to matching the exported field name, but `go vet` reports both tags as invalid struct-tag syntax.

This change makes the JSON metadata valid and protects the intended field mapping without changing ML-DSA behavior.

### Description of changes

- Correct the `externalMu` JSON tags in the ML-DSA sigGen and sigVer test-group structures.
- Add a focused regression test that checks both structures expose `externalMu` as their JSON field name.

### Testing

- `go test ./util/fipstools/acvp/acvptool/subprocess` with Go 1.20.14 and Go 1.27.0
- `go vet ./util/fipstools/acvp/acvptool/subprocess` with Go 1.20.14 and Go 1.27.0
- `go test -race ./util/fipstools/acvp/acvptool/subprocess`
- `go test ./util/fipstools/acvp/acvptool/...`

The regression test reads the tags through `reflect.StructTag.Get`, which returns an empty JSON name for the malformed tags and therefore fails before this change.

### Review considerations

This change does not affect the public API, ABI, cryptographic primitives, module-wrapper protocol, or FIPS boundary. With the standard `encoding/json` decoder, current ACVP vectors are expected to retain the same runtime behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
