### PR TITLE
Run OpenSSL's EVP vectors through the aws-lc-provider in CI

### DIFF
--- a/.github/workflows/aws-lc-provider.yml
+++ b/.github/workflows/aws-lc-provider.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none
           sudo apt-get -y --no-install-recommends install \
             cmake ninja-build make perl binutils
-      - name: Build the provider and run its unit tests
+      - name: Build the provider, run its unit tests and EVP vectors
         run: |
           if [[ "${{ matrix.fips }}" == "1" ]]; then
             ./tests/ci/run_aws_lc_provider_tests.sh --fips

--- a/provider/test/run_evp_vectors.sh
+++ b/provider/test/run_evp_vectors.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+# Drive OpenSSL's own EVP known-answer vectors through the provider, using the
+# pinned OpenSSL source tree's evp_test binary over its stock data files. This
+# test suite has a number of caveats though. Mainly, we can't strongly assert
+# that AWS-LC answered each vector. Our signal is that given a mixture of
+# aws-lc-provider (preferred) and the OpenSSL default (fallback) providers
+# loaded, all of the test vectors pass.
+#
+# What is asserted per data file is the case count, the skip count, and a fetch
+# count per algorithm name, not merely that the run exited 0: a case whose init
+# fails abandons the remainder, so "0 errors" also describes a run that stopped
+# after the first case.
+#
+# Exits 0 when every expectation is met and non-zero otherwise.
+
+set -euo pipefail
+
+fail() {
+  echo "FAILED: $*" >&2
+  exit 1
+}
+
+OPENSSL_SRC="$1"
+EXPECTED_TAG="$2"
+MODULE_DIR="$3"
+
+export LC_ALL=C
+
+PROVIDER_CNF="$(dirname "${BASH_SOURCE[0]}")/provider.cnf"
+
+EVP_TEST="${OPENSSL_SRC}/test/evp_test"
+WRAP="${OPENSSL_SRC}/util/wrap.pl"
+DATA_DIR="${OPENSSL_SRC}/test/recipes/30-test_evp_data"
+
+PROVIDER_NAME="awslc"
+
+# One line per data file: name, expected case count, expected skip count, then a
+# required fetch count per algorithm the provider backs.
+#
+#   cases   Known answers in the file.
+#   skips   Cases evp_test declines to run.
+#   fetches Times evp_test reported fetching that specific algorithm name.
+#
+# Algorithms the provider does not back are the default provider's to serve and
+# are left unconstrained.
+EXPECTATIONS=(
+  "evpmd_sha.txt 74 0 SHA224:3 SHA256:3 SHA384:3 SHA512:3 SHA512-224:7 SHA512-256:7 shA512:1"
+)
+
+# --------------------------------------------------------------------------
+# Shared parsing
+# --------------------------------------------------------------------------
+
+# "Completed %d tests with %d errors and %d skipped", from the test framework's
+# own summary line, as "<tests> <errors> <skips>".
+completion_counts() {
+  sed -n \
+    's/.*Completed \([0-9][0-9]*\) tests with \([0-9][0-9]*\) errors and \([0-9][0-9]*\) skipped.*/\1 \2 \3/p' |
+    tail -n 1
+}
+
+# From the "<alg> is fetched" lines evp_test prints. Printed only when
+# EVP_MD_fetch returned an implementation, so it distinguishes a real fetch from
+# the built-in name table evp_test falls back to when a fetch fails.
+fetch_histogram() {
+  awk '
+    / is fetched$/ {
+      line = $0
+      sub(/[ \t]+is fetched$/, "", line)
+      count = split(line, parts, /[ \t]+/)
+      print parts[count]
+    }
+  ' |
+    sort |
+    uniq -c |
+    awk '{ print $2 ":" $1 }'
+}
+
+fetch_count() {
+  awk -F: -v name="$1" '$1 == name { print $2 }' <<<"$2"
+}
+
+export OPENSSL_MODULES="${MODULE_DIR}"
+
+# --------------------------------------------------------------------------
+# The vectors
+# --------------------------------------------------------------------------
+
+files_run=0
+files_passed=0
+files_with_skips=0
+files_failed=0
+
+for entry in "${EXPECTATIONS[@]}"; do
+  read -r datafile want_cases want_skips want_fetches <<<"${entry}"
+  files_run=$((files_run + 1))
+
+  # Run in place: wrap.pl bakes absolute configure-time paths. Its completion line
+  # and fetch stream go to stderr, hence the merge.
+  output="$(
+    perl "${WRAP}" "${EVP_TEST}" -config "${PROVIDER_CNF}" \
+      "${DATA_DIR}/${datafile}" 2>&1
+  )" && run_status=0 || run_status=$?
+
+  counts="$(completion_counts <<<"${output}")"
+  if [[ -z "${counts}" ]]; then
+    {
+      echo "FAIL ${datafile}: no completion line, evp_test exited ${run_status}"
+      sed 's/^/    /' <<<"${output}"
+    } >&2
+    fail "${datafile} did not run to completion"
+  fi
+  read -r got_cases got_errors got_skips <<<"${counts}"
+  got_fetches="$(fetch_histogram <<<"${output}")"
+
+  problems=()
+  [[ "${run_status}" -eq 0 ]] || problems+=("evp_test exited ${run_status}")
+  [[ "${got_errors}" -eq 0 ]] || problems+=("${got_errors} vector errors")
+  [[ "${got_cases}" -eq "${want_cases}" ]] ||
+    problems+=("ran ${got_cases} cases, expected ${want_cases}")
+  [[ "${got_skips}" -eq "${want_skips}" ]] ||
+    problems+=("skipped ${got_skips} cases, expected ${want_skips}")
+
+  for spec in ${want_fetches}; do
+    name="${spec%%:*}"
+    want="${spec##*:}"
+    got="$(fetch_count "${name}" "${got_fetches}")"
+    [[ "${got:-0}" -eq "${want}" ]] ||
+      problems+=("${name} fetched ${got:-0} times, expected ${want}")
+  done
+
+  if [[ "${#problems[@]}" -eq 0 ]]; then
+    files_passed=$((files_passed + 1))
+    echo "PASS ${datafile}: tests=${got_cases} errors=${got_errors}" \
+      "skips=${got_skips}, all fetch counts match"
+  else
+    files_failed=$((files_failed + 1))
+    {
+      echo "FAIL ${datafile}: tests=${got_cases} errors=${got_errors}" \
+        "skips=${got_skips}"
+      for problem in "${problems[@]}"; do
+        echo "  ${problem}"
+      done
+      echo "  evp_test output:"
+      sed 's/^/    /' <<<"${output}"
+    } >&2
+  fi
+
+  # Named separately because a skipped case is coverage lost rather than a wrong
+  # answer. Every row expects none, so a skip also fails the file.
+  if [[ "${got_skips}" -ne 0 ]]; then
+    files_with_skips=$((files_with_skips + 1))
+    echo "     ${datafile}: ${got_skips} cases skipped and did not run"
+  fi
+done
+
+echo ""
+echo "files run: ${files_run}, passed: ${files_passed}," \
+  "with skips: ${files_with_skips}, failed: ${files_failed}"
+
+# Before the statement of what a green run covers, so a failing run cannot print
+# that statement.
+[[ "${files_failed}" -eq 0 ]] || fail "${files_failed} of ${files_run} vector files"
+
+echo "run_evp_vectors completed successfully."

