### PR TITLE
fix: restore alloc-size >= ivlen invariant in legacy AES-GCM SET_IVLEN

### DIFF
--- a/crypto/cipher_extra/cipher_test.cc
+++ b/crypto/cipher_extra/cipher_test.cc
@@ -1424,6 +1424,94 @@ TEST(CipherTest, GCMIncrementingIV) {
   }
 }
 
+// Regression for EVP_CTRL_AEAD_SET_IVLEN not maintaining the invariant
+// alloc-size(gctx->iv) >= gctx->ivlen for the legacy AES-GCM EVP path.
+// Zig-zagging ivlen across EVP_MAX_IV_LENGTH with EVP_CIPHER_CTX_copy
+// interleaved used to leave gctx->iv pointing at an undersized buffer, so a
+// subsequent EncryptInit_ex would OOB-write the IV and later GCM_IV_GEN
+// could satisfy the ivlen >= 8 guard on a 4-byte allocation.
+TEST(CipherTest, GCMRepeatedlyChangeIVLength) {
+  const EVP_CIPHER *kCipher = EVP_aes_128_gcm();
+  static const uint8_t kKey[16] = {0, 1, 2,  3,  4,  5,  6,  7,
+                                   8, 9, 10, 11, 12, 13, 14, 15};
+  static const uint8_t kInput[] = {'h', 'e', 'l', 'l', 'o'};
+
+  const std::vector<std::vector<int>> kLengthSequences = {
+      {64, 128, 256},
+      {12, 13, 14, 15, 16},
+      {256, 128, 64},
+      {12, 11, 10, 9},
+      {256, 128, 64, 32, 16, 8, 4, 8, 16},
+      {256, 128, 64, 32, 16, 8, 4, 8, 16, 32, 64, 128},
+  };
+
+  for (size_t i = 0; i < kLengthSequences.size(); i++) {
+    const std::vector<int> &seq = kLengthSequences[i];
+    SCOPED_TRACE(i);
+    const int final_len = seq.back();
+    std::vector<uint8_t> iv(final_len, 0);
+
+    // Compute the expected ciphertext + tag by setting the final IV length in
+    // one step.
+    uint8_t expected_ct[sizeof(kInput)];
+    uint8_t expected_tag[16];
+    {
+      bssl::UniquePtr<EVP_CIPHER_CTX> ref(EVP_CIPHER_CTX_new());
+      ASSERT_TRUE(ref);
+      ASSERT_TRUE(EVP_EncryptInit_ex(ref.get(), kCipher, /*impl=*/nullptr, kKey,
+                                     /*iv=*/nullptr));
+      ASSERT_TRUE(EVP_CIPHER_CTX_ctrl(ref.get(), EVP_CTRL_AEAD_SET_IVLEN,
+                                      final_len, nullptr));
+      ASSERT_TRUE(EVP_EncryptInit_ex(ref.get(), /*cipher=*/nullptr,
+                                     /*impl=*/nullptr, /*key=*/nullptr,
+                                     iv.data()));
+      int ct_len = 0, extra = 0;
+      ASSERT_TRUE(EVP_EncryptUpdate(ref.get(), expected_ct, &ct_len, kInput,
+                                    sizeof(kInput)));
+      ASSERT_TRUE(EVP_EncryptFinal_ex(ref.get(), nullptr, &extra));
+      ASSERT_EQ(extra, 0);
+      ASSERT_EQ(ct_len, static_cast<int>(sizeof(kInput)));
+      ASSERT_TRUE(EVP_CIPHER_CTX_ctrl(ref.get(), EVP_CTRL_AEAD_GET_TAG,
+                                      sizeof(expected_tag), expected_tag));
+    }
+
+    for (bool copy : {false, true}) {
+      SCOPED_TRACE(copy);
+      bssl::UniquePtr<EVP_CIPHER_CTX> ctx(EVP_CIPHER_CTX_new());
+      ASSERT_TRUE(ctx);
+      ASSERT_TRUE(EVP_EncryptInit_ex(ctx.get(), kCipher, /*impl=*/nullptr, kKey,
+                                     /*iv=*/nullptr));
+      ASSERT_TRUE(MaybeCopyCipherContext(copy, &ctx));
+
+      // Walk the sequence, interleaving copies. The last SET_IVLEN leaves
+      // ivlen == final_len, matching the reference encrypt above.
+      for (int len : seq) {
+        ASSERT_TRUE(EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_IVLEN, len,
+                                        nullptr));
+        ASSERT_TRUE(MaybeCopyCipherContext(copy, &ctx));
+      }
+
+      ASSERT_TRUE(EVP_EncryptInit_ex(ctx.get(), /*cipher=*/nullptr,
+                                     /*impl=*/nullptr, /*key=*/nullptr,
+                                     iv.data()));
+      ASSERT_TRUE(MaybeCopyCipherContext(copy, &ctx));
+      uint8_t ct[sizeof(kInput)];
+      int ct_len = 0, extra = 0;
+      ASSERT_TRUE(EVP_EncryptUpdate(ctx.get(), ct, &ct_len, kInput,
+                                    sizeof(kInput)));
+      ASSERT_TRUE(EVP_EncryptFinal_ex(ctx.get(), nullptr, &extra));
+      ASSERT_EQ(extra, 0);
+      ASSERT_EQ(ct_len, static_cast<int>(sizeof(kInput)));
+      uint8_t tag[16];
+      ASSERT_TRUE(EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_GET_TAG,
+                                      sizeof(tag), tag));
+
+      EXPECT_EQ(Bytes(ct, ct_len), Bytes(expected_ct, sizeof(expected_ct)));
+      EXPECT_EQ(Bytes(tag), Bytes(expected_tag));
+    }
+  }
+}
+
 #define CHECK_ERROR(function, err) \
     ERR_clear_error();                 \
     EXPECT_FALSE(function);                          \

