### PR TITLE
Fix BIO socket error handling

### DIFF
--- a/crypto/bio/bio_socket_test.cc
+++ b/crypto/bio/bio_socket_test.cc
@@ -516,6 +516,19 @@ TEST(BIOTest, SocketNonBlockingConnectFailure) {
   EXPECT_EQ(ERR_LIB_BIO, ERR_GET_LIB(error));
   EXPECT_EQ(BIO_R_NBIO_CONNECT_ERROR, ERR_GET_REASON(error));
   EXPECT_EQ(0u, ERR_get_error());
+
+  // Reading SO_ERROR above cleared it, so a further attempt must keep failing
+  // rather than read the now-clear error as a completed connection.
+  EXPECT_EQ(0, BIO_do_connect(bio.get()));
+  EXPECT_FALSE(BIO_should_retry(bio.get()));
+  error = ERR_get_error();
+  EXPECT_EQ(ERR_LIB_BIO, ERR_GET_LIB(error));
+  EXPECT_EQ(BIO_R_NBIO_CONNECT_ERROR, ERR_GET_REASON(error));
+  EXPECT_EQ(0u, ERR_get_error());
+
+  // Writing to a BIO whose connection never completed must fail too.
+  EXPECT_GE(0, BIO_write(bio.get(), "test", 4));
+  EXPECT_FALSE(BIO_should_retry(bio.get()));
 }
 
 TEST(BIOTest, SocketNonBlocking) {

--- a/crypto/bio/bio_socket_test.cc
+++ b/crypto/bio/bio_socket_test.cc
@@ -383,49 +383,40 @@ static bool SocketSetNonBlocking(Socket sock) {
 #endif
 }
 
-enum class WaitType { kRead, kWrite };
+enum class WaitType { kRead, kWrite, kConnect };
 
 static bool WaitForSocket(Socket sock, WaitType wait_type) {
-  // Use an arbitrary 5-second timeout, so the test doesn't hang indefinitely if
-  // there's an issue.
-  static constexpr int kTimeoutSeconds = 5;
+  // Arbitrary timeouts, so the test cannot hang. |kConnect| waits on a full
+  // connection attempt, which Windows can take a couple of seconds to refuse.
+  const int timeout_seconds = wait_type == WaitType::kConnect ? 30 : 5;
+  // A failed connection attempt can surface as an error, not writability.
+  const bool watch_errors = wait_type == WaitType::kConnect;
 #if defined(OPENSSL_WINDOWS)
-  fd_set read_set, write_set;
+  fd_set read_set, write_set, error_set;
   FD_ZERO(&read_set);
   FD_ZERO(&write_set);
+  FD_ZERO(&error_set);
   fd_set *wait_set = wait_type == WaitType::kRead ? &read_set : &write_set;
   FD_SET(sock, wait_set);
-  timeval timeout = {kTimeoutSeconds, 0};
-  if (select(0 /* unused on Windows */, &read_set, &write_set, nullptr,
-             &timeout) <= 0) {
+  if (watch_errors) {
+    FD_SET(sock, &error_set);
+  }
+  timeval timeout = {timeout_seconds, 0};
+  if (select(0 /* unused on Windows */, &read_set, &write_set,
+             watch_errors ? &error_set : nullptr, &timeout) <= 0) {
     return false;
   }
-  return FD_ISSET(sock, wait_set);
+  return FD_ISSET(sock, wait_set) ||
+         (watch_errors && FD_ISSET(sock, &error_set));
 #else
   const short events = wait_type == WaitType::kRead ? POLLIN : POLLOUT;
   pollfd fd = {.fd = sock, .events = events, .revents = 0};
-  return poll(&fd, 1, kTimeoutSeconds * 1000) == 1 && (fd.revents & events);
-#endif
-}
-
-static bool WaitForConnect(Socket sock) {
-  static constexpr int kTimeoutSeconds = 5;
-#if defined(OPENSSL_WINDOWS)
-  fd_set write_set, error_set;
-  FD_ZERO(&write_set);
-  FD_ZERO(&error_set);
-  FD_SET(sock, &write_set);
-  FD_SET(sock, &error_set);
-  timeval timeout = {kTimeoutSeconds, 0};
-  if (select(0 /* unused on Windows */, nullptr, &write_set, &error_set,
-             &timeout) <= 0) {
+  if (poll(&fd, 1, timeout_seconds * 1000) != 1) {
     return false;
   }
-  return FD_ISSET(sock, &write_set) || FD_ISSET(sock, &error_set);
-#else
-  pollfd fd = {.fd = sock, .events = POLLOUT, .revents = 0};
-  return poll(&fd, 1, kTimeoutSeconds * 1000) == 1 &&
-         (fd.revents & (POLLOUT | POLLERR | POLLHUP));
+  // POLLERR and POLLHUP are reported regardless of |events|.
+  const int accepted = watch_errors ? (events | POLLERR | POLLHUP) : events;
+  return (fd.revents & accepted) != 0;
 #endif
 }
 
@@ -500,7 +491,7 @@ TEST(BIOTest, SocketNonBlockingConnectFailure) {
 
   const int fd = BIO_get_fd(bio.get(), nullptr);
   ASSERT_NE(-1, fd);
-  ASSERT_TRUE(WaitForConnect(fd)) << LastSocketError();
+  ASSERT_TRUE(WaitForSocket(fd, WaitType::kConnect)) << LastSocketError();
 
   // A successful readiness call need not clear the retryable socket error left
   // by connect. Ensure the connect BIO uses SO_ERROR, not this stale value.
@@ -516,6 +507,8 @@ TEST(BIOTest, SocketNonBlockingConnectFailure) {
 
   uint32_t error = ERR_get_error();
   EXPECT_EQ(ERR_LIB_SYS, ERR_GET_LIB(error));
+  // |ERR_GET_REASON| truncates to 12 bits, so Winsock codes (10000 and up)
+  // cannot round-trip. Only assert the reason where it is representable.
 #if !defined(OPENSSL_WINDOWS)
   EXPECT_EQ(ECONNREFUSED, ERR_GET_REASON(error));
 #endif

--- a/crypto/bio/bio_socket_test.cc
+++ b/crypto/bio/bio_socket_test.cc
@@ -43,6 +43,7 @@ using Socket = int;
 #define INVALID_SOCKET (-1)
 static int closesocket(const int sock) { return close(sock); }
 static std::string LastSocketError() { return strerror(errno); }
+static void SetLastSocketError(int error) { errno = error; }
 #else
 using Socket = SOCKET;
 static std::string LastSocketError() {
@@ -50,6 +51,7 @@ static std::string LastSocketError() {
   snprintf(buf, sizeof(buf), "%d", WSAGetLastError());
   return buf;
 }
+static void SetLastSocketError(int error) { WSASetLastError(error); }
 #endif
 
 struct SockaddrStorage {
@@ -406,6 +408,27 @@ static bool WaitForSocket(Socket sock, WaitType wait_type) {
 #endif
 }
 
+static bool WaitForConnect(Socket sock) {
+  static constexpr int kTimeoutSeconds = 5;
+#if defined(OPENSSL_WINDOWS)
+  fd_set write_set, error_set;
+  FD_ZERO(&write_set);
+  FD_ZERO(&error_set);
+  FD_SET(sock, &write_set);
+  FD_SET(sock, &error_set);
+  timeval timeout = {kTimeoutSeconds, 0};
+  if (select(0 /* unused on Windows */, nullptr, &write_set, &error_set,
+             &timeout) <= 0) {
+    return false;
+  }
+  return FD_ISSET(sock, &write_set) || FD_ISSET(sock, &error_set);
+#else
+  pollfd fd = {.fd = sock, .events = POLLOUT, .revents = 0};
+  return poll(&fd, 1, kTimeoutSeconds * 1000) == 1 &&
+         (fd.revents & (POLLOUT | POLLERR | POLLHUP));
+#endif
+}
+
 TEST(BIOTest, SocketConnect) {
   static constexpr char kTestMessage[] = "test";
   const OwnedSocket listening_sock = ListenLoopback(SOCK_STREAM);
@@ -445,6 +468,61 @@ TEST(BIOTest, SocketConnect) {
             recv(sock.get(), buf, sizeof(buf), 0))
       << LastSocketError();
   ASSERT_EQ(Bytes(kTestMessage, sizeof(kTestMessage)), Bytes(buf, sizeof(buf)));
+}
+
+TEST(BIOTest, SocketNonBlockingConnectFailure) {
+  sockaddr_in sin;
+  OPENSSL_cleanse(&sin, sizeof(sin));
+  sin.sin_family = AF_INET;
+  ASSERT_EQ(1, inet_pton(AF_INET, "127.0.0.1", &sin.sin_addr));
+
+  // Find an unused loopback port for the connection attempt.
+  OwnedSocket bound_sock(Bind(AF_INET, SOCK_STREAM,
+                              reinterpret_cast<const sockaddr *>(&sin),
+                              sizeof(sin)));
+  ASSERT_TRUE(bound_sock.is_valid()) << LastSocketError();
+
+  SockaddrStorage addr;
+  ASSERT_EQ(0, getsockname(bound_sock.get(), addr.addr_mut(), &addr.len))
+      << LastSocketError();
+
+  char hostname[80];
+  snprintf(hostname, sizeof(hostname), "127.0.0.1:%d",
+           ntohs(addr.ToIPv4().sin_port));
+  bound_sock.reset();
+
+  const bssl::UniquePtr<BIO> bio(BIO_new_connect(hostname));
+  ASSERT_TRUE(bio);
+  ASSERT_TRUE(BIO_set_nbio(bio.get(), 1));
+
+  ASSERT_EQ(-1, BIO_do_connect(bio.get()));
+  ASSERT_TRUE(BIO_should_retry(bio.get()));
+
+  const int fd = BIO_get_fd(bio.get(), nullptr);
+  ASSERT_NE(-1, fd);
+  ASSERT_TRUE(WaitForConnect(fd)) << LastSocketError();
+
+  // A successful readiness call need not clear the retryable socket error left
+  // by connect. Ensure the connect BIO uses SO_ERROR, not this stale value.
+#if defined(OPENSSL_WINDOWS)
+  SetLastSocketError(WSAEWOULDBLOCK);
+#else
+  SetLastSocketError(EINPROGRESS);
+#endif
+  ERR_clear_error();
+
+  EXPECT_EQ(0, BIO_do_connect(bio.get()));
+  EXPECT_FALSE(BIO_should_retry(bio.get()));
+
+  uint32_t error = ERR_get_error();
+  EXPECT_EQ(ERR_LIB_SYS, ERR_GET_LIB(error));
+#if !defined(OPENSSL_WINDOWS)
+  EXPECT_EQ(ECONNREFUSED, ERR_GET_REASON(error));
+#endif
+  error = ERR_get_error();
+  EXPECT_EQ(ERR_LIB_BIO, ERR_GET_LIB(error));
+  EXPECT_EQ(BIO_R_NBIO_CONNECT_ERROR, ERR_GET_REASON(error));
+  EXPECT_EQ(0u, ERR_get_error());
 }
 
 TEST(BIOTest, SocketNonBlocking) {

--- a/crypto/bio/connect.c
+++ b/crypto/bio/connect.c
@@ -198,7 +198,17 @@ static int conn_state(BIO *bio, BIO_CONNECT *c) {
 
       case BIO_CONN_S_BLOCKED_CONNECT:
         i = bio_sock_error_get_and_clear(bio->num);
+        if (i < 0) {
+          BIO_clear_retry_flags(bio);
+          OPENSSL_PUT_SYSTEM_ERROR();
+          OPENSSL_PUT_ERROR(BIO, BIO_R_NBIO_CONNECT_ERROR);
+          ERR_add_error_data(4, "host=", c->param_hostname, ":",
+                             c->param_port);
+          ret = 0;
+          goto exit_loop;
+        }
         if (i) {
+          bio_socket_set_error(i);
           if (bio_socket_should_retry(ret)) {
             BIO_set_flags(bio, (BIO_FLAGS_IO_SPECIAL | BIO_FLAGS_SHOULD_RETRY));
             c->state = BIO_CONN_S_BLOCKED_CONNECT;

--- a/crypto/bio/connect.c
+++ b/crypto/bio/connect.c
@@ -202,14 +202,15 @@ static int conn_state(BIO *bio, BIO_CONNECT *c) {
           BIO_clear_retry_flags(bio);
           OPENSSL_PUT_SYSTEM_ERROR();
           OPENSSL_PUT_ERROR(BIO, BIO_R_NBIO_CONNECT_ERROR);
-          ERR_add_error_data(4, "host=", c->param_hostname, ":",
-                             c->param_port);
+          ERR_add_error_data(4, "host=", c->param_hostname, ":", c->param_port);
           ret = 0;
           goto exit_loop;
         }
         if (i) {
+          // |bio_socket_should_retry| classifies the thread's last socket
+          // error, not its argument, so publish |i| first.
           bio_socket_set_error(i);
-          if (bio_socket_should_retry(ret)) {
+          if (bio_socket_should_retry(-1)) {
             BIO_set_flags(bio, (BIO_FLAGS_IO_SPECIAL | BIO_FLAGS_SHOULD_RETRY));
             c->state = BIO_CONN_S_BLOCKED_CONNECT;
             bio->retry_reason = BIO_RR_CONNECT;

--- a/crypto/bio/connect.c
+++ b/crypto/bio/connect.c
@@ -32,6 +32,9 @@ enum {
   BIO_CONN_S_BEFORE,
   BIO_CONN_S_BLOCKED_CONNECT,
   BIO_CONN_S_OK,
+  // BIO_CONN_S_ERROR is terminal: the connect attempt failed and its socket
+  // error was already consumed. Keep last; |bio_info_cb| sees these values.
+  BIO_CONN_S_ERROR,
 };
 
 typedef struct bio_connect_st {
@@ -203,6 +206,7 @@ static int conn_state(BIO *bio, BIO_CONNECT *c) {
           OPENSSL_PUT_SYSTEM_ERROR();
           OPENSSL_PUT_ERROR(BIO, BIO_R_NBIO_CONNECT_ERROR);
           ERR_add_error_data(4, "host=", c->param_hostname, ":", c->param_port);
+          c->state = BIO_CONN_S_ERROR;
           ret = 0;
           goto exit_loop;
         }
@@ -220,6 +224,7 @@ static int conn_state(BIO *bio, BIO_CONNECT *c) {
             OPENSSL_PUT_SYSTEM_ERROR();
             OPENSSL_PUT_ERROR(BIO, BIO_R_NBIO_CONNECT_ERROR);
             ERR_add_error_data(4, "host=", c->param_hostname, ":", c->param_port);
+            c->state = BIO_CONN_S_ERROR;
             ret = 0;
           }
           goto exit_loop;
@@ -227,6 +232,15 @@ static int conn_state(BIO *bio, BIO_CONNECT *c) {
           c->state = BIO_CONN_S_OK;
         }
         break;
+
+      case BIO_CONN_S_ERROR:
+        // |SO_ERROR| was cleared when this failure was first reported, so
+        // re-reading it would look like success. |errno| is stale too.
+        BIO_clear_retry_flags(bio);
+        OPENSSL_PUT_ERROR(BIO, BIO_R_NBIO_CONNECT_ERROR);
+        ERR_add_error_data(4, "host=", c->param_hostname, ":", c->param_port);
+        ret = 0;
+        goto exit_loop;
 
       case BIO_CONN_S_OK:
         ret = 1;

--- a/crypto/bio/internal.h
+++ b/crypto/bio/internal.h
@@ -52,8 +52,12 @@ int bio_socket_nbio(int sock, int on);
 // bio_clear_socket_error clears the last socket error on |sock|.
 void bio_clear_socket_error(int sock);
 
-// bio_sock_error_get_and_clear clears and returns the last socket error on |sock|.
+// bio_sock_error_get_and_clear clears and returns the last socket error on
+// |sock|, or -1 if querying the socket error failed.
 int bio_sock_error_get_and_clear(int sock);
+
+// bio_socket_set_error sets the last socket error for the current thread.
+void bio_socket_set_error(int error);
 
 // bio_socket_should_retry returns non-zero if |return_value| indicates an error
 // and the last socket error indicates that it's non-fatal.

--- a/crypto/bio/socket_helper.c
+++ b/crypto/bio/socket_helper.c
@@ -11,6 +11,7 @@
 
 #if !defined(OPENSSL_NO_SOCK)
 
+#include <errno.h>
 #include <time.h>
 #include <fcntl.h>
 #include <string.h>
@@ -108,9 +109,17 @@ int bio_sock_error_get_and_clear(int sock) {
   socklen_t error_size = sizeof(error);
   // Get and clear the pending socket error. The SO_ERROR option is read-only.
   if (getsockopt(sock, SOL_SOCKET, SO_ERROR, (char *)&error, &error_size) < 0) {
-    return 1;
+    return -1;
   }
   return error;
+}
+
+void bio_socket_set_error(int error) {
+#if defined(OPENSSL_WINDOWS)
+  WSASetLastError(error);
+#else
+  errno = error;
+#endif
 }
 
 int bio_socket_should_retry(int return_value) {

--- a/crypto/bio/socket_helper.c
+++ b/crypto/bio/socket_helper.c
@@ -12,10 +12,10 @@
 #if !defined(OPENSSL_NO_SOCK)
 
 #include <errno.h>
-#include <time.h>
 #include <fcntl.h>
 #include <string.h>
 #include <sys/types.h>
+#include <time.h>
 
 #if !defined(OPENSSL_WINDOWS)
 #include <netdb.h>


### PR DESCRIPTION
### Context and motivation

A non-blocking `BIO_s_connect` could report success after the peer had already refused the connection. `BIO_do_connect` classified the completed attempt using the thread-local socket error left by the original `EINPROGRESS`/`WSAEWOULDBLOCK` `connect()`, so a real `SO_ERROR` failure was treated as "try again." Reading `SO_ERROR` also clears it, so the next `BIO_do_connect` saw a clean socket and transitioned to `BIO_CONN_S_OK`. A caller polling `BIO_do_connect` would observe 0 once and then 1, on a socket that never connected and with an empty error queue.

### Description of changes

Classify the blocked-connect path from the `SO_ERROR` value, not the leftover thread-local error. `getsockopt` failure is now a hard error (`-1`) rather than a fake errno 1.

Add a terminal `BIO_CONN_S_ERROR` state. Once the failure has been reported, further `BIO_do_connect` / read / write calls keep failing until `BIO_reset`. Repeat attempts only push `BIO_R_NBIO_CONNECT_ERROR`: the original `SO_ERROR` was consumed and `errno` no longer describes it.

### Testing

`BIOTest.SocketNonBlockingConnectFailure` drives a non-blocking connect at a just-released loopback port, plants a stale retryable socket error after the attempt completes, and checks the first hard failure, a second `BIO_do_connect` (must not flip to success), and a subsequent write.

Off Windows the test also checks `ECONNREFUSED` as the `SYS` reason. Winsock codes do not survive `ERR_GET_REASON`'s 12-bit pack, so that assert is POSIX-only.

### Review considerations

No public API or ABI change. The new state is internal; `bio_info_cb` may now observe it. Not in the FIPS module boundary.

`WaitForSocket` now has a `kConnect` mode that also watches `POLLERR`/`POLLHUP` (and the Windows exception set) and uses a 30s timeout. Windows can take ~2s to refuse a loopback connect.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
