### PR TITLE
[FIPS 2026-06] Add FIPS_module_name to report the cryptographic module name

### DIFF
--- a/crypto/fipsmodule/FIPS.md
+++ b/crypto/fipsmodule/FIPS.md
@@ -26,7 +26,13 @@ It returns 0 when AWS-LC is not built in FIPS mode. The FIPS version number is i
 
 ## Module name
 
-The `AWSLC_MODULE_NAME_STRING` macro, defined in `openssl/service_indicator.h`, is the name of the cryptographic module: `AWS-LC FIPS` in FIPS builds and `AWS-LC` otherwise. Together with `FIPS_version`, it identifies the module, for example `AWS-LC FIPS module 5`, which is what `openssl version -fips` prints:
+The `FIPS_module_name` API, declared in `openssl/crypto.h`, returns the name of the cryptographic module:
+
+```c
+OPENSSL_EXPORT const char *FIPS_module_name(void);
+```
+
+It returns `AWS-LC FIPS` in FIPS builds and `AWS-LC` otherwise. Together with `FIPS_version`, it identifies the module, for example `AWS-LC FIPS module 5`, which is what `openssl version -fips` prints:
 
 ```
 $ openssl version -fips

--- a/crypto/fipsmodule/self_check/fips.c
+++ b/crypto/fipsmodule/self_check/fips.c
@@ -34,4 +34,6 @@ uint32_t FIPS_version(void) {
 #endif
 }
 
+const char *FIPS_module_name(void) { return AWSLC_MODULE_NAME_STRING; }
+
 int FIPS_mode_set(int on) { return on == FIPS_mode(); }

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -115,6 +115,11 @@ OPENSSL_EXPORT int FIPS_is_entropy_cpu_jitter(void);
 // built in FIPS mode.
 OPENSSL_EXPORT uint32_t FIPS_version(void);
 
+// FIPS_module_name returns the name of the cryptographic module, "AWS-LC FIPS"
+// in FIPS builds and "AWS-LC" otherwise. Together with |FIPS_version| it
+// identifies the module, for example "AWS-LC FIPS module 5".
+OPENSSL_EXPORT const char *FIPS_module_name(void);
+
 // Deprecated functions.
 
 // OPENSSL_VERSION_TEXT contains a string the identifies the version of

--- a/tool-openssl/version.cc
+++ b/tool-openssl/version.cc
@@ -8,7 +8,6 @@
 
 #include <openssl/base.h>
 #include <openssl/crypto.h>
-#include <openssl/service_indicator.h>
 #include "internal.h"
 
 static const argument_t kArguments[] = {
@@ -64,7 +63,7 @@ bool VersionTool(const args_list_t &args) {
   if (fips) {
     if (FIPS_mode()) {
       printf("FIPS: enabled\n");
-      printf("FIPS module: %s module %" PRIu32 "\n", AWSLC_MODULE_NAME_STRING,
+      printf("FIPS module: %s module %" PRIu32 "\n", FIPS_module_name(),
              FIPS_version());
     } else {
       printf("FIPS: disabled\n");


### PR DESCRIPTION
### Context and motivation
The FIPS lab needs an API it can designate in the Security Policy as returning the module name. `awslc_version_string()` returns the name but carries the AWS-LC library version with it (`AWS-LC FIPS 5.1.0`), which is independent of the FIPS module version and changes every release.

  ### Description of changes
Adds `FIPS_module_name()`, which returns just the name — `"AWS-LC FIPS"` in FIPS builds and `"AWS-LC"` otherwise — alongside `FIPS_version()` inside the module boundary. `openssl version -fips` now calls it instead of expanding the `AWSLC_MODULE_NAME_STRING` macro added in #3472.

The mainline commit also registered the new symbol in `crypto/libcrypto.txt` and `crypto/libcrypto.map`. Those files do not exist on this branch, which predates symbol versioning, so they are omitted here. That is the only deviation from the mainline change.

  ### Testing
No new tests. Verified on this branch with a `-DFIPS=1` build that `version -fips` prints `FIPS module: AWS-LC FIPS module 5`, that `FIPS_module_name` exports from libcrypto, and that `Crypto.OnDemandIntegrityTest`, `CryptoTest.FIPSVersion`, and `ServiceIndicatorTest.AWSLCVersionString` pass — the integrity test covering the new string constant inside the module boundary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

(cherry picked from commit add9bcbc8700dc57151e02a627f71df783da49ea)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.