### PR TITLE
Print FIPS module name in cli tooling

### DIFF
--- a/crypto/fipsmodule/FIPS.md
+++ b/crypto/fipsmodule/FIPS.md
@@ -28,6 +28,17 @@ OPENSSL_EXPORT uint32_t FIPS_version(void);
 
 It returns 0 when AWS-LC is not built in FIPS mode. The FIPS version number is independent of the AWS-LC version number and is incremented each time a new FIPS branch is cut from mainline.
 
+## Module name
+
+The `AWSLC_MODULE_NAME_STRING` macro, defined in `openssl/service_indicator.h`, is the name of the cryptographic module: `AWS-LC FIPS` in FIPS builds and `AWS-LC` otherwise. Together with `FIPS_version`, it identifies the module, for example `AWS-LC FIPS module 5`, which is what `openssl version -fips` prints:
+
+```
+$ openssl version -fips
+OpenSSL 1.1.1 (compatible; AWS-LC 5.7.0)
+FIPS: enabled
+FIPS module: AWS-LC FIPS module 5
+```
+
 ## Platform Limitations
 
 When building AWS-LC in FIPS mode, please be aware of the following platform limitations:

--- a/include/openssl/service_indicator.h
+++ b/include/openssl/service_indicator.h
@@ -37,7 +37,9 @@ enum FIPSStatus {
 
 #if defined(AWSLC_FIPS)
 
-#define AWSLC_MODE_STRING "AWS-LC FIPS "
+// AWSLC_MODULE_NAME_STRING is the name of the cryptographic module, "AWS-LC
+// FIPS" in FIPS builds and "AWS-LC" otherwise.
+#define AWSLC_MODULE_NAME_STRING AWSLC_VERSION_NAME " FIPS"
 
 // CALL_SERVICE_AND_CHECK_APPROVED performs an approval check and runs the service.
 // The |approved| value passed in will change to |AWSLC_APPROVED| and
@@ -64,7 +66,7 @@ enum FIPSStatus {
 
 #else
 
-#define AWSLC_MODE_STRING "AWS-LC "
+#define AWSLC_MODULE_NAME_STRING AWSLC_VERSION_NAME
 
 // CALL_SERVICE_AND_CHECK_APPROVED always returns |AWSLC_APPROVED| when AWS-LC
 // is not built in FIPS mode for easier consumer compatibility that have both
@@ -77,6 +79,8 @@ enum FIPSStatus {
  while(0)                                                           \
 
 #endif // AWSLC_FIPS
+
+#define AWSLC_MODE_STRING AWSLC_MODULE_NAME_STRING " "
 
 #define AWSLC_VERSION_STRING AWSLC_MODE_STRING AWSLC_VERSION_NUMBER_STRING
 

--- a/tool-openssl/version.cc
+++ b/tool-openssl/version.cc
@@ -8,13 +8,15 @@
 
 #include <openssl/base.h>
 #include <openssl/crypto.h>
+#include <openssl/service_indicator.h>
 #include "internal.h"
 
 static const argument_t kArguments[] = {
     {"-help", kBooleanArgument, "Display option summary"},
     {"-a", kBooleanArgument, "Print all version information"},
     {"-p", kBooleanArgument, "Print platform"},
-    {"-fips", kBooleanArgument, "Print FIPS status and module version"},
+    {"-fips", kBooleanArgument,
+     "Print FIPS status and module name and version"},
     {"", kOptionalArgument, ""}
 };
 
@@ -62,7 +64,8 @@ bool VersionTool(const args_list_t &args) {
   if (fips) {
     if (FIPS_mode()) {
       printf("FIPS: enabled\n");
-      printf("FIPS module version: %" PRIu32 "\n", FIPS_version());
+      printf("FIPS module: %s module %" PRIu32 "\n", AWSLC_MODULE_NAME_STRING,
+             FIPS_version());
     } else {
       printf("FIPS: disabled\n");
     }


### PR DESCRIPTION
### Context and motivation
`openssl version -fips` prints FIPS status and the module version number, but nothing identifying which module it refers to. The FIPS lab reviewing our Security Policy needs the CLI to report the proposed FIPS module identifier, "AWS-LC FIPS module 5".

  ### Description of changes
  Splits the module name out of the existing version string into `AWSLC_MODULE_NAME_STRING` and prints it from `version -fips`, which now reports `FIPS module: AWS-LC FIPS module 5`.

  ### Testing
No new tests: `ServiceIndicatorTest.AWSLCVersionString` already pins `awslc_version_string()` exactly in both modes, so any drift in the recomposed macro fails it. Verified the CLI output and that test by building and running both a `-DFIPS=1` and a default build.

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.