### PR TITLE
Add legacy SSL function codes for OpenSSL compatibility

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -6717,4 +6717,14 @@ BSSL_NAMESPACE_END
 #define SSL_R_TLSV1_ALERT_ECH_REQUIRED 1121
 #define SSL_R_SERIALIZATION_INVALID_SERDE_VERSION 1122
 
+// The following SSL_F_* function codes are defined for compatibility with
+// callers written against OpenSSL, which pass them as the |function| argument
+// to |ERR_put_error|. AWS-LC does not support function codes and ignores that
+// argument, so these are all defined to zero, as OpenSSL 3.0 does for its
+// legacy SSL_F_* names. SSL_F_SSL3_GET_SERVER_CERTIFICATE was removed in
+// OpenSSL 1.1.0 and is retained here for callers that still reference it.
+#define SSL_F_SSL_CTX_SET_SSL_VERSION 0
+#define SSL_F_SSL3_GET_SERVER_CERTIFICATE 0
+#define SSL_F_TLS_PROCESS_SERVER_CERTIFICATE 0
+
 #endif  // OPENSSL_HEADER_SSL_H

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -6451,6 +6451,16 @@ BSSL_NAMESPACE_END
 #define SSL_R_VERSION_TOO_HIGH (SSL_R_BACKWARDS_COMPATABILITY_OFFSET + 4)
 #define SSL_R_VERSION_TOO_LOW (SSL_R_BACKWARDS_COMPATABILITY_OFFSET + 5)
 
+// The following SSL_F_* function codes are defined for compatibility with
+// callers written against OpenSSL, which pass them as the |function| argument
+// to |ERR_put_error|. AWS-LC does not support function codes and ignores that
+// argument, so these are all defined to zero, as OpenSSL 3.0 does for its
+// legacy SSL_F_* names. SSL_F_SSL3_GET_SERVER_CERTIFICATE was removed in
+// OpenSSL 1.1.0 and is retained here for callers that still reference it.
+#define SSL_F_SSL_CTX_SET_SSL_VERSION 0
+#define SSL_F_SSL3_GET_SERVER_CERTIFICATE 0
+#define SSL_F_TLS_PROCESS_SERVER_CERTIFICATE 0
+
 #define SSL_R_APP_DATA_IN_HANDSHAKE 100
 #define SSL_R_ATTEMPT_TO_REUSE_SESSION_IN_DIFFERENT_CONTEXT 101
 #define SSL_R_BAD_ALERT 102
@@ -6716,15 +6726,5 @@ BSSL_NAMESPACE_END
 #define SSL_R_TLSV1_ALERT_NO_APPLICATION_PROTOCOL 1120
 #define SSL_R_TLSV1_ALERT_ECH_REQUIRED 1121
 #define SSL_R_SERIALIZATION_INVALID_SERDE_VERSION 1122
-
-// The following SSL_F_* function codes are defined for compatibility with
-// callers written against OpenSSL, which pass them as the |function| argument
-// to |ERR_put_error|. AWS-LC does not support function codes and ignores that
-// argument, so these are all defined to zero, as OpenSSL 3.0 does for its
-// legacy SSL_F_* names. SSL_F_SSL3_GET_SERVER_CERTIFICATE was removed in
-// OpenSSL 1.1.0 and is retained here for callers that still reference it.
-#define SSL_F_SSL_CTX_SET_SSL_VERSION 0
-#define SSL_F_SSL3_GET_SERVER_CERTIFICATE 0
-#define SSL_F_TLS_PROCESS_SERVER_CERTIFICATE 0
 
 #endif  // OPENSSL_HEADER_SSL_H

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -995,6 +995,34 @@ TEST(SSLTest, SetVersion) {
   EXPECT_EQ(0, SSL_CTX_get_min_proto_version(ctx.get()));
 }
 
+// AWS-LC does not support OpenSSL function codes, but exposes a handful of
+// legacy SSL_F_* names for source compatibility. They must all be zero and
+// must be usable as the |function| argument to |ERR_put_error| without
+// affecting the reason code that is recorded.
+static_assert(SSL_F_SSL_CTX_SET_SSL_VERSION == 0,
+              "SSL_F_* compatibility codes must be zero");
+static_assert(SSL_F_SSL3_GET_SERVER_CERTIFICATE == 0,
+              "SSL_F_* compatibility codes must be zero");
+static_assert(SSL_F_TLS_PROCESS_SERVER_CERTIFICATE == 0,
+              "SSL_F_* compatibility codes must be zero");
+
+TEST(SSLTest, LegacyFunctionCodes) {
+  ERR_clear_error();
+  ERR_put_error(ERR_LIB_SSL, SSL_F_SSL_CTX_SET_SSL_VERSION,
+                SSL_R_UNSUPPORTED_PROTOCOL, NULL, 0);
+  EXPECT_TRUE(ExpectSingleError(ERR_LIB_SSL, SSL_R_UNSUPPORTED_PROTOCOL));
+
+  ERR_put_error(ERR_LIB_SSL, SSL_F_SSL3_GET_SERVER_CERTIFICATE,
+                SSL_R_CERTIFICATE_VERIFY_FAILED, NULL, 0);
+  EXPECT_TRUE(
+      ExpectSingleError(ERR_LIB_SSL, SSL_R_CERTIFICATE_VERIFY_FAILED));
+
+  ERR_put_error(ERR_LIB_SSL, SSL_F_TLS_PROCESS_SERVER_CERTIFICATE,
+                SSL_R_CERTIFICATE_VERIFY_FAILED, NULL, 0);
+  EXPECT_TRUE(
+      ExpectSingleError(ERR_LIB_SSL, SSL_R_CERTIFICATE_VERIFY_FAILED));
+}
+
 TEST(SSLTest, SetVerifyResult) {
   bssl::UniquePtr<SSL_CTX> client_ctx(SSL_CTX_new(TLS_method()));
   bssl::UniquePtr<SSL_CTX> server_ctx =


### PR DESCRIPTION
### Context and motivation

Some OpenSSL consumers, including trilogy, pass legacy `SSL_F_*` function codes to `ERR_put_error`. AWS-LC did not define three of these names, preventing those consumers from compiling.

### Description of changes

Define `SSL_F_SSL_CTX_SET_SSL_VERSION`, `SSL_F_SSL3_GET_SERVER_CERTIFICATE`, and `SSL_F_TLS_PROCESS_SERVER_CERTIFICATE` as zero. AWS-LC ignores the function-code argument, and zero is consistent with OpenSSL 3.0's legacy function codes.

### Testing

Added `SSLTest.LegacyFunctionCodes` to verify the compatibility definitions and their use with `ERR_put_error`. The full `ssl_test` suite passes.

### Review considerations

This adds public preprocessor definitions for source compatibility only. It does not change the ABI or runtime behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
