### PR TITLE
Preserve the error queue mark across ERR_save_state/ERR_restore_state

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -101,6 +101,12 @@ static void err_copy(struct err_error_st *dst, const struct err_error_st *src) {
   }
   dst->packed = src->packed;
   dst->line = src->line;
+  // The mark is part of the queue's state, so |ERR_save_state| and
+  // |ERR_restore_state| have to round-trip it. Dropping it would break a caller
+  // that set a mark and then called into code which saved and restored the
+  // queue: the caller's |ERR_pop_to_mark| would find no mark and discard the
+  // caller's own errors.
+  dst->mark = src->mark;
 }
 
 

--- a/crypto/err/err_test.cc
+++ b/crypto/err/err_test.cc
@@ -223,6 +223,30 @@ TEST(ErrTest, SaveAndRestore) {
   }
 }
 
+// A mark is part of the queue's state, so it must survive a save and restore.
+// Otherwise a caller that marks the queue and then calls into code which saves
+// and restores it loses its own errors to the next |ERR_pop_to_mark|.
+TEST(ErrTest, SaveAndRestorePreservesMark) {
+  ERR_clear_error();
+  ERR_put_error(1, 0 /* unused */, 1, "test1.c", 1);
+  ASSERT_TRUE(ERR_set_mark());
+
+  bssl::UniquePtr<ERR_SAVE_STATE> saved(ERR_save_state());
+  ASSERT_TRUE(saved);
+
+  // Stand in for the errors the saving code queues and means to discard.
+  ERR_put_error(2, 0 /* unused */, 2, "test2.c", 2);
+  ERR_restore_state(saved.get());
+
+  // The mark came back with the entry it was set on, so popping to it reports
+  // success and leaves the marked error in place.
+  EXPECT_TRUE(ERR_pop_to_mark());
+  uint32_t packed_error = ERR_get_error();
+  EXPECT_EQ(ERR_GET_LIB(packed_error), 1);
+  EXPECT_EQ(ERR_GET_REASON(packed_error), 1);
+  EXPECT_EQ(0u, ERR_get_error());
+}
+
 // Querying the error queue should not affect the OS error.
 #if defined(OPENSSL_WINDOWS)
 TEST(ErrTest, PreservesLastError) {


### PR DESCRIPTION
### Context and motivation

`err_copy` copies every field of an error queue entry except the mark bit, so
saving and restoring the queue silently drops any mark a caller has set. A
caller who marks the queue and then calls into code that saves and restores it
finds no mark left: their `ERR_pop_to_mark` reports failure and drains their own
errors.

`ssl_send_alert` already hits this. It wraps the alert path in a save and restore
to keep the alert's errors out of the caller's queue, and in doing so wipes any
mark the caller set around the surrounding call.

### Description of changes

- Copy the mark along with the rest of an error queue entry, so a mark survives
  a save and restore round-trip.

### Testing

- New unit test sets a mark, saves the queue, queues a throwaway error, restores,
  and pops to the mark. Reverting the one-line fix makes it fail: the pop drains
  the marked error and `ERR_get_error` returns nothing.
- Full `crypto_test` and `ssl_test` exercise every other reader of the save and
  restore path, including the alert code above.

### Review considerations

- No public API or ABI change. `ERR_save_state` already documents itself as
  holding "the current state of the error queue", and `err_copy` has only the two
  callers that implement save and restore, so nothing else observes the new field.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
