### PR TITLE
ci: record integration failure metadata

### DIFF
--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   integrations:
-    name: ${{ matrix.name }}-${{ matrix.arch }}
+    name: ${{ matrix.name }}-${{ matrix.arch }}${{ matrix.allow_failure && '-allow-failure' || '' }}
     continue-on-error: ${{ matrix.allow_failure || false }}
     runs-on:
       - codebuild-aws-lc-ci-github-actions-${{ github.run_id }}-${{ github.run_attempt }}
@@ -461,6 +461,7 @@ jobs:
           image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/${{ matrix.image }}
           env: |
             ACCP_FIPS
+            GITHUB_SHA
           options: ${{ matrix.options || '' }}
           user: ${{ matrix.user || '' }}
           ipv6: ${{ matrix.ipv6 || false }}
@@ -468,34 +469,12 @@ jobs:
           run: |
             source /opt/compiler-env/setup-${{ matrix.compiler }}.sh
             ${{ matrix.run }}
-      # Emit a marker only when the integration test itself fails, not on
-      # operational failures, so the report-failures alarm counts real downstream breakages only, except for tests
-      # that are purely informational and breakages are accepted.
-      - name: Mark integration failure
-        if: always() && steps.integration-test.outcome == 'failure' && github.event_name == 'schedule' && !matrix.allow_failure
-
-        env:
-          INTEGRATION_RUNNER_COMMAND: ${{ matrix.run }}
-        run: |
-          # Read each line so multi-line run blocks (e.g. bind9 runs pip install
-          # before invocating the runner) still resolve to the runner script + its version.
-          while read -r script_path version _; do
-            [[ "$script_path" == *_integration.sh ]] && break
-          done <<< "$INTEGRATION_RUNNER_COMMAND"
-
-          # Strip the path, run_ prefix, and _integration.sh suffix to get the
-          # bare integration name (e.g. .../run_postgres_integration.sh -> postgres).
-          integration=${script_path##*/}              # .../run_postgres_integration.sh -> run_postgres_integration.sh
-          integration=${integration#run_}             # -> postgres_integration.sh
-          integration=${integration%_integration.sh}  # -> postgres
-          version=${version//[\'\"]/}  # strip quotes (e.g. pyopenssl '25.3.0')
-          echo -e "${integration}\t${version}" > integration-failure.txt
-
       - uses: actions/upload-artifact@v7
         if: always() && steps.integration-test.outcome == 'failure' && github.event_name == 'schedule' && !matrix.allow_failure
         with:
           name: integration-failure-${{ matrix.name }}-${{ matrix.arch }}
           path: integration-failure.txt
+          if-no-files-found: ignore
 
   python:
     name: python-${{ matrix.version }}${{ matrix.buildFIPS == 1 && '-fips' || '' }}-${{ matrix.crtUseSystemCrypto == 1 && 'crt-vendored-crypto' || 'crt-system-crypto' }}-${{ matrix.arch }}
@@ -538,18 +517,17 @@ jobs:
           env: |
             FIPS
             AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO
+            GITHUB_SHA
           ipv6: true
           run: |
             source /opt/compiler-env/setup-gcc-12.sh
             ./tests/ci/integration/run_python_integration.sh ${{ matrix.version }}
-      - name: Mark integration failure
-        if: always() && steps.integration-test.outcome == 'failure' && github.event_name == 'schedule'
-        run: echo -e "python\t${{ matrix.version }}" > integration-failure.txt
       - uses: actions/upload-artifact@v7
         if: always() && steps.integration-test.outcome == 'failure' && github.event_name == 'schedule'
         with:
           name: integration-failure-python-${{ matrix.version }}-${{ matrix.buildFIPS }}-${{ matrix.crtUseSystemCrypto }}-${{ matrix.arch }}
           path: integration-failure.txt
+          if-no-files-found: ignore
 
   ruby:
     name: ruby-${{ matrix.version }}${{ matrix.buildFIPS == 1 && '-fips' || '' }}-${{ matrix.arch }}
@@ -581,18 +559,17 @@ jobs:
           image: ${{ steps.login-ecr.outputs.registry }}/aws-lc/ubuntu:24.04
           env: |
             FIPS
+            GITHUB_SHA
           ipv6: true
           run: |
             source /opt/compiler-env/setup-gcc-13.sh
             ./tests/ci/integration/run_ruby_integration.sh ${{ matrix.version }}
-      - name: Mark integration failure
-        if: always() && steps.integration-test.outcome == 'failure' && github.event_name == 'schedule'
-        run: echo -e "ruby\t${{ matrix.version }}" > integration-failure.txt
       - uses: actions/upload-artifact@v7
         if: always() && steps.integration-test.outcome == 'failure' && github.event_name == 'schedule'
         with:
           name: integration-failure-ruby-${{ matrix.version }}-${{ matrix.buildFIPS }}-${{ matrix.arch }}
           path: integration-failure.txt
+          if-no-files-found: ignore
 
   report-failures:
     name: report-failures
@@ -612,12 +589,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -exo pipefail
-          # Count the failure artifacts to get the number of broken integration tests.
-          # We keep only the integration-failure-* markers and count lines with wc -l instead of jq length,
-          # since --paginate would make jq emit a separate count for each page.
+          # Count the number of failing tests, excluding tests which are allowed to fail.
           failure_count=$(gh api --paginate \
-            "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
-            --jq '.artifacts[] | select(.name | startswith("integration-failure-")) | .name' \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.conclusion == "failure" and (.name | endswith("-allow-failure") | not)) | .name' \
             | wc -l | tr -d ' ')
 
           aws cloudwatch put-metric-data \

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -19,6 +19,40 @@ cd $SRC_ROOT
 BUILD_ROOT="${SRC_ROOT}/test_build_dir"
 echo BUILD_ROOT="$BUILD_ROOT"
 
+INTEGRATION_FAILURE_FILE="${SRC_ROOT}/integration-failure.txt"
+
+# Create the failure artifact with the integration name, optional version, and AWS-LC commit.
+# Example: run_python_integration.sh 3.13 records "python<TAB>3.13".
+function record_integration() {
+  local runner="${1##*/}"
+  local integration="${runner#run_}"
+  integration="${integration%_integration.sh}"
+  printf '%s\t%s\nawslc_sha=%s\n' \
+    "${integration}" "${2:-}" "${GITHUB_SHA:-}" > "${INTEGRATION_FAILURE_FILE}"
+}
+
+# Append the cloned repository's URL and exact commit to the failure artifact.
+# A URL is required only for repositories without an origin remote.
+function record_repo_commit() {
+  local dir="$1"
+  local url="${2:-}"
+  local sha
+
+  if [[ -z "${url}" ]]; then
+    url="$(git -C "${dir}" remote get-url origin)" || return 1
+  fi
+  sha="$(git -C "${dir}" rev-parse HEAD)" || return 1
+  printf 'commit=%s %s\n' "${url}" "${sha}" >> "${INTEGRATION_FAILURE_FILE}"
+}
+
+# Every integration runner sources this setup file when it starts, so BASH_SOURCE[1]
+# identifies the integration runner and automatically records its name, version, and AWS-LC commit.
+# Build and setup scripts are skipped so unrelated CI jobs do not create artifacts.
+integration_runner="${BASH_SOURCE[1]:-}"
+if [[ "${integration_runner##*/}" == run_*_integration.sh ]]; then
+  record_integration "${integration_runner}" "${1:-}"
+fi
+
 PLATFORM=$(uname -m)
 
 NUM_CPU_THREADS=''

--- a/tests/ci/integration/run_accp_integration.sh
+++ b/tests/ci/integration/run_accp_integration.sh
@@ -23,7 +23,8 @@ mkdir -p "${SCRATCH_FOLDER}"
 rm -rf "${SCRATCH_FOLDER:?}"/*
 pushd "${SCRATCH_FOLDER}"
 
-git clone --depth 1 https://github.com/corretto/amazon-corretto-crypto-provider.git
+git clone --depth 1 https://github.com/corretto/amazon-corretto-crypto-provider.git "${ACCP_SRC}"
+record_repo_commit "${ACCP_SRC}"
 
 build_and_test_accp
 

--- a/tests/ci/integration/run_bind9_integration.sh
+++ b/tests/ci/integration/run_bind9_integration.sh
@@ -65,6 +65,7 @@ rm -rf ${SCRATCH_FOLDER}/*
 cd ${SCRATCH_FOLDER}
 
 git clone https://gitlab.isc.org/isc-projects/bind9.git ${BIND9_SRC_FOLDER} --depth 1
+record_repo_commit "${BIND9_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${BIND9_BUILD_FOLDER}
 ls
 

--- a/tests/ci/integration/run_crt_integration.sh
+++ b/tests/ci/integration/run_crt_integration.sh
@@ -7,15 +7,17 @@ source tests/ci/common_posix_setup.sh
 
 # Assumes script is executed from the root of aws-lc directory
 SCRATCH_FOLDER=${SYS_ROOT}/SCRATCH_AWSLC_CRT_TEST
+CRT_SRC_FOLDER="${SCRATCH_FOLDER}/aws-crt-cpp"
 
 # Make script execution idempotent.
 mkdir -p ${SCRATCH_FOLDER}
 rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
-git clone --recursive https://github.com/awslabs/aws-crt-cpp.git
+git clone --recursive https://github.com/awslabs/aws-crt-cpp.git "${CRT_SRC_FOLDER}"
+record_repo_commit "${CRT_SRC_FOLDER}"
 
-cd aws-crt-cpp
+cd "${CRT_SRC_FOLDER}"
 # The CRT has a submodule for AWS-LC, overwrite that with the local version
 rm -rf crt/aws-lc/*
 cp -r ${SRC_ROOT}/* crt/aws-lc/

--- a/tests/ci/integration/run_curl_integration.sh
+++ b/tests/ci/integration/run_curl_integration.sh
@@ -45,6 +45,7 @@ function curl_run_tests() {
 
 # Get latest curl version.
 git clone https://github.com/curl/curl.git ${CURL_SRC_FOLDER}
+record_repo_commit "${CURL_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${CURL_BUILD_FOLDER}
 ls
 

--- a/tests/ci/integration/run_cyrus_sasl_integration.sh
+++ b/tests/ci/integration/run_cyrus_sasl_integration.sh
@@ -49,6 +49,7 @@ function cyrus_build() {
 # TO-DO: Setup Kerberos and DB, then use sample client and server programs to test GSSAPI
 
 git clone --depth 1 https://github.com/cyrusimap/cyrus-sasl.git ${CYRUS_SRC_FOLDER}
+record_repo_commit "${CYRUS_SRC_FOLDER}"
 cd ${CYRUS_SRC_FOLDER}
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 ls

--- a/tests/ci/integration/run_grpc_integration.sh
+++ b/tests/ci/integration/run_grpc_integration.sh
@@ -35,6 +35,7 @@ cd ${SCRATCH_FOLDER}
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 
 git clone --depth 1 --branch "${GRPC_REF}" https://github.com/grpc/grpc.git ${GRPC_SRC_FOLDER}
+record_repo_commit "${GRPC_SRC_FOLDER}"
 cd ${GRPC_SRC_FOLDER}
 git submodule update --recursive --init
 

--- a/tests/ci/integration/run_haproxy_integration.sh
+++ b/tests/ci/integration/run_haproxy_integration.sh
@@ -49,8 +49,9 @@ rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
-git clone --depth 1 https://github.com/haproxy/haproxy.git
-cd haproxy
+git clone --depth 1 https://github.com/haproxy/haproxy.git "${HAPROXY_SRC}"
+record_repo_commit "${HAPROXY_SRC}"
+cd "${HAPROXY_SRC}"
 ./scripts/build-vtest.sh
 
 # Test with static AWS-LC libraries

--- a/tests/ci/integration/run_ibmtpm_integration.sh
+++ b/tests/ci/integration/run_ibmtpm_integration.sh
@@ -43,6 +43,7 @@ function ibmtpm_build() {
 }
 
 git clone https://github.com/kgoldman/ibmswtpm2.git ${IBMTPM_SRC_FOLDER}
+record_repo_commit "${IBMTPM_SRC_FOLDER}"
 cd ${IBMTPM_SRC_FOLDER}
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 ls

--- a/tests/ci/integration/run_krb5_integration.sh
+++ b/tests/ci/integration/run_krb5_integration.sh
@@ -101,6 +101,7 @@ function krb5_run_tests() {
 
 git clone --depth 1 --branch "${KRB5_GIT_REF}" \
   https://github.com/krb5/krb5.git "${KRB5_SRC_FOLDER}"
+record_repo_commit "${KRB5_SRC_FOLDER}"
 mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" \
          "${KRB5_BUILD_FOLDER}" "${KRB5_INSTALL_FOLDER}"
 ls

--- a/tests/ci/integration/run_libgit2_integration.sh
+++ b/tests/ci/integration/run_libgit2_integration.sh
@@ -96,6 +96,7 @@ function libgit2_run_tests() {
 git init "${LIBGIT2_SRC_FOLDER}"
 git -C "${LIBGIT2_SRC_FOLDER}" fetch --depth 1 https://github.com/libgit2/libgit2.git "${LIBGIT2_REF}"
 git -C "${LIBGIT2_SRC_FOLDER}" checkout FETCH_HEAD
+record_repo_commit "${LIBGIT2_SRC_FOLDER}" "https://github.com/libgit2/libgit2.git"
 mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${LIBGIT2_BUILD_FOLDER}" "${LIBGIT2_INSTALL_FOLDER}"
 ls
 

--- a/tests/ci/integration/run_librelp_integration.sh
+++ b/tests/ci/integration/run_librelp_integration.sh
@@ -56,6 +56,7 @@ if [[ -n "${LIBRELP_REF}" ]]; then
 else
   git clone --depth 1 https://github.com/rsyslog/librelp.git ${LIBRELP_SRC_FOLDER}
 fi
+record_repo_commit "${LIBRELP_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${LIBRELP_BUILD_FOLDER}
 ls
 

--- a/tests/ci/integration/run_libwebsockets_integration.sh
+++ b/tests/ci/integration/run_libwebsockets_integration.sh
@@ -63,6 +63,7 @@ aws_lc_build "$SRC_ROOT" "$AWS_LC_BUILD_FOLDER" "$AWS_LC_INSTALL_FOLDER" -DCMAKE
 pushd ${SOCKET_SRC_FOLDER}
 LATEST_TAG=$(git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -n 1)
 git checkout $LATEST_TAG
+record_repo_commit "${SOCKET_SRC_FOLDER}"
 echo "Using libwebsockets version: ${LATEST_TAG}"
 
 libwebsockets_patch

--- a/tests/ci/integration/run_mariadb_integration.sh
+++ b/tests/ci/integration/run_mariadb_integration.sh
@@ -80,6 +80,7 @@ function mariadb_patch() {
 
 # Get latest mariadb version, we can pin to a specific version if MariaDB's code changes break us too often.
 git clone https://github.com/MariaDB/server.git ${MARIADB_SRC_FOLDER} --depth 1
+record_repo_commit "${MARIADB_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${MARIADB_BUILD_FOLDER}
 ls
 

--- a/tests/ci/integration/run_monit_integration.sh
+++ b/tests/ci/integration/run_monit_integration.sh
@@ -55,6 +55,7 @@ rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 git clone https://bitbucket.org/tildeslash/monit.git ${MONIT_SRC_FOLDER} -b ${MONIT_VERSION_TAG} --depth 1
+record_repo_commit "${MONIT_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${MONIT_BUILD_FOLDER}
 ls
 

--- a/tests/ci/integration/run_mysql_integration.sh
+++ b/tests/ci/integration/run_mysql_integration.sh
@@ -117,6 +117,7 @@ pushd ${MYSQL_SRC_FOLDER}
 
 mysql_patch_reminder
 git checkout ${MYSQL_VERSION_TAG}
+record_repo_commit "${MYSQL_SRC_FOLDER}"
 
 mysql_patch_tests
 mysql_patch_error_strings

--- a/tests/ci/integration/run_nginx_integration.sh
+++ b/tests/ci/integration/run_nginx_integration.sh
@@ -62,6 +62,8 @@ function nginx_patch_tests() {
 
 git clone https://github.com/nginx/nginx.git ${NGINX_SRC_FOLDER} --depth 1
 git clone https://github.com/nginx/nginx-tests.git ${NGINX_TEST_FOLDER} --depth 1
+record_repo_commit "${NGINX_SRC_FOLDER}"
+record_repo_commit "${NGINX_TEST_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${NGINX_BUILD_FOLDER}
 ls
 

--- a/tests/ci/integration/run_nmap_integration.sh
+++ b/tests/ci/integration/run_nmap_integration.sh
@@ -88,6 +88,7 @@ NMAP_PATCH_FOLDER="$(nmap_patch_folder_for_ref "${NMAP_REF}")" || exit 1
 git init ${NMAP_SRC_FOLDER}
 git -C ${NMAP_SRC_FOLDER} fetch --depth 1 https://github.com/nmap/nmap.git ${NMAP_REF}
 git -C ${NMAP_SRC_FOLDER} checkout FETCH_HEAD
+record_repo_commit "${NMAP_SRC_FOLDER}" "https://github.com/nmap/nmap.git"
 cd ${NMAP_SRC_FOLDER}
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 ls

--- a/tests/ci/integration/run_ntp_integration.sh
+++ b/tests/ci/integration/run_ntp_integration.sh
@@ -58,6 +58,10 @@ rm -rf "${SCRATCH_FOLDER:?}/*"
 cd "$SCRATCH_FOLDER"
 
 wget -q $NTP_DOWNLOAD_URL
+# NTP downloads the latest source archive dynamically, so record its URL and checksum for autofix to reproduce failures.
+printf 'archive=%s sha256=%s\n' \
+  "${NTP_DOWNLOAD_URL}" "$(sha256sum "${NTP_TAR}" | cut -d ' ' -f1)" \
+  >> "${INTEGRATION_FAILURE_FILE}"
 mkdir -p "$NTP_SRC_FOLDER"
 tar -xzf "$NTP_TAR" -C "$NTP_SRC_FOLDER" --strip-components=1
 

--- a/tests/ci/integration/run_openldap_integration.sh
+++ b/tests/ci/integration/run_openldap_integration.sh
@@ -76,6 +76,7 @@ function openldap_patch() {
     git clone https://github.com/openldap/openldap.git ${src_dir} \
         --depth 1 \
         --branch ${branch}
+    record_repo_commit "${src_dir}"
     for patchfile in $(find -L ${patch_dir} -type f -name '*.patch'); do
       echo "Apply patch ${patchfile}..."
       cat ${patchfile} \

--- a/tests/ci/integration/run_openssh_integration.sh
+++ b/tests/ci/integration/run_openssh_integration.sh
@@ -83,6 +83,7 @@ mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${OPENSSH_INSTALL_
 
 # Get OpenSSH at the requested ref.
 git clone --depth 1 --branch "${OPENSSH_REF}" https://github.com/openssh/openssh-portable.git "${OPENSSH_WORKSPACE_FOLDER}"
+record_repo_commit "${OPENSSH_WORKSPACE_FOLDER}"
 ls
 
 # Build AWS-LC as a shared library

--- a/tests/ci/integration/run_openvpn_integration.sh
+++ b/tests/ci/integration/run_openvpn_integration.sh
@@ -68,6 +68,7 @@ function openvpn_run_tests() {
 
 git clone https://github.com/OpenVPN/openvpn.git ${OPENVPN_SRC_FOLDER}
 cd ${OPENVPN_SRC_FOLDER} && git checkout $BRANCH_NAME
+record_repo_commit "${OPENVPN_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 ls
 

--- a/tests/ci/integration/run_postgres_integration.sh
+++ b/tests/ci/integration/run_postgres_integration.sh
@@ -72,6 +72,7 @@ function postgres_patch() {
 
 # Get latest postgres version.
 git clone https://github.com/postgres/postgres.git ${POSTGRES_SRC_FOLDER}
+record_repo_commit "${POSTGRES_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${POSTGRES_BUILD_FOLDER}
 ls
 

--- a/tests/ci/integration/run_pq_tls_integration.sh
+++ b/tests/ci/integration/run_pq_tls_integration.sh
@@ -39,6 +39,7 @@ echo "AWS-LC build succeeded. Found ${AWS_LC_CMD}"
 
 echo "clone s2n-tls"
 git clone --depth 1 --branch "$S2N_BRANCH" "$S2N_URL" "$S2N_TLS_SRC_FOLDER"
+record_repo_commit "${S2N_TLS_SRC_FOLDER}"
 
 echo "build s2n-tls with aws-lc"
 cd "$S2N_TLS_SRC_FOLDER"
@@ -82,6 +83,7 @@ done
 
 echo "clone boring-ssl"
 git clone --depth 1 --branch "$BSSL_BRANCH" "$BSSL_URL" "$BSSL_SRC_FOLDER"
+record_repo_commit "${BSSL_SRC_FOLDER}"
 
 echo "build boring-ssl with aws-lc"
 cd "$BSSL_SRC_FOLDER"

--- a/tests/ci/integration/run_pyopenssl_integration.sh
+++ b/tests/ci/integration/run_pyopenssl_integration.sh
@@ -33,6 +33,7 @@ function pyopenssl_clone() {
     git clone https://github.com/pyca/pyopenssl.git ${src_dir} \
         --depth 1 \
         --branch ${branch}
+    record_repo_commit "${src_dir}"
     for patchfile in $(find -L ${patch_dir} -type f -name '*.patch'); do
         echo "Applying patch ${patchfile}..."
         patch -p1 --quiet -d ${src_dir} -i "${patchfile}"

--- a/tests/ci/integration/run_python_integration.sh
+++ b/tests/ci/integration/run_python_integration.sh
@@ -90,6 +90,7 @@ function fetch_crt_python() {
     pushd ${CRT_SRC_FOLDER}
     git clone https://github.com/awslabs/aws-crt-python.git .
     git submodule update --init
+    record_repo_commit "${CRT_SRC_FOLDER}"
     popd
 }
 
@@ -186,6 +187,7 @@ function python_patch() {
     git clone https://github.com/python/cpython.git ${src_dir} \
         --depth 1 \
         --branch ${branch}
+    record_repo_commit "${src_dir}"
     for patchfile in $(find -L ${patch_dir} -type f -name '*.patch'); do
       echo "Apply patch ${patchfile}..."
       cat ${patchfile} \

--- a/tests/ci/integration/run_ruby_integration.sh
+++ b/tests/ci/integration/run_ruby_integration.sh
@@ -69,6 +69,7 @@ function ruby_patch() {
     git clone https://github.com/ruby/ruby.git ${src_dir} \
         --depth 1 \
         --branch ${branch}
+    record_repo_commit "${src_dir}"
 
     # Add directory of backport patches if branch is a version later than Ruby 3.4.
     if [[ "${branch}" != "master" && "${branch}" != "ruby_3_4" ]]; then

--- a/tests/ci/integration/run_s2n_integration.sh
+++ b/tests/ci/integration/run_s2n_integration.sh
@@ -23,6 +23,7 @@ source tests/ci/common_posix_setup.sh
 SCRATCH_FOLDER=${SYS_ROOT}/"SCRATCH_AWSLC_S2N_INTERN_TEST"
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
+S2N_TLS_SRC_FOLDER="${SCRATCH_FOLDER}/s2n-tls"
 S2N_TLS_BUILD_FOLDER="${SCRATCH_FOLDER}/s2n-tls-build"
 
 # Make script execution idempotent.
@@ -58,7 +59,8 @@ function s2n_tls_prepare_new_build() {
 # Get latest s2n-tls version.
 
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${S2N_TLS_BUILD_FOLDER}
-git clone https://github.com/aws/s2n-tls.git
+git clone https://github.com/aws/s2n-tls.git "${S2N_TLS_SRC_FOLDER}"
+record_repo_commit "${S2N_TLS_SRC_FOLDER}"
 ls
 
 # s2n-tls's FindLibCrypto.cmake expects to find both the static and shared

--- a/tests/ci/integration/run_sslproxy_integration.sh
+++ b/tests/ci/integration/run_sslproxy_integration.sh
@@ -31,6 +31,7 @@ EXPECTED_AWSLC_API_VERSION="22"
 
 function libevent_install() {
   git clone https://github.com/libevent/libevent.git ${LIBEVENT_SRC_FOLDER} --depth 1
+  record_repo_commit "${LIBEVENT_SRC_FOLDER}"
   pushd ${LIBEVENT_SRC_FOLDER}
   cmake -DOPENSSL_ROOT_DIR="${AWS_LC_INSTALL_FOLDER}" -DCMAKE_INSTALL_PREFIX="${LIBEVENT_INSTALL_FOLDER}"
   make -j "$NUM_CPU_THREADS" install
@@ -71,6 +72,7 @@ rm -rf "${SCRATCH_FOLDER:?}"/*
 cd ${SCRATCH_FOLDER}
 
 git clone https://github.com/sonertari/SSLproxy.git ${SSLPROXY_SRC_FOLDER} --depth 1
+record_repo_commit "${SSLPROXY_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${SSLPROXY_BUILD_FOLDER}
 ls
 

--- a/tests/ci/integration/run_strongswan_integration.sh
+++ b/tests/ci/integration/run_strongswan_integration.sh
@@ -45,6 +45,7 @@ rm -rf ${SCRATCH_FOLDER}/*
 cd ${SCRATCH_FOLDER}
 
 git clone --depth 1 https://github.com/strongswan/strongswan.git ${STRONGSWAN_SRC_FOLDER}
+record_repo_commit "${STRONGSWAN_SRC_FOLDER}"
 
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 

--- a/tests/ci/integration/run_tcpdump_integration.sh
+++ b/tests/ci/integration/run_tcpdump_integration.sh
@@ -47,6 +47,7 @@ function tcpdump_run_tests() {
 
 # Get latest tcpdump version.
 git clone https://github.com/the-tcpdump-group/tcpdump.git "${TCPDUMP_SRC_FOLDER}"
+record_repo_commit "${TCPDUMP_SRC_FOLDER}"
 mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${TCPDUMP_INSTALL_FOLDER}"
 ls
 

--- a/tests/ci/integration/run_tpm2_tss_integration.sh
+++ b/tests/ci/integration/run_tpm2_tss_integration.sh
@@ -80,6 +80,10 @@ git clone https://github.com/curl/curl.git "${CURL_SRC_FOLDER}"
 git clone https://github.com/tpm2-software/tpm2-tss.git "${TPM2_TSS_SRC_FOLDER}"
 git clone https://github.com/tpm2-software/tpm2-abrmd.git "${TPM2_ABRMD_SRC_FOLDER}"
 git clone https://github.com/tpm2-software/tpm2-tools.git "${TPM2_TOOLS_SRC_FOLDER}"
+record_repo_commit "${CURL_SRC_FOLDER}"
+record_repo_commit "${TPM2_TSS_SRC_FOLDER}"
+record_repo_commit "${TPM2_ABRMD_SRC_FOLDER}"
+record_repo_commit "${TPM2_TOOLS_SRC_FOLDER}"
 mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${CURL_BUILD_FOLDER}" "${CURL_INSTALL_FOLDER}"
 ls
 

--- a/tests/ci/integration/run_trousers_integration.sh
+++ b/tests/ci/integration/run_trousers_integration.sh
@@ -43,6 +43,7 @@ function trousers_build() {
 
 # Get latest trousers version.
 git clone https://git.code.sf.net/p/trousers/trousers "${TROUSERS_SRC_FOLDER}"
+record_repo_commit "${TROUSERS_SRC_FOLDER}"
 mkdir -p "${AWS_LC_BUILD_FOLDER}" "${AWS_LC_INSTALL_FOLDER}" "${TROUSERS_INSTALL_FOLDER}"
 ls
 

--- a/tests/ci/integration/run_xmlsec_integration.sh
+++ b/tests/ci/integration/run_xmlsec_integration.sh
@@ -47,6 +47,7 @@ function xmlsec_run_tests() {
 }
 
 git clone https://github.com/lsh123/xmlsec.git ${XMLSEC_SRC_FOLDER}
+record_repo_commit "${XMLSEC_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER}
 ls
 

--- a/tests/ci/integration/run_xtrabackup_integration.sh
+++ b/tests/ci/integration/run_xtrabackup_integration.sh
@@ -40,6 +40,7 @@ function xtrabackup_build() {
 }
 
 git clone --recurse-submodules https://github.com/percona/percona-xtrabackup.git ${XTRABACKUP_SRC_FOLDER} --depth 1
+record_repo_commit "${XTRABACKUP_SRC_FOLDER}"
 mkdir -p ${AWS_LC_BUILD_FOLDER} ${AWS_LC_INSTALL_FOLDER} ${XTRABACKUP_BUILD_FOLDER}
 ls
 


### PR DESCRIPTION

### Context and motivation
- The current [autofix bot](https://github.com/aws/aws-lc/blob/main/tests/ci/integration/autofix_integration_failures/autofix.sh) runs until it produces a patch, and only relies on `patch --dry-run -p1` to verify that the patch it produced fixes the failing integration test. 

- The problem with this is that a patch successfully applying does not mean the integration test with the script and the runner job was necessarily fixed. We need to be able to re-run the integration test in the autofix sandbox with its fixes and make sure it has a self-verification loop.

### Description of changes
- `Integration-omnibus` failure artifacts now include the integration name and version, AWS-LC commit SHA it built against, and each downstream repository’s URL and commit SHA. NTP failures record the archive URL and SHA-256 checksum instead. 
- The failing tests step now count failed jobs directly from the Github API instead of counting artifacts that were produced by failing jobs.

A follow-up PR will make the autofix workflow/bot consume this metadata and reproduce the environment, apply its fix, and rerun the failed integration runner to verify its fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
