### PR TITLE
Support PKCS#12 KEY_EX and KEY_SIG attributes

### DIFF
--- a/crypto/pkcs8/internal.h
+++ b/crypto/pkcs8/internal.h
@@ -27,6 +27,14 @@ int pkcs8_pbe_decrypt(uint8_t **out, size_t *out_len, CBS *algorithm,
                       const char *pass, size_t pass_len, const uint8_t *in,
                       size_t in_len);
 
+// pkcs8_marshal_encrypted_private_key_info encrypts the serialized
+// PrivateKeyInfo in |plaintext| and writes an EncryptedPrivateKeyInfo to |out|.
+// |salt| must be non-NULL and |iterations| must be positive.
+int pkcs8_marshal_encrypted_private_key_info(
+    CBB *out, int pbe_nid, const EVP_CIPHER *cipher, const char *pass,
+    size_t pass_len, const uint8_t *salt, size_t salt_len, int iterations,
+    const uint8_t *plaintext, size_t plaintext_len);
+
 #define PKCS12_KEY_ID 1
 #define PKCS12_IV_ID 2
 #define PKCS12_MAC_ID 3

--- a/crypto/pkcs8/pkcs12_test.cc
+++ b/crypto/pkcs8/pkcs12_test.cc
@@ -366,9 +366,12 @@ static bool ParseDataContentInfo(CBS *out, CBS *content_info) {
          CBS_len(&wrapper) == 0 && CBS_len(content_info) == 0;
 }
 
