### PR TITLE
Add FIPS support to the aws-lc-provider

### DIFF
--- a/.github/workflows/aws-lc-provider.yml
+++ b/.github/workflows/aws-lc-provider.yml
@@ -16,8 +16,13 @@ permissions:
 
 jobs:
   aws-lc-provider-linux:
+    name: aws-lc-provider Linux FIPS=${{ matrix.fips }}
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fips: [0, 1]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
@@ -30,4 +35,8 @@ jobs:
             cmake ninja-build make perl binutils
       - name: Build the provider and run its unit tests
         run: |
-          ./tests/ci/run_aws_lc_provider_tests.sh
+          if [[ "${{ matrix.fips }}" == "1" ]]; then
+            ./tests/ci/run_aws_lc_provider_tests.sh --fips
+          else
+            ./tests/ci/run_aws_lc_provider_tests.sh
+          fi

--- a/provider/CMakeLists.txt
+++ b/provider/CMakeLists.txt
@@ -154,6 +154,9 @@ if(BUILD_TESTING AND NOT ANDROID)
   target_compile_definitions(awslc_provider_test PRIVATE
     "AWSLC_PROVIDER_MODULE_DIR=\"$<TARGET_FILE_DIR:awslc_provider>\""
     "AWSLC_PROVIDER_CONFIG_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/test/provider.cnf\"")
+  if(FIPS)
+    target_compile_definitions(awslc_provider_test PRIVATE AWSLC_FIPS)
+  endif()
 
   # Both test binaries run straight out of the build tree, so they carry the
   # paths to the OpenSSL they link and to the build's own shared libraries.

--- a/provider/README.md
+++ b/provider/README.md
@@ -36,6 +36,29 @@ cmake -GNinja -Bbuild -DCMAKE_BUILD_TYPE=Release \
 
 The provider artifact is `build/provider/awslc.so` (`awslc.dylib` on macOS).
 
+## FIPS
+
+The provider maps OpenSSL's FIPS-facing provider interfaces onto AWS-LC's FIPS
+build, self-tests, and service indicator. A deployment claiming FIPS compliance
+must build and package the provider with an applicable FIPS build of AWS-LC and
+satisfy the requirements of that validation:
+
+```bash
+# Building AWS-LC-FIPS with aws-lc-provider
+cmake -GNinja -S . -Bbuild -DCMAKE_BUILD_TYPE=Release \
+  -DFIPS=1 -DBUILD_SHARED_LIBS=ON -DENABLE_DIST_PKG=ON \
+  -DBUILD_AWSLC_PROVIDER=ON -DAWSLC_PROVIDER_OPENSSL_ROOT="${OPENSSL_ROOT}"
+```
+
+| Feature | Provider behavior |
+|---|---|
+| `fips=yes` algorithm property | Identifies implementations of algorithms that AWS-LC can approve. It classifies the algorithm rather than attesting the linked AWS-LC. Approved-only fetches must include `fips=yes`. |
+| `fips-indicator` operation parameter | Reports whether AWS-LC reports FIPS mode and approved the completed operation. Applications enforcing per-operation approval must read it after each operation. |
+| Indicator callback | When AWS-LC reports FIPS mode, invokes OpenSSL's configured indicator callback if an operation is not approved. If the callback vetoes the result, the provider clears the output and returns an error. |
+| Provider `status` parameter | Reports one after successful provider initialization. AWS-LC terminates the process if a FIPS self-test puts the module into a failure state. |
+| `OSSL_PROVIDER_self_test()` | Runs AWS-LC's known-answer self-tests through `BORINGSSL_self_test()` and propagates the result. |
+| Provider `buildinfo` parameter | Reports the linked AWS-LC version string, including AWS-LC's FIPS build identity when applicable. |
+
 ## Testing
 
 There are two test binaries for `aws-lc-provider`, one per side of the split.

