### PR TITLE
Implement narrow distro TLS policy support for Amazon Linux 2023

### DIFF
--- a/.github/workflows/linux-multi-arch-omnibus.yml
+++ b/.github/workflows/linux-multi-arch-omnibus.yml
@@ -400,6 +400,31 @@ jobs:
             source /opt/compiler-env/setup-${{ matrix.compiler }}.sh
             ./tests/ci/run_dist_pkg_${{ matrix.test }}_tests.sh
 
+  security_policy_tests:
+    name: security-policy-tests-${{ matrix.image }}-${{ matrix.compiler }}-${{ matrix.arch }}
+    runs-on:
+      - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
+        image:${{ matrix.arch == 'x86_64' && 'linux-5.0' || matrix.arch == 'aarch64' && 'arm-3.0' }}
+        instance-size:large
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+        compiler: [gcc-11]
+        image: ["amazonlinux:2023"]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - uses: ./.github/actions/codebuild-docker-run
+        name: Run Container (${{ matrix.image }})
+        with:
+          image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/${{ matrix.image }}
+          run: |
+            source /opt/compiler-env/setup-${{ matrix.compiler }}.sh
+            ./tests/ci/run_security_policy_tests.sh
+
   prefix_tests:
     name: prefix-tests-${{ matrix.image }}-${{ matrix.compiler }}-${{ matrix.arch }}
     runs-on:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -109,6 +109,18 @@ Symbol versioning ensures backward compatibility and enables multiple AWS-LC ver
 coexist on the same system. See [docs/SymbolVersioning.md](docs/SymbolVersioning.md) for
 detailed information about symbol versioning, version evolution, and CI integration.
 
