### PR TITLE
Retry failed rndr register read a bounded number of times

### DIFF
--- a/crypto/fipsmodule/rand/asm/rndr-armv8.pl
+++ b/crypto/fipsmodule/rand/asm/rndr-armv8.pl
@@ -35,11 +35,14 @@ $code.=<<___;
 .type CRYPTO_rndr_multiple8,%function
 .align 4
 CRYPTO_rndr_multiple8:
-  cbz $len, .Lrndr_multiple8_error  // len = 0 is not supported
+  cbz $len, .Lrndr_multiple8_error      // len = 0 is not supported
 
 .Lrndr_multiple8_loop:
+  // A read of rndr sets PSTATE.NZCV to 0b0100 if a random number could not be
+  // returned, and to 0b0000 otherwise. The returned value is 0 on failure, but
+  // a genuine random number can be 0 as well. Hence, use the flags.
   mrs $rndr64, s3_3_c2_c4_0             // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
-  cbz $rndr64, .Lrndr_multiple8_error   // Check if rndr failed
+  b.eq .Lrndr_multiple8_error           // Check if rndr failed
 
   str $rndr64, [$out], #8               // Copy 8 bytes to *out and increment pointer by 8
   sub $len, $len, #8

--- a/crypto/fipsmodule/rand/asm/rndr-armv8.pl
+++ b/crypto/fipsmodule/rand/asm/rndr-armv8.pl
@@ -40,7 +40,8 @@ CRYPTO_rndr_multiple8:
 .Lrndr_multiple8_loop:
   // A read of rndr sets PSTATE.NZCV to 0b0100 if a random number could not be
   // returned, and to 0b0000 otherwise. The returned value is 0 on failure, but
-  // a genuine random number can be 0 as well. Hence, use the flags.
+  // a genuine random number can be 0 as well. Hence, check the Z flag not the
+  // return value.
   mrs $rndr64, s3_3_c2_c4_0             // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
   b.eq .Lrndr_multiple8_error           // Check if rndr failed
 