--- a/provider/backend/info.c
+++ b/provider/backend/info.c
@@ -13,3 +13,17 @@ const char *awslc_prov_backend_version(void) {
 int awslc_prov_backend_is_fips(void) {
   return FIPS_mode();
 }
+
+uint64_t awslc_prov_service_indicator_before_call(void) {
+  return FIPS_service_indicator_before_call();
+}
+
+int awslc_prov_service_indicator_after_call(uint64_t before) {
+  const uint64_t after = FIPS_service_indicator_after_call();
+
+  return before != after;
+}
+
+int awslc_prov_backend_self_test(void) {
+  return BORINGSSL_self_test();
+}

--- a/provider/backend/mem.c
+++ b/provider/backend/mem.c
@@ -1,10 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-// Allocation, deliberately on AWS-LC's allocator rather than the core's memory
-// upcalls: routing through OpenSSL's allocator would entangle the two libcryptos'
-// memory management for no benefit. Only caller-owned OSSL_PARAM buffers cross
-// the boundary, and those are never allocated by us.
+// Expose openssl/mem.h functions from AWS-LC for use in the provider.
 
 #include <openssl/mem.h>
 
@@ -16,4 +13,8 @@ void *awslc_prov_zalloc(size_t size) {
 
 void awslc_prov_clear_free(void *ptr, size_t size) {
   OPENSSL_clear_free(ptr, size);
+}
+
+void awslc_prov_cleanse(void *ptr, size_t size) {
+  OPENSSL_cleanse(ptr, size);
 }

--- a/provider/frontend/operations/digests/digests.c
+++ b/provider/frontend/operations/digests/digests.c
@@ -16,9 +16,20 @@ static const OSSL_PARAM awslc_prov_digest_gettable[] = {
     OSSL_PARAM_int(OSSL_DIGEST_PARAM_ALGID_ABSENT, NULL),
     OSSL_PARAM_END};
 
+static const OSSL_PARAM awslc_prov_digest_gettable_ctx[] = {
+    OSSL_PARAM_int(OSSL_ALG_PARAM_FIPS_APPROVED_INDICATOR, NULL),
+    OSSL_PARAM_END};
+
 const OSSL_PARAM *awslc_prov_digest_gettable_params(void *provctx) {
   (void)provctx;
   return awslc_prov_digest_gettable;
+}
+
+const OSSL_PARAM *awslc_prov_digest_gettable_ctx_params(void *dctx,
+                                                        void *provctx) {
+  (void)dctx;
+  (void)provctx;
+  return awslc_prov_digest_gettable_ctx;
 }
 
 int awslc_prov_digest_get_params(OSSL_PARAM params[], size_t block_size,
@@ -45,4 +56,11 @@ int awslc_prov_digest_get_params(OSSL_PARAM params[], size_t block_size,
     return 0;
   }
   return 1;
+}
+
+int awslc_prov_digest_get_fips_indicator(OSSL_PARAM params[], int approved) {
+  OSSL_PARAM *p =
+      OSSL_PARAM_locate(params, OSSL_ALG_PARAM_FIPS_APPROVED_INDICATOR);
+
+  return p == NULL || OSSL_PARAM_set_int(p, approved);
 }

--- a/provider/frontend/operations/digests/sha2.c
+++ b/provider/frontend/operations/digests/sha2.c
@@ -9,6 +9,9 @@
 #include "internal/backend.h"
 #include "internal/backend/digests.h"
 #include "internal/frontend/digests.h"
+#include "internal/provider.h"
+
+#include <string.h>
 
 // Changes the DER OpenSSL emits for this digest inside PKI structures. The value
 // must match the OpenSSL default provider's, or our encodings differ from it.
@@ -21,54 +24,99 @@ typedef int (*awslc_prov_sha2_final_fn)(void *ctx, unsigned char *out,
                                         size_t out_size);
 typedef int (*awslc_prov_sha2_copy_fn)(void *dst, const void *src);
 
-static void awslc_prov_sha2_freectx(void *dctx, size_t ctx_size) {
-  if (dctx == NULL) {
-    return;
-  }
-  awslc_prov_clear_free(dctx, ctx_size);
-}
+typedef struct {
+  AWSLC_PROV_CTX *provctx;
+  void *backend_ctx;
+  size_t backend_ctx_size;
+  const char *algorithm_name;
+  int fips_approved;
+} AWSLC_PROV_SHA2_CTX;
 
-static void *awslc_prov_sha2_dupctx(void *dctx, size_t ctx_size,
-                                    awslc_prov_sha2_copy_fn copy) {
-  void *duplicate = NULL;
+static void *awslc_prov_sha2_newctx(void *provctx, size_t backend_ctx_size,
+                                    const char *algorithm_name) {
+  AWSLC_PROV_SHA2_CTX *ctx = awslc_prov_zalloc(sizeof(*ctx));
 
-  if (dctx == NULL) {
+  if (ctx == NULL) {
     return NULL;
   }
-  duplicate = awslc_prov_zalloc(ctx_size);
+  ctx->backend_ctx = awslc_prov_zalloc(backend_ctx_size);
+  if (ctx->backend_ctx == NULL) {
+    awslc_prov_clear_free(ctx, sizeof(*ctx));
+    return NULL;
+  }
+  ctx->provctx = (AWSLC_PROV_CTX *)provctx;
+  ctx->backend_ctx_size = backend_ctx_size;
+  ctx->algorithm_name = algorithm_name;
+  ctx->fips_approved = awslc_prov_ctx_is_fips(ctx->provctx);
+  return ctx;
+}
+
+static void awslc_prov_sha2_freectx(void *dctx) {
+  AWSLC_PROV_SHA2_CTX *ctx = (AWSLC_PROV_SHA2_CTX *)dctx;
+
+  if (ctx == NULL) {
+    return;
+  }
+  awslc_prov_clear_free(ctx->backend_ctx, ctx->backend_ctx_size);
+  awslc_prov_clear_free(ctx, sizeof(*ctx));
+}
+
+static void *awslc_prov_sha2_dupctx(void *dctx,
+                                    awslc_prov_sha2_copy_fn copy) {
+  AWSLC_PROV_SHA2_CTX *ctx = (AWSLC_PROV_SHA2_CTX *)dctx;
+  AWSLC_PROV_SHA2_CTX *duplicate = NULL;
+
+  if (ctx == NULL) {
+    return NULL;
+  }
+  duplicate = awslc_prov_sha2_newctx(
+      ctx->provctx, ctx->backend_ctx_size, ctx->algorithm_name);
   if (duplicate == NULL) {
     return NULL;
   }
-  if (!copy(duplicate, dctx)) {
-    awslc_prov_clear_free(duplicate, ctx_size);
+  if (!copy(duplicate->backend_ctx, ctx->backend_ctx)) {
+    awslc_prov_sha2_freectx(duplicate);
     return NULL;
   }
+  duplicate->fips_approved = ctx->fips_approved;
   return duplicate;
 }
 
 static void awslc_prov_sha2_copyctx(void *outctx, void *inctx,
                                     awslc_prov_sha2_copy_fn copy) {
-  if (outctx == NULL || inctx == NULL) {
+  AWSLC_PROV_SHA2_CTX *out = (AWSLC_PROV_SHA2_CTX *)outctx;
+  AWSLC_PROV_SHA2_CTX *in = (AWSLC_PROV_SHA2_CTX *)inctx;
+
+  if (out == NULL || in == NULL ||
+      out->backend_ctx_size != in->backend_ctx_size) {
     return;
   }
-  (void)copy(outctx, inctx);
+  (void)copy(out->backend_ctx, in->backend_ctx);
+  out->provctx = in->provctx;
+  out->algorithm_name = in->algorithm_name;
+  out->fips_approved = in->fips_approved;
 }
 
 // The init params are forwarded signature-operation params, not a digest-scoped
 // array. No digest can honor keys such as pad-mode or saltlen, so ignore them.
 static int awslc_prov_sha2_init_op(void *dctx, const OSSL_PARAM params[],
                                    awslc_prov_sha2_init_fn init) {
+  AWSLC_PROV_SHA2_CTX *ctx = (AWSLC_PROV_SHA2_CTX *)dctx;
+
   (void)params;
-  if (dctx == NULL) {
+  if (ctx == NULL) {
     return 0;
   }
-  return init(dctx);
+  ctx->fips_approved = awslc_prov_ctx_is_fips(ctx->provctx);
+  return init(ctx->backend_ctx);
 }
 
 static int awslc_prov_sha2_update_op(void *dctx, const unsigned char *in,
                                      size_t inl,
                                      awslc_prov_sha2_update_fn update) {
-  if (dctx == NULL) {
+  AWSLC_PROV_SHA2_CTX *ctx = (AWSLC_PROV_SHA2_CTX *)dctx;
+
+  if (ctx == NULL) {
     return 0;
   }
   // A zero-length update with a NULL |in| is legal per the EVP contract. AWS-LC
@@ -80,21 +128,50 @@ static int awslc_prov_sha2_update_op(void *dctx, const unsigned char *in,
   if (in == NULL) {
     return 0;
   }
-  return update(dctx, in, inl);
+  return update(ctx->backend_ctx, in, inl);
 }
 
 static int awslc_prov_sha2_final_op(void *dctx, unsigned char *out, size_t *outl,
                                     size_t outsz,
                                     awslc_prov_sha2_final_fn final_fn,
                                     size_t digest_size) {
-  if (dctx == NULL || out == NULL || outl == NULL) {
+  AWSLC_PROV_SHA2_CTX *ctx = (AWSLC_PROV_SHA2_CTX *)dctx;
+  uint64_t before;
+  int approved;
+  int is_fips;
+  int ok;
+
+  if (ctx == NULL || out == NULL || outl == NULL) {
     return 0;
   }
-  if (!final_fn(dctx, out, outsz)) {
+  before = awslc_prov_service_indicator_before_call();
+  ok = final_fn(ctx->backend_ctx, out, outsz);
+  is_fips = awslc_prov_ctx_is_fips(ctx->provctx);
+  approved = is_fips && awslc_prov_service_indicator_after_call(before);
+  if (!ok) {
+    return 0;
+  }
+  if (!approved) {
+    ctx->fips_approved = 0;
+  }
+  if (is_fips && !approved &&
+      !awslc_prov_indicator_on_unapproved(
+          ctx->provctx, ctx->algorithm_name,
+          AWSLC_PROV_DIGEST_OPERATION_DESCRIPTION)) {
+    memset(out, 0, digest_size);
     return 0;
   }
   *outl = digest_size;
   return 1;
+}
+
+static int awslc_prov_sha2_get_ctx_params(void *dctx, OSSL_PARAM params[]) {
+  AWSLC_PROV_SHA2_CTX *ctx = (AWSLC_PROV_SHA2_CTX *)dctx;
+
+  if (ctx == NULL) {
+    return 0;
+  }
+  return awslc_prov_digest_get_fips_indicator(params, ctx->fips_approved);
 }
 
 static int awslc_prov_sha2_get_params(OSSL_PARAM params[],
@@ -108,17 +185,16 @@ static int awslc_prov_sha2_get_params(OSSL_PARAM params[],
 AWSLC_PROV_DECLARE_FIXED_DIGEST_SLOTS(sha224);
 
 static void *awslc_prov_sha224_newctx(void *provctx) {
-  (void)provctx;
-  return awslc_prov_zalloc(awslc_prov_sha224_ctx_size());
+  return awslc_prov_sha2_newctx(provctx, awslc_prov_sha224_ctx_size(),
+                                "SHA2-224");
 }
 
 static void awslc_prov_sha224_freectx(void *dctx) {
-  awslc_prov_sha2_freectx(dctx, awslc_prov_sha224_ctx_size());
+  awslc_prov_sha2_freectx(dctx);
 }
 
 static void *awslc_prov_sha224_dupctx(void *dctx) {
-  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha224_ctx_size(),
-                                awslc_prov_sha224_copy);
+  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha224_copy);
 }
 
 static void awslc_prov_sha224_copyctx(void *outctx, void *inctx) {
@@ -146,24 +222,23 @@ static int awslc_prov_sha224_get_params(OSSL_PARAM params[]) {
                                     awslc_prov_sha224_digest_size());
 }
 
-AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha224);
+AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha224, sha2);
 
 // SHA-256
 
 AWSLC_PROV_DECLARE_FIXED_DIGEST_SLOTS(sha256);
 
 static void *awslc_prov_sha256_newctx(void *provctx) {
-  (void)provctx;
-  return awslc_prov_zalloc(awslc_prov_sha256_ctx_size());
+  return awslc_prov_sha2_newctx(provctx, awslc_prov_sha256_ctx_size(),
+                                "SHA2-256");
 }
 
 static void awslc_prov_sha256_freectx(void *dctx) {
-  awslc_prov_sha2_freectx(dctx, awslc_prov_sha256_ctx_size());
+  awslc_prov_sha2_freectx(dctx);
 }
 
 static void *awslc_prov_sha256_dupctx(void *dctx) {
-  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha256_ctx_size(),
-                                awslc_prov_sha256_copy);
+  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha256_copy);
 }
 
 static void awslc_prov_sha256_copyctx(void *outctx, void *inctx) {
@@ -191,24 +266,23 @@ static int awslc_prov_sha256_get_params(OSSL_PARAM params[]) {
                                     awslc_prov_sha256_digest_size());
 }
 
-AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha256);
+AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha256, sha2);
 
 // SHA-384
 
 AWSLC_PROV_DECLARE_FIXED_DIGEST_SLOTS(sha384);
 
 static void *awslc_prov_sha384_newctx(void *provctx) {
-  (void)provctx;
-  return awslc_prov_zalloc(awslc_prov_sha384_ctx_size());
+  return awslc_prov_sha2_newctx(provctx, awslc_prov_sha384_ctx_size(),
+                                "SHA2-384");
 }
 
 static void awslc_prov_sha384_freectx(void *dctx) {
-  awslc_prov_sha2_freectx(dctx, awslc_prov_sha384_ctx_size());
+  awslc_prov_sha2_freectx(dctx);
 }
 
 static void *awslc_prov_sha384_dupctx(void *dctx) {
-  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha384_ctx_size(),
-                                awslc_prov_sha384_copy);
+  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha384_copy);
 }
 
 static void awslc_prov_sha384_copyctx(void *outctx, void *inctx) {
@@ -236,24 +310,23 @@ static int awslc_prov_sha384_get_params(OSSL_PARAM params[]) {
                                     awslc_prov_sha384_digest_size());
 }
 
-AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha384);
+AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha384, sha2);
 
 // SHA-512
 
 AWSLC_PROV_DECLARE_FIXED_DIGEST_SLOTS(sha512);
 
 static void *awslc_prov_sha512_newctx(void *provctx) {
-  (void)provctx;
-  return awslc_prov_zalloc(awslc_prov_sha512_ctx_size());
+  return awslc_prov_sha2_newctx(provctx, awslc_prov_sha512_ctx_size(),
+                                "SHA2-512");
 }
 
 static void awslc_prov_sha512_freectx(void *dctx) {
-  awslc_prov_sha2_freectx(dctx, awslc_prov_sha512_ctx_size());
+  awslc_prov_sha2_freectx(dctx);
 }
 
 static void *awslc_prov_sha512_dupctx(void *dctx) {
-  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha512_ctx_size(),
-                                awslc_prov_sha512_copy);
+  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha512_copy);
 }
 
 static void awslc_prov_sha512_copyctx(void *outctx, void *inctx) {
@@ -281,24 +354,23 @@ static int awslc_prov_sha512_get_params(OSSL_PARAM params[]) {
                                     awslc_prov_sha512_digest_size());
 }
 
-AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha512);
+AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha512, sha2);
 
 // SHA-512/224
 
 AWSLC_PROV_DECLARE_FIXED_DIGEST_SLOTS(sha512_224);
 
 static void *awslc_prov_sha512_224_newctx(void *provctx) {
-  (void)provctx;
-  return awslc_prov_zalloc(awslc_prov_sha512_224_ctx_size());
+  return awslc_prov_sha2_newctx(provctx, awslc_prov_sha512_224_ctx_size(),
+                                "SHA2-512/224");
 }
 
 static void awslc_prov_sha512_224_freectx(void *dctx) {
-  awslc_prov_sha2_freectx(dctx, awslc_prov_sha512_224_ctx_size());
+  awslc_prov_sha2_freectx(dctx);
 }
 
 static void *awslc_prov_sha512_224_dupctx(void *dctx) {
-  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha512_224_ctx_size(),
-                                awslc_prov_sha512_224_copy);
+  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha512_224_copy);
 }
 
 static void awslc_prov_sha512_224_copyctx(void *outctx, void *inctx) {
@@ -330,24 +402,23 @@ static int awslc_prov_sha512_224_get_params(OSSL_PARAM params[]) {
                                     awslc_prov_sha512_224_digest_size());
 }
 
-AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha512_224);
+AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha512_224, sha2);
 
 // SHA-512/256
 
 AWSLC_PROV_DECLARE_FIXED_DIGEST_SLOTS(sha512_256);
 
 static void *awslc_prov_sha512_256_newctx(void *provctx) {
-  (void)provctx;
-  return awslc_prov_zalloc(awslc_prov_sha512_256_ctx_size());
+  return awslc_prov_sha2_newctx(provctx, awslc_prov_sha512_256_ctx_size(),
+                                "SHA2-512/256");
 }
 
 static void awslc_prov_sha512_256_freectx(void *dctx) {
-  awslc_prov_sha2_freectx(dctx, awslc_prov_sha512_256_ctx_size());
+  awslc_prov_sha2_freectx(dctx);
 }
 
 static void *awslc_prov_sha512_256_dupctx(void *dctx) {
-  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha512_256_ctx_size(),
-                                awslc_prov_sha512_256_copy);
+  return awslc_prov_sha2_dupctx(dctx, awslc_prov_sha512_256_copy);
 }
 
 static void awslc_prov_sha512_256_copyctx(void *outctx, void *inctx) {
@@ -379,4 +450,4 @@ static int awslc_prov_sha512_256_get_params(OSSL_PARAM params[]) {
                                     awslc_prov_sha512_256_digest_size());
 }
 
-AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha512_256);
+AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(sha512_256, sha2);

--- a/provider/frontend/operations/digests/sha2.c
+++ b/provider/frontend/operations/digests/sha2.c
@@ -11,8 +11,6 @@
 #include "internal/frontend/digests.h"
 #include "internal/provider.h"
 
-#include <string.h>
-
 // Changes the DER OpenSSL emits for this digest inside PKI structures. The value
 // must match the OpenSSL default provider's, or our encodings differ from it.
 #define AWSLC_PROV_SHA2_FLAGS AWSLC_PROV_DIGEST_FLAG_ALGID_ABSENT
@@ -136,18 +134,14 @@ static int awslc_prov_sha2_final_op(void *dctx, unsigned char *out, size_t *outl
                                     awslc_prov_sha2_final_fn final_fn,
                                     size_t digest_size) {
   AWSLC_PROV_SHA2_CTX *ctx = (AWSLC_PROV_SHA2_CTX *)dctx;
-  uint64_t before;
-  int approved;
-  int is_fips;
-  int ok;
 
   if (ctx == NULL || out == NULL || outl == NULL) {
     return 0;
   }
-  before = awslc_prov_service_indicator_before_call();
-  ok = final_fn(ctx->backend_ctx, out, outsz);
-  is_fips = awslc_prov_ctx_is_fips(ctx->provctx);
-  approved = is_fips && awslc_prov_service_indicator_after_call(before);
+  uint64_t before = awslc_prov_service_indicator_before_call();
+  int ok = final_fn(ctx->backend_ctx, out, outsz);
+  int is_fips = awslc_prov_ctx_is_fips(ctx->provctx);
+  int approved = is_fips && awslc_prov_service_indicator_after_call(before);
   if (!ok) {
     return 0;
   }
@@ -158,7 +152,7 @@ static int awslc_prov_sha2_final_op(void *dctx, unsigned char *out, size_t *outl
       !awslc_prov_indicator_on_unapproved(
           ctx->provctx, ctx->algorithm_name,
           AWSLC_PROV_DIGEST_OPERATION_DESCRIPTION)) {
-    memset(out, 0, digest_size);
+    awslc_prov_cleanse(out, digest_size);
     return 0;
   }
   *outl = digest_size;

--- a/provider/frontend/provider.c
+++ b/provider/frontend/provider.c
@@ -31,10 +31,30 @@
 struct awslc_prov_ctx_st {
   const OSSL_CORE_HANDLE *handle;
   OPENSSL_CORE_CTX *corectx;
+  OSSL_FUNC_indicator_cb_fn *indicator_cb;
+  int is_fips;
 };
 
 const OSSL_CORE_HANDLE *awslc_prov_ctx_handle(const AWSLC_PROV_CTX *ctx) {
   return ctx->handle;
+}
+
+int awslc_prov_ctx_is_fips(const AWSLC_PROV_CTX *ctx) {
+  return ctx != NULL && ctx->is_fips;
+}
+
+int awslc_prov_indicator_on_unapproved(AWSLC_PROV_CTX *ctx, const char *type,
+                                       const char *description) {
+  OSSL_INDICATOR_CALLBACK *callback = NULL;
+
+  if (ctx == NULL || type == NULL || description == NULL) {
+    return 0;
+  }
+  if (ctx->indicator_cb == NULL) {
+    return 1;
+  }
+  ctx->indicator_cb(ctx->corectx, &callback);
+  return callback == NULL || callback(type, description, NULL);
 }
 
 // Parameters we answer about ourselves.
@@ -90,6 +110,13 @@ static void awslc_prov_teardown(void *provctx) {
   awslc_prov_clear_free(ctx, sizeof(*ctx));
 }
 
+static int awslc_prov_self_test(void *provctx) {
+  if (provctx == NULL) {
+    return 0;
+  }
+  return awslc_prov_backend_self_test();
+}
+
 // Functions we provide to the core.
 static const OSSL_DISPATCH awslc_prov_dispatch_table[] = {
     {OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))awslc_prov_teardown},