+### Distribution TLS Policy Detection
+
+AWS-LC can be built with opt-in support for detecting distro-managed TLS policy
+files on Linux by passing `-DENABLE_DISTRIBUTION_TLS_POLICY=ON` to CMake.
+
+This option is disabled by default. When enabled, libssl will look for Amazon
+Linux 2023 policy files, and Fedora when it uses the same
+`/etc/crypto-policies/back-ends/openssl*.config` backend format, during
+`SSL_CTX_new` for flexible TLS methods only. Missing, malformed, or partially
+unsupported policy content fails open and is reported through the OpenSSL error
+queue.
+
 ### Other Build Options
 
 See [CMake's documentation](https://cmake.org/cmake/help/v3.4/manual/cmake-variables.7.html)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option(DISABLE_CPU_JITTER_ENTROPY "Disable usage of CPU Jitter Entropy as an ent
 option(GENERATE_RUST_BINDINGS "Generate Rust bindings using bindgen-cli" OFF)
 option(ENABLE_DIST_PKG "Enables a set of packaging that take highest precedence to any other packaging configuration i.e. ENABLE_PRE_SONAME_BUILD" OFF)
 option(ENABLE_DIST_PKG_OPENSSL_SHIM "Controls whether the OpenSSL shim components are installed when ENABLE_DIST_PKG is enabled" OFF)
+option(ENABLE_DISTRIBUTION_TLS_POLICY "Enable distro-managed TLS policy autodetection for libssl on supported Linux distributions" OFF)
 
 if(MSVC)
   # On Windows, prefer cl over gcc if both are available. By default most of
@@ -118,6 +119,11 @@ message(STATUS "SET_LIB_SONAME: ${SET_LIB_SONAME}")
 message(STATUS "COHABITANT_HEADERS: ${COHABITANT_HEADERS}")
 message(STATUS "COHABITANT_BINARIES: ${COHABITANT_BINARIES}")
 message(STATUS "INSTALL_OPENSSL_SHIM: ${INSTALL_OPENSSL_SHIM}")
+message(STATUS "ENABLE_DISTRIBUTION_TLS_POLICY: ${ENABLE_DISTRIBUTION_TLS_POLICY}")
+
+if(ENABLE_DISTRIBUTION_TLS_POLICY)
+  add_definitions(-DAWSLC_ENABLE_DISTRIBUTION_TLS_POLICY)
+endif()
 
 if(SET_LIB_SONAME)
   set(CRYPTO_LIB_NAME "${CRYPTO_LIB_NAME}-${SOFTWARE_NAME}")

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
   s3_both.cc
   s3_lib.cc
   s3_pkt.cc
+  security_policy.cc
   ssl_aead_ctx.cc
   ssl_asn1.cc
   ssl_buffer.cc
@@ -44,6 +45,9 @@ add_library(
   tls13_server.cc
 )
 target_compile_definitions(ssl PRIVATE BORINGSSL_IMPLEMENTATION)
+if(BUILD_TESTING)
+  target_compile_definitions(ssl PRIVATE AWS_LC_TEST_ENV)
+endif()
 
 target_link_libraries(ssl crypto)
 
@@ -105,6 +109,7 @@ if(BUILD_TESTING)
     ssl_key_share_test.cc
     ssl_alps_test.cc
     ssl_common_test.cc
+    security_policy_test.cc
     ssl_misc_test.cc
     ssl_version_test.cc
     ssl_ech_test.cc

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -3654,6 +3654,15 @@ void ssl_get_current_time(const SSL *ssl, struct OPENSSL_timeval *out_clock);
 void ssl_ctx_get_current_time(const SSL_CTX *ctx,
                               struct OPENSSL_timeval *out_clock);
 
+// ssl_ctx_apply_distribution_tls_policy applies a supported distro TLS policy
+// to |ctx|. Unsupported or malformed policy content fails open.
+bool ssl_ctx_apply_distribution_tls_policy(SSL_CTX *ctx);
+
+// ssl_set_distribution_tls_policy_test_root overrides the filesystem root used
+// to discover distro TLS policy files in test builds. Passing nullptr clears
+// the override.
+void ssl_set_distribution_tls_policy_test_root(const char *path);
+
 // ssl_reset_error_state resets state for |SSL_get_error|.
 void ssl_reset_error_state(SSL *ssl);
 

--- a/ssl/security_policy.cc
+++ b/ssl/security_policy.cc
@@ -1,0 +1,557 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <openssl/ssl.h>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <algorithm>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+
+#include "internal.h"
+
+BSSL_NAMESPACE_BEGIN
+
+#if !defined(AWSLC_ENABLE_DISTRIBUTION_TLS_POLICY)
+
+bool ssl_ctx_apply_distribution_tls_policy(SSL_CTX *ctx) {
+  (void)ctx;
+  return true;
+}
+
+void ssl_set_distribution_tls_policy_test_root(const char *path) { (void)path; }
+
+#else
+
+namespace {
+
+struct DistributionPolicyCache {
+  bool loaded = false;
+  bool supported_distro = false;
+  bool policy_found = false;
+  bool has_min_version = false;
+  uint16_t min_version = 0;
+  bool has_max_version = false;
+  uint16_t max_version = 0;
+  bool has_cipher_string = false;
+  std::string cipher_string;
+  bool has_ciphersuites = false;
+  std::string ciphersuites;
+  std::string warnings;
+};
+
+struct PendingPolicy {
+  bool has_min_version = false;
+  std::string min_version;
+  bool has_max_version = false;
+  std::string max_version;
+  bool has_cipher_string = false;
+  std::string cipher_string;
+  bool has_ciphersuites = false;
+  std::string ciphersuites;
+};
+
+static struct CRYPTO_STATIC_MUTEX g_distribution_policy_lock =
+    CRYPTO_STATIC_MUTEX_INIT;
+static DistributionPolicyCache g_distribution_policy_cache;
+#if defined(AWS_LC_TEST_ENV)
+static std::string g_distribution_policy_test_root;
+#endif
+
+static std::string TrimASCII(const std::string &input) {
+  size_t start = 0;
+  while (start < input.size() &&
+         isspace(static_cast<unsigned char>(input[start]))) {
+    start++;
+  }
+
+  size_t end = input.size();
+  while (end > start && isspace(static_cast<unsigned char>(input[end - 1]))) {
+    end--;
+  }
+
+  return input.substr(start, end - start);
+}
+
+static std::string ToLowerASCII(const std::string &input) {
+  std::string result = input;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return static_cast<char>(tolower(c)); });
+  return result;
+}
+
+static std::string MaybeUnquote(const std::string &input) {
+  if (input.size() >= 2 && ((input.front() == '"' && input.back() == '"') ||
+                            (input.front() == '\'' && input.back() == '\''))) {
+    return input.substr(1, input.size() - 2);
+  }
+  return input;
+}
+
+static std::string JoinRoot(const std::string &root, const char *path) {
+  if (root.empty()) {
+    return std::string(path);
+  }
+  return root + path;
+}
+
+static void AppendWarning(std::string *warnings, const std::string &warning) {
+  if (!warnings->empty()) {
+    warnings->append("; ");
+  }
+  warnings->append(warning);
+}
+
+static bool ReadFileToString(std::string *out, const std::string &path) {
+  FILE *file = fopen(path.c_str(), "rb");
+  if (file == nullptr) {
+    return false;
+  }
+
+  out->clear();
+  bool ok = true;
+  for (;;) {
+    char buffer[1024];
+    const size_t bytes_read = fread(buffer, 1, sizeof(buffer), file);
+    if (bytes_read > 0) {
+      out->append(buffer, bytes_read);
+    }
+    if (bytes_read < sizeof(buffer)) {
+      if (ferror(file)) {
+        ok = false;
+      }
+      break;
+    }
+  }
+
+  fclose(file);
+  return ok;
+}
+
+static std::map<std::string, std::string> ParseAssignments(
+    const std::string &contents) {
+  std::map<std::string, std::string> values;
+  std::istringstream stream(contents);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+    const size_t comment = line.find('#');
+    if (comment != std::string::npos) {
+      line.resize(comment);
+    }
+    const size_t equals = line.find('=');
+    if (equals == std::string::npos) {
+      continue;
+    }
+
+    const std::string key = TrimASCII(line.substr(0, equals));
+    if (key.empty()) {
+      continue;
+    }
+    const std::string value = TrimASCII(line.substr(equals + 1));
+    values[key] = MaybeUnquote(value);
+  }
+  return values;
+}
+
+static bool ParseProtocolVersionString(uint16_t *out,
+                                       const std::string &value) {
+  if (value == "TLSv1") {
+    *out = TLS1_VERSION;
+    return true;
+  }
+  if (value == "TLSv1.1") {
+    *out = TLS1_1_VERSION;
+    return true;
+  }
+  if (value == "TLSv1.2") {
+    *out = TLS1_2_VERSION;
+    return true;
+  }
+  if (value == "TLSv1.3") {
+    *out = TLS1_3_VERSION;
+    return true;
+  }
+  return false;
+}
+
+static const char *ProtocolVersionString(uint16_t version) {
+  switch (version) {
+    case TLS1_VERSION:
+      return "TLSv1";
+    case TLS1_1_VERSION:
+      return "TLSv1.1";
+    case TLS1_2_VERSION:
+      return "TLSv1.2";
+    case TLS1_3_VERSION:
+      return "TLSv1.3";
+    default:
+      return "unknown";
+  }
+}
+
+static std::vector<std::string> SplitOnColon(const std::string &value) {
+  std::vector<std::string> tokens;
+  size_t start = 0;
+  for (;;) {
+    size_t end = value.find(':', start);
+    std::string token = TrimASCII(value.substr(start, end - start));
+    if (!token.empty()) {
+      tokens.push_back(token);
+    }
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+  return tokens;
+}
+
+static std::string JoinWithColon(const std::vector<std::string> &tokens) {
+  std::string result;
+  for (size_t i = 0; i < tokens.size(); i++) {
+    if (i > 0) {
+      result.push_back(':');
+    }
+    result.append(tokens[i]);
+  }
+  return result;
+}
+
+static bool IsSupportedTLS13Cipher(const std::string &token) {
+  return token == "TLS_AES_128_GCM_SHA256" ||
+         token == "TLS_AES_256_GCM_SHA384" ||
+         token == "TLS_CHACHA20_POLY1305_SHA256";
+}
+
+static std::string SanitizeCipherString(const std::string &value,
+                                        std::string *warnings) {
+  std::vector<std::string> sanitized;
+  for (std::string token : SplitOnColon(value)) {
+    const size_t security_level = token.find("@SECLEVEL=");
+    if (security_level != std::string::npos) {
+      AppendWarning(warnings,
+                    std::string("ignored unsupported CipherString fragment '") +
+                        token + "'");
+      token = TrimASCII(token.substr(0, security_level));
+      if (token.empty()) {
+        continue;
+      }
+    }
+    sanitized.push_back(token);
+  }
+  return JoinWithColon(sanitized);
+}
+
+static std::string SanitizeTLS13Ciphersuites(const std::string &value,
+                                             std::string *warnings) {
+  std::vector<std::string> sanitized;
+  for (const std::string &token : SplitOnColon(value)) {
+    if (IsSupportedTLS13Cipher(token)) {
+      sanitized.push_back(token);
+    } else {
+      AppendWarning(warnings,
+                    std::string("ignored unsupported Ciphersuites entry '") +
+                        token + "'");
+    }
+  }
+  return JoinWithColon(sanitized);
+}
+
+static void ParsePolicyFile(const std::string &contents,
+                            DistributionPolicyCache *out) {
+  PendingPolicy pending;
+  std::istringstream stream(contents);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+
+    const size_t comment = line.find('#');
+    if (comment != std::string::npos) {
+      line.resize(comment);
+    }
+    line = TrimASCII(line);
+    if (line.empty()) {
+      continue;
+    }
+    if (line.front() == '[' && line.back() == ']') {
+      continue;
+    }
+
+    const size_t equals = line.find('=');
+    if (equals == std::string::npos) {
+      AppendWarning(
+          &out->warnings,
+          std::string("ignored malformed policy line '") + line + "'");
+      continue;
+    }
+
+    const std::string key = TrimASCII(line.substr(0, equals));
+    const std::string value = TrimASCII(line.substr(equals + 1));
+    if (key.empty()) {
+      AppendWarning(
+          &out->warnings,
+          std::string("ignored malformed policy line '") + line + "'");
+      continue;
+    }
+
+    if (key == "MinProtocol" || key == "TLS.MinProtocol") {
+      pending.has_min_version = true;
+      pending.min_version = value;
+      continue;
+    }
+    if (key == "MaxProtocol" || key == "TLS.MaxProtocol") {
+      pending.has_max_version = true;
+      pending.max_version = value;
+      continue;
+    }
+    if (key == "CipherString") {
+      pending.has_cipher_string = true;
+      pending.cipher_string = value;
+      continue;
+    }
+    if (key == "Ciphersuites") {
+      pending.has_ciphersuites = true;
+      pending.ciphersuites = value;
+      continue;
+    }
+
+    AppendWarning(
+        &out->warnings,
+        std::string("ignored unsupported policy directive '") + key + "'");
+  }
+
+  if (pending.has_min_version) {
+    if (!pending.min_version.empty() &&
+        ParseProtocolVersionString(&out->min_version, pending.min_version)) {
+      out->has_min_version = true;
+    } else {
+      AppendWarning(&out->warnings,
+                    std::string("ignored invalid MinProtocol value '") +
+                        pending.min_version + "'");
+    }
+  }
+
+  if (pending.has_max_version) {
+    if (!pending.max_version.empty() &&
+        ParseProtocolVersionString(&out->max_version, pending.max_version)) {
+      out->has_max_version = true;
+    } else {
+      AppendWarning(&out->warnings,
+                    std::string("ignored invalid MaxProtocol value '") +
+                        pending.max_version + "'");
+    }
+  }
+
+  if (pending.has_cipher_string) {
+    if (pending.cipher_string.empty()) {
+      AppendWarning(&out->warnings, "ignored empty CipherString directive");
+    } else {
+      out->cipher_string =
+          SanitizeCipherString(pending.cipher_string, &out->warnings);
+      out->has_cipher_string = !out->cipher_string.empty();
+    }
+  }
+
+  if (pending.has_ciphersuites) {
+    if (pending.ciphersuites.empty()) {
+      AppendWarning(&out->warnings, "ignored empty Ciphersuites directive");
+    } else {
+      out->ciphersuites =
+          SanitizeTLS13Ciphersuites(pending.ciphersuites, &out->warnings);
+      out->has_ciphersuites = !out->ciphersuites.empty();
+    }
+  }
+}
+
+static bool IsAmazonLinux2023(const std::string &root) {
+  std::string cpe;
+  if (ReadFileToString(&cpe, JoinRoot(root, "/etc/amazon-linux-release-cpe"))) {
+    const std::string lowered = ToLowerASCII(cpe);
+    if (lowered.find("amazon") != std::string::npos &&
+        lowered.find("2023") != std::string::npos) {
+      return true;
+    }
+  }
+
+  std::string os_release;
+  if (!ReadFileToString(&os_release, JoinRoot(root, "/etc/os-release"))) {
+    return false;
+  }
+  const std::map<std::string, std::string> values =
+      ParseAssignments(os_release);
+  const auto id_iter = values.find("ID");
+  const auto version_iter = values.find("VERSION_ID");
+  if (id_iter == values.end() || version_iter == values.end()) {
+    return false;
+  }
+  return ToLowerASCII(id_iter->second) == "amzn" &&
+         version_iter->second == "2023";
+}
+
+static bool IsFedora(const std::string &root) {
+  std::string os_release;
+  if (!ReadFileToString(&os_release, JoinRoot(root, "/etc/os-release"))) {
+    return false;
+  }
+  const std::map<std::string, std::string> values =
+      ParseAssignments(os_release);
+  const auto id_iter = values.find("ID");
+  return id_iter != values.end() && ToLowerASCII(id_iter->second) == "fedora";
+}
+
+static bool LoadPolicyFile(std::string *contents, const std::string &root) {
+  static const char *kCandidates[] = {
+      "/etc/crypto-policies/back-ends/opensslcnf.config",
+      "/etc/crypto-policies/back-ends/openssl.config",
+  };
+
+  for (const char *candidate : kCandidates) {
+    if (ReadFileToString(contents, JoinRoot(root, candidate))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static const char *DefaultTLS13Ciphersuites(const SSL_CTX *ctx) {
+  const bool has_aes_hw = ctx->aes_hw_override ? ctx->aes_hw_override_value
+                                               : EVP_has_aes_hardware();
+  return has_aes_hw ? TLS13_DEFAULT_CIPHER_LIST_AES_HW
+                    : TLS13_DEFAULT_CIPHER_LIST_NO_AES_HW;
+}
+
+static std::string CurrentPolicyRootLocked() {
+#if defined(AWS_LC_TEST_ENV)
+  return g_distribution_policy_test_root;
+#else
+  return std::string();
+#endif
+}
+
+static DistributionPolicyCache LoadDistributionPolicyLocked() {
+  DistributionPolicyCache cache;
+  cache.loaded = true;
+
+  const std::string root = CurrentPolicyRootLocked();
+#if defined(AWS_LC_TEST_ENV)
+  if (root.empty()) {
+    return cache;
+  }
+#endif
+
+  if (IsAmazonLinux2023(root) || IsFedora(root)) {
+    cache.supported_distro = true;
+  } else {
+    return cache;
+  }
+
+  std::string contents;
+  if (!LoadPolicyFile(&contents, root)) {
+    return cache;
+  }
+
+  cache.policy_found = true;
+  ParsePolicyFile(contents, &cache);
+  return cache;
+}
+
+static DistributionPolicyCache GetDistributionPolicy() {
+  CRYPTO_STATIC_MUTEX_lock_write(&g_distribution_policy_lock);
+  if (!g_distribution_policy_cache.loaded) {
+    g_distribution_policy_cache = LoadDistributionPolicyLocked();
+  }
+  DistributionPolicyCache cache = g_distribution_policy_cache;
+  CRYPTO_STATIC_MUTEX_unlock_write(&g_distribution_policy_lock);
+  return cache;
+}
+
+static void ReportPolicyWarning(const std::string &warnings) {
+  if (warnings.empty()) {
+    return;
+  }
+  OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
+  ERR_add_error_data(2, "distribution TLS policy: ", warnings.c_str());
+}
+
+}  // namespace
+
+bool ssl_ctx_apply_distribution_tls_policy(SSL_CTX *ctx) {
+  DistributionPolicyCache cache = GetDistributionPolicy();
+  if (!cache.supported_distro || !cache.policy_found) {
+    return true;
+  }
+
+  std::string warnings = cache.warnings;
+  if (cache.has_min_version && cache.has_max_version &&
+      cache.min_version > cache.max_version) {
+    AppendWarning(&warnings,
+                  std::string("ignored conflicting protocol bounds '") +
+                      ProtocolVersionString(cache.min_version) + "' and '" +
+                      ProtocolVersionString(cache.max_version) + "'");
+  } else {
+    if (cache.has_min_version &&
+        !SSL_CTX_set_min_proto_version(ctx, cache.min_version)) {
+      ERR_clear_error();
+      (void)SSL_CTX_set_min_proto_version(ctx, 0);
+      AppendWarning(&warnings, std::string("failed to apply MinProtocol '") +
+                                   ProtocolVersionString(cache.min_version) +
+                                   "'");
+    }
+
+    if (cache.has_max_version &&
+        !SSL_CTX_set_max_proto_version(ctx, cache.max_version)) {
+      ERR_clear_error();
+      (void)SSL_CTX_set_max_proto_version(ctx, 0);
+      AppendWarning(&warnings, std::string("failed to apply MaxProtocol '") +
+                                   ProtocolVersionString(cache.max_version) +
+                                   "'");
+    }
+  }
+
+  if (cache.has_cipher_string &&
+      !SSL_CTX_set_strict_cipher_list(ctx, cache.cipher_string.c_str())) {
+    ERR_clear_error();
+    (void)SSL_CTX_set_strict_cipher_list(ctx, SSL_DEFAULT_CIPHER_LIST);
+    AppendWarning(&warnings, std::string("failed to apply CipherString '") +
+                                 cache.cipher_string + "'");
+  }
+
+  if (cache.has_ciphersuites &&
+      !SSL_CTX_set_ciphersuites(ctx, cache.ciphersuites.c_str())) {
+    ERR_clear_error();
+    (void)SSL_CTX_set_ciphersuites(ctx, DefaultTLS13Ciphersuites(ctx));
+    AppendWarning(&warnings, std::string("failed to apply Ciphersuites '") +
+                                 cache.ciphersuites + "'");
+  }
+
+  ReportPolicyWarning(warnings);
+  return true;
+}
+
+void ssl_set_distribution_tls_policy_test_root(const char *path) {
+#if defined(AWS_LC_TEST_ENV)
+  CRYPTO_STATIC_MUTEX_lock_write(&g_distribution_policy_lock);
+  g_distribution_policy_test_root = path == nullptr ? "" : path;
+  g_distribution_policy_cache = DistributionPolicyCache();
+  CRYPTO_STATIC_MUTEX_unlock_write(&g_distribution_policy_lock);
+#else
+  (void)path;
+#endif
+}
+
+#endif  // AWSLC_ENABLE_DISTRIBUTION_TLS_POLICY
+
+BSSL_NAMESPACE_END

--- a/ssl/security_policy_test.cc
+++ b/ssl/security_policy_test.cc
@@ -1,0 +1,230 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <openssl/ssl.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <openssl/err.h>
+
+#include "../crypto/test/test_util.h"
+#include "internal.h"
+
+#if defined(OPENSSL_WINDOWS)
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#endif
+
+BSSL_NAMESPACE_BEGIN
+
+#if defined(AWSLC_ENABLE_DISTRIBUTION_TLS_POLICY)
+
+namespace {
+
+static std::vector<std::string> CipherNames(
+    const STACK_OF(SSL_CIPHER) *ciphers) {
+  std::vector<std::string> names;
+  for (size_t i = 0; i < sk_SSL_CIPHER_num(ciphers); i++) {
+    names.push_back(SSL_CIPHER_get_name(sk_SSL_CIPHER_value(ciphers, i)));
+  }
+  return names;
+}
+
+static bool CreateDirectory(const std::string &path) {
+#if defined(OPENSSL_WINDOWS)
+  return _mkdir(path.c_str()) == 0 || errno == EEXIST;
+#else
+  return mkdir(path.c_str(), 0700) == 0 || errno == EEXIST;
+#endif
+}
+
+static bool EnsureParentDirectories(const std::string &path) {
+  size_t search_start = 0;
+  while (true) {
+    const size_t slash = path.find('/', search_start);
+    if (slash == std::string::npos) {
+      return true;
+    }
+    if (slash > 0 && !CreateDirectory(path.substr(0, slash))) {
+      return false;
+    }
+    search_start = slash + 1;
+  }
+}
+
+static std::string ReadSingleWarning() {
+  const char *file = nullptr;
+  const char *data = nullptr;
+  int line = 0;
+  int flags = 0;
+  const uint32_t err = ERR_get_error_line_data(&file, &line, &data, &flags);
+  EXPECT_NE(0u, err);
+  EXPECT_EQ(ERR_LIB_SSL, ERR_GET_LIB(err));
+  EXPECT_EQ(ERR_R_INTERNAL_ERROR, ERR_GET_REASON(err));
+  EXPECT_EQ(0u, ERR_peek_error());
+  if ((flags & ERR_TXT_STRING) == 0 || data == nullptr) {
+    return std::string();
+  }
+  return data;
+}
+
+class SSLSystemPolicyTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_NE(static_cast<size_t>(0), createTempDirPath(root_buffer_));
+    root_ = root_buffer_;
+    ERR_clear_error();
+  }
+
+  void TearDown() override {
+    ssl_set_distribution_tls_policy_test_root(nullptr);
+    ERR_clear_error();
+  }
+
+  std::string RootPath(const std::string &suffix) const {
+    return root_ + suffix;
+  }
+
+  void WriteFile(const std::string &suffix, const std::string &contents) {
+    const std::string path = RootPath(suffix);
+    ASSERT_TRUE(EnsureParentDirectories(path));
+    FILE *file = fopen(path.c_str(), "wb");
+    ASSERT_NE(nullptr, file);
+    ASSERT_EQ(contents.size(),
+              fwrite(contents.data(), 1, contents.size(), file));
+    ASSERT_EQ(0, fclose(file));
+  }
+
+  void WriteAmazonLinux2023ReleaseFiles() {
+    WriteFile("/etc/os-release", "ID=amzn\nVERSION_ID=2023\n");
+  }
+
+  void WriteFedoraReleaseFile() {
+    WriteFile("/etc/os-release", "ID=fedora\nVERSION_ID=40\n");
+  }
+
+  void WritePolicy(const std::string &contents,
+                   const std::string &name = "opensslcnf.config") {
+    WriteFile("/etc/crypto-policies/back-ends/" + name, contents);
+  }
+
+  void UseTestRoot() {
+    ssl_set_distribution_tls_policy_test_root(root_.c_str());
+    ERR_clear_error();
+  }
+
+  char root_buffer_[PATH_MAX];
+  std::string root_;
+};
+
+TEST_F(SSLSystemPolicyTest, AppliesAmazonLinux2023Policy) {
+  WriteAmazonLinux2023ReleaseFiles();
+  WritePolicy(
+      "MinProtocol = TLSv1.2\n"
+      "MaxProtocol = TLSv1.3\n"
+      "CipherString = ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256\n"
+      "Ciphersuites = TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256\n");
+  UseTestRoot();
+
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+  EXPECT_EQ(TLS1_2_VERSION, SSL_CTX_get_min_proto_version(ctx.get()));
+  EXPECT_EQ(TLS1_3_VERSION, SSL_CTX_get_max_proto_version(ctx.get()));
+
+  EXPECT_EQ((std::vector<std::string>{
+                "TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256",
+                "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-RSA-AES128-GCM-SHA256"}),
+            CipherNames(ctx->cipher_list->ciphers.get()));
+  EXPECT_EQ((std::vector<std::string>{"TLS_AES_256_GCM_SHA384",
+                                      "TLS_AES_128_GCM_SHA256"}),
+            CipherNames(ctx->tls13_cipher_list->ciphers.get()));
+  EXPECT_EQ(0u, ERR_peek_error());
+}
+
+TEST_F(SSLSystemPolicyTest, AcceptsFedoraBackendFormat) {
+  WriteFedoraReleaseFile();
+  WritePolicy("TLS.MinProtocol = TLSv1.2\n", "openssl.config");
+  UseTestRoot();
+
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+  EXPECT_EQ(TLS1_2_VERSION, SSL_CTX_get_min_proto_version(ctx.get()));
+  EXPECT_EQ(0u, ERR_peek_error());
+}
+
+TEST_F(SSLSystemPolicyTest, InvalidCipherStringPreservesDefaultsAndWarns) {
+  ssl_set_distribution_tls_policy_test_root(nullptr);
+  bssl::UniquePtr<SSL_CTX> defaults(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(defaults);
+  const std::vector<std::string> default_ciphers =
+      CipherNames(defaults->cipher_list->ciphers.get());
+  ERR_clear_error();
+
+  WriteAmazonLinux2023ReleaseFiles();
+  WritePolicy("CipherString = this-is-not-a-valid-cipher\n");
+  UseTestRoot();
+
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+  EXPECT_EQ(default_ciphers, CipherNames(ctx->cipher_list->ciphers.get()));
+
+  const std::string warning = ReadSingleWarning();
+  EXPECT_NE(std::string::npos, warning.find("CipherString"));
+}
+
+TEST_F(SSLSystemPolicyTest,
+       UnsupportedDirectiveWarnsButAppliesSupportedSettings) {
+  WriteAmazonLinux2023ReleaseFiles();
+  WritePolicy("MinProtocol = TLSv1.2\nGroups = X25519:P-256\n");
+  UseTestRoot();
+
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+  EXPECT_EQ(TLS1_2_VERSION, SSL_CTX_get_min_proto_version(ctx.get()));
+
+  const std::string warning = ReadSingleWarning();
+  EXPECT_NE(std::string::npos, warning.find("Groups"));
+}
+
+TEST_F(SSLSystemPolicyTest, MissingPolicyFilesPreserveDefaults) {
+  WriteAmazonLinux2023ReleaseFiles();
+  UseTestRoot();
+
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx);
+  EXPECT_EQ(0, SSL_CTX_get_min_proto_version(ctx.get()));
+  EXPECT_EQ(0, SSL_CTX_get_max_proto_version(ctx.get()));
+  EXPECT_EQ(0u, ERR_peek_error());
+}
+
+TEST_F(SSLSystemPolicyTest, TestBuildDoesNotReadHostPolicyWithoutOverride) {
+  WriteAmazonLinux2023ReleaseFiles();
+  WritePolicy("MinProtocol = TLSv1.2\n");
+  UseTestRoot();
+
+  bssl::UniquePtr<SSL_CTX> ctx_with_override(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx_with_override);
+  EXPECT_EQ(TLS1_2_VERSION,
+            SSL_CTX_get_min_proto_version(ctx_with_override.get()));
+  EXPECT_EQ(0u, ERR_peek_error());
+
+  ssl_set_distribution_tls_policy_test_root(nullptr);
+  bssl::UniquePtr<SSL_CTX> ctx_without_override(SSL_CTX_new(TLS_method()));
+  ASSERT_TRUE(ctx_without_override);
+  EXPECT_EQ(0, SSL_CTX_get_min_proto_version(ctx_without_override.get()));
+  EXPECT_EQ(0u, ERR_peek_error());
+}
+
+}  // namespace
+
+#endif  // AWSLC_ENABLE_DISTRIBUTION_TLS_POLICY
+
+BSSL_NAMESPACE_END

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -504,6 +504,9 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *method) {
   // defer to the protocol method's default min/max values in that case.
   ret->conf_max_version_use_default = true;
   ret->conf_min_version_use_default = true;
+  if (method->version == 0 && !ret->method->is_dtls) {
+    (void)ssl_ctx_apply_distribution_tls_policy(ret.get());
+  }
   ret->enable_read_ahead = false;
 
   return ret.release();

--- a/tests/ci/run_security_policy_tests.sh
+++ b/tests/ci/run_security_policy_tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -exo pipefail
+
+source tests/ci/common_posix_setup.sh
+
+echo "Testing distro TLS policy support in libssl."
+run_build -DENABLE_DISTRIBUTION_TLS_POLICY=ON -DCMAKE_BUILD_TYPE=Release
+
+"${BUILD_ROOT}/ssl/ssl_test" --gtest_filter=SSLSystemPolicyTest.*


### PR DESCRIPTION
## Summary

This change uses the narrow approach for distro TLS policy support.

- add a default-off `ENABLE_DISTRIBUTION_TLS_POLICY` build flag for opt-in distro policy handling
- apply distro-managed TLS policy in libssl only, directly from `SSL_CTX_new`, for Amazon Linux 2023 and Fedora-compatible crypto-policies backends
- fail open on missing, malformed, or partially unsupported policy content and report warnings through the OpenSSL error queue only
- add focused unit coverage plus AL23 CI jobs for `x86_64` and `aarch64`

## Testing

- `cmake -GNinja -B build-security-policy -DENABLE_DISTRIBUTION_TLS_POLICY=ON -DCMAKE_BUILD_TYPE=Release .`
- `cmake --build build-security-policy --target ssl_test -j 4`
- `./build-security-policy/ssl/ssl_test --gtest_filter=SSLSystemPolicyTest.*`
