### PR TITLE
Limit push-triggered CI to main and fips-* branches

### DIFF
--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -1,7 +1,7 @@
 name: ABI Monitoring
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 concurrency:

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -1,7 +1,7 @@
 name: General CI Tests
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request:
     branches: ["*"]
 concurrency:

--- a/.github/workflows/android-omnibus.yml
+++ b/.github/workflows/android-omnibus.yml
@@ -1,7 +1,7 @@
 name: android-omnibus
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request_target:
     branches: ["*"]
 concurrency:

--- a/.github/workflows/aws-lc-rs.yml
+++ b/.github/workflows/aws-lc-rs.yml
@@ -1,7 +1,7 @@
 name: aws-lc-rs tests
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 concurrency:

--- a/.github/workflows/bsd-ci.yml
+++ b/.github/workflows/bsd-ci.yml
@@ -1,7 +1,7 @@
 name: BSD CI Tests
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request:
     branches: ["*"]
   schedule:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,7 +1,7 @@
 name: CMake Compatability
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 concurrency:

--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -1,7 +1,7 @@
 name: Code Coverage
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 concurrency:

--- a/.github/workflows/cross-test.yml
+++ b/.github/workflows/cross-test.yml
@@ -1,7 +1,7 @@
 name: Cross Build & Test
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request:
     branches: ["*"]
 concurrency:

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -4,7 +4,7 @@
 name: WASM Build & Test
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request:
     branches: ["*"]
 concurrency:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 name: Go Compatability
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 concurrency:

--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -1,7 +1,7 @@
 name: integration-omnibus
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
   schedule:

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -1,7 +1,7 @@
 name: Integration tests
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 concurrency:

--- a/.github/workflows/linux-multi-arch-omnibus.yml
+++ b/.github/workflows/linux-multi-arch-omnibus.yml
@@ -1,7 +1,7 @@
 name: linux-multi-arch-omnibus
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request:
     branches: ["*"]
 concurrency:

--- a/.github/workflows/linux_arm_omnibus.yml
+++ b/.github/workflows/linux_arm_omnibus.yml
@@ -1,7 +1,7 @@
 name: linux-arm-omnibus
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 concurrency:

--- a/.github/workflows/linux_x86_omnibus.yml
+++ b/.github/workflows/linux_x86_omnibus.yml
@@ -1,7 +1,7 @@
 name: linux-x86-omnibus
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request:
     branches: ["*"]
 concurrency:

--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -1,7 +1,7 @@
 name: Miscellaneous test jobs
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request:
     branches: ["*"]
 concurrency:

--- a/.github/workflows/openssl-small.yml
+++ b/.github/workflows/openssl-small.yml
@@ -13,7 +13,7 @@
 name: OPENSSL_SMALL
 on:
   push:
-    branches: ['*']
+    branches: ['main', 'fips-*']
   pull_request:
     branches: ['*']
 concurrency:

--- a/.github/workflows/opensslcomparison.yml
+++ b/.github/workflows/opensslcomparison.yml
@@ -1,7 +1,7 @@
 name: OpenSSL CLI Comparison Tests
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 

--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -4,7 +4,7 @@
 name: WASI Build & Test
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request:
     branches: ["*"]
 concurrency:

--- a/.github/workflows/windows-alt.yml
+++ b/.github/workflows/windows-alt.yml
@@ -1,7 +1,7 @@
 name: Windows Alternative Compilers
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 concurrency:

--- a/.github/workflows/windows-omnibus.yml
+++ b/.github/workflows/windows-omnibus.yml
@@ -1,7 +1,7 @@
 name: windows-omnibus
 on:
   push:
-    branches: ["*"]
+    branches: ["main", "fips-*"]
   pull_request:
     branches: ["*"]
 concurrency:

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -1,7 +1,7 @@
 name: Zig compiler
 on:
   push:
-    branches: [ '*' ]
+    branches: ['main', 'fips-*']
   pull_request:
     branches: [ '*' ]
 concurrency:


### PR DESCRIPTION
### Context and motivation

Stack PRs require their branches to live on the same repository rather than a fork, so every branch push now fires the push-triggered half of CI on top of the `pull_request` half. Both halves test the same commits, so roughly half the work is thrown away.

The effect is easy to see by comparing check counts. A stacked PR like https://github.com/aws/aws-lc/pull/3432 runs **1054** checks, where an equivalent single-branch PR like https://github.com/aws/aws-lc/pull/3475 runs **530**.

The outcome we want: pushes to a working branch produce one round of CI, not two, while `main` and the `fips-*` release branches keep the push coverage they need.

### Description of changes

Change the `push` trigger from `branches: ['*']` to `branches: ['main', 'fips-*']` on the 22 workflows that run against day-to-day PRs. `main` and `fips-*` are the branches where a push is the only signal we get; everywhere else the `pull_request` trigger already covers the same commits.

### Testing

No new tests; this only narrows workflow trigger conditions.

### Review considerations

- There is no way to factor this filter into one place, this is the simplest way to enact this change.
- If there are any other branches beyond main/fips that deserve this extra scrutiny. AFAICT, all we have beyond these are stale branches that should probably be deleted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.