@@ -98,6 +125,7 @@ static const OSSL_DISPATCH awslc_prov_dispatch_table[] = {
     {OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))awslc_prov_get_params},
     {OSSL_FUNC_PROVIDER_QUERY_OPERATION,
      (void (*)(void))awslc_prov_query_operation},
+    {OSSL_FUNC_PROVIDER_SELF_TEST, (void (*)(void))awslc_prov_self_test},
     OSSL_DISPATCH_END};
 
 // Entry point for the entire provider.
@@ -106,6 +134,7 @@ AWSLC_PROV_ENTRY int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                                         const OSSL_DISPATCH **out,
                                         void **provctx) {
   OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
+  OSSL_FUNC_indicator_cb_fn *c_indicator_cb = NULL;
   AWSLC_PROV_CTX *ctx = NULL;
 
   // Scan the upcalls the core offers and keep the ones we use. Unrecognized ids
@@ -116,14 +145,16 @@ AWSLC_PROV_ENTRY int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
       case OSSL_FUNC_CORE_GET_LIBCTX:
         c_get_libctx = OSSL_FUNC_core_get_libctx(in);
         break;
+      case OSSL_FUNC_INDICATOR_CB:
+        c_indicator_cb = OSSL_FUNC_indicator_cb(in);
+        break;
       default:
         break;
     }
   }
 
-  // Without a libctx we cannot guarantee that calls we make land in the same
-  // library context the core called us with, so refuse to load rather than
-  // guess.
+  // The indicator upcall addresses callback state through the opaque core
+  // context. Refuse to load if the core cannot supply one.
   if (c_get_libctx == NULL) {
     return 0;
   }
@@ -134,6 +165,13 @@ AWSLC_PROV_ENTRY int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
   }
   ctx->handle = handle;
   ctx->corectx = c_get_libctx(handle);
+  ctx->indicator_cb = c_indicator_cb;
+  ctx->is_fips = awslc_prov_backend_is_fips() != 0;
+
+  if (ctx->corectx == NULL) {
+    awslc_prov_clear_free(ctx, sizeof(*ctx));
+    return 0;
+  }
 
   *provctx = ctx;
   *out = awslc_prov_dispatch_table;

--- a/provider/frontend/provider.c
+++ b/provider/frontend/provider.c
@@ -164,14 +164,11 @@ AWSLC_PROV_ENTRY int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
     return 0;
   }
   ctx->handle = handle;
+  // n.b. corectx can and is expected to be NULL. OpenSSL uses that as a sentinel
+  // for the process default core library context.
   ctx->corectx = c_get_libctx(handle);
   ctx->indicator_cb = c_indicator_cb;
   ctx->is_fips = awslc_prov_backend_is_fips() != 0;
-
-  if (ctx->corectx == NULL) {
-    awslc_prov_clear_free(ctx, sizeof(*ctx));
-    return 0;
-  }
 
   *provctx = ctx;
   *out = awslc_prov_dispatch_table;

--- a/provider/frontend/registry.c
+++ b/provider/frontend/registry.c
@@ -13,36 +13,43 @@
 // providers/implementations/include/prov/names.h
 // They include legacy spellings, aliases, and the OID.
 //
+// |properties| state both provider ownership and the entry's FIPS posture.
+//
 // |algorithm| is the symbol-name stem for each specific algorithm's macro
 // defined symbols and should be given in lower_snake_case.
 //
 // |description| is a simple string description for the algorithm.