-static bool ExtractKeyBagPrivateKeyInfo(std::vector<uint8_t> *out,
-                                        const PKCS12 *p12,
-                                        const char *password) {
+static bool ExtractKeyBagPrivateKeyInfo(
+    std::vector<uint8_t> *out, const PKCS12 *p12, const char *password,
+    uint64_t *out_pbe_iterations = nullptr) {
+  if (out_pbe_iterations != nullptr) {
+    *out_pbe_iterations = 0;
+  }
   uint8_t *der = nullptr;
   int der_len = i2d_PKCS12(p12, &der);
   if (der_len <= 0) {
@@ -433,6 +436,18 @@ static bool ExtractKeyBagPrivateKeyInfo(std::vector<uint8_t> *out,
                           CBS_ASN1_OCTETSTRING) ||
             CBS_len(&encrypted_private_key_info) != 0) {
           return false;
+        }
+
+        if (out_pbe_iterations != nullptr) {
+          CBS algorithm_copy = algorithm, oid, params, salt;
+          if (!CBS_get_asn1(&algorithm_copy, &oid, CBS_ASN1_OBJECT) ||
+              !CBS_get_asn1(&algorithm_copy, &params, CBS_ASN1_SEQUENCE) ||
+              CBS_len(&algorithm_copy) != 0 ||
+              !CBS_get_asn1(&params, &salt, CBS_ASN1_OCTETSTRING) ||
+              !CBS_get_asn1_uint64(&params, out_pbe_iterations) ||
+              CBS_len(&params) != 0) {
+            return false;
+          }
         }
 
         uint8_t *plaintext = nullptr;
@@ -587,6 +602,12 @@ TEST(PKCS12Test, CreateWithKeyUsageNormalizesNegativeIterations) {
   bssl::UniquePtr<PKCS12> p12(PKCS12_create(
       kPassword, nullptr, key.get(), nullptr, nullptr, 0, 0, -1, 1, KEY_EX));
   ASSERT_TRUE(p12);
+
+  std::vector<uint8_t> private_key_info;
+  uint64_t iterations = 0;
+  ASSERT_TRUE(ExtractKeyBagPrivateKeyInfo(
+      &private_key_info, p12.get(), kPassword, &iterations));
+  EXPECT_EQ(static_cast<uint64_t>(PKCS12_DEFAULT_ITER), iterations);
   ExpectKeyUsageAttribute(p12.get(), kPassword, kKeyExAttribute,
                           kKeyExBitString);
 }

--- a/crypto/pkcs8/pkcs12_test.cc
+++ b/crypto/pkcs8/pkcs12_test.cc
@@ -546,8 +546,10 @@ TEST(PKCS12Test, CreateWithKeyUsage) {
     bssl::Span<const uint8_t> attribute;
     bssl::Span<const uint8_t> bit_string;
   } kTests[] = {
-      {KEY_EX, kKeyExAttribute, kKeyExBitString},
-      {KEY_SIG, kKeySigAttribute, kKeySigBitString},
+      {KEY_EX, bssl::Span<const uint8_t>(kKeyExAttribute),
+       bssl::Span<const uint8_t>(kKeyExBitString)},
+      {KEY_SIG, bssl::Span<const uint8_t>(kKeySigAttribute),
+       bssl::Span<const uint8_t>(kKeySigBitString)},
   };
   for (const auto &test : kTests) {
     SCOPED_TRACE(test.key_type);

--- a/crypto/pkcs8/pkcs12_test.cc
+++ b/crypto/pkcs8/pkcs12_test.cc
@@ -9,11 +9,13 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/pkcs8.h>
+#include <openssl/pkcs12.h>
 #include <openssl/mem.h>
 #include <openssl/span.h>
 #include <openssl/stack.h>
 #include <openssl/x509.h>
 
+#include "internal.h"
 #include "../test/test_util.h"
 
 
@@ -337,6 +339,275 @@ static bssl::UniquePtr<X509> LoadX509(bssl::Span<const uint8_t> der) {
 static bssl::UniquePtr<EVP_PKEY> LoadPrivateKey(bssl::Span<const uint8_t> der) {
   CBS cbs = der;
   return bssl::UniquePtr<EVP_PKEY>(EVP_parse_private_key(&cbs));
+}
+
+// 1.2.840.113549.1.7.1
+static const uint8_t kPKCS7DataOID[] = {0x2a, 0x86, 0x48, 0x86, 0xf7,
+                                        0x0d, 0x01, 0x07, 0x01};
+
+// 1.2.840.113549.1.12.10.1.1
+static const uint8_t kKeyBagOID[] = {0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d,
+                                     0x01, 0x0c, 0x0a, 0x01, 0x01};
+
+// 1.2.840.113549.1.12.10.1.2
+static const uint8_t kPKCS8ShroudedKeyBagOID[] = {
+    0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x0c, 0x0a, 0x01, 0x02};
+
+// 2.5.29.15
+static const uint8_t kKeyUsageOID[] = {0x55, 0x1d, 0x0f};
+
+static bool ParseDataContentInfo(CBS *out, CBS *content_info) {
+  CBS oid, wrapper;
+  return CBS_get_asn1(content_info, &oid, CBS_ASN1_OBJECT) &&
+         CBS_mem_equal(&oid, kPKCS7DataOID, sizeof(kPKCS7DataOID)) &&
+         CBS_get_asn1(content_info, &wrapper,
+                      CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0) &&
+         CBS_get_asn1(&wrapper, out, CBS_ASN1_OCTETSTRING) &&
+         CBS_len(&wrapper) == 0 && CBS_len(content_info) == 0;
+}
+
+static bool ExtractKeyBagPrivateKeyInfo(std::vector<uint8_t> *out,
+                                        const PKCS12 *p12,
+                                        const char *password) {
+  uint8_t *der = nullptr;
+  int der_len = i2d_PKCS12(p12, &der);
+  if (der_len <= 0) {
+    return false;
+  }
+  bssl::UniquePtr<uint8_t> free_der(der);
+
+  CBS input, pfx, auth_safe_info, auth_safe, content_infos;
+  uint64_t version;
+  CBS_init(&input, der, (size_t)der_len);
+  if (!CBS_get_asn1(&input, &pfx, CBS_ASN1_SEQUENCE) || CBS_len(&input) != 0 ||
+      !CBS_get_asn1_uint64(&pfx, &version) || version != 3 ||
+      !CBS_get_asn1(&pfx, &auth_safe_info, CBS_ASN1_SEQUENCE) ||
+      !ParseDataContentInfo(&auth_safe, &auth_safe_info) ||
+      !CBS_get_asn1(&auth_safe, &content_infos, CBS_ASN1_SEQUENCE) ||
+      CBS_len(&auth_safe) != 0) {
+    return false;
+  }
+
+  bool found = false;
+  while (CBS_len(&content_infos) != 0) {
+    CBS content_info, safe_contents_der, safe_contents;
+    if (!CBS_get_asn1(&content_infos, &content_info, CBS_ASN1_SEQUENCE) ||
+        !ParseDataContentInfo(&safe_contents_der, &content_info) ||
+        !CBS_get_asn1(&safe_contents_der, &safe_contents, CBS_ASN1_SEQUENCE) ||
+        CBS_len(&safe_contents_der) != 0) {
+      return false;
+    }
+
+    while (CBS_len(&safe_contents) != 0) {
+      CBS bag, bag_oid, bag_value;
+      if (!CBS_get_asn1(&safe_contents, &bag, CBS_ASN1_SEQUENCE) ||
+          !CBS_get_asn1(&bag, &bag_oid, CBS_ASN1_OBJECT) ||
+          !CBS_get_asn1(
+              &bag, &bag_value,
+              CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0)) {
+        return false;
+      }
+      const bool is_key_bag =
+          CBS_mem_equal(&bag_oid, kKeyBagOID, sizeof(kKeyBagOID));
+      const bool is_shrouded_key_bag = CBS_mem_equal(
+          &bag_oid, kPKCS8ShroudedKeyBagOID,
+          sizeof(kPKCS8ShroudedKeyBagOID));
+      if (!is_key_bag && !is_shrouded_key_bag) {
+        continue;
+      }
+      if (found) {
+        return false;
+      }
+
+      if (is_key_bag) {
+        out->assign(CBS_data(&bag_value),
+                    CBS_data(&bag_value) + CBS_len(&bag_value));
+      } else {
+        CBS encrypted_private_key_info, algorithm, ciphertext;
+        if (!CBS_get_asn1(&bag_value, &encrypted_private_key_info,
+                          CBS_ASN1_SEQUENCE) ||
+            CBS_len(&bag_value) != 0 ||
+            !CBS_get_asn1(&encrypted_private_key_info, &algorithm,
+                          CBS_ASN1_SEQUENCE) ||
+            !CBS_get_asn1(&encrypted_private_key_info, &ciphertext,
+                          CBS_ASN1_OCTETSTRING) ||
+            CBS_len(&encrypted_private_key_info) != 0) {
+          return false;
+        }
+
+        uint8_t *plaintext = nullptr;
+        size_t plaintext_len = 0;
+        size_t password_len = password == nullptr ? 0 : strlen(password);
+        if (!pkcs8_pbe_decrypt(&plaintext, &plaintext_len, &algorithm, password,
+                               password_len, CBS_data(&ciphertext),
+                               CBS_len(&ciphertext))) {
+          return false;
+        }
+        out->assign(plaintext, plaintext + plaintext_len);
+        OPENSSL_free(plaintext);
+      }
+      found = true;
+    }
+  }
+
+  return found;
+}
+
+static void ExpectKeyUsageAttribute(
+    const PKCS12 *p12, const char *password,
+    bssl::Span<const uint8_t> expected_attribute,
+    bssl::Span<const uint8_t> expected_bit_string) {
+  std::vector<uint8_t> private_key_info;
+  ASSERT_TRUE(ExtractKeyBagPrivateKeyInfo(&private_key_info, p12, password));
+
+  CBS input, pki, algorithm, private_key;
+  uint64_t version;
+  CBS_init(&input, private_key_info.data(), private_key_info.size());
+  ASSERT_TRUE(CBS_get_asn1(&input, &pki, CBS_ASN1_SEQUENCE));
+  ASSERT_EQ(0u, CBS_len(&input));
+  ASSERT_TRUE(CBS_get_asn1_uint64(&pki, &version));
+  EXPECT_EQ(0u, version);
+  ASSERT_TRUE(CBS_get_asn1(&pki, &algorithm, CBS_ASN1_SEQUENCE));
+  ASSERT_TRUE(CBS_get_asn1(&pki, &private_key, CBS_ASN1_OCTETSTRING));
+
+  if (expected_attribute.empty()) {
+    EXPECT_EQ(0u, CBS_len(&pki));
+    return;
+  }
+
+  CBS attribute_element;
+  ASSERT_TRUE(CBS_get_asn1_element(
+      &pki, &attribute_element,
+      CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0));
+  EXPECT_EQ(Bytes(expected_attribute),
+            Bytes(CBS_data(&attribute_element), CBS_len(&attribute_element)));
+  EXPECT_EQ(0u, CBS_len(&pki));
+
+  CBS attributes, attribute, oid, values, bit_string;
+  ASSERT_TRUE(CBS_get_asn1(
+      &attribute_element, &attributes,
+      CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0));
+  ASSERT_EQ(0u, CBS_len(&attribute_element));
+  ASSERT_TRUE(CBS_get_asn1(&attributes, &attribute, CBS_ASN1_SEQUENCE));
+  ASSERT_EQ(0u, CBS_len(&attributes));
+  ASSERT_TRUE(CBS_get_asn1(&attribute, &oid, CBS_ASN1_OBJECT));
+  EXPECT_TRUE(CBS_mem_equal(&oid, kKeyUsageOID, sizeof(kKeyUsageOID)));
+  ASSERT_TRUE(CBS_get_asn1(&attribute, &values, CBS_ASN1_SET));
+  ASSERT_EQ(0u, CBS_len(&attribute));
+  ASSERT_TRUE(CBS_get_asn1(&values, &bit_string, CBS_ASN1_BITSTRING));
+  ASSERT_EQ(0u, CBS_len(&values));
+  EXPECT_EQ(Bytes(expected_bit_string),
+            Bytes(CBS_data(&bit_string), CBS_len(&bit_string)));
+}
+
+// OpenSSL 3.0.18 defines the constants and emits these exact attribute
+// elements through PKCS8_add_keyusage. The reference sources are:
+// https://github.com/openssl/openssl/blob/openssl-3.0.18/include/openssl/pkcs12.h.in
+// https://github.com/openssl/openssl/blob/openssl-3.0.18/crypto/pkcs12/p12_attr.c
+static const uint8_t kKeyExAttribute[] = {
+    0xa0, 0x0d, 0x30, 0x0b, 0x06, 0x03, 0x55, 0x1d,
+    0x0f, 0x31, 0x04, 0x03, 0x02, 0x04, 0x10};
+static const uint8_t kKeySigAttribute[] = {
+    0xa0, 0x0d, 0x30, 0x0b, 0x06, 0x03, 0x55, 0x1d,
+    0x0f, 0x31, 0x04, 0x03, 0x02, 0x07, 0x80};
+static const uint8_t kKeyExBitString[] = {0x04, 0x10};
+static const uint8_t kKeySigBitString[] = {0x07, 0x80};
+
+TEST(PKCS12Test, CreateWithKeyUsage) {
+  EXPECT_EQ(0x10, KEY_EX);
+  EXPECT_EQ(0x80, KEY_SIG);
+
+  bssl::UniquePtr<EVP_PKEY> key = LoadPrivateKey(kTestKey);
+  ASSERT_TRUE(key);
+
+  const struct {
+    int key_type;
+    bssl::Span<const uint8_t> attribute;
+    bssl::Span<const uint8_t> bit_string;
+  } kTests[] = {
+      {KEY_EX, kKeyExAttribute, kKeyExBitString},
+      {KEY_SIG, kKeySigAttribute, kKeySigBitString},
+  };
+  for (const auto &test : kTests) {
+    SCOPED_TRACE(test.key_type);
+
+    bssl::UniquePtr<PKCS12> unencrypted(PKCS12_create(
+        kPassword, nullptr, key.get(), nullptr, nullptr, -1, 0, 1, 1,
+        test.key_type));
+    ASSERT_TRUE(unencrypted);
+    ExpectKeyUsageAttribute(unencrypted.get(), kPassword, test.attribute,
+                            test.bit_string);
+
+    bssl::UniquePtr<PKCS12> encrypted(PKCS12_create(
+        kPassword, nullptr, key.get(), nullptr, nullptr, 0, 0, 1, 1,
+        test.key_type));
+    ASSERT_TRUE(encrypted);
+    ExpectKeyUsageAttribute(encrypted.get(), kPassword, test.attribute,
+                            test.bit_string);
+    EVP_PKEY *parsed_key = nullptr;
+    X509 *parsed_cert = nullptr;
+    STACK_OF(X509) *parsed_ca = nullptr;
+    ASSERT_TRUE(PKCS12_parse(encrypted.get(), kPassword, &parsed_key,
+                             &parsed_cert, &parsed_ca));
+    bssl::UniquePtr<EVP_PKEY> free_parsed_key(parsed_key);
+    bssl::UniquePtr<X509> free_parsed_cert(parsed_cert);
+    bssl::UniquePtr<STACK_OF(X509)> free_parsed_ca(parsed_ca);
+    ASSERT_TRUE(parsed_key);
+    EXPECT_EQ(1, EVP_PKEY_cmp(key.get(), parsed_key));
+    EXPECT_EQ(nullptr, parsed_cert);
+    ASSERT_TRUE(parsed_ca);
+    EXPECT_EQ(0u, sk_X509_num(parsed_ca));
+  }
+}
+
+TEST(PKCS12Test, CreateWithDefaultKeyTypePreservesKeyEncoding) {
+  bssl::UniquePtr<EVP_PKEY> key = LoadPrivateKey(kTestKey);
+  ASSERT_TRUE(key);
+  bssl::UniquePtr<PKCS12> p12(PKCS12_create(
+      kPassword, nullptr, key.get(), nullptr, nullptr, -1, 0, 1, 1, 0));
+  ASSERT_TRUE(p12);
+
+  std::vector<uint8_t> private_key_info;
+  ASSERT_TRUE(
+      ExtractKeyBagPrivateKeyInfo(&private_key_info, p12.get(), kPassword));
+
+  CBB expected;
+  ASSERT_TRUE(CBB_init(&expected, 0));
+  ASSERT_TRUE(EVP_marshal_private_key(&expected, key.get()));
+  EXPECT_EQ(Bytes(CBB_data(&expected), CBB_len(&expected)),
+            Bytes(private_key_info));
+  CBB_cleanup(&expected);
+
+  ExpectKeyUsageAttribute(p12.get(), kPassword, {}, {});
+}
+
+TEST(PKCS12Test, CreateWithKeyUsageNormalizesNegativeIterations) {
+  bssl::UniquePtr<EVP_PKEY> key = LoadPrivateKey(kTestKey);
+  ASSERT_TRUE(key);
+  bssl::UniquePtr<PKCS12> p12(PKCS12_create(
+      kPassword, nullptr, key.get(), nullptr, nullptr, 0, 0, -1, 1, KEY_EX));
+  ASSERT_TRUE(p12);
+  ExpectKeyUsageAttribute(p12.get(), kPassword, kKeyExAttribute,
+                          kKeyExBitString);
+}
+
+TEST(PKCS12Test, CreateRejectsUnsupportedKeyType) {
+  bssl::UniquePtr<EVP_PKEY> key = LoadPrivateKey(kTestKey);
+  ASSERT_TRUE(key);
+
+  const int kUnsupported[] = {-1, 1, KEY_EX | KEY_SIG};
+  for (int key_type : kUnsupported) {
+    SCOPED_TRACE(key_type);
+    ERR_clear_error();
+    bssl::UniquePtr<PKCS12> p12(PKCS12_create(
+        kPassword, nullptr, key.get(), nullptr, nullptr, -1, 0, 1, 1,
+        key_type));
+    EXPECT_FALSE(p12);
+    uint32_t error = ERR_get_error();
+    EXPECT_EQ(ERR_LIB_PKCS8, ERR_GET_LIB(error));
+    EXPECT_EQ(PKCS8_R_UNSUPPORTED_OPTIONS, ERR_GET_REASON(error));
+    ERR_clear_error();
+  }
 }
 
 static void TestRoundTrip(const char *password, const char *name,

--- a/crypto/pkcs8/pkcs12_test.cc
+++ b/crypto/pkcs8/pkcs12_test.cc
@@ -15,7 +15,9 @@
 #include <openssl/stack.h>
 #include <openssl/x509.h>
 
+#if !defined(BORINGSSL_SHARED_LIBRARY)
 #include "internal.h"
+#endif
 #include "../test/test_util.h"
 
 
@@ -450,6 +452,9 @@ static bool ExtractKeyBagPrivateKeyInfo(
           }
         }
 
+#if defined(BORINGSSL_SHARED_LIBRARY)
+        return false;
+#else
         uint8_t *plaintext = nullptr;
         size_t plaintext_len = 0;
         size_t password_len = password == nullptr ? 0 : strlen(password);
@@ -460,6 +465,7 @@ static bool ExtractKeyBagPrivateKeyInfo(
         }
         out->assign(plaintext, plaintext + plaintext_len);
         OPENSSL_free(plaintext);
+#endif
       }
       found = true;
     }
@@ -553,12 +559,16 @@ TEST(PKCS12Test, CreateWithKeyUsage) {
     ExpectKeyUsageAttribute(unencrypted.get(), kPassword, test.attribute,
                             test.bit_string);
 
-    bssl::UniquePtr<PKCS12> encrypted(PKCS12_create(
-        kPassword, nullptr, key.get(), nullptr, nullptr, 0, 0, 1, 1,
-        test.key_type));
+    bssl::UniquePtr<PKCS12> encrypted(PKCS12_create(kPassword, nullptr,
+                                                    key.get(), nullptr, nullptr,
+                                                    0, 0, 1, 1, test.key_type));
     ASSERT_TRUE(encrypted);
+#if !defined(BORINGSSL_SHARED_LIBRARY)
+    // Inspecting the encrypted plaintext requires an internal decryption
+    // helper, which is intentionally unavailable from shared libraries.
     ExpectKeyUsageAttribute(encrypted.get(), kPassword, test.attribute,
                             test.bit_string);
+#endif
     EVP_PKEY *parsed_key = nullptr;
     X509 *parsed_cert = nullptr;
     STACK_OF(X509) *parsed_ca = nullptr;
@@ -596,6 +606,7 @@ TEST(PKCS12Test, CreateWithDefaultKeyTypePreservesKeyEncoding) {
   ExpectKeyUsageAttribute(p12.get(), kPassword, {}, {});
 }
 
+#if !defined(BORINGSSL_SHARED_LIBRARY)
 TEST(PKCS12Test, CreateWithKeyUsageNormalizesNegativeIterations) {
   bssl::UniquePtr<EVP_PKEY> key = LoadPrivateKey(kTestKey);
   ASSERT_TRUE(key);
@@ -605,12 +616,13 @@ TEST(PKCS12Test, CreateWithKeyUsageNormalizesNegativeIterations) {
 
   std::vector<uint8_t> private_key_info;
   uint64_t iterations = 0;
-  ASSERT_TRUE(ExtractKeyBagPrivateKeyInfo(
-      &private_key_info, p12.get(), kPassword, &iterations));
+  ASSERT_TRUE(ExtractKeyBagPrivateKeyInfo(&private_key_info, p12.get(),
+                                          kPassword, &iterations));
   EXPECT_EQ(static_cast<uint64_t>(PKCS12_DEFAULT_ITER), iterations);
   ExpectKeyUsageAttribute(p12.get(), kPassword, kKeyExAttribute,
                           kKeyExBitString);
 }
+#endif  // !BORINGSSL_SHARED_LIBRARY
 
 TEST(PKCS12Test, CreateRejectsUnsupportedKeyType) {
   bssl::UniquePtr<EVP_PKEY> key = LoadPrivateKey(kTestKey);

--- a/crypto/pkcs8/pkcs8.c
+++ b/crypto/pkcs8/pkcs8.c
@@ -394,44 +394,13 @@ EVP_PKEY *PKCS8_parse_encrypted_private_key(CBS *cbs, const char *pass,
   return ret;
 }
 
-int PKCS8_marshal_encrypted_private_key(CBB *out, int pbe_nid,
-                                        const EVP_CIPHER *cipher,
-                                        const char *pass, size_t pass_len,
-                                        const uint8_t *salt, size_t salt_len,
-                                        int iterations, const EVP_PKEY *pkey) {
+int pkcs8_marshal_encrypted_private_key_info(
+    CBB *out, int pbe_nid, const EVP_CIPHER *cipher, const char *pass,
+    size_t pass_len, const uint8_t *salt, size_t salt_len, int iterations,
+    const uint8_t *plaintext, size_t plaintext_len) {
   int ret = 0;
-  uint8_t *plaintext = NULL, *salt_buf = NULL;
-  size_t plaintext_len = 0;
   EVP_CIPHER_CTX ctx;
   EVP_CIPHER_CTX_init(&ctx);
-
-  // Generate a random salt if necessary.
-  if (salt == NULL) {
-    if (salt_len == 0) {
-      salt_len = PKCS12_SALT_LEN;
-    }
-
-    salt_buf = OPENSSL_malloc(salt_len);
-    if (salt_buf == NULL) {
-      goto err;
-    }
-    AWSLC_ABORT_IF_NOT_ONE(RAND_bytes(salt_buf, salt_len));
-
-    salt = salt_buf;
-  }
-
-  if (iterations <= 0) {
-    iterations = PKCS12_DEFAULT_ITER;
-  }
-
-  // Serialize the input key.
-  CBB plaintext_cbb;
-  if (!CBB_init(&plaintext_cbb, 128) ||
-      !EVP_marshal_private_key(&plaintext_cbb, pkey) ||
-      !CBB_finish(&plaintext_cbb, &plaintext, &plaintext_len)) {
-    CBB_cleanup(&plaintext_cbb);
-    goto err;
-  }
 
   CBB epki;
   if (!CBB_add_asn1(out, &epki, CBS_ASN1_SEQUENCE)) {
@@ -480,8 +449,53 @@ int PKCS8_marshal_encrypted_private_key(CBB *out, int pbe_nid,
   ret = 1;
 
 err:
+  EVP_CIPHER_CTX_cleanup(&ctx);
+  return ret;
+}
+
+int PKCS8_marshal_encrypted_private_key(CBB *out, int pbe_nid,
+                                        const EVP_CIPHER *cipher,
+                                        const char *pass, size_t pass_len,
+                                        const uint8_t *salt, size_t salt_len,
+                                        int iterations, const EVP_PKEY *pkey) {
+  int ret = 0;
+  uint8_t *plaintext = NULL, *salt_buf = NULL;
+  size_t plaintext_len = 0;
+
+  // Generate a random salt if necessary.
+  if (salt == NULL) {
+    if (salt_len == 0) {
+      salt_len = PKCS12_SALT_LEN;
+    }
+
+    salt_buf = OPENSSL_malloc(salt_len);
+    if (salt_buf == NULL) {
+      goto err;
+    }
+    AWSLC_ABORT_IF_NOT_ONE(RAND_bytes(salt_buf, salt_len));
+
+    salt = salt_buf;
+  }
+
+  if (iterations <= 0) {
+    iterations = PKCS12_DEFAULT_ITER;
+  }
+
+  // Serialize the input key.
+  CBB plaintext_cbb;
+  if (!CBB_init(&plaintext_cbb, 128) ||
+      !EVP_marshal_private_key(&plaintext_cbb, pkey) ||
+      !CBB_finish(&plaintext_cbb, &plaintext, &plaintext_len)) {
+    CBB_cleanup(&plaintext_cbb);
+    goto err;
+  }
+
+  ret = pkcs8_marshal_encrypted_private_key_info(
+      out, pbe_nid, cipher, pass, pass_len, salt, salt_len, iterations,
+      plaintext, plaintext_len);
+
+err:
   OPENSSL_free(plaintext);
   OPENSSL_free(salt_buf);
-  EVP_CIPHER_CTX_cleanup(&ctx);
   return ret;
 }

--- a/crypto/pkcs8/pkcs8_x509.c
+++ b/crypto/pkcs8/pkcs8_x509.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <openssl/pkcs8.h>
+#include <openssl/pkcs12.h>
 
 #include <limits.h>
 
@@ -1107,6 +1108,80 @@ out:
   return ret;
 }
 
+static int marshal_private_key_with_key_usage(CBB *out,
+                                              const EVP_PKEY *pkey,
+                                              int key_type) {
+  if (key_type == 0) {
+    return EVP_marshal_private_key(out, pkey);
+  }
+
+  PKCS8_PRIV_KEY_INFO *p8 = EVP_PKEY2PKCS8(pkey);
+  if (p8 == NULL) {
+    return 0;
+  }
+
+  int ret = 0;
+  uint8_t usage = (uint8_t)key_type;
+  X509_ATTRIBUTE *attribute = X509_ATTRIBUTE_create_by_NID(
+      NULL, NID_key_usage, V_ASN1_BIT_STRING, &usage, 1);
+  if (p8->attributes == NULL) {
+    p8->attributes = sk_X509_ATTRIBUTE_new_null();
+  }
+  if (attribute == NULL || p8->attributes == NULL ||
+      !sk_X509_ATTRIBUTE_push(p8->attributes, attribute)) {
+    X509_ATTRIBUTE_free(attribute);
+    goto out;
+  }
+
+  int len = i2d_PKCS8_PRIV_KEY_INFO(p8, NULL);
+  uint8_t *ptr;
+  if (len < 0 || !CBB_add_space(out, &ptr, (size_t)len) ||
+      i2d_PKCS8_PRIV_KEY_INFO(p8, &ptr) != len || !CBB_flush(out)) {
+    goto out;
+  }
+  ret = 1;
+
+out:
+  PKCS8_PRIV_KEY_INFO_free(p8);
+  return ret;
+}
+
+static int marshal_pkcs12_key(CBB *out, int key_nid, const char *password,
+                              size_t password_len, int iterations,
+                              const EVP_PKEY *pkey, int key_type) {
+  if (key_nid < 0) {
+    return marshal_private_key_with_key_usage(out, pkey, key_type);
+  }
+  if (key_type == 0) {
+    return PKCS8_marshal_encrypted_private_key(
+        out, key_nid, NULL, password, password_len,
+        NULL /* generate a random salt */, 0 /* use default salt length */,
+        iterations, pkey);
+  }
+  if (iterations <= 0) {
+    iterations = PKCS12_DEFAULT_ITER;
+  }
+
+  CBB plaintext_cbb;
+  uint8_t *plaintext = NULL;
+  size_t plaintext_len = 0;
+  if (!CBB_init(&plaintext_cbb, 128) ||
+      !marshal_private_key_with_key_usage(&plaintext_cbb, pkey, key_type) ||
+      !CBB_finish(&plaintext_cbb, &plaintext, &plaintext_len)) {
+    CBB_cleanup(&plaintext_cbb);
+    OPENSSL_free(plaintext);
+    return 0;
+  }
+
+  uint8_t salt[PKCS12_SALT_LEN];
+  AWSLC_ABORT_IF_NOT_ONE(RAND_bytes(salt, sizeof(salt)));
+  int ret = pkcs8_marshal_encrypted_private_key_info(
+      out, key_nid, NULL, password, password_len, salt, sizeof(salt),
+      iterations, plaintext, plaintext_len);
+  OPENSSL_free(plaintext);
+  return ret;
+}
+
 PKCS12 *PKCS12_create(const char *password, const char *name,
                       const EVP_PKEY *pkey, X509 *cert,
                       const STACK_OF(X509)* chain, int key_nid, int cert_nid,
@@ -1123,9 +1198,7 @@ PKCS12 *PKCS12_create(const char *password, const char *name,
   if (mac_iterations == 0) {
     mac_iterations = 1;
   }
-  if (// In OpenSSL, this specifies a non-standard Microsoft key usage extension
-      // which we do not currently support.
-      key_type != 0 ||
+  if ((key_type != 0 && key_type != KEY_EX && key_type != KEY_SIG) ||
       // In OpenSSL, -1 here means to omit the MAC, which we do not
       // currently support. Omitting it is also invalid for a password-based
       // PKCS#12 file.
@@ -1254,29 +1327,24 @@ PKCS12 *PKCS12_create(const char *password, const char *name,
                       CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0) ||
         !CBB_add_asn1(&wrapper, &data, CBS_ASN1_OCTETSTRING) ||
         !CBB_add_asn1(&data, &safe_contents, CBS_ASN1_SEQUENCE) ||
-        // Add a SafeBag containing a PKCS8ShroudedKeyBag.
+        // Add a SafeBag containing the private key.
         !CBB_add_asn1(&safe_contents, &bag, CBS_ASN1_SEQUENCE) ||
         !CBB_add_asn1(&bag, &bag_oid, CBS_ASN1_OBJECT)) {
       goto err;
     }
     if (key_nid < 0) {
-      if (!CBB_add_bytes(&bag_oid, kKeyBag, sizeof(kKeyBag)) ||
-          !CBB_add_asn1(&bag, &bag_contents,
-                        CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0) ||
-          !EVP_marshal_private_key(&bag_contents, pkey)) {
+      if (!CBB_add_bytes(&bag_oid, kKeyBag, sizeof(kKeyBag))) {
         goto err;
       }
-    } else {
-      if (!CBB_add_bytes(&bag_oid, kPKCS8ShroudedKeyBag,
-                         sizeof(kPKCS8ShroudedKeyBag)) ||
-          !CBB_add_asn1(&bag, &bag_contents,
-                        CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0) ||
-          !PKCS8_marshal_encrypted_private_key(
-              &bag_contents, key_nid, NULL, password, password_len,
-              NULL /* generate a random salt */,
-              0 /* use default salt length */, iterations, pkey)) {
-        goto err;
-      }
+    } else if (!CBB_add_bytes(&bag_oid, kPKCS8ShroudedKeyBag,
+                              sizeof(kPKCS8ShroudedKeyBag))) {
+      goto err;
+    }
+    if (!CBB_add_asn1(&bag, &bag_contents,
+                      CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0) ||
+        !marshal_pkcs12_key(&bag_contents, key_nid, password, password_len,
+                            iterations, pkey, key_type)) {
+      goto err;
     }
     size_t name_len = 0;
     if (name) {

--- a/include/openssl/pkcs12.h
+++ b/include/openssl/pkcs12.h
@@ -5,7 +5,3 @@
    OpenSSL easier. */
 
 #include "pkcs8.h"
-
-// Microsoft key usage constants.
-#define KEY_EX 0x10
-#define KEY_SIG 0x80

--- a/include/openssl/pkcs12.h
+++ b/include/openssl/pkcs12.h
@@ -5,3 +5,7 @@
    OpenSSL easier. */
 
 #include "pkcs8.h"
+
+// Microsoft key usage constants.
+#define KEY_EX 0x10
+#define KEY_SIG 0x80

--- a/include/openssl/pkcs8.h
+++ b/include/openssl/pkcs8.h
@@ -174,6 +174,10 @@ OPENSSL_EXPORT int PKCS12_set_mac(PKCS12 *p12, const char *password,
 OPENSSL_EXPORT int PKCS12_verify_mac(const PKCS12 *p12, const char *password,
                                      int password_len);
 
+// KEY_EX and KEY_SIG are Microsoft key usage constants for |PKCS12_create|.
+#define KEY_EX 0x10
+#define KEY_SIG 0x80
+
 // PKCS12_DEFAULT_ITER is the default number of KDF iterations used when
 // creating a |PKCS12| object.
 #define PKCS12_DEFAULT_ITER 2048

--- a/include/openssl/pkcs8.h
+++ b/include/openssl/pkcs8.h
@@ -184,7 +184,9 @@ OPENSSL_EXPORT int PKCS12_verify_mac(const PKCS12 *p12, const char *password,
 // certificate. The key and certificates are encrypted with |key_nid| and
 // |cert_nid|, respectively, using |iterations| iterations in the
 // KDF. |mac_iterations| is the number of iterations when deriving the MAC
-// key. |key_type| must be zero. |pkey| and |cert| may be NULL to omit them.
+// key. |key_type| may be zero, |KEY_EX|, or |KEY_SIG|. The named values add a
+// Microsoft-compatible key usage attribute to the encoded private key.
+// |pkey| and |cert| may be NULL to omit them.
 //
 // Each of |key_nid|, |cert_nid|, |iterations|, and |mac_iterations| may be zero
 // to use defaults, which are |NID_pbe_WithSHA1And3_Key_TripleDES_CBC|,

--- a/tests/ci/integration/ruby_patch/master/aws-lc-ruby.patch
+++ b/tests/ci/integration/ruby_patch/master/aws-lc-ruby.patch
@@ -116,3 +116,48 @@ index be79909..8e162ad 100644
  
      key_file = ML_DSA_65_PRIVATE_KEY_FILE
  
+diff --git a/ext/openssl/ossl_pkcs12.c b/ext/openssl/ossl_pkcs12.c
+--- a/ext/openssl/ossl_pkcs12.c
++++ b/ext/openssl/ossl_pkcs12.c
+@@ -118,15 +118,9 @@
+     if (!NIL_P(keytype))
+         ktype = NUM2INT(keytype);
+-
++
+-#if defined(OPENSSL_IS_AWSLC)
+-    if (ktype != 0) {
+-        ossl_raise(rb_eArgError, "Unknown key usage type %"PRIsVALUE, INT2NUM(ktype));
+-    }
+-#else
+     if (ktype != 0 && ktype != KEY_SIG && ktype != KEY_EX) {
+         ossl_raise(rb_eArgError, "Unknown key usage type %"PRIsVALUE, INT2NUM(ktype));
+     }
+-#endif
+-
++
+     obj = ossl_pkcs12_s_allocate(cPKCS12);
+     x509s = NIL_P(ca) ? NULL : ossl_x509_ary2sk(ca);
+@@ -311,9 +305,7 @@
+     rb_define_method(cPKCS12, "to_der", ossl_pkcs12_to_der, 0);
+     rb_define_method(cPKCS12, "set_mac", pkcs12_set_mac, -1);
+-
++
+-#if !defined(OPENSSL_IS_AWSLC)
+     /* MSIE specific PKCS12 key usage extensions */
+     rb_define_const(cPKCS12, "KEY_EX", INT2NUM(KEY_EX));
+     rb_define_const(cPKCS12, "KEY_SIG", INT2NUM(KEY_SIG));
+-#endif
+ }
+diff --git a/test/openssl/test_pkcs12.rb b/test/openssl/test_pkcs12.rb
+--- a/test/openssl/test_pkcs12.rb
++++ b/test/openssl/test_pkcs12.rb
+@@ -201,8 +201,6 @@
+     end
+-
++
+     def test_create_with_keytype
+-      omit "AWS-LC does not support KEY_SIG and KEY_EX" if aws_lc?
+-
+       OpenSSL::PKCS12.create(
+         "omg",
+         "hello",

--- a/tests/ci/integration/ruby_patch/ruby_3_2/aws-lc-ruby-temp.patch
+++ b/tests/ci/integration/ruby_patch/ruby_3_2/aws-lc-ruby-temp.patch
@@ -29,23 +29,7 @@ index 6c532ac..a53162c 100644
  #else
               Qfalse
  #endif
-diff --git ruby/ext/openssl/ossl_pkcs12.c ruby/ext/openssl/ossl_pkcs12.c
-index fb947df..969aa25 100644
---- ruby/ext/openssl/ossl_pkcs12.c
-+++ ruby/ext/openssl/ossl_pkcs12.c
-@@ -134,6 +134,12 @@ ossl_pkcs12_s_create(int argc, VALUE *argv, VALUE self)
-     if (!NIL_P(keytype))
-         ktype = NUM2INT(keytype);
- 
-+#if defined(OPENSSL_IS_AWSLC)
-+    if (ktype != 0) {
-+        ossl_raise(rb_eArgError, "Unknown key usage type with AWS-LC %"PRIsVALUE, INT2NUM(ktype));
-+    }
-+#endif
-+
-     obj = NewPKCS12(cPKCS12);
-     x509s = NIL_P(ca) ? NULL : ossl_x509_ary2sk(ca);
-     p12 = PKCS12_create(passphrase, friendlyname, key, x509, x509s,
+
 diff --git ruby/ext/openssl/ossl_pkey_ec.c ruby/ext/openssl/ossl_pkey_ec.c
 index 92842f9..1af95d0 100644
 --- ruby/ext/openssl/ossl_pkey_ec.c

--- a/tests/ci/integration/ruby_patch/ruby_3_3/aws-lc-ruby.patch
+++ b/tests/ci/integration/ruby_patch/ruby_3_3/aws-lc-ruby.patch
@@ -29,23 +29,7 @@ index 00eded5..86cc918 100644
  #else
  		    Qfalse
  #endif
-diff --git a/ext/openssl/ossl_pkcs12.c b/ext/openssl/ossl_pkcs12.c
-index 164b2da..c4a8f94 100644
---- a/ext/openssl/ossl_pkcs12.c
-+++ b/ext/openssl/ossl_pkcs12.c
-@@ -134,6 +134,12 @@ ossl_pkcs12_s_create(int argc, VALUE *argv, VALUE self)
-     if (!NIL_P(keytype))
-         ktype = NUM2INT(keytype);
- 
-+#if defined(OPENSSL_IS_AWSLC)
-+    if (ktype != 0) {
-+        ossl_raise(rb_eArgError, "Unknown key usage type with AWS-LC %"PRIsVALUE, INT2NUM(ktype));
-+    }
-+#endif
-+
-     obj = NewPKCS12(cPKCS12);
-     x509s = NIL_P(ca) ? NULL : ossl_x509_ary2sk(ca);
-     p12 = PKCS12_create(passphrase, friendlyname, key, x509, x509s,
+
 diff --git a/ext/openssl/ossl_pkey_ec.c b/ext/openssl/ossl_pkey_ec.c
 index 4b3a1fd..72c14ad 100644
 --- a/ext/openssl/ossl_pkey_ec.c

--- a/tests/ci/integration/ruby_patch/ruby_3_4/aws-lc-ruby.patch
+++ b/tests/ci/integration/ruby_patch/ruby_3_4/aws-lc-ruby.patch
@@ -29,36 +29,7 @@ index 1eb0f95..2b0a39a 100644
  #else
               Qfalse
  #endif
-diff --git ruby/ext/openssl/ossl_pkcs12.c ruby/ext/openssl/ossl_pkcs12.c
-index bda90ae..5042b2d 100644
---- ruby/ext/openssl/ossl_pkcs12.c
-+++ ruby/ext/openssl/ossl_pkcs12.c
-@@ -134,9 +134,15 @@ ossl_pkcs12_s_create(int argc, VALUE *argv, VALUE self)
-     if (!NIL_P(keytype))
-         ktype = NUM2INT(keytype);
- 
-+#if defined(OPENSSL_IS_AWSLC)
-+    if (ktype != 0) {
-+        ossl_raise(rb_eArgError, "Unknown key usage type %"PRIsVALUE, INT2NUM(ktype));
-+    }
-+#else
-     if (ktype != 0 && ktype != KEY_SIG && ktype != KEY_EX) {
-         ossl_raise(rb_eArgError, "Unknown key usage type %"PRIsVALUE, INT2NUM(ktype));
-     }
-+#endif
- 
-     obj = NewPKCS12(cPKCS12);
-     x509s = NIL_P(ca) ? NULL : ossl_x509_ary2sk(ca);
-@@ -320,7 +326,9 @@ Init_ossl_pkcs12(void)
-     rb_define_method(cPKCS12, "to_der", ossl_pkcs12_to_der, 0);
-     rb_define_method(cPKCS12, "set_mac", pkcs12_set_mac, -1);
- 
-+#if !defined(OPENSSL_IS_AWSLC)
-     /* MSIE specific PKCS12 key usage extensions */
-     rb_define_const(cPKCS12, "KEY_EX", INT2NUM(KEY_EX));
-     rb_define_const(cPKCS12, "KEY_SIG", INT2NUM(KEY_SIG));
-+#endif
- }
+
 diff --git ruby/ext/openssl/ossl_pkey_ec.c ruby/ext/openssl/ossl_pkey_ec.c
 index 9852be6..f970b06 100644
 --- ruby/ext/openssl/ossl_pkey_ec.c
@@ -210,19 +181,7 @@ index 4a3dd43..8a33cec 100644
  
      assert_separately(["-ropenssl"], <<~"end;")
        begin
-diff --git ruby/test/openssl/test_pkcs12.rb ruby/test/openssl/test_pkcs12.rb
-index 68a23b2..1b53287 100644
---- ruby/test/openssl/test_pkcs12.rb
-+++ ruby/test/openssl/test_pkcs12.rb
-@@ -178,6 +178,8 @@ module OpenSSL
-     end
- 
-     def test_create_with_keytype
-+      omit "AWS-LC does not support KEY_SIG and KEY_EX" if aws_lc?
-+
-       OpenSSL::PKCS12.create(
-         "omg",
-         "hello",
+
 diff --git ruby/test/openssl/test_pkcs7.rb ruby/test/openssl/test_pkcs7.rb
 index 862716b..dc209f9 100644
 --- ruby/test/openssl/test_pkcs7.rb


### PR DESCRIPTION


### Context and motivation

`PKCS12_create` currently rejects non-zero key types, requiring consumers such as Ruby to conditionally remove the OpenSSL-compatible `KEY_EX` and `KEY_SIG` API when built with AWS-LC.

### Description of changes

- Add the `KEY_EX` and `KEY_SIG` constants and encode the corresponding Microsoft key usage attribute for encrypted and unencrypted private keys.
- Remove the Ruby integration workarounds that disabled these key types with AWS-LC.
- Preserve the existing encoding when `key_type` is zero.

### Testing

- Add coverage for both supported key types, encrypted and unencrypted key bags, default encoding behavior, iteration normalization, and unsupported key types.
- Ran `./crypto/crypto_test --gtest_filter=PKCS12Test.*:PKCS8Test.*` with all 31 tests passing.

### Review considerations

This expands the accepted values for the existing `PKCS12_create` API and adds public constants, but does not change the ABI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.