### PR TITLE
Upgrade JDK to JDK21 for ACCP tests

### DIFF
--- a/.github/docker_images/aws-lc/ubuntu/Dockerfile.2204
+++ b/.github/docker_images/aws-lc/ubuntu/Dockerfile.2204
@@ -119,7 +119,7 @@ apt-get -y --no-install-recommends install \
     net-tools \
     netcat-openbsd \
     ninja-build \
-    openjdk-11-jdk \
+    openjdk-21-jdk \
     openssl \
     pandoc \
     patch \


### PR DESCRIPTION
### Related issues

P494396766
https://github.com/corretto/amazon-corretto-crypto-provider/pull/564
https://github.com/aws/aws-lc/actions/runs/32489970260/job/96795064360?pr=3426#step:4:1660

### Context and motivation

ACCP jobs are failing because of a new requirement to build using a JDK that has KEM support.

```
CMake Error at CMakeLists.txt:238 (message):
    Building ACCP requires a JDK that exposes the javax.crypto.KEM API (JDK
    21+, or a KEM-backported JDK 17 such as Corretto 17).  The build JDK's
    javac (/usr/lib/jvm/java-11-openjdk-amd64/bin/javac) could not compile
    against it; set JAVA_HOME to a KEM-capable JDK.
```

### Description of changes

Updates JDK on Ubuntu image from 17 to 21.

### Testing

ACCP CI jobs should pass now.

### Review considerations

This impacts all CI jobs using Java on Ubuntu. I believe ACCP is the only job in this category. I also believe upgrading to JDK21 is generally better than using JDK11.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
