### PR TITLE
ci: consolidate android-omnibus deployments on external PRs

### DIFF
--- a/.github/workflows/android-omnibus.yml
+++ b/.github/workflows/android-omnibus.yml
@@ -30,10 +30,20 @@ jobs:
       - uses: ./.github/actions/check-authorization
         id: authz
 
+  maintainer-approval:
+    needs: authorization-check
+    runs-on: ubuntu-latest
+    # This job exists only to pause the run on the manual-approval gate.
+    # It waits until a maintainer approves, so its token sits idle in the runner during that window.
+    # Empty permissions strip that token to zero scopes, so the waiting job can never touch AWS or the repo.
+    permissions: {}
+    environment: ${{ needs.authorization-check.outputs.approval-env == 'manual-approval' && 'manual-approval' || '' }}
+    steps:
+      - run: "true"
+
   device-farm:
     name: android-${{ matrix.fips && 'fips-' || '' }}${{ matrix.release && 'release' || 'debug' }}-${{ matrix.shared && 'shared' || 'static' }}
-    needs: [authorization-check]
-    environment: ${{ needs.authorization-check.outputs.approval-env == 'manual-approval' && 'manual-approval' || '' }}
+    needs: [authorization-check, maintainer-approval]
     runs-on:
       - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
         image:linux-5.0
@@ -51,7 +61,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
           # Safe: this job's fork checkout is gated behind the
-          # authorization-check deployment-environment approval (AWS-542), so
+          # maintainer-approval deployment-environment approval (AWS-542), so
           # fork code is only checked out after a maintainer approves the run.
           # That approval gate is exactly the human-in-the-loop mitigation that
           # actions/checkout@v7's new pull_request_target default requires; this


### PR DESCRIPTION
### Context and motivation

- Addendum to https://github.com/aws/aws-lc/pull/3445

- Looking at https://github.com/aws/aws-lc/pull/3429 from an external contributor, there still remains "deployment" noise as `android-omnibus` runs its `device-farm` job as a 6-way build matrix, and each matrix job references an `environment` directly. 
- [GitHub creates a deployment object](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments#how-environments-relate-to-deployments) per  job that references an `environment`, so those six jobs produce six deployment objects that show up on the PR timeline UI. This gets noisy on PRs from external contributors. 

### Description of changes

- This PR moves the `environment` reference outside of the matrix and into a new `maintainer-approval` job. The `environment` is declared once and used across jobs.

- On external contributor PRs, this will cut down the deployments on PRs from 7 to 2 per commit:
     - previously 6 for android + 1 for security review -> now 1 for `android-omnibus` + 1 for `security-review`
- External contributors will still need approval for any workflows to run on their PRs , and `device-farm` is gated behind the new `maintainer-approval` check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
