### PR TITLE
Register -tls1_2 and -tls1_3 flags in bssl client

### DIFF
--- a/tool/client.cc
+++ b/tool/client.cc
@@ -146,6 +146,14 @@ static const argument_t kArguments[] = {
         "Use TLS version 1.1 only",
     },
     {
+        "-tls1_2", kBooleanArgument,
+        "Use TLS version 1.2 only",
+    },
+    {
+        "-tls1_3", kBooleanArgument,
+        "Use TLS version 1.3 only",
+    },
+    {
         "-server-name", kOptionalArgument, "The server name to advertise",
     },
     {


### PR DESCRIPTION
### Issues:

N/A

### Description of changes:

`tool/client.cc` checks `args_map` for `-tls1_2` and `-tls1_3` when computing the pinned protocol version:

```c
if (args_map.count("-tls1_1") != 0) { tls_version_flags++; selected_version = TLS1_1_VERSION; }
if (args_map.count("-tls1_2") != 0) { tls_version_flags++; selected_version = TLS1_2_VERSION; }
if (args_map.count("-tls1_3") != 0) { tls_version_flags++; selected_version = TLS1_3_VERSION; }
```

but only `-tls1_1` was declared in `kArguments`. `ParseKeyValueArguments` rejects any undeclared argument beginning with `-` before those checks are ever reached, so the `-tls1_2` and `-tls1_3` branches were unreachable dead code:

```
$ bssl s_client -connect amazon.com:443 -tls1_2
Unknown flag: -tls1_2
```

This declares both flags so they work like the already-registered `-tls1_1`, pinning both min and max proto version to the selected version. No behavior change for any existing accepted invocation; `-min-version`/`-max-version` are unaffected.

### Call-outs:

* `tool/server.cc` has no `-tls1_X` flags at all (and no corresponding dead code), so it is left alone. Server-side version pinning is still done with `-min-version`/`-max-version`.
* The existing manual `tls_version_flags > 1` check already covers mutual exclusion, so the unused `kExclusiveBooleanArgument` mechanism was not introduced here.
* `tool-openssl/s_client.cc` already declares `-tls1_1`, `-tls1_2`, and `-tls1_3` in its own argument table, so the shared `DoClient()` version-pinning code was written for that frontend; `bssl client`'s table simply never caught up. This brings the two frontends to parity.

### Testing:

The `bssl` tool has no unit test target, so this was verified by running the built binary.

Against a real endpoint:

```
$ bssl s_client -connect amazon.com:443 -tls1_2   =>   Version: TLSv1.2, Cipher: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
$ bssl s_client -connect amazon.com:443 -tls1_3   =>   Version: TLSv1.3, Cipher: TLS_AES_128_GCM_SHA256
$ bssl s_client -connect amazon.com:443 -tls1_2 -tls1_3
Cannot supply multiple protocol flags
```

Against `bssl server` pinned to one version, confirming each flag sets *both* min and max (mismatches get alert 70, `TLSV1_ALERT_PROTOCOL_VERSION`):

| server | client | result |
|---|---|---|
| tls1.2 | `-tls1_2` | `Version: TLSv1.2` |
| tls1.2 | `-tls1_3` | protocol version alert (min pinned to 1.3) |
| tls1.3 | `-tls1_2` | protocol version alert (max pinned to 1.2) |
| tls1.3 | `-tls1_3` | `Version: TLSv1.3` |
| tls1.1 | `-tls1_1` | `Version: TLSv1.1` (unchanged) |
| tls1.2 | *(no flag)* | `Version: TLSv1.2` (unchanged) |

Regression check that the long-form options still work: `-min-version tls1.2 -max-version tls1.2` negotiates TLSv1.2, `-min-version tls1.3` negotiates TLSv1.3. Both new flags appear in `bssl client` usage output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
