### PR TITLE
Fix EVP signing-context control collision

### DIFF
--- a/crypto/evp_extra/evp_extra_test.cc
+++ b/crypto/evp_extra/evp_extra_test.cc
@@ -1829,6 +1829,53 @@ TEST(EVPExtraTest, ECKeygen) {
   }
 }
 
+TEST(EVPExtraTest, ECSignatureContextRejected) {
+  // |EVP_PKEY_CTRL_SIGNING_CONTEXT| previously collided with
+  // |EVP_PKEY_CTRL_PEER_KEY|, so EC treated a signature-context set as a
+  // successful no-op. It must fail: ECDSA does not take a context string.
+  bssl::UniquePtr<EVP_PKEY> pkey(
+      ParsePrivateKey(EVP_PKEY_EC, kExampleECKeyDER, sizeof(kExampleECKeyDER)));
+  ASSERT_TRUE(pkey);
+
+  bssl::UniquePtr<EVP_PKEY_CTX> ctx(EVP_PKEY_CTX_new(pkey.get(), nullptr));
+  ASSERT_TRUE(ctx);
+  ASSERT_TRUE(EVP_PKEY_sign_init(ctx.get()));
+
+  static const uint8_t kContext[] = {1, 2, 3, 4};
+  ERR_clear_error();
+  EXPECT_FALSE(EVP_PKEY_CTX_set1_signature_context_string(
+      ctx.get(), kContext, sizeof(kContext)));
+  EXPECT_TRUE(ErrorEquals(ERR_get_error(), ERR_LIB_EVP,
+                          EVP_R_COMMAND_NOT_SUPPORTED));
+
+  const uint8_t *out_ctx = nullptr;
+  size_t out_len = 0;
+  ERR_clear_error();
+  EXPECT_FALSE(
+      EVP_PKEY_CTX_get0_signature_context(ctx.get(), &out_ctx, &out_len));
+  EXPECT_TRUE(ErrorEquals(ERR_get_error(), ERR_LIB_EVP,
+                          EVP_R_COMMAND_NOT_SUPPORTED));
+
+  // |EVP_PKEY_CTRL_PEER_KEY| must still work for ECDH after the renumbering.
+  bssl::UniquePtr<EVP_PKEY_CTX> peer_ctx(
+      EVP_PKEY_CTX_new_id(EVP_PKEY_EC, nullptr));
+  ASSERT_TRUE(peer_ctx);
+  ASSERT_TRUE(EVP_PKEY_keygen_init(peer_ctx.get()));
+  ASSERT_TRUE(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(peer_ctx.get(),
+                                                     NID_X9_62_prime256v1));
+  EVP_PKEY *raw = nullptr;
+  ASSERT_TRUE(EVP_PKEY_keygen(peer_ctx.get(), &raw));
+  bssl::UniquePtr<EVP_PKEY> peer(raw);
+
+  ctx.reset(EVP_PKEY_CTX_new(pkey.get(), nullptr));
+  ASSERT_TRUE(ctx);
+  ASSERT_TRUE(EVP_PKEY_derive_init(ctx.get()));
+  ASSERT_TRUE(EVP_PKEY_derive_set_peer(ctx.get(), peer.get()));
+  size_t secret_len = 0;
+  ASSERT_TRUE(EVP_PKEY_derive(ctx.get(), nullptr, &secret_len));
+  EXPECT_GT(secret_len, 0u);
+}
+
 TEST(EVPExtraTest, DHKeygen) {
   // Set up some DH params in an |EVP_PKEY|. There is currently no API to do
   // this from EVP directly.

--- a/crypto/fipsmodule/evp/internal.h
+++ b/crypto/fipsmodule/evp/internal.h
@@ -155,8 +155,6 @@ int EVP_RSA_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *
 
 #define EVP_PKEY_CTRL_MD 1
 #define EVP_PKEY_CTRL_GET_MD 2
-#define EVP_PKEY_CTRL_SIGNING_CONTEXT 3
-#define EVP_PKEY_CTRL_GET_SIGNING_CONTEXT 4
 
 // EVP_PKEY_CTRL_PEER_KEY is called with different values of |p1|:
 //   0: Is called from |EVP_PKEY_derive_set_peer| and |p2| contains a peer key.
@@ -198,6 +196,12 @@ int EVP_RSA_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *
 #define EVP_PKEY_CTRL_DSA_PARAMGEN_BITS (EVP_PKEY_ALG_CTRL + 23)
 #define EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS (EVP_PKEY_ALG_CTRL + 24)
 #define EVP_PKEY_CTRL_DSA_PARAMGEN_MD (EVP_PKEY_ALG_CTRL + 25)
+
+// These must not reuse |EVP_PKEY_CTRL_PEER_KEY|. EC (and other derive
+// algorithms) treat that command as a successful no-op, so a colliding
+// signing-context command would be silently ignored on ECDSA.
+#define EVP_PKEY_CTRL_SIGNING_CONTEXT (EVP_PKEY_ALG_CTRL + 26)
+#define EVP_PKEY_CTRL_GET_SIGNING_CONTEXT (EVP_PKEY_ALG_CTRL + 27)
 
 // EVP_PKEY_CTX_KEYGEN_INFO_COUNT is the maximum array length for
 // |EVP_PKEY_CTX->keygen_info|. The array length corresponds to the number of


### PR DESCRIPTION
### Context and motivation

`EVP_PKEY_CTRL_SIGNING_CONTEXT` had the same command value as `EVP_PKEY_CTRL_PEER_KEY`. EC handles the peer-key command as a successful no-op, so setting a signature context on an ECDSA `EVP_PKEY_CTX` incorrectly returned success even though ECDSA does not support context strings.

### Description of changes

- Move the signing-context set and get commands to unused values in the `EVP_PKEY_ALG_CTRL` range.
- Add regression coverage confirming that ECDSA rejects signature-context operations with `EVP_R_COMMAND_NOT_SUPPORTED`.
- Confirm that ECDH peer-key setup continues to work.

### Testing

- Added `EVPExtraTest.ECSignatureContextRejected`, which fails against the previous behavior because the signature-context setter incorrectly returns success.
- Ran the focused ECDSA, Ed25519ph, and ML-DSA context tests: 6 passed.
- Ran the full `crypto_test` suite: 2952 passed and 2 skipped.

### Review considerations

The control identifiers are internal and are not part of the public API or ABI. Callers and algorithm handlers use the same definitions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