--- a/crypto/fipsmodule/cipher/e_aes.c
+++ b/crypto/fipsmodule/cipher/e_aes.c
@@ -367,15 +367,27 @@ static int aes_gcm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr) {
         return 0;
       }
 
-      // Allocate memory for IV if needed
-      if (arg > EVP_MAX_IV_LENGTH && arg > gctx->ivlen) {
+      // IVs <= EVP_MAX_IV_LENGTH are stored in the built-in buffer, so
+      // downstream callers (e.g. EVP_CTRL_GCM_IV_GEN, EVP_CTRL_COPY) can rely
+      // on buffer-size(gctx->iv) >= gctx->ivlen without a separate capacity
+      // field. Shrinking below EVP_MAX_IV_LENGTH must return the pointer to
+      // c->iv, or a later COPY memdup(gctx->iv, gctx->ivlen) will produce a
+      // heap buffer smaller than a subsequent SET_IVLEN can grow ivlen to.
+      if (arg <= EVP_MAX_IV_LENGTH) {
+        if (gctx->iv != c->iv) {
+          OPENSSL_free(gctx->iv);
+          gctx->iv = c->iv;
+        }
+      } else if (arg > gctx->ivlen) {
+        // Allocate before freeing so OOM leaves the context intact.
+        uint8_t *new_iv = OPENSSL_malloc(arg);
+        if (!new_iv) {
+          return 0;
+        }
         if (gctx->iv != c->iv) {
           OPENSSL_free(gctx->iv);
         }
-        gctx->iv = OPENSSL_malloc(arg);
-        if (!gctx->iv) {
-          return 0;
-        }
+        gctx->iv = new_iv;
       }
       gctx->ivlen = arg;
       return 1;


### PR DESCRIPTION
### Context and motivation

`EVP_CTRL_AEAD_SET_IVLEN` did not maintain the invariant that
`alloc-size(gctx->iv) >= gctx->ivlen`. Its old guard
`arg > EVP_MAX_IV_LENGTH && arg > gctx->ivlen` skipped reallocation
when shrinking (leaving `gctx->iv` pointing at a stale heap buffer
while callers assumed the built-in `c->iv` was in use) and, after an
intervening `EVP_CIPHER_CTX_copy`, allowed a subsequent grow within
the "no reallocation" range to raise `gctx->ivlen` above the actual
buffer size. This bypasses the `ivlen >= 8` guard on
`EVP_CTRL_GCM_IV_GEN` and lets its 8-byte counter store land
out-of-bounds.

Concrete bypass sequence, all through public EVP APIs:

- `SET_IVLEN(large)` allocates a heap buffer
- `SET_IVLEN(4)` leaves `gctx->iv` pointing at that heap buffer
  but sets `ivlen = 4`
- `EVP_CIPHER_CTX_copy` triggers `EVP_CTRL_COPY`, which does
  `memdup(gctx->iv, gctx->ivlen)` = a 4-byte heap allocation on
  the destination
- `SET_IVLEN(8)` on the destination fails the old guard
  (`8 > 16 && 8 > 4` → false), so no reallocation, and now
  `ivlen = 8` sits on a 4-byte buffer
- `EVP_CTRL_GCM_IV_GEN` passes its `ivlen < 8` check, then writes
  8 bytes at `iv + ivlen - 8 = iv + 0`, four of which are OOB

### Description of changes

Ports BoringSSL commit
[`04aa32f9`](https://github.com/google/boringssl/commit/04aa32f96f3094994a2971d703f7489b75b94f84).
`EVP_CTRL_AEAD_SET_IVLEN` is rewritten into two explicit branches:

- `arg <= EVP_MAX_IV_LENGTH` — if `gctx->iv` currently points at a
  heap buffer, free it and reset `gctx->iv = c->iv`. This makes the
  small-IV state always live in the built-in buffer.
- `arg > gctx->ivlen` — allocate the new buffer first, then free the
  old one, so an OOM leaves the context intact.
- Otherwise (existing heap buffer is already large enough) — reuse
  in place.

With the invariant restored, the existing `EVP_CTRL_COPY` handler's
`memdup(gctx->iv, gctx->ivlen)` reads a validly-sized buffer in every
reachable state, so no separate change to the copy handler is needed.

### Testing

Adds `TEST(CipherTest, GCMRepeatedlyChangeIVLength)`, mirroring the
shape of upstream's regression test. Six length sequences (monotonic
grow and shrink in both the heap and the built-in-buffer regime, plus
two zig-zag sequences crossing `EVP_MAX_IV_LENGTH`) run in both
no-copy and copy-interleaved variants, comparing the resulting
ciphertext and tag against a straight-line reference encryption.

**The regression manifests as an OOB heap access, not as a ciphertext
mismatch.** `aes_gcm_init_key` computes GCM state from the caller's
`iv` pointer, not from `gctx->iv`, so the specific `EncryptUpdate` /
`GET_TAG` path this test drives produces the correct ciphertext even
when `gctx->iv` is undersized — the OOB `memcpy` into `gctx->iv`
smashes adjacent heap silently. This test therefore only fails
pre-fix under an AddressSanitizer build. Please pay particular
attention to the Linux ASan CI job; that is the signal that
distinguishes fixed from broken.

### Review considerations

- **FIPS boundary.** `crypto/fipsmodule/cipher/e_aes.c` is inside the
  FIPS module. This change is internal buffer-management bookkeeping
  only. No public API, no ABI change, no algorithm behavior change
  visible outside the module, no new entry points. The bypass path
  was reachable before this change; it is not any more.
- **Prior work.** A related fix rejecting `ivlen < 8` in
  `EVP_CTRL_GCM_IV_GEN` shipped earlier (tracked in an internal SIM).
  That guard is only sound against the bypass this PR closes;
  together the two commits close the underflow class end-to-end.
- No CHANGES file to update in this repo. `clang-format` was not run
  locally; CI will flag drift if any.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.