### PR TITLE
Implement aws-lc-provider error queue handling

### DIFF
--- a/provider/CMakeLists.txt
+++ b/provider/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 add_library(awslc_provider_front OBJECT
   frontend/provider.c
   frontend/registry.c
+  frontend/errors.c
   frontend/operations/digests/digests.c
   frontend/operations/digests/sha2.c)
 set_target_properties(awslc_provider_front PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -63,6 +64,7 @@ set_property(TARGET awslc_provider_front PROPERTY INCLUDE_DIRECTORIES
 add_library(awslc_provider_back OBJECT
   backend/mem.c
   backend/info.c
+  backend/errors.c
   backend/operations/digests/sha2.c)
 set_target_properties(awslc_provider_back PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_add_awslc_include_paths(TARGET awslc_provider_back SCOPE PRIVATE)
@@ -175,6 +177,7 @@ if(BUILD_TESTING AND NOT ANDROID)
   # awslc_provider_linkage_test.
   add_executable(awslc_provider_backend_test
     test/test_main.cc
+    test/backend/errors_test.cc
     test/backend/operations/digests/sha2_test.cc
     $<TARGET_OBJECTS:awslc_provider_back>)
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -203,7 +203,9 @@ algorithm count from what does not.
 | `internal/frontend/<operation>.h` | OpenSSL | Per-operation dispatch tables, for `registry.c` |
 | `frontend/provider.c` | OpenSSL | The entry point. Implements provider-level dispatch table functions. |
 | `frontend/registry.c` | OpenSSL | One `OSSL_ALGORITHM` table per operation. |
+| `frontend/<service>.c` | OpenSSL | Provider-wide frontend services, such as error reporting. |
 | `frontend/operations/<operation>/<alg>.c` | OpenSSL | Dispatch slots and their `OSSL_PARAM` plumbing |
+| `backend/<service>.c` | AWS-LC | Provider-wide AWS-LC bindings: allocation, introspection, the error queue. |
 | `backend/operations/<operation>/<alg>.c` | AWS-LC | The calls that actually compute |
 | `test/frontend/**` | OpenSSL | Main test suite driving from the OpenSSL Provider interface. |
 | `test/backend/**` | AWS-LC | Test suite for invoking `backend/` functions directly. |

--- a/provider/backend/errors.c
+++ b/provider/backend/errors.c
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// Back side: draining AWS-LC's error queue.
+
+#include <openssl/err.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include "internal/backend.h"
+
+void awslc_prov_error_mark(void) {
+  // Marking an empty queue marks nothing and reports zero, which needs no
+  // handling: the discard then clears the queue, exactly the records this call
+  // is answerable for.
+  ERR_set_mark();
+}
+
+void awslc_prov_error_discard(void) {
+  ERR_pop_to_mark();
+}
+
+int awslc_prov_error_shift(AWSLC_PROV_ERROR *out) {
+  const char *file = NULL;
+  const char *data = NULL;
+  int line = 0;
+  int flags = 0;
+  uint32_t packed = 0;
+  uint32_t library = 0;
+  uint32_t reason = 0;
+
+  if (out == NULL) {
+    return 0;
+  }
+  memset(out, 0, sizeof(*out));
+
+  packed = ERR_get_error_line_data(&file, &line, &data, &flags);
+  if (packed == 0) {
+    return 0;
+  }
+  library = (uint32_t)ERR_GET_LIB(packed);
+  reason = (uint32_t)ERR_GET_REASON(packed);
+
+  if (reason == 0 || library > AWSLC_PROV_ERROR_MAX_LIB) {
+    // Nothing to name, or a library id too wide to tag. |detail| still reports
+    // what AWS-LC said.
+    out->reason = AWSLC_PROV_R_BACKEND_ERROR;
+  } else if (reason < AWSLC_PROV_ERROR_FIRST_OWN_REASON) {
+    // AWS-LC's cross-library reasons retain their reason code.
+    out->reason = reason;
+  } else {
+    // Remap the library id and its reason code to the provider's reason codes.
+    out->reason = AWSLC_PROV_ERROR_REASON(library, reason);
+  }
+  out->file = file;
+  out->line = line;
+
+  // Composed here because ERR_reason_error_string resolves against AWS-LC's
+  // tables, which only this side can see. |data| belongs to the queue and dies on
+  // the next call that touches it, so copy it now.
+  if ((flags & ERR_FLAG_STRING) != 0 && data != NULL && data[0] != '\0') {
+    snprintf(out->detail, sizeof(out->detail), "AWS-LC %s: %s: %s",
+             ERR_lib_error_string(packed), ERR_reason_error_string(packed),
+             data);
+  } else {
+    snprintf(out->detail, sizeof(out->detail), "AWS-LC %s: %s",
+             ERR_lib_error_string(packed), ERR_reason_error_string(packed));
+  }
+  return 1;
+}

--- a/provider/backend/errors.c
+++ b/provider/backend/errors.c
@@ -6,7 +6,6 @@
 #include <openssl/err.h>
 
 #include <stdio.h>
-#include <string.h>
 
 #include "internal/backend.h"
 
@@ -33,7 +32,7 @@ int awslc_prov_error_shift(AWSLC_PROV_ERROR *out) {
   if (out == NULL) {
     return 0;
   }
-  memset(out, 0, sizeof(*out));
+  awslc_prov_cleanse(out, sizeof(*out));
 
   packed = ERR_get_error_line_data(&file, &line, &data, &flags);
   if (packed == 0) {

--- a/provider/frontend/errors.c
+++ b/provider/frontend/errors.c
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// Front side: reporting into OpenSSL's error queue under the provider's private
+// error library.
+
+#include <openssl/core.h>
+#include <openssl/core_dispatch.h>
+
+#include <stdarg.h>
+
+#include "internal/backend.h"
+#include "internal/provider.h"
+
+// Statically define reason strings for the provider's private reason codes.
+static const OSSL_ITEM awslc_prov_reason_strings[] = {
+    {AWSLC_PROV_R_BACKEND_ERROR, (void *)"AWS-LC reported a failure"},
+    {AWSLC_PROV_R_INVALID_PARAMETER, (void *)"invalid parameter"},
+    {AWSLC_PROV_R_UNAPPROVED_OPERATION, (void *)"unapproved operation"},
+    {0, NULL}};
+
+const OSSL_ITEM *awslc_prov_get_reason_strings(void *provctx) {
+  (void)provctx;
+  return awslc_prov_reason_strings;
+}
+
+// core_vset_error takes a va_list, so the variadic stack frame is built here.
+static void awslc_prov_vset_error(OSSL_FUNC_core_vset_error_fn *vset_error,
+                                  const OSSL_CORE_HANDLE *handle,
+                                  uint32_t reason, const char *fmt, ...) {
+  va_list args;
+
+  va_start(args, fmt);
+  vset_error(handle, reason, fmt, args);
+  va_end(args);
+}
+
+void awslc_prov_error_raise(const AWSLC_PROV_CTX *ctx, uint32_t reason,
+                            const char *file, int line, const char *detail) {
+  const AWSLC_PROV_UPCALLS *upcalls = awslc_prov_ctx_upcalls(ctx);
+  const OSSL_CORE_HANDLE *handle = NULL;
+
+  if (upcalls == NULL) {
+    return;
+  }
+  // core_vset_error reads |handle| for the library id to file under, so unlike the
+  // other two upcalls it cannot be passed NULL.
+  handle = awslc_prov_ctx_handle(ctx);
+
+  upcalls->new_error(handle);
+  // AWS-LC records no function name, so OpenSSL's slot for one stays empty.
+  upcalls->set_error_debug(handle, file, line, NULL);
+  if (detail == NULL || detail[0] == '\0') {
+    awslc_prov_vset_error(upcalls->vset_error, handle, reason, NULL);
+  } else {
+    // "%s", not |detail| itself, which is data and can contain a percent sign.
+    awslc_prov_vset_error(upcalls->vset_error, handle, reason, "%s", detail);
+  }
+}
+
+// Re-raise AWS-LC's records oldest first and return how many came off the queue.
+// Zero means the back side queued nothing.
+static size_t awslc_prov_error_flush(const AWSLC_PROV_CTX *ctx) {
+  AWSLC_PROV_ERROR record;
+  size_t drained = 0;
+
+  while (awslc_prov_error_shift(&record)) {
+    awslc_prov_error_raise(ctx, record.reason, record.file, record.line,
+                           record.detail);
+    drained++;
+  }
+  return drained;
+}
+
+int awslc_prov_error_settle(const AWSLC_PROV_CTX *ctx, int succeeded,
+                            uint32_t reason, const char *file, int line,
+                            const char *detail) {
+  if (succeeded) {
+    awslc_prov_error_discard();
+    return succeeded;
+  }
+  // A failed dispatch call must never leave the queue empty, or the caller cannot
+  // tell a lost cause from no cause. Backend paths that queue nothing, and the
+  // provider's own checks, fall back to the slot's reason.
+  if (awslc_prov_error_flush(ctx) == 0) {
+    awslc_prov_error_raise(ctx, reason, file, line, detail);
+  }
+  return succeeded;
+}

--- a/provider/frontend/operations/digests/digests.c
+++ b/provider/frontend/operations/digests/digests.c
@@ -58,9 +58,18 @@ int awslc_prov_digest_get_params(OSSL_PARAM params[], size_t block_size,
   return 1;
 }
 
-int awslc_prov_digest_get_fips_indicator(OSSL_PARAM params[], int approved) {
+int awslc_prov_digest_get_fips_indicator(const AWSLC_PROV_CTX *provctx,
+                                         OSSL_PARAM params[], int approved) {
   OSSL_PARAM *p =
       OSSL_PARAM_locate(params, OSSL_ALG_PARAM_FIPS_APPROVED_INDICATOR);
 
-  return p == NULL || OSSL_PARAM_set_int(p, approved);
+  if (p == NULL) {
+    return 1;
+  }
+  if (!OSSL_PARAM_set_int(p, approved)) {
+    AWSLC_PROV_ERROR_RAISE(provctx, AWSLC_PROV_R_INVALID_PARAMETER,
+                           OSSL_ALG_PARAM_FIPS_APPROVED_INDICATOR);
+    return 0;
+  }
+  return 1;
 }

--- a/provider/frontend/operations/digests/sha2.c
+++ b/provider/frontend/operations/digests/sha2.c
@@ -32,16 +32,24 @@ typedef struct {
 
 static void *awslc_prov_sha2_newctx(void *provctx, size_t backend_ctx_size,
                                     const char *algorithm_name) {
-  AWSLC_PROV_SHA2_CTX *ctx = awslc_prov_zalloc(sizeof(*ctx));
+  AWSLC_PROV_SHA2_CTX *ctx = NULL;
+  void *backend_ctx = NULL;
 
-  if (ctx == NULL) {
+  awslc_prov_error_mark();
+  ctx = awslc_prov_zalloc(sizeof(*ctx));
+  if (ctx != NULL) {
+    backend_ctx = awslc_prov_zalloc(backend_ctx_size);
+    if (backend_ctx == NULL) {
+      awslc_prov_clear_free(ctx, sizeof(*ctx));
+      ctx = NULL;
+    }
+  }
+  if (!AWSLC_PROV_ERROR_SETTLE((AWSLC_PROV_CTX *)provctx, ctx != NULL,
+                              AWSLC_PROV_R_BACKEND_ERROR, algorithm_name)) {
     return NULL;
   }
-  ctx->backend_ctx = awslc_prov_zalloc(backend_ctx_size);
-  if (ctx->backend_ctx == NULL) {
-    awslc_prov_clear_free(ctx, sizeof(*ctx));
-    return NULL;
-  }
+
+  ctx->backend_ctx = backend_ctx;
   ctx->provctx = (AWSLC_PROV_CTX *)provctx;
   ctx->backend_ctx_size = backend_ctx_size;
   ctx->algorithm_name = algorithm_name;
@@ -85,8 +93,12 @@ static void awslc_prov_sha2_copyctx(void *outctx, void *inctx,
   AWSLC_PROV_SHA2_CTX *out = (AWSLC_PROV_SHA2_CTX *)outctx;
   AWSLC_PROV_SHA2_CTX *in = (AWSLC_PROV_SHA2_CTX *)inctx;
 
-  if (out == NULL || in == NULL ||
-      out->backend_ctx_size != in->backend_ctx_size) {
+  if (out == NULL || in == NULL) {
+    return;
+  }
+  if (out->backend_ctx_size != in->backend_ctx_size) {
+    AWSLC_PROV_ERROR_RAISE(in->provctx, AWSLC_PROV_R_INVALID_PARAMETER,
+                           in->algorithm_name);
     return;
   }
   (void)copy(out->backend_ctx, in->backend_ctx);
@@ -106,7 +118,11 @@ static int awslc_prov_sha2_init_op(void *dctx, const OSSL_PARAM params[],
     return 0;
   }
   ctx->fips_approved = awslc_prov_ctx_is_fips(ctx->provctx);
-  return init(ctx->backend_ctx);
+
+  awslc_prov_error_mark();
+  int ok = init(ctx->backend_ctx);
+  return AWSLC_PROV_ERROR_SETTLE(ctx->provctx, ok, AWSLC_PROV_R_BACKEND_ERROR,
+                                ctx->algorithm_name);
 }
 
 static int awslc_prov_sha2_update_op(void *dctx, const unsigned char *in,
@@ -124,9 +140,15 @@ static int awslc_prov_sha2_update_op(void *dctx, const unsigned char *in,
     return 1;
   }
   if (in == NULL) {
+    AWSLC_PROV_ERROR_RAISE(ctx->provctx, AWSLC_PROV_R_INVALID_PARAMETER,
+                           ctx->algorithm_name);
     return 0;
   }
-  return update(ctx->backend_ctx, in, inl);
+
+  awslc_prov_error_mark();
+  int ok = update(ctx->backend_ctx, in, inl);
+  return AWSLC_PROV_ERROR_SETTLE(ctx->provctx, ok, AWSLC_PROV_R_BACKEND_ERROR,
+                                ctx->algorithm_name);
 }
 
 static int awslc_prov_sha2_final_op(void *dctx, unsigned char *out, size_t *outl,
@@ -135,14 +157,21 @@ static int awslc_prov_sha2_final_op(void *dctx, unsigned char *out, size_t *outl
                                     size_t digest_size) {
   AWSLC_PROV_SHA2_CTX *ctx = (AWSLC_PROV_SHA2_CTX *)dctx;
 
-  if (ctx == NULL || out == NULL || outl == NULL) {
+  if (ctx == NULL) {
     return 0;
   }
+  if (out == NULL || outl == NULL) {
+    AWSLC_PROV_ERROR_RAISE(ctx->provctx, AWSLC_PROV_R_INVALID_PARAMETER,
+                           ctx->algorithm_name);
+    return 0;
+  }
+  awslc_prov_error_mark();
   uint64_t before = awslc_prov_service_indicator_before_call();
   int ok = final_fn(ctx->backend_ctx, out, outsz);
   int is_fips = awslc_prov_ctx_is_fips(ctx->provctx);
   int approved = is_fips && awslc_prov_service_indicator_after_call(before);
-  if (!ok) {
+  if (!AWSLC_PROV_ERROR_SETTLE(ctx->provctx, ok, AWSLC_PROV_R_BACKEND_ERROR,
+                              ctx->algorithm_name)) {
     return 0;
   }
   if (!approved) {
@@ -153,6 +182,8 @@ static int awslc_prov_sha2_final_op(void *dctx, unsigned char *out, size_t *outl
           ctx->provctx, ctx->algorithm_name,
           AWSLC_PROV_DIGEST_OPERATION_DESCRIPTION)) {
     awslc_prov_cleanse(out, digest_size);
+    AWSLC_PROV_ERROR_RAISE(ctx->provctx, AWSLC_PROV_R_UNAPPROVED_OPERATION,
+                           ctx->algorithm_name);
     return 0;
   }
   *outl = digest_size;
@@ -165,7 +196,8 @@ static int awslc_prov_sha2_get_ctx_params(void *dctx, OSSL_PARAM params[]) {
   if (ctx == NULL) {
     return 0;
   }
-  return awslc_prov_digest_get_fips_indicator(params, ctx->fips_approved);
+  return awslc_prov_digest_get_fips_indicator(ctx->provctx, params,
+                                              ctx->fips_approved);
 }
 
 static int awslc_prov_sha2_get_params(OSSL_PARAM params[],

--- a/provider/frontend/provider.c
+++ b/provider/frontend/provider.c
@@ -30,13 +30,19 @@
 
 struct awslc_prov_ctx_st {
   const OSSL_CORE_HANDLE *handle;
+  // The opaque core context the indicator upcall is addressed to, so a result of
+  // an upcall rather than one of them.
   OPENSSL_CORE_CTX *corectx;
-  OSSL_FUNC_indicator_cb_fn *indicator_cb;
+  AWSLC_PROV_UPCALLS upcalls;
   int is_fips;
 };
 
 const OSSL_CORE_HANDLE *awslc_prov_ctx_handle(const AWSLC_PROV_CTX *ctx) {
   return ctx->handle;
+}
+
+const AWSLC_PROV_UPCALLS *awslc_prov_ctx_upcalls(const AWSLC_PROV_CTX *ctx) {
+  return ctx == NULL ? NULL : &ctx->upcalls;
 }
 
 int awslc_prov_ctx_is_fips(const AWSLC_PROV_CTX *ctx) {
@@ -50,10 +56,9 @@ int awslc_prov_indicator_on_unapproved(AWSLC_PROV_CTX *ctx, const char *type,
   if (ctx == NULL || type == NULL || description == NULL) {
     return 0;
   }
-  if (ctx->indicator_cb == NULL) {
-    return 1;
-  }
-  ctx->indicator_cb(ctx->corectx, &callback);
+  // A NULL |callback| is the application not having registered one, which
+  // permits.
+  ctx->upcalls.indicator_cb(ctx->corectx, &callback);
   return callback == NULL || callback(type, description, NULL);
 }
 
@@ -78,17 +83,25 @@ static int awslc_prov_get_params(void *provctx, OSSL_PARAM params[]) {
     return 0;
   }
 
+  // A failed set means the caller asked for a parameter at a type that cannot
+  // hold it. Raise, so the caller learns which key was wrong.
   p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
   if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, AWSLC_PROV_NAME)) {
+    AWSLC_PROV_ERROR_RAISE(ctx, AWSLC_PROV_R_INVALID_PARAMETER,
+                           OSSL_PROV_PARAM_NAME);
     return 0;
   }
   p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
   if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, AWSLC_PROV_VERSION)) {
+    AWSLC_PROV_ERROR_RAISE(ctx, AWSLC_PROV_R_INVALID_PARAMETER,
+                           OSSL_PROV_PARAM_VERSION);
     return 0;
   }
   p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
   if (p != NULL &&
       !OSSL_PARAM_set_utf8_ptr(p, awslc_prov_backend_version())) {
+    AWSLC_PROV_ERROR_RAISE(ctx, AWSLC_PROV_R_INVALID_PARAMETER,
+                           OSSL_PROV_PARAM_BUILDINFO);
     return 0;
   }
   p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_STATUS);
@@ -96,6 +109,8 @@ static int awslc_prov_get_params(void *provctx, OSSL_PARAM params[]) {
   // fails, so unlike OpenSSL's FIPS module there is no refusing-but-alive state
   // for this to report.
   if (p != NULL && !OSSL_PARAM_set_int(p, 1)) {
+    AWSLC_PROV_ERROR_RAISE(ctx, AWSLC_PROV_R_INVALID_PARAMETER,
+                           OSSL_PROV_PARAM_STATUS);
     return 0;
   }
   return 1;
@@ -125,6 +140,8 @@ static const OSSL_DISPATCH awslc_prov_dispatch_table[] = {
     {OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))awslc_prov_get_params},
     {OSSL_FUNC_PROVIDER_QUERY_OPERATION,
      (void (*)(void))awslc_prov_query_operation},
+    {OSSL_FUNC_PROVIDER_GET_REASON_STRINGS,
+     (void (*)(void))awslc_prov_get_reason_strings},
     {OSSL_FUNC_PROVIDER_SELF_TEST, (void (*)(void))awslc_prov_self_test},
     OSSL_DISPATCH_END};
 
@@ -133,8 +150,7 @@ AWSLC_PROV_ENTRY int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                                         const OSSL_DISPATCH *in,
                                         const OSSL_DISPATCH **out,
                                         void **provctx) {
-  OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
-  OSSL_FUNC_indicator_cb_fn *c_indicator_cb = NULL;
+  AWSLC_PROV_UPCALLS upcalls = {0};
   AWSLC_PROV_CTX *ctx = NULL;
 
   // Scan the upcalls the core offers and keep the ones we use. Unrecognized ids
@@ -143,19 +159,29 @@ AWSLC_PROV_ENTRY int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
   for (; in->function_id != 0; in++) {
     switch (in->function_id) {
       case OSSL_FUNC_CORE_GET_LIBCTX:
-        c_get_libctx = OSSL_FUNC_core_get_libctx(in);
+        upcalls.get_libctx = OSSL_FUNC_core_get_libctx(in);
         break;
       case OSSL_FUNC_INDICATOR_CB:
-        c_indicator_cb = OSSL_FUNC_indicator_cb(in);
+        upcalls.indicator_cb = OSSL_FUNC_indicator_cb(in);
+        break;
+      case OSSL_FUNC_CORE_NEW_ERROR:
+        upcalls.new_error = OSSL_FUNC_core_new_error(in);
+        break;
+      case OSSL_FUNC_CORE_SET_ERROR_DEBUG:
+        upcalls.set_error_debug = OSSL_FUNC_core_set_error_debug(in);
+        break;
+      case OSSL_FUNC_CORE_VSET_ERROR:
+        upcalls.vset_error = OSSL_FUNC_core_vset_error(in);
         break;
       default:
         break;
     }
   }
 
-  // The indicator upcall addresses callback state through the opaque core
-  // context. Refuse to load if the core cannot supply one.
-  if (c_get_libctx == NULL) {
+  // Check that all required upcalls have been cached.
+  if (upcalls.get_libctx == NULL || upcalls.indicator_cb == NULL ||
+      upcalls.new_error == NULL || upcalls.set_error_debug == NULL ||
+      upcalls.vset_error == NULL) {
     return 0;
   }
 
@@ -166,8 +192,8 @@ AWSLC_PROV_ENTRY int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
   ctx->handle = handle;
   // n.b. corectx can and is expected to be NULL. OpenSSL uses that as a sentinel
   // for the process default core library context.
-  ctx->corectx = c_get_libctx(handle);
-  ctx->indicator_cb = c_indicator_cb;
+  ctx->corectx = upcalls.get_libctx(handle);
+  ctx->upcalls = upcalls;
   ctx->is_fips = awslc_prov_backend_is_fips() != 0;
 
   *provctx = ctx;

--- a/provider/internal/backend.h
+++ b/provider/internal/backend.h
@@ -50,6 +50,8 @@
 //   internal/backend.h                       this file: the contract
 //   internal/backend/<class>.h               per-class backend entry points
 //   internal/frontend/<class>.h              per-class frontend contract
+//   frontend/<service>.c                     provider-wide frontend services
+//   backend/<service>.c                      provider-wide AWS-LC bindings
 //   frontend/operations/<class>/<class>.c    class-wide frontend behavior
 //   frontend/operations/<class>/<family>.c   family helpers and dispatch slots
 //   backend/operations/<class>/<family>.c    explicit AWS-LC bindings
@@ -104,6 +106,64 @@ int awslc_prov_service_indicator_after_call(uint64_t before);
 
 // Re-run AWS-LC's known-answer self-tests.
 int awslc_prov_backend_self_test(void);
+
+// ===========================================================================
+// Error translation.
+// ===========================================================================
+//
+// The provider reports every error under its own private "awslc" error library.
+//
+// The reason code space has three disjoint ranges:
+//
+//   1 to 99                  AWS-LC's cross-library reasons. Any AWS-LC library
+//                            can raise these and AWS-LC resolves them without
+//                            consulting the library field, so neither do we.
+//   100 to 4095              The provider's own reasons, AWSLC_PROV_R_* below.
+//   4096+                    An AWS-LC library-specific reason, tagged with the
+//                            library that raised it.
+//
+// AWS-LC layers on its own coded "libraries". e.g. ec, cipher, hmac...
+// Each library numbers its reasons independently which we then remap onto the
+// provider's own reason code namespace.
+// A remapped library-specific reason code looks like this:
+// [31:18] Used by OpenSSL, [17:12] AWS-LC library ID, [11:0] AWS-LC reason code
+
+#define AWSLC_PROV_ERROR_LIB_SHIFT 12
+#define AWSLC_PROV_ERROR_MAX_LIB 63
+#define AWSLC_PROV_ERROR_FIRST_OWN_REASON 100
+
+// The provider reason code for AWS-LC library |lib|'s reason |reason|.
+#define AWSLC_PROV_ERROR_REASON(lib, reason) \
+  ((uint32_t)((uint32_t)(lib) << AWSLC_PROV_ERROR_LIB_SHIFT) | (uint32_t)(reason))
+
+// The provider's own reasons codes.
+#define AWSLC_PROV_R_BACKEND_ERROR 100
+#define AWSLC_PROV_R_INVALID_PARAMETER 101
+#define AWSLC_PROV_R_UNAPPROVED_OPERATION 102
+
+// Max length for the error detail string.
+#define AWSLC_PROV_ERROR_DETAIL_SIZE 256
+
+// One AWS-LC error record.
+typedef struct {
+  // The provider reason code, ready to hand to the core.
+  uint32_t reason;
+  // AWS-LC's origin file:line. A static literal AWS-LC owns, or NULL.
+  const char *file;
+  int line;
+  // Human-readable detail that AWS-LC raised for the record, the reason
+  // text AWS-LC itself resolves for it, and whatever per-record detail AWS-LC
+  // attached.
+  char detail[AWSLC_PROV_ERROR_DETAIL_SIZE];
+} AWSLC_PROV_ERROR;
+
+// Primitives for scoping the AWS-LC error queue to one dispatch call.
+// Set the mark prior to calling an AWS-LC operation.
+void awslc_prov_error_mark(void);
+// Clear the AWS-LC error queue to the mark and discard any reported errors
+void awslc_prov_error_discard(void);
+// Pop one error off of the AWS-LC error-queue and write it to |out|
+int awslc_prov_error_shift(AWSLC_PROV_ERROR *out);
 
 #if defined(__cplusplus)
 }  // extern "C"

--- a/provider/internal/frontend/digests.h
+++ b/provider/internal/frontend/digests.h
@@ -13,6 +13,8 @@
 
 #include <openssl/core_dispatch.h>
 
+#include "internal/provider.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -29,7 +31,8 @@ OSSL_FUNC_digest_gettable_ctx_params_fn
 
 int awslc_prov_digest_get_params(OSSL_PARAM params[], size_t block_size,
                                  size_t digest_size, uint32_t flags);
-int awslc_prov_digest_get_fips_indicator(OSSL_PARAM params[], int approved);
+int awslc_prov_digest_get_fips_indicator(const AWSLC_PROV_CTX *provctx,
+                                         OSSL_PARAM params[], int approved);
 
 // Declare one fixed-length digest's slots at the exact types OpenSSL calls.
 #define AWSLC_PROV_DECLARE_FIXED_DIGEST_SLOTS(algorithm)                       \

--- a/provider/internal/provider.h
+++ b/provider/internal/provider.h
@@ -9,6 +9,8 @@
 #include <openssl/core.h>
 #include <openssl/core_dispatch.h>
 
+#include "internal/backend.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -23,6 +25,38 @@ typedef struct awslc_prov_ctx_st AWSLC_PROV_CTX;
 
 // The core handle for this load, used when raising errors back to the core.
 const OSSL_CORE_HANDLE *awslc_prov_ctx_handle(const AWSLC_PROV_CTX *ctx);
+
+// The core upcalls this provider uses, captured at init.
+typedef struct {
+  // OPENSSL_CORE_CTX *(const OSSL_CORE_HANDLE *prov)
+  // The opaque core context for this load, which the indicator upcall is
+  // addressed to.
+  OSSL_FUNC_core_get_libctx_fn *get_libctx;
+
+  // void (OPENSSL_CORE_CTX *ctx, OSSL_INDICATOR_CALLBACK **cb)
+  // Fetches the application's FIPS indicator callback, or leaves |cb| NULL.
+  OSSL_FUNC_indicator_cb_fn *indicator_cb;
+
+  // void (const OSSL_CORE_HANDLE *prov)
+  // Opens a new record on the caller's error queue.
+  OSSL_FUNC_core_new_error_fn *new_error;
+
+  // void (const OSSL_CORE_HANDLE *prov, const char *file, int line,
+  //       const char *func)
+  // Attaches origin metadata to the open record.
+  OSSL_FUNC_core_set_error_debug_fn *set_error_debug;
+
+  // void (const OSSL_CORE_HANDLE *prov, uint32_t reason, const char *fmt,
+  //       va_list args)
+  // Sets the reason and formatted detail on the open record. Unlike
+  // the other two error upcalls it reads |prov| to find the error library to file
+  // under, so it cannot be passed NULL.
+  OSSL_FUNC_core_vset_error_fn *vset_error;
+} AWSLC_PROV_UPCALLS;
+
+// NULL for a NULL |ctx|, which is what makes raising without a context a no-op
+// rather than a crash.
+const AWSLC_PROV_UPCALLS *awslc_prov_ctx_upcalls(const AWSLC_PROV_CTX *ctx);
 
 // Whether the linked AWS-LC reported FIPS mode when this provider initialized.
 int awslc_prov_ctx_is_fips(const AWSLC_PROV_CTX *ctx);
@@ -40,6 +74,45 @@ int awslc_prov_indicator_on_unapproved(AWSLC_PROV_CTX *ctx, const char *type,
 // per-class headers, which only registry.c and the class implementations include.
 const OSSL_ALGORITHM *awslc_prov_query_operation(void *provctx, int operation_id,
                                                  int *no_store);
+
+// Error reporting, implemented in errors.c. The reason namespace is in
+// internal/backend.h.
+
+// The reason-string table for the provider's private error library, published by
+// provider.c in the top-level dispatch table.
+OSSL_FUNC_provider_get_reason_strings_fn awslc_prov_get_reason_strings;
+
+// Raise one error from the provider layer itself. |detail| is optional
+// per-occurrence text.
+void awslc_prov_error_raise(const AWSLC_PROV_CTX *ctx, uint32_t reason,
+                            const char *file, int line, const char *detail);
+
+// Raise at the call site's own file and line.
+#define AWSLC_PROV_ERROR_RAISE(ctx, reason, detail) \
+  awslc_prov_error_raise((ctx), (reason), __FILE__, __LINE__, (detail))
+
+// Every dispatch slot that calls into AWS-LC brackets those calls, handing its own
+// result to the macro below and returning what the macro returns:
+//
+//   awslc_prov_error_mark();
+//   ok = <one or more backend calls>;
+//   return AWSLC_PROV_ERROR_SETTLE(ctx->provctx, ok, AWSLC_PROV_R_BACKEND_ERROR,
+//                                  ctx->algorithm_name);
+//
+// |succeeded| comes back unchanged, and the AWS-LC queue is left empty either way:
+//
+//   true    Discard. AWS-LC queues records on recoverable internal paths that a
+//           successful call must not leak to the application.
+//   false   Translate AWS-LC's records onto OpenSSL's queue, oldest first, or
+//           raise |reason| and |detail| if AWS-LC queued none, so a failed call
+//           never leaves the queue empty.
+int awslc_prov_error_settle(const AWSLC_PROV_CTX *ctx, int succeeded,
+                            uint32_t reason, const char *file, int line,
+                            const char *detail);
+
+#define AWSLC_PROV_ERROR_SETTLE(ctx, succeeded, reason, detail)          \
+  awslc_prov_error_settle((ctx), (succeeded), (reason), __FILE__, __LINE__, \
+                          (detail))
 
 #if defined(__cplusplus)
 }  // extern "C"

--- a/provider/test/backend/errors_test.cc
+++ b/provider/test/backend/errors_test.cc
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// The AWS-LC side of the error bridge. Only this binary can force a record onto
+// AWS-LC's queue, so the translation is covered here rather than through the
+// provider interface. test/frontend/provider_test.cc covers the front side.
+
+#include <gtest/gtest.h>
+
+#include <openssl/err.h>
+
+#include <string>
+
+#include "internal/backend.h"
+
+namespace {
+
+// EC reason 100 and BN reason 100 are different errors, which is what makes the
+// library tag observable.
+constexpr int kEcBufferTooSmall = 100;
+constexpr int kBnArg2LtArg3 = 100;
+
+class BackendErrorTest : public ::testing::Test {
+ protected:
+  void SetUp() override { ERR_clear_error(); }
+  void TearDown() override { ERR_clear_error(); }
+
+    static void Put(int library, int reason, const char *file, unsigned line) {
+    ERR_put_error(library, 0, reason, file, line);
+  }
+
+  static AWSLC_PROV_ERROR Shift() {
+    AWSLC_PROV_ERROR record;
+    EXPECT_TRUE(awslc_prov_error_shift(&record));
+    return record;
+  }
+};
+
+TEST_F(BackendErrorTest, TagsReasonsWithTheirAwslcLibrary) {
+  Put(ERR_LIB_EC, kEcBufferTooSmall, "ec.c", 1);
+  Put(ERR_LIB_BN, kBnArg2LtArg3, "bn.c", 2);
+
+  const AWSLC_PROV_ERROR ec = Shift();
+  const AWSLC_PROV_ERROR bn = Shift();
+
+  EXPECT_EQ(AWSLC_PROV_ERROR_REASON(ERR_LIB_EC, kEcBufferTooSmall), ec.reason);
+  EXPECT_EQ(AWSLC_PROV_ERROR_REASON(ERR_LIB_BN, kBnArg2LtArg3), bn.reason);
+  EXPECT_NE(ec.reason, bn.reason);
+}
+
+// The detail is the only place the AWS-LC library or reason name reaches the
+// application, since the front side registers no reason string for an AWS-LC code.
+TEST_F(BackendErrorTest, CarriesAwslcLibraryAndReasonAsDetail) {
+  Put(ERR_LIB_EC, kEcBufferTooSmall, "ec.c", 1);
+
+  const AWSLC_PROV_ERROR record = Shift();
+  const std::string detail(record.detail);
+
+  EXPECT_NE(std::string::npos, detail.find("AWS-LC"));
+  EXPECT_NE(std::string::npos,
+            detail.find(ERR_lib_error_string(
+                ERR_PACK(ERR_LIB_EC, kEcBufferTooSmall))))
+      << detail;
+  EXPECT_NE(std::string::npos,
+            detail.find(ERR_reason_error_string(
+                ERR_PACK(ERR_LIB_EC, kEcBufferTooSmall))))
+      << detail;
+}
+
+// AWS-LC's data pointer belongs to the queue and dies on the next call that
+// touches it, so the shift has to copy it.
+TEST_F(BackendErrorTest, CopiesTheAwslcRecordDetail) {
+  Put(ERR_LIB_EC, kEcBufferTooSmall, "ec.c", 1);
+  ERR_add_error_data(1, "curve P-256");
+  Put(ERR_LIB_BN, kBnArg2LtArg3, "bn.c", 2);
+
+  const AWSLC_PROV_ERROR first = Shift();
+  // This shift invalidates |first|'s original data pointer.
+  const AWSLC_PROV_ERROR second = Shift();
+
+  EXPECT_NE(std::string::npos, std::string(first.detail).find("curve P-256"))
+      << first.detail;
+  EXPECT_EQ(std::string::npos, std::string(second.detail).find("curve P-256"))
+      << second.detail;
+}
+
+TEST_F(BackendErrorTest, CarriesTheAwslcOrigin) {
+  Put(ERR_LIB_EC, kEcBufferTooSmall, "some/file.c", 4321);
+
+  const AWSLC_PROV_ERROR record = Shift();
+
+  ASSERT_NE(nullptr, record.file);
+  EXPECT_STREQ("some/file.c", record.file);
+  EXPECT_EQ(4321, record.line);
+}
+
+TEST_F(BackendErrorTest, ShiftsOldestFirst) {
+  Put(ERR_LIB_EC, kEcBufferTooSmall, "first.c", 1);
+  Put(ERR_LIB_BN, kBnArg2LtArg3, "second.c", 2);
+
+  EXPECT_STREQ("first.c", Shift().file);
+  EXPECT_STREQ("second.c", Shift().file);
+
+  AWSLC_PROV_ERROR record;
+  EXPECT_FALSE(awslc_prov_error_shift(&record));
+}
+
+// A zero reason names nothing and an over-wide library cannot round-trip. Both
+// must stay visible as a failure rather than resolve to another library's reason.
+TEST_F(BackendErrorTest, SubstitutesItsOwnReasonWhenAwslcCannotBeTagged) {
+  Put(ERR_LIB_EC, 0, "ec.c", 1);
+  Put(AWSLC_PROV_ERROR_MAX_LIB + 1, kEcBufferTooSmall, "wide.c", 2);
+
+  EXPECT_EQ((uint32_t)AWSLC_PROV_R_BACKEND_ERROR, Shift().reason);
+  EXPECT_EQ((uint32_t)AWSLC_PROV_R_BACKEND_ERROR, Shift().reason);
+}
+
+// AWS-LC resolves a reason below 100 without the library field, so the bridge
+// leaves those untagged and ERR_GET_REASON stays equal to what AWS-LC raised.
+TEST_F(BackendErrorTest, LeavesCrossLibraryReasonsUntagged) {
+  const int cross_library_reason = ERR_LIB_EC;
+
+  Put(ERR_LIB_EVP, cross_library_reason, "evp.c", 1);
+
+  EXPECT_EQ((uint32_t)cross_library_reason, Shift().reason);
+}
+
+// AWS-LC queues records on recoverable internal paths, which a successful dispatch
+// call must not leak to the application.
+TEST_F(BackendErrorTest, DiscardsRecordsQueuedSinceTheMark) {
+  awslc_prov_error_mark();
+  Put(ERR_LIB_EC, kEcBufferTooSmall, "ec.c", 1);
+  awslc_prov_error_discard();
+
+  AWSLC_PROV_ERROR record;
+  EXPECT_FALSE(awslc_prov_error_shift(&record));
+}
+
+}  // namespace

--- a/provider/test/frontend/provider_test.cc
+++ b/provider/test/frontend/provider_test.cc
@@ -13,6 +13,9 @@
 #include <openssl/provider.h>
 
 #include <string>
+#include <vector>
+
+#include "internal/backend.h"
 
 namespace awslc_provider_test {
 namespace {
@@ -65,6 +68,27 @@ TEST_F(ProviderTest, ReportsSelfDescribingParams) {
 #endif
 
   EXPECT_EQ(1, status);
+}
+
+TEST_F(ProviderTest, RaisesErrorsUnderItsOwnErrorLibrary) {
+  int wrong_type = 0;
+  OSSL_PARAM params[] = {
+      OSSL_PARAM_construct_int(OSSL_PROV_PARAM_NAME, &wrong_type),
+      OSSL_PARAM_construct_end()};
+
+  ASSERT_FALSE(OSSL_PROVIDER_get_params(awslc(), params))
+      << "provider accepted OSSL_PROV_PARAM_NAME as an integer";
+
+  const std::vector<ErrorRecord> ours = ProviderErrors(DrainErrors());
+  ASSERT_EQ(1u, ours.size()) << "a failed get_params raised " << ours.size()
+                             << " errors under " << kProviderName;
+
+  EXPECT_EQ((unsigned long)AWSLC_PROV_R_INVALID_PARAMETER, ours[0].reason());
+  ASSERT_NE(nullptr, ours[0].reason_text());
+  EXPECT_STREQ("invalid parameter", ours[0].reason_text());
+  EXPECT_NE(std::string::npos, ours[0].file.find("provider.c")) << ours[0].file;
+  EXPECT_GT(ours[0].line, 0);
+  EXPECT_EQ(OSSL_PROV_PARAM_NAME, ours[0].data);
 }
 
 TEST_F(ProviderTest, DeclaresGettableParams) {

--- a/provider/test/test_fixture.h
+++ b/provider/test/test_fixture.h
@@ -18,10 +18,13 @@
 #include <gtest/gtest.h>
 
 #include <openssl/crypto.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/provider.h>
 
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace awslc_provider_test {
 
@@ -65,10 +68,66 @@ using ProviderPtr = std::unique_ptr<OSSL_PROVIDER, ProviderDeleter>;
 using MdPtr = std::unique_ptr<EVP_MD, MdDeleter>;
 using MdCtxPtr = std::unique_ptr<EVP_MD_CTX, MdCtxDeleter>;
 
-// Loads the provider into a private libctx, alongside the default provider.
-// Keeping default loaded is not incidental: it is the fallback leg that makes
-// '?provider=awslc' safe, so the fixture reproduces the deployed arrangement
-// rather than a provider-only one.
+// One drained OpenSSL error record. In the shared fixture because any operation
+// with a failure path owes the queue an explanation.
+struct ErrorRecord {
+  unsigned long code = 0;
+  std::string file;
+  int line = 0;
+  std::string data;
+
+  unsigned long library() const { return ERR_GET_LIB(code); }
+  unsigned long reason() const { return ERR_GET_REASON(code); }
+  const char *reason_text() const { return ERR_reason_error_string(code); }
+
+  // OpenSSL returns NULL for an unnamed library. Rendered rather than returned raw
+  // so that surfaces as a failed comparison instead of a crash in the test.
+  std::string library_name() const {
+    const char *name = ERR_lib_error_string(code);
+    return name == nullptr ? "<unregistered>" : name;
+  }
+};
+
+// The whole queue, oldest first.
+inline std::vector<ErrorRecord> DrainErrors() {
+  std::vector<ErrorRecord> records;
+
+  for (;;) {
+    const char *file = nullptr;
+    const char *data = nullptr;
+    int line = 0;
+    int flags = 0;
+    const unsigned long code =
+        ERR_get_error_all(&file, &line, nullptr, &data, &flags);
+
+    if (code == 0) {
+      return records;
+    }
+    ErrorRecord record;
+    record.code = code;
+    record.file = file == nullptr ? "" : file;
+    record.line = line;
+    record.data = data == nullptr ? "" : data;
+    records.push_back(record);
+  }
+}
+
+// Only the records the provider filed. OpenSSL raises its own around a dispatch
+// call, so position does not identify ours; the private error library does.
+inline std::vector<ErrorRecord> ProviderErrors(
+    const std::vector<ErrorRecord> &records) {
+  std::vector<ErrorRecord> ours;
+
+  for (const ErrorRecord &record : records) {
+    if (record.library_name() == AWSLC_TEST_PROVIDER_NAME) {
+      ours.push_back(record);
+    }
+  }
+  return ours;
+}
+
+// Loads the provider into a private libctx alongside the default provider, which
+// is the fallback leg that makes '?provider=awslc' safe.
 class ProviderTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -86,9 +145,13 @@ class ProviderTest : public ::testing::Test {
 
     default_.reset(OSSL_PROVIDER_load(libctx_.get(), "default"));
     ASSERT_TRUE(default_) << "could not load the default provider";
+
+    // The queue is per-thread and process-wide, so each test starts from empty.
+    ERR_clear_error();
   }
 
   void TearDown() override {
+    ERR_clear_error();
     default_.reset();
     awslc_.reset();
     libctx_.reset();


### PR DESCRIPTION
### Context and motivation

This wires up error reporting for the provider so users can get feedback on failed operations. We align the implementation strategy around the ACCP precedent of marking and draining the error queues on each border-crossing.

Two properties of the two libraries shape what is possible here:

- **AWS-LC's error queue is pull-only.** There is no raise-time callback to bridge, so records can only be
  collected around a call that has already returned.
- **The two libraries' error numbering diverges.** AWS-LC's library ids differ from OpenSSL's above 11, and
  each library numbers its reasons independently, so an AWS-LC code filed under an OpenSSL library id
  resolves against the wrong per-library table and renders as another library's reason.

### Description of changes

**A private error library.** The provider files everything under its own `awslc` error library through the
core error upcalls, and publishes reason strings for its own codes via
`OSSL_FUNC_PROVIDER_GET_REASON_STRINGS`.

**A reason namespace with three disjoint ranges** (`internal/backend.h`):

| Range | Contents |
|---|---|
| 1 to 99 | AWS-LC's cross-library reasons, kept at their own numbers. AWS-LC resolves these without consulting the library field, so one entry serves every library and the provider does not tag them. |
| 100 to 4095 | The provider's own reasons, `AWSLC_PROV_R_*`. |
| 4096 and up | An AWS-LC library-specific reason, as `(library << 12) | reason`. |

**A bracket around every call into AWS-LC.** `awslc_prov_error_mark()` before, then
`AWSLC_PROV_ERROR_SETTLE(...)` with the slot's own result, which comes back unchanged:

- **Success** discards to the mark. AWS-LC queues records on recoverable internal paths, and a successful
  call must not leak those to the application.
- **Failure** re-raises AWS-LC's records oldest first, which is how OpenSSL's queue is read, or raises the
  slot's own reason and detail if AWS-LC queued none. A failed dispatch call never leaves the queue empty.

**Detail composed on the AWS-LC side.** `backend/errors.c` renders `AWS-LC <library>: <reason>: <data>`,
because only that translation unit can see AWS-LC's reason tables.

**First integration.** SHA-2 brackets its `init`, `update`, `final`, and context allocation, and raises
`AWSLC_PROV_R_INVALID_PARAMETER` for its own argument rejections and `AWSLC_PROV_R_UNAPPROVED_OPERATION`
when an indicator callback vetoes a result.

### Testing

**Backend suite** (`test/backend/errors_test.cc`, 8 tests). Only the AWS-LC-linked binary can force a
record onto AWS-LC's queue, so the translation is covered there rather than through the provider interface.

### Review considerations

- Looking for feedback on the error code remapping strategy and how we pack in the library IDs.
- **The failure half of the bracket has no test that executes it.** No SHA-2 path can fail through EVP:
  `SHA*_Init` and `SHA*_Update` do not fail, `EVP_DigestFinal_ex` always passes the advertised size so the
  backend bounds check is unreachable, and only the AWS-LC-linked binary can force an allocation failure
  while that binary does not run dispatch functions. It closes with the first operation whose backend can
  fail. The discard half, the raise half, and the substitution are each covered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache
2.0 license and the ISC license.