--- a/tests/ci/common_posix_setup.sh
+++ b/tests/ci/common_posix_setup.sh
@@ -262,6 +262,8 @@ function sde_getenforce_check {
 
 function build_openssl {
     branch=$1
+    # If 1, leaves the checkout in place for callers that need OpenSSL source.
+    keep_source=${2:-0}
     echo "building OpenSSL ${branch}"
     git clone --depth 1 --branch "${branch}" "${openssl_url}" "${scratch_folder}/openssl-${branch}"
     pushd "${scratch_folder}/openssl-${branch}"
@@ -274,11 +276,13 @@ function build_openssl {
     cp "${scratch_folder}/openssl-${branch}/apps/openssl.cnf" "${install_dir}/openssl-${branch}/openssl.cnf"
 
     popd
-    rm -rf "${scratch_folder}/openssl-${branch}"
+    [[ "${keep_source}" == "1" ]] || rm -rf "${scratch_folder}/openssl-${branch}"
 }
 
 function build_openssl_no_debug {
     branch=$1
+    # If 1, leaves the checkout in place for callers that need OpenSSL source.
+    keep_source=${2:-0}
     echo "building OpenSSL ${branch}"
     git clone --depth 1 --branch "${branch}" "${openssl_url}" "${scratch_folder}/openssl-${branch}"
     pushd "${scratch_folder}/openssl-${branch}"
@@ -287,7 +291,7 @@ function build_openssl_no_debug {
     make "-j${NUM_CPU_THREADS}" > /dev/null
     make install_sw
     popd
-    rm -rf "${scratch_folder}/openssl-${branch}"
+    [[ "${keep_source}" == "1" ]] || rm -rf "${scratch_folder}/openssl-${branch}"
 }
 
 print_executable_information "cmake" "--version" "CMake version"

--- a/tests/ci/run_aws_lc_provider_tests.sh
+++ b/tests/ci/run_aws_lc_provider_tests.sh
@@ -2,11 +2,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
-# Build the AWS-LC OpenSSL provider in its shipping configuration and run its
-# two unit suites. Linux only, deliberately: ENABLE_DIST_PKG is a FATAL_ERROR
-# elsewhere, and without it the two-libcrypto linkage checks below have nothing
-# to assert against, so a green run on another platform would claim more than it
-# proved. Other platforms are for development; see provider/README.md.
+# Build the AWS-LC OpenSSL provider in its shipping configuration, run its two
+# unit suites, and drive OpenSSL's own EVP vectors through it. Linux only:
+# ENABLE_DIST_PKG is a FATAL_ERROR elsewhere, so the linkage checks below would
+# have nothing to assert against.
 #
 # The provider is off by default and needs OpenSSL's provider headers, which
 # AWS-LC's own tree does not carry, so this script builds the pinned OpenSSL from
@@ -49,7 +48,6 @@ source tests/ci/common_posix_setup.sh
 # earlier 3.x lacks provider interface the front side depends on.
 openssl_provider_tag='openssl-3.5.5'
 
-# build_openssl_no_debug reads these three as globals, so the names are its.
 openssl_url='https://github.com/openssl/openssl.git'
 scratch_folder="${SYS_ROOT}/awslc-provider-scratch"
 install_dir="${scratch_folder}/openssl_install_dir"
@@ -65,10 +63,10 @@ banner "Building OpenSSL ${openssl_provider_tag}"
 mkdir -p "${scratch_folder}"
 rm -rf "${scratch_folder:?}"/*
 
-# Installs into ${install_dir}/openssl-${1} and deletes its source tree after.
-build_openssl_no_debug "${openssl_provider_tag}"
+build_openssl_no_debug "${openssl_provider_tag}" 1
 
 OPENSSL_ROOT="${install_dir}/openssl-${openssl_provider_tag}"
+OPENSSL_SRC="${scratch_folder}/openssl-${openssl_provider_tag}"
 
 # The provider headers are the actual dependency, and an install can carry a
 # libcrypto without them. Checked here so a bad prefix fails with its own message
@@ -78,6 +76,7 @@ OPENSSL_ROOT="${install_dir}/openssl-${openssl_provider_tag}"
 
 echo ""
 echo "OpenSSL prefix: ${OPENSSL_ROOT}"
+echo "OpenSSL source: ${OPENSSL_SRC}"
 
 # --------------------------------------------------------------------------
 # 2. Build AWS-LC with the provider
@@ -189,9 +188,33 @@ for binary in "${TEST_BINARIES[@]}"; do
   "${binary}" || fail "$(basename "${binary}") reported failures"
 done
 
-banner "Provider build and unit tests passed"
+# --------------------------------------------------------------------------
+# 6. OpenSSL's own EVP vectors
+# --------------------------------------------------------------------------
+#
+# OpenSSL's own known-answer corpus, driven through OpenSSL's own evp_test over
+# the real 3.x fetch path. Because the provider is a preference, a fetch it does
+# not serve falls through to the default provider and still produces the known
+# answer. So these counts do not say which provider served a case; that is the
+# unit suites' job, and they run above.
 
-# Say plainly what a green run here covers, so it is not mistaken for more.
-echo "Covered: the provider builds, loads, and its two unit suites pass, and its"
-echo "         AWS-LC references match their registered version nodes."
-echo ""
+banner "OpenSSL EVP vectors"
+
+VECTOR_RUNNER="${SRC_ROOT}/provider/test/run_evp_vectors.sh"
+# Teed so the checks below can read it while CI still sees it stream. Created up
+# front so a tee that cannot open its file is not reported as a vector failure.
+VECTOR_LOG="${BUILD_ROOT}/evp_vectors.log"
+: > "${VECTOR_LOG}" || fail "cannot write the vector log at ${VECTOR_LOG}"
+
+bash "${VECTOR_RUNNER}" \
+  "${OPENSSL_SRC}" "${openssl_provider_tag}" "${PROVIDER_DIR}" \
+  2>&1 | tee "${VECTOR_LOG}" \
+  || fail "the EVP vector gate failed"
+
+# Exit 0 alone is not evidence the runner asserted anything; one that returned
+# early would look identical. Its summary line is printed last, so requiring it
+# distinguishes a run that finished from one that bailed.
+grep -q '^files run: ' "${VECTOR_LOG}" \
+  || fail "the EVP vector gate exited 0 without reporting a summary; it did not run to completion"
+
+banner "Provider build, unit tests, and EVP vectors passed"


### PR DESCRIPTION
### Context and motivation

Everything the provider is checked against so far is a test this project wrote. OpenSSL ships its own
known-answer corpus and the `evp_test` driver that consumes it, so the provider can be held to the same
vectors OpenSSL holds itself to, over the real 3.x fetch path with both providers loaded and `awslc`
preferred.

### Description of changes

**`provider/test/run_evp_vectors.sh`** drives the OpenSSL source tree's `evp_test` binary over its
stock data files, using the provider's own test config.

Per data file it asserts a case count, a skip count, and a fetch count per algorithm name, not merely that
the run exited 0. That distinction is the point: a case whose init fails abandons the rest of the file, so
`0 errors` also describes a run that stopped after the first case. A skipped case is coverage lost rather
than a wrong answer, so it is named separately and also fails the file. Algorithms the provider does not
back are left unconstrained, because they are the default provider's to serve.

One row today: `evpmd_sha.txt`, 74 cases, 0 skips, with the fetch counts for the six SHA-2 names pinned. A
family arriving later adds rows and moves counts from unclaimed to claimed rather than vendoring vectors.

**Curated files rather than the whole corpus.** This avoids pulling in large amounts of coverage which AWS-LC does not support and the associated maintenance liabilities.

**CI.** `tests/ci/run_aws_lc_provider_tests.sh` runs the vectors after the two unit suites and the linkage
checks. It tees the runner's output and requires the runner's final summary line, because exit 0 alone does
not show the runner reached the end; a runner that returned early would look identical.

### Testing

The change is a test gate. It is green on both Linux axes, FIPS and non-FIPS, at 74 cases, 0 errors, 0
skips, with every pinned fetch count matching, run alongside the unit suites in the same job.

Control run in place: perturbing one expectation (`SHA512-224` at 6 rather than its actual 7) exits 1 with
`SHA512-224 fetched 7 times, expected 6`. An earlier attempt at that control was invalid because it copied
the script to `/tmp`, which broke its self-location of `provider.cnf`, and the script refused rather than
running.

### Review considerations

- There is no way to strongly require AWS-LC as the provider for this test suite without breaking the test suite. In other words, if we set AWS-LC as required, the test suite will error out on the first algorithm/vector that is unsupported. There is no easy way to filter out unsupported algorithms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache
2.0 license and the ISC license.