### PR TITLE
ci: stop deployment noise for maintainers

### DIFF
--- a/.github/workflows/android-omnibus.yml
+++ b/.github/workflows/android-omnibus.yml
@@ -33,7 +33,7 @@ jobs:
   device-farm:
     name: android-${{ matrix.fips && 'fips-' || '' }}${{ matrix.release && 'release' || 'debug' }}-${{ matrix.shared && 'shared' || 'static' }}
     needs: [authorization-check]
-    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    environment: ${{ needs.authorization-check.outputs.approval-env == 'manual-approval' && 'manual-approval' || '' }}
     runs-on:
       - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
         image:linux-5.0

--- a/.github/workflows/image-build-android.yml
+++ b/.github/workflows/image-build-android.yml
@@ -47,7 +47,7 @@ jobs:
 
   build:
     needs: [authorization-check]
-    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    environment: ${{ needs.authorization-check.outputs.approval-env == 'manual-approval' && 'manual-approval' || '' }}
     runs-on:
       codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
       image:linux-5.0
@@ -99,7 +99,7 @@ jobs:
 
   push:
     if: ${{ github.event_name != 'pull_request_target' }}
-    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    environment: ${{ needs.authorization-check.outputs.approval-env == 'manual-approval' && 'manual-approval' || '' }}
     runs-on:
       codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
       image:linux-5.0

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -48,7 +48,7 @@ jobs:
     if: github.event_name != 'push'
     needs: authorize
     runs-on: ubuntu-latest
-    environment: ${{ needs.authorize.outputs.approval-env }}
+    environment: ${{ needs.authorize.outputs.approval-env == 'manual-approval' && 'manual-approval' || '' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### Context and motivation
PR #2843 added two GitHub Environments to restrict CI: external contributor PRs are tagged with `manual-approval` and need a maintainer to explicitly approve the workflows to run, while maintainer PRs are tagged with `auto-approve` and run CI immediately. 

Because GitHub treats every `auto-approve` CI job as a Deployment, it adds multiple unnecessary "deployed to auto-approve" entries for each commit. However, the  environment has no required reviewers, secrets, or protection rules, verified with: 
```
$ gh api repos/aws/aws-lc/environments/auto-approve --jq '{name, protection_rules, deployment_branch_policy}' && \
$ gh api repos/aws/aws-lc/environments/auto-approve/secrets --jq '{total_count, names: [.secrets[].name]}' && \
$ gh api repos/aws/aws-lc/environments/auto-approve/variables --jq '{total_count, names: [.variables[].name]}'
   
  {"deployment_branch_policy":null,"name":"auto-approve","protection_rules":[]}
  {"names":[],"total_count":0}
  {"names":[],"total_count":0}
```
This adds a lot of noise in each PR as it buries review comments and makes the timeline view extensively long. 

### Description of changes
Update the Android, image-build-Android, and security-review jobs so maintainer PRs no longer attach the `auto-approve` environment, removing the "deployment" entries on each commit. This is safe because `auto-approve` has no extra protection as mentioned above. 

External contributor PRs continue to be tagged with `manual-approval` and still need approval from a maintainer to run workflows.


### Testing

- Created a [dummy PR](https://github.com/prasden/pd-aws-lc/pull/38) on my fork before this change to view the deployment noise
- committed this PR's change on a [dummy branch](https://github.com/prasden/pd-aws-lc/commit/f2aecdaba06249a41e4664a05ff29a402668be51) on my fork
- [opened a PR](https://github.com/prasden/pd-aws-lc/pull/40) onto that dummy branch to ensure there was no noise after the change. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
