### PR TITLE
Fix Android Device Farm OIDC sessions

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -6,12 +6,16 @@ description: 'A helper for configure AWS credentials for AWS-LC GitHub actions'
 inputs:
   roleName:
     description: "The target IAM role to assume using the OIDC role credentials"
-    required: true
+    required: false
     default: 'AwsLcGitHubActionStandardRole'
   oidcRole:
-    description: "The OIDC entry role to assume from the GitHub token before chaining to the target role"
+    description: "The IAM role to assume directly with the GitHub OIDC token"
     required: false
     default: 'AwsLcGitHubActionsOidcRole'
+  roleDurationSeconds:
+    description: "Duration of the target role session in seconds"
+    required: false
+    default: '3600'
 runs:
   using: 'composite'
   steps:
@@ -25,9 +29,12 @@ runs:
       with:
         role-to-assume: arn:aws:iam::${{ steps.env.outputs.aws_account_id }}:role/${{ inputs.oidcRole }}
         role-session-name: ${{ github.run_id }}-${{ github.run_attempt }}
+        role-duration-seconds: ${{ inputs.roleDurationSeconds }}
     - name: Retrieve GitHub Actions Role Credentials
+      if: ${{ inputs.roleName != '' }}
       uses: aws-actions/configure-aws-credentials@v5
       with:
         role-to-assume: arn:aws:iam::${{ steps.env.outputs.aws_account_id }}:role/${{ inputs.roleName }}
         role-session-name: ${{ github.run_id }}-${{ github.run_attempt }}
+        role-duration-seconds: ${{ inputs.roleDurationSeconds }}
         role-chaining: true

--- a/.github/workflows/android-omnibus.yml
+++ b/.github/workflows/android-omnibus.yml
@@ -1,9 +1,10 @@
 name: android-omnibus
 on:
   push:
-    branches: ["*"]
+    branches:
+      - main
+      - "fips-*"
   pull_request_target:
-    branches: ["*"]
 concurrency:
   group: >
     ${{ github.workflow }}-
@@ -64,7 +65,9 @@ jobs:
       - name: Retrieve Credentials
         uses: ./.github/actions/configure-aws-credentials
         with:
-          roleName: AwsLcGitHubActionDeviceFarmRole
+          roleName: ''
+          oidcRole: AwsLcGitHubActionDeviceFarmRole
+          roleDurationSeconds: 14400
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2

--- a/tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py
+++ b/tests/ci/cdk/cdk/aws_lc_github_oidc_stack.py
@@ -38,35 +38,36 @@ class AwsLcGitHubOidcStack(Stack):
                                                      "sts.amazonaws.com"],
                                                  url="https://token.actions.githubusercontent.com")
 
+        github_repo_name = (
+            STAGING_GITHUB_REPO_NAME
+            if (env.account == PRE_PROD_ACCOUNT)
+            else GITHUB_REPO_NAME
+        )
+        github_actions_oidc_conditions = {
+            "StringEquals": {
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+            },
+            "StringLike": {
+                # Check the subject claim is from our repository VERY IMPORTANT!
+                # See https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims
+                "token.actions.githubusercontent.com:sub":
+                    "repo:{}/{}:*".format(GITHUB_REPO_OWNER, github_repo_name)
+            },
+            "StringNotLike": {
+                "token.actions.githubusercontent.com:job_workflow_ref":
+                    "{}/{}/.github/workflows/autofix_integration_failures.yml@*".format(
+                        GITHUB_REPO_OWNER, github_repo_name
+                    )
+            },
+        }
+
         oidc_role_name = "AwsLcGitHubActionsOidcRole"
         # This role should only be granted necessary permissions to assume other roles
         self.minimal_oidc_role = iam.Role(self, id=oidc_role_name, role_name=oidc_role_name,
-                                          assumed_by=iam.WebIdentityPrincipal(self.oidc_provider.attr_arn, {
-                                              "StringEquals": {
-                                                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-                                              },
-                                              "StringLike": {
-                                                  # Check the subject claim is from our repository VERY IMPORTANT!
-                                                  # See https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims
-                                                  "token.actions.githubusercontent.com:sub": "repo:{}/{}:*".format(
-                                                      GITHUB_REPO_OWNER, (
-                                                          STAGING_GITHUB_REPO_NAME
-                                                          if (env.account == PRE_PROD_ACCOUNT)
-                                                          else GITHUB_REPO_NAME
-                                                      )
-                                                  )
-                                              },
-                                              "StringNotLike": {
-                                                  "token.actions.githubusercontent.com:job_workflow_ref":
-                                                      "{}/{}/.github/workflows/autofix_integration_failures.yml@*".format(
-                                                          GITHUB_REPO_OWNER, (
-                                                              STAGING_GITHUB_REPO_NAME
-                                                              if (env.account == PRE_PROD_ACCOUNT)
-                                                              else GITHUB_REPO_NAME
-                                                          )
-                                                      )
-                                              },
-                                          }))
+                                          assumed_by=iam.WebIdentityPrincipal(
+                                              self.oidc_provider.attr_arn,
+                                              github_actions_oidc_conditions,
+                                          ))
 
         autofix_oidc_role_name = "AwsLcGitHubActionsAutofixOidcRole"
         self.autofix_oidc_role = iam.Role(self, id=autofix_oidc_role_name, role_name=autofix_oidc_role_name,
@@ -103,6 +104,17 @@ class AwsLcGitHubOidcStack(Stack):
 
         self.device_farm_role = create_device_farm_role(
             self, "AwsLcGitHubActionDeviceFarmRole", env, self.minimal_oidc_role, ecr_repos, devicefarm=devicefarm)
+        self.device_farm_role.assume_role_policy.add_statements(
+            iam.PolicyStatement(
+                actions=["sts:AssumeRoleWithWebIdentity"],
+                principals=[
+                    iam.WebIdentityPrincipal(
+                        self.oidc_provider.attr_arn,
+                        github_actions_oidc_conditions,
+                    )
+                ],
+            )
+        )
         self.device_farm_role.grant_assume_role(self.minimal_oidc_role)
 
         self.docker_image_build_role = create_docker_image_build_role(


### PR DESCRIPTION
### Context and motivation

Android Device Farm jobs can outlive the one-hour STS role-chaining limit. Their credentials then expire while jobs are queued or running, causing otherwise valid CI runs to fail.

### Description of changes

- Allow the Device Farm role to be assumed directly through GitHub OIDC while preserving its existing chained trust path and repository/workflow restrictions.
- Add configurable role-session duration to the credential action and skip role chaining when `roleName` is empty.
- Configure Android jobs to request a four-hour direct session.
- Run Android PR validation through `pull_request_target` for all target branches, while limiting push runs to `main` and `fips-*`.

### Testing

- Parsed the workflow and composite-action YAML with `yq`.
- Compiled the modified CDK module with `py_compile`.
- Synthesized the full CDK application with the pinned dependencies.
- Inspected the generated production Device Farm role and confirmed both the existing chained trust statement and the new conditioned `sts:AssumeRoleWithWebIdentity` statement.

No AWS deployment was performed from the development session.

### Review considerations

The changes can be merged before the production trust policy lands. Android runs may temporarily fail until the normal CI pipeline deploys the production OIDC stack; those jobs can be rerun afterward. Sessions are static and still fail if queue plus execution time exceeds four hours.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.