### PR TITLE
Verify provider-wide algorithm reachability

### DIFF
--- a/provider/CMakeLists.txt
+++ b/provider/CMakeLists.txt
@@ -124,6 +124,7 @@ if(BUILD_TESTING AND NOT ANDROID)
   add_executable(awslc_provider_test
     test/test_main.cc
     test/frontend/provider_test.cc
+    test/frontend/reachability_test.cc
     test/frontend/operations/digests/digests_test.cc
     test/frontend/operations/digests/sha2_test.cc)
 

--- a/provider/test/frontend/provider_test.cc
+++ b/provider/test/frontend/provider_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 // The provider-global surface: that the module loads, reports itself correctly,
-// and declines every operation class, so fetches fall through to another
+// and declines unsupported operation classes so fetches fall through to another
 // provider rather than failing.
 
 #include "test/test_fixture.h"

--- a/provider/test/frontend/reachability_test.cc
+++ b/provider/test/frontend/reachability_test.cc
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// The provider-wide inventory of advertised algorithms and their attributed
+// public fetch paths.
+
+#include "test/test_fixture.h"
+
+#include <openssl/core_dispatch.h>
+#include <openssl/evp.h>
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
+
+namespace awslc_provider_test {
+namespace {
+
+struct ReachabilityCell {
+  int operation;
+  const char *name;
+};
+
+// One attributed test cell per registry row. Duplicates stay duplicated so the
+// comparison below detects both missing coverage and accidental registrations.
+constexpr ReachabilityCell kReachabilityCells[] = {
+    {OSSL_OP_DIGEST, "SHA2-224"},
+    {OSSL_OP_DIGEST, "SHA2-256"},
+    {OSSL_OP_DIGEST, "SHA2-384"},
+    {OSSL_OP_DIGEST, "SHA2-512"},
+    {OSSL_OP_DIGEST, "SHA2-512/224"},
+    {OSSL_OP_DIGEST, "SHA2-512/256"},
+};
+
+std::string ReachabilityKey(int operation, const std::string &name) {
+  return std::to_string(operation) + ":" + name;
+}
+
+TEST_F(ProviderTest, AdvertisedAlgorithmsMatchReachabilityCells) {
+  std::vector<std::string> advertised;
+  for (int operation = 1; operation <= OSSL_OP__HIGHEST; operation++) {
+    int no_cache = 0;
+    const OSSL_ALGORITHM *algorithms =
+        OSSL_PROVIDER_query_operation(awslc(), operation, &no_cache);
+
+    for (const OSSL_ALGORITHM *algorithm = algorithms;
+         algorithm != nullptr && algorithm->algorithm_names != nullptr;
+         algorithm++) {
+      const std::string names = algorithm->algorithm_names;
+      const std::string name = names.substr(0, names.find(':'));
+      advertised.push_back(ReachabilityKey(operation, name));
+    }
+
+    OSSL_PROVIDER_unquery_operation(awslc(), operation, algorithms);
+  }
+
+  std::vector<std::string> covered;
+  for (const ReachabilityCell &cell : kReachabilityCells) {
+    covered.push_back(ReachabilityKey(cell.operation, cell.name));
+  }
+
+  std::sort(advertised.begin(), advertised.end());
+  std::sort(covered.begin(), covered.end());
+  EXPECT_EQ(advertised, covered);
+}
+
+class ReachabilityTest
+    : public ProviderTest,
+      public ::testing::WithParamInterface<ReachabilityCell> {};
+
+TEST_P(ReachabilityTest, IsReachableAndAttributed) {
+  const ReachabilityCell &cell = GetParam();
+
+  switch (cell.operation) {
+    case OSSL_OP_DIGEST: {
+      MdPtr md(EVP_MD_fetch(libctx(), cell.name, kRequireAwslc));
+      ASSERT_TRUE(md) << cell.name << " was not reachable";
+      EXPECT_STREQ(kProviderName,
+                   OSSL_PROVIDER_get0_name(EVP_MD_get0_provider(md.get())));
+      break;
+    }
+    default:
+      FAIL() << "operation " << cell.operation
+             << " has no attributed reachability handler";
+  }
+}
+
+std::string ReachabilityName(
+    const testing::TestParamInfo<ReachabilityCell> &info) {
+  std::string name =
+      "Op" + std::to_string(info.param.operation) + "_" + info.param.name;
+  for (char &c : name) {
+    if (!isalnum(static_cast<unsigned char>(c))) {
+      c = '_';
+    }
+  }
+  return name;
+}
+
+INSTANTIATE_TEST_SUITE_P(Provider, ReachabilityTest,
+                         testing::ValuesIn(kReachabilityCells),
+                         ReachabilityName);
+
+}  // namespace
+}  // namespace awslc_provider_test


### PR DESCRIPTION
### Context and motivation

This test asserts that all algorithms advertised by the provider match against an inventory and that all algorithms in that inventory are available and served by AWS-LC. This provides breadth coverage for asserting that all algorithms we claim to support are in fact supported.

### Description of changes

`test/frontend/reachability_test.cc` holds one cell per registry row, as an operation id and the row's
primary name.

**The inventory.** `AdvertisedAlgorithmsMatchReachabilityCells` queries the provider directly for every
operation id from 1 to `OSSL_OP__HIGHEST`, collects the primary name of each advertised row, and compares
that against the cell table. The comparison is over duplicate-preserving sorted vectors rather than sets,
so an accidental second registration of the same name fails it as well as a missing cell.

**The cells.** `ReachabilityTest.IsReachableAndAttributed` fetches each cell with `provider=awslc`
required and asserts the implementation it got back reports this provider, so a fallthrough to the
default provider cannot pass as reachability. An operation class with no attributed handler in the switch
fails the cell rather than skipping it, which is what makes the table's growth deliberate for future
operation types.

### Testing

The test is the change. Control run: duplicating the SHA2-512/256 registry row fails the inventory. Under
a set comparison the same duplicate passes, which is why the vectors preserve duplicates.

### Review considerations

- The cell table is hand-maintained by design, and the inventory is what makes forgetting it a test
  failure rather than a silent gap.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache
2.0 license and the ISC license.