--- a/crypto/fipsmodule/rand/entropy/entropy_source_test.cc
+++ b/crypto/fipsmodule/rand/entropy/entropy_source_test.cc
@@ -32,7 +32,7 @@ TEST(EntropySourceHw, Aarch64) {
   ASSERT_FALSE(rndr_multiple8(buf, 0));
 
   // Multiples of 8 allowed.
-  for (size_t i = 8; i < MAX_MULTIPLE_FROM_RNG; i += 8) {
+  for (size_t i = 8; i <= sizeof(buf); i += 8) {
     ASSERT_TRUE(rndr_multiple8(buf, i));
   }
 
@@ -59,7 +59,7 @@ TEST(EntropySourceHw, x86_64) {
   ASSERT_FALSE(rdrand_multiple8(buf, 0));
 
   // Multiples of 8 allowed.
-  for (size_t i = 8; i < MAX_MULTIPLE_FROM_RNG; i += 8) {
+  for (size_t i = 8; i <= sizeof(buf); i += 8) {
     ASSERT_TRUE(rdrand_multiple8(buf, i));
   }
 

--- a/crypto/fipsmodule/rand/entropy/entropy_source_test.cc
+++ b/crypto/fipsmodule/rand/entropy/entropy_source_test.cc
@@ -3,12 +3,122 @@
 
 #include <gtest/gtest.h>
 
+#include <string.h>
+
 #include <openssl/crypto.h>
 
 #include "internal.h"
 #include "../../../ube/vm_ube_detect.h"
 
-#define MAX_MULTIPLE_FROM_RNG (16)
+#define MAX_MULTIPLE_FROM_RNG 16
+
+// We can't easily induce a controllable hardware rng failure, which means the
+// retry logic in |rndr_multiple8| and |rdrand_multiple8| can't be exercised by
+// calling the real hardware rng. Instead, mock the failures using a fake
+// hardware rng function.
+struct MockedHwRng {
+  // failures is the number of leading calls that must fail.
+  size_t failures = 0;
+  // bytes_written_on_failure is the number of bytes a failing call writes to
+  // the output buffer before failing. RNDR[RS]/RD[SEED|RAND] return 8 bytes and
+  // can therefore fail after having written a prefix of the output buffer.
+  size_t bytes_written_on_failure = 0;
+  // calls is the number of calls observed.
+  size_t calls = 0;
+};
+
+// kFailureFill is the byte a failing call writes to the output buffer. It must
+// differ from |kSuccessFill| to be able to detect a stale prefix left behind by
+// a failing call.
+static const uint8_t kFailureFill = 0xaa;
+// kSuccessFill is the byte a succeeding call writes to the output buffer.
+static const uint8_t kSuccessFill = 0x55;
+
+static MockedHwRng mocked_hw_rng;
+
+static int mocked_hw_rng_multiple8(uint8_t *buf, size_t len) {
+  mocked_hw_rng.calls += 1;
+
+  if (mocked_hw_rng.calls <= mocked_hw_rng.failures) {
+    size_t prefix = mocked_hw_rng.bytes_written_on_failure;
+    if (prefix > len) {
+      prefix = len;
+    }
+    memset(buf, kFailureFill, prefix);
+    return 0;
+  }
+
+  memset(buf, kSuccessFill, len);
+  return 1;
+}
+
+// TestHwRngRetryLogic exercises the retry logic with |max_retries| as the retry
+// bound configured for a hardware rng e.g. |RNDR_MAX_RETRIES|.
+static void TestHwRngRetryLogic(size_t max_retries) {
+  ASSERT_GT(max_retries, 0u);
+
+  uint8_t buf[MAX_MULTIPLE_FROM_RNG*8];
+  const size_t len = sizeof(buf);
+
+  // Succeeding on the first call executes the hardware rng exactly once.
+  mocked_hw_rng = MockedHwRng();
+  memset(buf, 0, len);
+  ASSERT_TRUE(hw_rng_multiple8_with_retry_FOR_TESTING(
+    mocked_hw_rng_multiple8, buf, len, max_retries));
+  EXPECT_EQ(1u, mocked_hw_rng.calls);
+  for (size_t i = 0; i < len; i++) {
+    EXPECT_EQ(kSuccessFill, buf[i]);
+  }
+
+  // Succeeding on the last permitted call is still a success.
+  mocked_hw_rng = MockedHwRng();
+  mocked_hw_rng.failures = max_retries - 1;
+  memset(buf, 0, len);
+  ASSERT_TRUE(hw_rng_multiple8_with_retry_FOR_TESTING(
+    mocked_hw_rng_multiple8, buf, len, max_retries));
+  EXPECT_EQ(max_retries, mocked_hw_rng.calls);
+
+  // Exhausting the retry bound is a failure and no further calls are made.
+  mocked_hw_rng = MockedHwRng();
+  mocked_hw_rng.failures = max_retries + 1;
+  memset(buf, 0, len);
+  ASSERT_FALSE(hw_rng_multiple8_with_retry_FOR_TESTING(
+    mocked_hw_rng_multiple8, buf, len, max_retries));
+  EXPECT_EQ(max_retries, mocked_hw_rng.calls);
+
+  // A failing call can leave a prefix of the output buffer written. The
+  // succeeding retry must overwrite the entire output buffer.
+  if (max_retries > 1) {
+    mocked_hw_rng = MockedHwRng();
+    mocked_hw_rng.failures = 1;
+    mocked_hw_rng.bytes_written_on_failure = len / 2;
+    memset(buf, 0, len);
+    ASSERT_TRUE(hw_rng_multiple8_with_retry_FOR_TESTING(
+      mocked_hw_rng_multiple8, buf, len, max_retries));
+    EXPECT_EQ(2u, mocked_hw_rng.calls);
+    for (size_t i = 0; i < len; i++) {
+      EXPECT_EQ(kSuccessFill, buf[i]);
+    }
+  }
+
+  // Unsupported lengths are rejected without executing the hardware rng.
+  for (size_t bad_len : {0, 1, 7, 9, 15}) {
+    mocked_hw_rng = MockedHwRng();
+    ASSERT_FALSE(hw_rng_multiple8_with_retry_FOR_TESTING(
+      mocked_hw_rng_multiple8, buf, bad_len, max_retries));
+    EXPECT_EQ(0u, mocked_hw_rng.calls);
+  }
+}
+
+TEST(EntropySourceHw, HwRngRetryLogic) {
+  // The retry logic is shared between |rndr_multiple8| and |rdrand_multiple8|,
+  // but each hardware rng configures its own retry bound. A bound of 1 is the
+  // boundary case where no retry is permitted.
+  for (size_t max_retries : {1, RNDR_MAX_RETRIES, RDRAND_MAX_RETRIES}) {
+    SCOPED_TRACE(max_retries);
+    TestHwRngRetryLogic(max_retries);
+  }
+}
 
 // In the future this test can be improved by being able to predict whether the
 // test is running on hardware that we expect to support RNDR. This will require

--- a/crypto/fipsmodule/rand/entropy/entropy_sources.c
+++ b/crypto/fipsmodule/rand/entropy/entropy_sources.c
@@ -14,7 +14,7 @@ DEFINE_BSS_GET(const struct entropy_source_methods *, entropy_source_methods_ove
 DEFINE_BSS_GET(int, allow_entropy_source_methods_override)
 DEFINE_STATIC_MUTEX(global_entropy_source_lock)
 
-static int entropy_cpu_get_entropy(uint8_t *entropy, size_t entropy_len) {
+static int entropy_cpu_get_entropy_multiple8(uint8_t *entropy, size_t entropy_len) {
 #if defined(OPENSSL_X86_64)
   if (rdrand_multiple8(entropy, entropy_len) == 1) {
     return 1;
@@ -30,13 +30,13 @@ static int entropy_cpu_get_entropy(uint8_t *entropy, size_t entropy_len) {
 static int entropy_cpu_get_prediction_resistance(
   const struct entropy_source_t *entropy_source,
   uint8_t pred_resistance[RAND_PRED_RESISTANCE_LEN]) {
-  return entropy_cpu_get_entropy(pred_resistance, RAND_PRED_RESISTANCE_LEN);
+  return entropy_cpu_get_entropy_multiple8(pred_resistance, RAND_PRED_RESISTANCE_LEN);
 }
 
 static int entropy_cpu_get_extra_entropy(
   const struct entropy_source_t *entropy_source,
   uint8_t extra_entropy[CTR_DRBG_ENTROPY_LEN]) {
-  return entropy_cpu_get_entropy(extra_entropy, CTR_DRBG_ENTROPY_LEN);
+  return entropy_cpu_get_entropy_multiple8(extra_entropy, CTR_DRBG_ENTROPY_LEN);
 }
 
 static int entropy_os_get_extra_entropy(
@@ -159,11 +159,33 @@ struct entropy_source_t * get_entropy_source(void) {
   return entropy_source;
 }
 
+// A read of the rndr system register can fail transiently [1]: if a random
+// number cannot be returned "in a reasonable period of time", PSTATE.NZCV is
+// set to 0b0100 and the returned value is 0. This has been observed in the wild
+// per [2].
+// The Arm architecture does not specify a failure probability. Therefore, use
+// the same retry bound as for rdrand.
+// [1] https://developer.arm.com/documentation/ddi0601/2024-09/AArch64-Registers/RNDR--Random-Number
+// [2] https://github.com/aws/aws-lc/issues/3453
+#define RNDR_MAX_RETRIES 10
+OPENSSL_STATIC_ASSERT(RNDR_MAX_RETRIES > 0, rndr_max_retries_must_be_positive)
+
+// rndr_multiple8 should only be called if |have_hw_rng_aarch64| returned true.
 int rndr_multiple8(uint8_t *buf, const size_t len) {
   if (len == 0 || ((len & 0x7) != 0)) {
     return 0;
   }
-  return CRYPTO_rndr_multiple8(buf, len);
+
+  // This retries all rndr reads for the requested |len|.
+  // |CRYPTO_rndr_multiple8| will typically execute rndr multiple times. But
+  // it's easier to implement on the C-level and it should be a very rare event.
+  for (size_t tries = 0; tries < RNDR_MAX_RETRIES; tries++) {
+    if (CRYPTO_rndr_multiple8(buf, len) == 1) {
+      return 1;
+    }
+  }
+
+  return 0;
 }
 
 int have_hw_rng_aarch64_for_testing(void) {

--- a/crypto/fipsmodule/rand/entropy/entropy_sources.c
+++ b/crypto/fipsmodule/rand/entropy/entropy_sources.c
@@ -159,62 +159,57 @@ struct entropy_source_t * get_entropy_source(void) {
   return entropy_source;
 }
 
-// A read of the rndr system register can fail transiently [1]: if a random
-// number cannot be returned "in a reasonable period of time", PSTATE.NZCV is
-// set to 0b0100 and the returned value is 0. This has been observed in the wild
-// per [2].
-// The Arm architecture does not specify a failure probability. Therefore, use
-// the same retry bound as for rdrand.
-// [1] https://developer.arm.com/documentation/ddi0601/2024-09/AArch64-Registers/RNDR--Random-Number
-// [2] https://github.com/aws/aws-lc/issues/3453
-#define RNDR_MAX_RETRIES 10
-OPENSSL_STATIC_ASSERT(RNDR_MAX_RETRIES > 0, rndr_max_retries_must_be_positive)
+// hw_rng_multiple8_func is the type of a hardware rng wrapper such as
+// |CRYPTO_rndr_multiple8| and |CRYPTO_rdrand_multiple8|. It writes |len| bytes
+// to |buf| and returns 1 on success, 0 otherwise.
+typedef int (*hw_rng_multiple8_func)(uint8_t *buf, size_t len);
 
-// rndr_multiple8 should only be called if |have_hw_rng_aarch64| returned true.
-int rndr_multiple8(uint8_t *buf, const size_t len) {
+// hw_rng_multiple8_with_retry validates |len| and then calls |hw_rng| until it
+// succeeds or |max_retries| calls have been made. |max_retries| must be
+// positive.
+// A hardware rng wrapper will typically execute the underlying instruction
+// multiple times and a failing call can therefore leave a prefix of |buf|
+// written. This is not an issue, because the retry re-generates the entire
+// |buf| and the contents of |buf| are only consumed on success. Retrying the
+// entire request, instead of only the failed instruction execution, is easier
+// to implement on the C-level and it should be a very rare event.
+// Outputs 1 on success, 0 otherwise.
+static int hw_rng_multiple8_with_retry(hw_rng_multiple8_func hw_rng,
+  uint8_t *buf, size_t len, size_t max_retries) {
+
   if (len == 0 || ((len & 0x7) != 0)) {
     return 0;
   }
 
-  // This retries all rndr reads for the requested |len|.
-  // |CRYPTO_rndr_multiple8| will typically execute rndr multiple times. But
-  // it's easier to implement on the C-level and it should be a very rare event.
-  for (size_t tries = 0; tries < RNDR_MAX_RETRIES; tries++) {
-    if (CRYPTO_rndr_multiple8(buf, len) == 1) {
+  for (size_t tries = 0; tries < max_retries; tries++) {
+    if (hw_rng(buf, len) == 1) {
       return 1;
     }
   }
 
   return 0;
+}
+
+int hw_rng_multiple8_with_retry_FOR_TESTING(
+  int (*hw_rng)(uint8_t *buf, size_t len), uint8_t *buf, size_t len,
+  size_t max_retries) {
+  return hw_rng_multiple8_with_retry(hw_rng, buf, len, max_retries);
+}
+
+// rndr_multiple8 should only be called if |have_hw_rng_aarch64| returned true.
+int rndr_multiple8(uint8_t *buf, const size_t len) {
+  return hw_rng_multiple8_with_retry(CRYPTO_rndr_multiple8, buf, len,
+                                     RNDR_MAX_RETRIES);
 }
 
 int have_hw_rng_aarch64_for_testing(void) {
   return have_hw_rng_aarch64();
 }
 
-// rdrand maximum retries as suggested by:
-// Intel® Digital Random Number Generator (DRNG) Software Implementation Guide
-// Revision 2.1
-// https://software.intel.com/content/www/us/en/develop/articles/intel-digital-random-number-generator-drng-software-implementation-guide.html
-#define RDRAND_MAX_RETRIES 10
-OPENSSL_STATIC_ASSERT(RDRAND_MAX_RETRIES > 0, rdrand_max_retries_must_be_positive)
-
 // rdrand_multiple8 should only be called if |have_hw_rng_x86_64| returned true.
 int rdrand_multiple8(uint8_t *buf, size_t len) {
-  if (len == 0 || ((len & 0x7) != 0)) {
-    return 0;
-  }
-
-  // This retries all rdrand calls for the requested |len|.
-  // |CRYPTO_rdrand_multiple8| will typically execute rdrand multiple times. But
-  // it's easier to implement on the C-level and it should be a very rare event.
-  for (size_t tries = 0; tries < RDRAND_MAX_RETRIES; tries++) {
-    if (CRYPTO_rdrand_multiple8(buf, len) == 1) {
-      return 1;
-    }
-  }
-
-  return 0;
+  return hw_rng_multiple8_with_retry(CRYPTO_rdrand_multiple8, buf, len,
+                                     RDRAND_MAX_RETRIES);
 }
 
 int have_hw_rng_x86_64_for_testing(void) {

--- a/crypto/fipsmodule/rand/entropy/internal.h
+++ b/crypto/fipsmodule/rand/entropy/internal.h
@@ -71,7 +71,8 @@ OPENSSL_EXPORT int get_entropy_source_method_id_FOR_TESTING(void);
 #endif // !defined(DISABLE_CPU_JITTER_ENTROPY)
 
 // rndr_multiple8 writes |len| number of bytes to |buf| generated using the
-// rndr instruction. |len| must be a multiple of 8.
+// rndr instruction. |len| must be a multiple of 8. Retries a bounded number of
+// times, because a read of rndr is allowed to fail transiently.
 // Outputs 1 on success, 0 otherwise.
 OPENSSL_EXPORT int rndr_multiple8(uint8_t *buf, const size_t len);
 
@@ -104,7 +105,8 @@ OPENSSL_INLINE int have_hw_rng_aarch64(void) {
 #endif  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
 
 // rdrand_multiple8 writes |len| number of bytes to |buf| generated using the
-// rdrand instruction. |len| must be a multiple of 8. Retries 
+// rdrand instruction. |len| must be a multiple of 8. Retries a bounded number
+// of times, because a read of rdrand is allowed to fail transiently.
 // Outputs 1 on success, 0 otherwise.
 OPENSSL_EXPORT int rdrand_multiple8(uint8_t *buf, size_t len);
 

--- a/crypto/fipsmodule/rand/entropy/internal.h
+++ b/crypto/fipsmodule/rand/entropy/internal.h
@@ -70,9 +70,31 @@ OPENSSL_EXPORT int get_entropy_source_method_id_FOR_TESTING(void);
   static inline int tree_jitter_get_seed(const struct entropy_source_t *entropy_source, uint8_t seed[CTR_DRBG_ENTROPY_LEN]) { return 0; }
 #endif // !defined(DISABLE_CPU_JITTER_ENTROPY)
 
+// hw_rng_multiple8_with_retry_FOR_TESTING exposes the retry logic that
+// |rndr_multiple8| and |rdrand_multiple8| use, but with an injectable hardware
+// rng |hw_rng|. This allows testing the retry logic on any platform and without
+// depending on transient hardware rng failures actually occurring.
+// |max_retries| must be positive.
+// Outputs 1 on success, 0 otherwise.
+OPENSSL_EXPORT int hw_rng_multiple8_with_retry_FOR_TESTING(
+  int (*hw_rng)(uint8_t *buf, size_t len), uint8_t *buf, size_t len,
+  size_t max_retries);
+
+// A read of the rndr system register can fail transiently [1]: if a random
+// number cannot be returned "in a reasonable period of time", PSTATE.NZCV is
+// set to 0b0100 and the returned value is 0. This has been observed in the wild
+// per [2].
+// The Arm architecture does not specify a failure probability. Therefore, use
+// the same retry bound as for rdrand.
+// [1] https://developer.arm.com/documentation/ddi0601/2024-09/AArch64-Registers/RNDR--Random-Number
+// [2] https://github.com/aws/aws-lc/issues/3453
+#define RNDR_MAX_RETRIES 10
+OPENSSL_STATIC_ASSERT(RNDR_MAX_RETRIES > 0, rndr_max_retries_must_be_positive)
+
 // rndr_multiple8 writes |len| number of bytes to |buf| generated using the
-// rndr instruction. |len| must be a multiple of 8. Retries a bounded number of
-// times, because a read of rndr is allowed to fail transiently.
+// rndr instruction. |len| must be a multiple of 8. Retries up to
+// |RNDR_MAX_RETRIES| times, because a read of rndr is allowed to fail
+// transiently.
 // Outputs 1 on success, 0 otherwise.
 OPENSSL_EXPORT int rndr_multiple8(uint8_t *buf, const size_t len);
 
@@ -104,9 +126,17 @@ OPENSSL_INLINE int have_hw_rng_aarch64(void) {
 
 #endif  // defined(OPENSSL_AARCH64) && !defined(OPENSSL_NO_ASM)
 
+// rdrand maximum retries as suggested by:
+// Intel® Digital Random Number Generator (DRNG) Software Implementation Guide
+// Revision 2.1
+// https://software.intel.com/content/www/us/en/develop/articles/intel-digital-random-number-generator-drng-software-implementation-guide.html
+#define RDRAND_MAX_RETRIES 10
+OPENSSL_STATIC_ASSERT(RDRAND_MAX_RETRIES > 0, rdrand_max_retries_must_be_positive)
+
 // rdrand_multiple8 writes |len| number of bytes to |buf| generated using the
-// rdrand instruction. |len| must be a multiple of 8. Retries a bounded number
-// of times, because a read of rdrand is allowed to fail transiently.
+// rdrand instruction. |len| must be a multiple of 8. Retries up to
+// |RDRAND_MAX_RETRIES| times, because a read of rdrand is allowed to fail
+// transiently.
 // Outputs 1 on success, 0 otherwise.
 OPENSSL_EXPORT int rdrand_multiple8(uint8_t *buf, size_t len);
 

--- a/crypto/libcrypto.map
+++ b/crypto/libcrypto.map
@@ -2813,6 +2813,7 @@ AWS_LC_1.0 {
     get_thread_and_global_tree_drbg_calls_FOR_TESTING;
     have_hw_rng_aarch64_for_testing;
     have_hw_rng_x86_64_for_testing;
+    hw_rng_multiple8_with_retry_FOR_TESTING;
     i2a_ASN1_ENUMERATED;
     i2a_ASN1_INTEGER;
     i2a_ASN1_OBJECT;

--- a/crypto/libcrypto.txt
+++ b/crypto/libcrypto.txt
@@ -2806,6 +2806,7 @@ get_public_thread_reseed_calls_since_initialization AWS_LC_1.0 PRIVATE
 get_thread_and_global_tree_drbg_calls_FOR_TESTING AWS_LC_1.0 PRIVATE
 have_hw_rng_aarch64_for_testing AWS_LC_1.0 PRIVATE
 have_hw_rng_x86_64_for_testing AWS_LC_1.0 PRIVATE
+hw_rng_multiple8_with_retry_FOR_TESTING AWS_LC_1.0 PRIVATE
 i2a_ASN1_ENUMERATED AWS_LC_1.0 PUBLIC
 i2a_ASN1_INTEGER AWS_LC_1.0 PUBLIC
 i2a_ASN1_OBJECT AWS_LC_1.0 PUBLIC

--- a/generated-src/ios-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/ios-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -15,11 +15,14 @@
 
 .align	4
 _CRYPTO_rndr_multiple8:
-	cbz	x1, Lrndr_multiple8_error  // len = 0 is not supported
+	cbz	x1, Lrndr_multiple8_error      // len = 0 is not supported
 
 Lrndr_multiple8_loop:
+  // A read of rndr sets PSTATE.NZCV to 0b0100 if a random number could not be
+  // returned, and to 0b0000 otherwise. The returned value is 0 on failure, but
+  // a genuine random number can be 0 as well. Hence, use the flags.
 	mrs	x2, s3_3_c2_c4_0             // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
-	cbz	x2, Lrndr_multiple8_error   // Check if rndr failed
+	b.eq	Lrndr_multiple8_error           // Check if rndr failed
 
 	str	x2, [x0], #8               // Copy 8 bytes to *out and increment pointer by 8
 	sub	x1, x1, #8

--- a/generated-src/linux-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/linux-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -15,11 +15,14 @@
 .type	CRYPTO_rndr_multiple8,%function
 .align	4
 CRYPTO_rndr_multiple8:
-	cbz	x1, .Lrndr_multiple8_error  // len = 0 is not supported
+	cbz	x1, .Lrndr_multiple8_error      // len = 0 is not supported
 
 .Lrndr_multiple8_loop:
+  // A read of rndr sets PSTATE.NZCV to 0b0100 if a random number could not be
+  // returned, and to 0b0000 otherwise. The returned value is 0 on failure, but
+  // a genuine random number can be 0 as well. Hence, use the flags.
 	mrs	x2, s3_3_c2_c4_0             // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
-	cbz	x2, .Lrndr_multiple8_error   // Check if rndr failed
+	b.eq	.Lrndr_multiple8_error           // Check if rndr failed
 
 	str	x2, [x0], #8               // Copy 8 bytes to *out and increment pointer by 8
 	sub	x1, x1, #8

--- a/generated-src/win-aarch64/crypto/fipsmodule/rndr-armv8.S
+++ b/generated-src/win-aarch64/crypto/fipsmodule/rndr-armv8.S
@@ -17,11 +17,14 @@
 .endef
 .align	4
 CRYPTO_rndr_multiple8:
-	cbz	x1, Lrndr_multiple8_error  // len = 0 is not supported
+	cbz	x1, Lrndr_multiple8_error      // len = 0 is not supported
 
 Lrndr_multiple8_loop:
+  // A read of rndr sets PSTATE.NZCV to 0b0100 if a random number could not be
+  // returned, and to 0b0000 otherwise. The returned value is 0 on failure, but
+  // a genuine random number can be 0 as well. Hence, use the flags.
 	mrs	x2, s3_3_c2_c4_0             // rndr instruction https://developer.arm.com/documentation/ddi0601/2024-09/Index-by-Encoding
-	cbz	x2, Lrndr_multiple8_error   // Check if rndr failed
+	b.eq	Lrndr_multiple8_error           // Check if rndr failed
 
 	str	x2, [x0], #8               // Copy 8 bytes to *out and increment pointer by 8
 	sub	x1, x1, #8


### PR DESCRIPTION
### Related issues

https://github.com/aws/aws-lc/issues/3453

### Context and motivation

#3453 observes rndr register read failures. Specifically on GKE n4a (Axion/N2) hardware but not on other hardware types. Unclear what the specific issue is, but can alleviate pain by retrying. It's reported that applications require a restart, but compute recover on their own; hence it's not "stuck" and retrying should be effective.

### Description of changes

Adds a bounded retry to rndr register reads.

### Testing

Can't induce an rndr register read failure atm. So, logic is not currently exercised through a test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
