### PR TITLE
Prepare 5.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0091 NEW)
 endif()
 
 set(SOFTWARE_NAME "awslc")
-set(SOFTWARE_VERSION "5.7.0")
+set(SOFTWARE_VERSION "5.8.0")
 set(AWSLC_FIPS_VERSION 5)
 set(ABI_VERSION 1)
 set(CRYPTO_LIB_NAME "crypto")

--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -65,7 +65,7 @@ extern "C" {
 // ServiceIndicatorTest.AWSLCVersionString
 // Note: there are two versions of this test. Only one test is compiled
 // depending on FIPS mode.
-#define AWSLC_VERSION_NUMBER_STRING "5.7.0"
+#define AWSLC_VERSION_NUMBER_STRING "5.8.0"
 
 // AWSLC_FIPS_VERSION_NUMBER is the FIPS version number of mainline AWS-LC,
 // independent of |AWSLC_VERSION_NUMBER_STRING|. It is incremented each time a


### PR DESCRIPTION
### Context and motivation

Bumps the AWS-LC minor version from 5.7.0 to 5.8.0 for the next mainline release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.