-#define AWSLC_PROV_ALG(names, algorithm, description)                     \
-  { names, AWSLC_PROV_PROPERTIES, awslc_prov_##algorithm##_functions,     \
-    description }
+#define AWSLC_PROV_ALG(names, properties, algorithm, description)          \
+  { names, properties, awslc_prov_##algorithm##_functions, description }
 
 // One table per operation class. Each row cites the names.h macro it copies.
 static const OSSL_ALGORITHM awslc_prov_digests[] = {
     // PROV_NAMES_SHA2_224
-    AWSLC_PROV_ALG("SHA2-224:SHA-224:SHA224:2.16.840.1.101.3.4.2.4", sha224,
+    AWSLC_PROV_ALG("SHA2-224:SHA-224:SHA224:2.16.840.1.101.3.4.2.4",
+                   AWSLC_PROV_FIPS_PROPERTIES, sha224,
                    "AWS-LC SHA2-224 implementation"),
     // PROV_NAMES_SHA2_256
-    AWSLC_PROV_ALG("SHA2-256:SHA-256:SHA256:2.16.840.1.101.3.4.2.1", sha256,
+    AWSLC_PROV_ALG("SHA2-256:SHA-256:SHA256:2.16.840.1.101.3.4.2.1",
+                   AWSLC_PROV_FIPS_PROPERTIES, sha256,
                    "AWS-LC SHA2-256 implementation"),
     // PROV_NAMES_SHA2_384
-    AWSLC_PROV_ALG("SHA2-384:SHA-384:SHA384:2.16.840.1.101.3.4.2.2", sha384,
+    AWSLC_PROV_ALG("SHA2-384:SHA-384:SHA384:2.16.840.1.101.3.4.2.2",
+                   AWSLC_PROV_FIPS_PROPERTIES, sha384,
                    "AWS-LC SHA2-384 implementation"),
     // PROV_NAMES_SHA2_512
-    AWSLC_PROV_ALG("SHA2-512:SHA-512:SHA512:2.16.840.1.101.3.4.2.3", sha512,
+    AWSLC_PROV_ALG("SHA2-512:SHA-512:SHA512:2.16.840.1.101.3.4.2.3",
+                   AWSLC_PROV_FIPS_PROPERTIES, sha512,
                    "AWS-LC SHA2-512 implementation"),
     // PROV_NAMES_SHA2_512_224
     AWSLC_PROV_ALG(
         "SHA2-512/224:SHA-512/224:SHA512-224:2.16.840.1.101.3.4.2.5",
-        sha512_224, "AWS-LC SHA2-512/224 implementation"),
+        AWSLC_PROV_FIPS_PROPERTIES, sha512_224,
+        "AWS-LC SHA2-512/224 implementation"),
     // PROV_NAMES_SHA2_512_256
     AWSLC_PROV_ALG(
         "SHA2-512/256:SHA-512/256:SHA512-256:2.16.840.1.101.3.4.2.6",
-        sha512_256, "AWS-LC SHA2-512/256 implementation"),
+        AWSLC_PROV_FIPS_PROPERTIES, sha512_256,
+        "AWS-LC SHA2-512/256 implementation"),
     {NULL, NULL, NULL, NULL}};
 
 const OSSL_ALGORITHM *awslc_prov_query_operation(void *provctx,

--- a/provider/internal/backend.h
+++ b/provider/internal/backend.h
@@ -64,6 +64,7 @@
 // into whatever the dispatch slot it is serving expects.
 
 #include <stddef.h>
+#include <stdint.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -86,9 +87,19 @@ void awslc_prov_clear_free(void *ptr, size_t size);
 // AWS-LC is underneath.
 const char *awslc_prov_backend_version(void);
 
-// Whether the AWS-LC linked here is a FIPS build. FIPS is a compile-time property
-// of AWS-LC, so this is constant for the life of the process.
+// Whether the linked AWS-LC reports FIPS mode through its public FIPS_mode()
+// API. FIPS is a compile-time property of AWS-LC, so this is constant for the
+// life of the process.
 int awslc_prov_backend_is_fips(void);
+
+// Bracket one complete AWS-LC service and report whether the service-indicator
+// counter advanced. Callers must also require the provider's stored runtime FIPS
+// state because non-FIPS AWS-LC deliberately returns a synthetic counter delta.
+uint64_t awslc_prov_service_indicator_before_call(void);
+int awslc_prov_service_indicator_after_call(uint64_t before);
+
+// Re-run AWS-LC's known-answer self-tests.
+int awslc_prov_backend_self_test(void);
 
 #if defined(__cplusplus)
 }  // extern "C"

--- a/provider/internal/backend.h
+++ b/provider/internal/backend.h
@@ -81,6 +81,10 @@ void *awslc_prov_zalloc(size_t size);
 // wipe is not optional.
 void awslc_prov_clear_free(void *ptr, size_t size);
 
+// Wipe |size| bytes at |ptr|. AWS-LC exports OPENSSL_cleanse, so a front-side
+// call to it would bind to AWS-LC's libcrypto rather than the host's.
+void awslc_prov_cleanse(void *ptr, size_t size);
+
 // The AWS-LC version this provider is linked against, e.g. "AWS-LC 5.4.0". The
 // returned string is static and outlives any caller. Reported through the
 // provider's buildinfo parameter, which is the only way a consumer can tell which

--- a/provider/internal/frontend/digests.h
+++ b/provider/internal/frontend/digests.h
@@ -17,14 +17,19 @@
 extern "C" {
 #endif
 
+#define AWSLC_PROV_DIGEST_OPERATION_DESCRIPTION "digest"
+
 // Reported through OSSL_DIGEST_PARAM_XOF and OSSL_DIGEST_PARAM_ALGID_ABSENT.
 #define AWSLC_PROV_DIGEST_FLAG_XOF 0x0001
 #define AWSLC_PROV_DIGEST_FLAG_ALGID_ABSENT 0x0002
 
 OSSL_FUNC_digest_gettable_params_fn awslc_prov_digest_gettable_params;
+OSSL_FUNC_digest_gettable_ctx_params_fn
+    awslc_prov_digest_gettable_ctx_params;
 
 int awslc_prov_digest_get_params(OSSL_PARAM params[], size_t block_size,
                                  size_t digest_size, uint32_t flags);
+int awslc_prov_digest_get_fips_indicator(OSSL_PARAM params[], int approved);
 
 // Declare one fixed-length digest's slots at the exact types OpenSSL calls.
 #define AWSLC_PROV_DECLARE_FIXED_DIGEST_SLOTS(algorithm)                       \
@@ -38,7 +43,7 @@ int awslc_prov_digest_get_params(OSSL_PARAM params[], size_t block_size,
   static OSSL_FUNC_digest_get_params_fn awslc_prov_##algorithm##_get_params
 
 // Emit the table only after the ordinary C slot bodies above it are defined.
-#define AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(algorithm)                      \
+#define AWSLC_PROV_FIXED_DIGEST_DISPATCH_TABLE(algorithm, family)              \
   const OSSL_DISPATCH awslc_prov_##algorithm##_functions[] = {                 \
       {OSSL_FUNC_DIGEST_NEWCTX,                                                \
        (void (*)(void))awslc_prov_##algorithm##_newctx},                       \
@@ -58,6 +63,10 @@ int awslc_prov_digest_get_params(OSSL_PARAM params[], size_t block_size,
        (void (*)(void))awslc_prov_##algorithm##_get_params},                   \
       {OSSL_FUNC_DIGEST_GETTABLE_PARAMS,                                       \
        (void (*)(void))awslc_prov_digest_gettable_params},                     \
+      {OSSL_FUNC_DIGEST_GET_CTX_PARAMS,                                        \
+       (void (*)(void))awslc_prov_##family##_get_ctx_params},                  \
+      {OSSL_FUNC_DIGEST_GETTABLE_CTX_PARAMS,                                   \
+       (void (*)(void))awslc_prov_digest_gettable_ctx_params},                 \
       OSSL_DISPATCH_END}
 
 #define AWSLC_PROV_DECLARE_DIGEST_TABLE(algorithm) \

--- a/provider/internal/provider.h
+++ b/provider/internal/provider.h
@@ -13,14 +13,27 @@
 extern "C" {
 #endif
 
-// The property string every algorithm we register carries.
+// The property strings every algorithm we register carries.
 #define AWSLC_PROV_PROPERTIES "provider=awslc"
+// Apply fips=yes to algorithms that AWS-LC can approve in FIPS mode.
+#define AWSLC_PROV_FIPS_PROPERTIES AWSLC_PROV_PROPERTIES ",fips=yes"
 
 // AWSLC_PROV_CTX is the per-load provider context.
 typedef struct awslc_prov_ctx_st AWSLC_PROV_CTX;
 
 // The core handle for this load, used when raising errors back to the core.
 const OSSL_CORE_HANDLE *awslc_prov_ctx_handle(const AWSLC_PROV_CTX *ctx);
+
+// Whether the linked AWS-LC reported FIPS mode when this provider initialized.
+int awslc_prov_ctx_is_fips(const AWSLC_PROV_CTX *ctx);
+
+// Notify the application through the provider context |ctx| that a fips=yes
+// operation completed without an approved verdict. |type| contains the
+// algorithm type and |description| contains the operation that is not approved.
+// A missing callback permits the result; a callback may veto it by returning
+// zero.
+int awslc_prov_indicator_on_unapproved(AWSLC_PROV_CTX *ctx, const char *type,
+                                       const char *description);
 
 // The fan-out, implemented in registry.c and published by provider.c in the
 // top-level dispatch table. The dispatch tables it hands out are declared in

--- a/provider/test/frontend/operations/digests/sha2_test.cc
+++ b/provider/test/frontend/operations/digests/sha2_test.cc
@@ -5,6 +5,7 @@
 
 #include <openssl/core_names.h>
 #include <openssl/evp.h>
+#include <openssl/indicator.h>
 #include <openssl/params.h>
 
 #include <algorithm>
@@ -226,6 +227,42 @@ TEST_P(Sha2Test, CopyCtxOverwritesInitializedDestination) {
 
   EXPECT_EQ(expected, ToHex(from_source, source_len));
   EXPECT_EQ(expected, ToHex(from_destination, destination_len));
+}
+
+TEST_F(ProviderTest, ReportsRuntimeFipsIndicator) {
+#if defined(AWSLC_FIPS)
+  constexpr int kExpectedFipsIndicator = 1;
+#else
+  constexpr int kExpectedFipsIndicator = 0;
+#endif
+
+  MdPtr md(EVP_MD_fetch(libctx(), "SHA2-256", kRequireAwslc));
+  MdCtxPtr ctx(EVP_MD_CTX_new());
+  ASSERT_TRUE(md);
+  ASSERT_TRUE(ctx);
+
+  OSSL_INDICATOR_set_callback(
+      libctx(), [](const char *, const char *, const OSSL_PARAM[]) { return 1; });
+
+  static const unsigned char kMessage[] = "fips indicator";
+  unsigned char digest[EVP_MAX_MD_SIZE];
+  unsigned int digest_len = 0;
+  ASSERT_TRUE(EVP_DigestInit_ex(ctx.get(), md.get(), nullptr));
+  ASSERT_TRUE(EVP_DigestUpdate(ctx.get(), kMessage, sizeof(kMessage) - 1));
+  ASSERT_TRUE(EVP_DigestFinal_ex(ctx.get(), digest, &digest_len));
+
+  const OSSL_PARAM *gettable = EVP_MD_CTX_gettable_params(ctx.get());
+  ASSERT_NE(nullptr, gettable);
+  EXPECT_NE(nullptr, OSSL_PARAM_locate_const(
+                         gettable, OSSL_ALG_PARAM_FIPS_APPROVED_INDICATOR));
+
+  int approved = -1;
+  OSSL_PARAM params[] = {
+      OSSL_PARAM_construct_int(OSSL_ALG_PARAM_FIPS_APPROVED_INDICATOR,
+                               &approved),
+      OSSL_PARAM_construct_end()};
+  ASSERT_TRUE(EVP_MD_CTX_get_params(ctx.get(), params));
+  EXPECT_EQ(kExpectedFipsIndicator, approved);
 }
 
 // Names the cell after the algorithm, so a failure reads

--- a/provider/test/frontend/provider_test.cc
+++ b/provider/test/frontend/provider_test.cc
@@ -53,6 +53,11 @@ TEST_F(ProviderTest, ReportsSelfDescribingParams) {
   // say.
   ASSERT_NE(nullptr, buildinfo);
   EXPECT_NE(std::string::npos, std::string(buildinfo).find("AWS-LC"));
+#if defined(AWSLC_FIPS)
+  EXPECT_NE(std::string::npos, std::string(buildinfo).find("AWS-LC FIPS"));
+#else
+  EXPECT_EQ(std::string::npos, std::string(buildinfo).find("AWS-LC FIPS"));
+#endif
 
   EXPECT_EQ(1, status);
 }
@@ -66,6 +71,10 @@ TEST_F(ProviderTest, DeclaresGettableParams) {
     EXPECT_NE(nullptr, OSSL_PARAM_locate_const(gettable, key))
         << "get_params answers " << key << " but does not advertise it";
   }
+}
+
+TEST_F(ProviderTest, RunsBackendSelfTest) {
+  EXPECT_TRUE(OSSL_PROVIDER_self_test(awslc()));
 }
 
 // An operation class the provider does not serve must return NULL from
@@ -95,6 +104,13 @@ TEST_F(ProviderTest, UnimplementedOperationsFallThroughToDefault) {
   EXPECT_STREQ("default",
                OSSL_PROVIDER_get0_name(EVP_CIPHER_get0_provider(cipher)));
   EVP_CIPHER_free(cipher);
+}
+
+TEST_F(ProviderTest, PublishesFipsCapabilityProperty) {
+  MdPtr md(EVP_MD_fetch(libctx(), "SHA2-256", "provider=awslc,fips=yes"));
+  ASSERT_TRUE(md);
+  EXPECT_STREQ(kProviderName,
+               OSSL_PROVIDER_get0_name(EVP_MD_get0_provider(md.get())));
 }
 
 // Reproduce the deployed path: the config activates both providers and installs

--- a/provider/test/frontend/provider_test.cc
+++ b/provider/test/frontend/provider_test.cc
@@ -26,6 +26,11 @@ TEST_F(ProviderTest, Loads) {
   EXPECT_STREQ(kProviderName, OSSL_PROVIDER_get0_name(awslc()));
 }
 
+TEST_F(DefaultLibCtxTest, Loads) {
+  EXPECT_TRUE(OSSL_PROVIDER_available(nullptr, kProviderName));
+  EXPECT_STREQ(kProviderName, OSSL_PROVIDER_get0_name(awslc()));
+}
+
 TEST_F(ProviderTest, ReportsSelfDescribingParams) {
   const char *name = nullptr;
   const char *version = nullptr;

--- a/provider/test/test_fixture.h
+++ b/provider/test/test_fixture.h
@@ -4,12 +4,16 @@
 #ifndef AWSLC_PROVIDER_TEST_FIXTURE_H
 #define AWSLC_PROVIDER_TEST_FIXTURE_H
 
-// The fixture every provider test builds on.
+// The fixtures every provider test builds on. The provider is loaded from the
+// build tree, so the suite runs without an install step.
 //
-// Each test gets its own OSSL_LIB_CTX rather than the process-global default, so
-// cells are isolated and a test can assert precisely which providers are
-// present. The provider is loaded from the build tree, so the suite runs without
-// an install step.
+// There are two, because a provider sees a different library context in each and
+// only one of them is what a deployed consumer has:
+//
+//   ProviderTest       a private OSSL_LIB_CTX per test, so cells are isolated and
+//                      a test can assert precisely which providers are present.
+//   DefaultLibCtxTest  OpenSSL's default library context, which it names with a
+//                      NULL pointer. Almost every real consumer is here.
 
 #include <gtest/gtest.h>
 
@@ -97,6 +101,33 @@ class ProviderTest : public ::testing::Test {
   LibCtxPtr libctx_;
   ProviderPtr awslc_;
   ProviderPtr default_;
+};
+
+// Loads the provider into OpenSSL's default library context. This is process
+// global and logic within OpenSSL handles it slightly differently from
+// explicitly created library contexts.
+class DefaultLibCtxTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(OSSL_PROVIDER_set_default_search_path(
+        nullptr, AWSLC_PROVIDER_MODULE_DIR))
+        << "could not point OpenSSL at " << AWSLC_PROVIDER_MODULE_DIR;
+    awslc_.reset(OSSL_PROVIDER_try_load(nullptr, kProviderName, 1));
+    ASSERT_TRUE(awslc_) << "could not load the provider from "
+                        << AWSLC_PROVIDER_MODULE_DIR
+                        << " into the default library context;"
+                           " OSSL_provider_init may have failed";
+  }
+
+  void TearDown() override {
+    awslc_.reset();
+    EXPECT_TRUE(OSSL_PROVIDER_set_default_search_path(nullptr, nullptr));
+  }
+
+  OSSL_PROVIDER *awslc() { return awslc_.get(); }
+
+ private:
+  ProviderPtr awslc_;
 };
 
 }  // namespace awslc_provider_test

--- a/tests/ci/run_aws_lc_provider_tests.sh
+++ b/tests/ci/run_aws_lc_provider_tests.sh
@@ -13,10 +13,6 @@
 # source the way the other CI scripts here build theirs. No runner image ships an
 # OpenSSL new enough to use instead, and probing for one would make what the
 # provider was compiled against a property of the host.
-#
-# It takes no arguments and reads no configuration. To build against some other
-# OpenSSL, invoke cmake directly with AWSLC_PROVIDER_OPENSSL_ROOT; see
-# provider/README.md.
 
 set -euo pipefail
 
@@ -32,6 +28,14 @@ function fail {
   echo >&2 "FAILED: $*"
   exit 1
 }
+
+FIPS=0
+for arg in "$@"; do
+  case "${arg}" in
+    --fips) FIPS=1 ;;
+    *) fail "unknown argument: ${arg}" ;;
+  esac
+done
 
 # Before sourcing anything, so the refusal is the first thing printed rather than
 # being buried under the setup script's environment dump.
@@ -92,7 +96,11 @@ cmake_args=(
   -DBUILD_AWSLC_PROVIDER=ON
   "-DAWSLC_PROVIDER_OPENSSL_ROOT=${OPENSSL_ROOT}"
 )
+if [[ "${FIPS}" == "1" ]]; then
+  cmake_args+=(-DFIPS=1)
+fi
 
+echo "FIPS build: $([[ "${FIPS}" == "1" ]] && echo yes || echo no)"
 echo "cmake flags: ${cmake_args[*]}"
 run_build "${cmake_args[@]}"
 


### PR DESCRIPTION
### Context and motivation

FIPS is one of the main motivations for this provider. OpenSSL 3.x expects a provider to carry FIPSt through six separate surfaces, and AWS-LC carries the same
information in its own shapes: `FIPS_mode()`, the service indicator, and `BORINGSSL_self_test()`. Nothing
in the provider connected the two, so a FIPS-aware application could not tell an approved operation from
an unapproved one, and an approved-only fetch had nothing to select on.

This change maps those surfaces onto AWS-LC and makes FIPS a build axis of the provider's own CI rather
than an untested configuration.

### Description of changes

**One provider compilation, not two.** `AWSLC_PROV_FIPS_PROPERTIES` statically appends `fips=yes` to
every SHA-2 registration. The property classifies an algorithm as one AWS-LC can approve;
it does not attest which AWS-LC build is linked underneath, and OpenSSL trusts provider property metadata
without checking the backing library.

**Runtime FIPS state.** The provider asks the linked AWS-LC for `FIPS_mode()` once at initialization and
stores it.

**Per-operation approval.** SHA-2 contexts become a provider-owned struct wrapping the backend context, so
a digest carries its provider context, its algorithm name, and its approval state. `final` brackets the
AWS-LC call with `FIPS_service_indicator_before_call()` and `FIPS_service_indicator_after_call()`, and
reports approved only when the provider's stored FIPS state is true *and* the counter advanced.

**Indicator callback.** The provider captures `OSSL_FUNC_INDICATOR_CB` and, under a backing library that
reports FIPS mode, invokes the application's callback when an operation completes unapproved.

**Self-test and status.** `OSSL_FUNC_PROVIDER_SELF_TEST` runs `BORINGSSL_self_test()` and propagates its
result. `status` stays constant 1, because AWS-LC terminates the process when a FIPS self-test puts the
module into a failure state, so unlike OpenSSL's FIPS module there is no refusing-but-alive state to
report.

**Build and CI.** `--fips` on `tests/ci/run_aws_lc_provider_tests.sh`, and the workflow becomes a
`fips: [0, 1]` matrix with `fail-fast: false`, so both axes report independently.

### Testing

FIPS behavior is asserted once through SHA2-256. Expectations derive from the parent CMake `FIPS` option through the test-only `AWSLC_FIPS` definition.

| Test | Asserts |
|---|---|
| `ProviderTest.PublishesFipsCapabilityProperty` | `SHA2-256` resolves under `provider=awslc,fips=yes` |
| `ProviderTest.ReportsRuntimeFipsIndicator` | `fips-indicator` is gettable and reports 1 in a FIPS build, 0 otherwise |
| `ProviderTest.ReportsSelfDescribingParams` | `buildinfo` contains `AWS-LC FIPS` in a FIPS build and does not otherwise |
| `ProviderTest.RunsBackendSelfTest` | `OSSL_PROVIDER_self_test()` succeeds against the real backend |
| `DefaultLibCtxTest.Loads` | The provider loads into OpenSSL's default library context |

Controls, each run and each observed to fail on its intended assertion: removing `fips=yes` from the
registrations; suppressing the service-indicator delta; restoring blanket approval on the non-FIPS path,
after a first attempt at that control proved too narrow and passed despite the injected defect; and
re-inserting the NULL core-context guard, which fails `DefaultLibCtxTest.Loads` and nothing else.

Both FIPS and non-FIPS axes build and pass on Linux and macOS.

### Review considerations

- **`fips=yes` is static.** A deployment claiming compliance must pair the provider with an
  applicable AWS-LC FIPS build; the provider cannot attest that and does not try.
- **The indicator callback path is registered by a test but not invoked by it.** Every current SHA-2
  success path is approved under a FIPS build. We'll need to explicitly test this feature when feasible.
- **Self-test failure propagation is covered only in the success direction.** An ordinary FIPS KAT mismatch
  calls AWS-LC's fatal handler and aborts before `BORINGSSL_self_test()` can return 0, so corrupting a
  production KAT does not produce the return-zero case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache
2.0 license and the ISC license.
