### PR TITLE
Add a reader for the system crypto-policies OpenSSL back-end

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,12 +449,14 @@ endif()
 if(ENABLE_CRYPTO_POLICIES)
   message(STATUS "Setting AWSLC_CRYPTO_POLICIES")
   add_definitions(-DAWSLC_CRYPTO_POLICIES)
-  # Optional override of the compile-time default policy path. Packagers can set
+  # Optional override of the compile-time default policy file. Packagers can set
   # this to relocate the system crypto-policies OpenSSL back-end file; tests use
-  # it to point at a fixture.
-  if(AWSLC_CRYPTO_POLICY_PATH)
-    message(STATUS "Setting AWSLC_CRYPTO_POLICY_PATH=${AWSLC_CRYPTO_POLICY_PATH}")
-    add_definitions(-DAWSLC_CRYPTO_POLICY_PATH=\"${AWSLC_CRYPTO_POLICY_PATH}\")
+  # it to point at a fixture. The AWSLC_CRYPTO_POLICY_FILE environment variable
+  # overrides it at run time.
+  if(AWSLC_CRYPTO_POLICY_FILE)
+    message(STATUS "Setting AWSLC_CRYPTO_POLICY_FILE=${AWSLC_CRYPTO_POLICY_FILE}")
+    add_definitions(
+      -DAWSLC_CRYPTO_POLICY_DEFAULT_FILE=\"${AWSLC_CRYPTO_POLICY_FILE}\")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(ENABLE_DIST_PKG "Enables a set of packaging that take highest precedence 
 option(ENABLE_DIST_PKG_OPENSSL_SHIM "Controls whether the OpenSSL shim components are installed when ENABLE_DIST_PKG is enabled" OFF)
 option(BUILD_AWSLC_PROVIDER "Build the OpenSSL provider backed by AWS-LC. Requires AWSLC_PROVIDER_OPENSSL_ROOT" OFF)
 set(AWSLC_PROVIDER_OPENSSL_ROOT "" CACHE PATH "Install prefix of an OpenSSL 3.5 or later build, supplying the provider headers BUILD_AWSLC_PROVIDER needs")
+option(ENABLE_CRYPTO_POLICIES "Build support for honoring the system crypto-policies OpenSSL back-end (Linux, e.g. Amazon Linux 2023 and Fedora; OFF by default)" OFF)
 
 if(MSVC)
   # On Windows, prefer cl over gcc if both are available. By default most of
@@ -443,6 +444,18 @@ if (TEST_SYSGENID_PATH)
   add_definitions(-DAWSLC_VM_UBE_TESTING=1)
   message(STATUS "Setting AWSLC_SYSGENID_PATH=${TEST_SYSGENID_PATH}")
   add_definitions(-DAWSLC_SYSGENID_PATH=\"${TEST_SYSGENID_PATH}\")
+endif()
+
+if(ENABLE_CRYPTO_POLICIES)
+  message(STATUS "Setting AWSLC_CRYPTO_POLICIES")
+  add_definitions(-DAWSLC_CRYPTO_POLICIES)
+  # Optional override of the compile-time default policy path. Packagers can set
+  # this to relocate the system crypto-policies OpenSSL back-end file; tests use
+  # it to point at a fixture.
+  if(AWSLC_CRYPTO_POLICY_PATH)
+    message(STATUS "Setting AWSLC_CRYPTO_POLICY_PATH=${AWSLC_CRYPTO_POLICY_PATH}")
+    add_definitions(-DAWSLC_CRYPTO_POLICY_PATH=\"${AWSLC_CRYPTO_POLICY_PATH}\")
+  endif()
 endif()
 
 if(NOT DISABLE_PERL)

--- a/crypto/fipsmodule/cpucap/cpu_getauxval_linux.h
+++ b/crypto/fipsmodule/cpucap/cpu_getauxval_linux.h
@@ -14,8 +14,8 @@
 // After including this header (on Linux), OPENSSL_HAS_GETAUXVAL is defined
 // and getauxval(type) is callable -- regardless of whether <sys/auxv.h> was
 // available -- so call sites do not need to special-case the libc.
-// AT_NULL, AT_HWCAP, AT_HWCAP2, and AT_EXECFN are also defined when the
-// system header omits them (for example, glibc < 2.18 lacks AT_HWCAP2).
+// AT_NULL, AT_HWCAP, AT_HWCAP2, AT_EXECFN, and AT_SECURE are also defined when
+// the system header omits them (for example, glibc < 2.18 lacks AT_HWCAP2).
 
 #if defined(OPENSSL_LINUX)
 
@@ -64,6 +64,9 @@
 #endif
 #if !defined(AT_EXECFN)
 #define AT_EXECFN 31
+#endif
+#if !defined(AT_SECURE)
+#define AT_SECURE 23
 #endif
 
 #if !defined(OPENSSL_HAS_GETAUXVAL)

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
   ssl
 
   bio_ssl.cc
+  crypto_policy.cc
   custom_extensions.cc
   d1_both.cc
   d1_lib.cc
@@ -120,6 +121,7 @@ if(BUILD_TESTING)
     ssl_hybrid_handshake_test.cc
     ssl_encoding_test.cc
     ssl_ciphers_test.cc
+    ssl_crypto_policy_test.cc
     ssl_handshake_test.cc
   )
 

--- a/ssl/crypto_policy.cc
+++ b/ssl/crypto_policy.cc
@@ -23,11 +23,6 @@
 
 #if defined(OPENSSL_LINUX)
 #include "../crypto/fipsmodule/cpucap/cpu_getauxval_linux.h"
-// AT_SECURE from the Linux kernel ABI (include/uapi/linux/auxvec.h); the shared
-// helper defines only the entries its own callers use.
-#if !defined(AT_SECURE)
-#define AT_SECURE 23
-#endif
 #endif
 
 BSSL_NAMESPACE_BEGIN

--- a/ssl/crypto_policy.cc
+++ b/ssl/crypto_policy.cc
@@ -21,6 +21,15 @@
 #include <unistd.h>
 #endif
 
+#if defined(OPENSSL_LINUX)
+#include "../crypto/fipsmodule/cpucap/cpu_getauxval_linux.h"
+// AT_SECURE from the Linux kernel ABI (include/uapi/linux/auxvec.h); the shared
+// helper defines only the entries its own callers use.
+#if !defined(AT_SECURE)
+#define AT_SECURE 23
+#endif
+#endif
+
 BSSL_NAMESPACE_BEGIN
 
 namespace {
@@ -150,15 +159,17 @@ bool ssl_crypto_policy_parse_file(const char *path, CryptoPolicyConfig *out) {
 
 const char *ssl_crypto_policy_default_path(void) {
   // The compile-time default is a root-owned file under /etc; the environment is
-  // not. Honoring the override in a set-uid or set-gid process would let an
-  // unprivileged caller choose the TLS policy that privileged process runs
-  // under, so the override is dropped across a privilege boundary.
-  //
-  // This compares the real and effective ids rather than using glibc's
-  // secure_getenv so that no libc feature detection is needed. It therefore does
-  // not catch the rarer AT_SECURE cases that leave the ids equal, such as file
-  // capabilities; a packager shipping such a binary should build with
-  // -DAWSLC_CRYPTO_POLICY_FILE and treat the compile-time path as the only one.
+  // not. Honoring the override in a process that gained privileges on exec
+  // would let an unprivileged caller choose the TLS policy that privileged
+  // process runs under, so the override is dropped across a privilege boundary.
+#if defined(OPENSSL_HAS_GETAUXVAL)
+  // The kernel sets AT_SECURE for every secure execution and never clears it,
+  // so this also covers what leaves the ids below equal: file capabilities, and
+  // a set-uid program that has already dropped privileges.
+  if (getauxval(AT_SECURE) != 0) {
+    return AWSLC_CRYPTO_POLICY_DEFAULT_FILE;
+  }
+#endif
 #if !defined(OPENSSL_WINDOWS)
   if (getuid() != geteuid() || getgid() != getegid()) {
     return AWSLC_CRYPTO_POLICY_DEFAULT_FILE;

--- a/ssl/crypto_policy.cc
+++ b/ssl/crypto_policy.cc
@@ -141,8 +141,11 @@ bool ssl_crypto_policy_parse_file(const char *path, CryptoPolicyConfig *out) {
     }
   }
 
+  // |fgets| and |fgetc| stop on a read error exactly as they stop at end of
+  // file, so without this a truncated read would pass for a whole policy.
+  const bool ok = ferror(f) == 0;
   fclose(f);
-  return true;
+  return ok;
 }
 
 const char *ssl_crypto_policy_default_path(void) {

--- a/ssl/crypto_policy.cc
+++ b/ssl/crypto_policy.cc
@@ -1,0 +1,173 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <openssl/ssl.h>
+
+#include "internal.h"
+
+// This file reads the system crypto-policies OpenSSL back-end (Amazon Linux 2023
+// and Fedora). It is only compiled with -DENABLE_CRYPTO_POLICIES; otherwise it is
+// an (almost) empty translation unit. |internal.h| is included unconditionally so
+// the unit always carries declarations and never trips empty-translation-unit
+// diagnostics.
+
+#if defined(AWSLC_CRYPTO_POLICIES)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if !defined(OPENSSL_WINDOWS)
+#include <unistd.h>
+#endif
+
+BSSL_NAMESPACE_BEGIN
+
+namespace {
+
+// IsAsciiWhitespace matches the horizontal and line-ending whitespace that can
+// appear around a directive in an OpenSSL config file.
+bool IsAsciiWhitespace(char c) {
+  return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+// CopyPolicyValue copies the |len| bytes at |value| into |out|, which has
+// capacity |out_size| including the NUL terminator. It returns true on success.
+// An overlong value is rejected rather than truncated, leaving |out| untouched.
+bool CopyPolicyValue(char *out, size_t out_size, const char *value,
+                     size_t len) {
+  if (len >= out_size) {
+    return false;
+  }
+  OPENSSL_memcpy(out, value, len);
+  out[len] = '\0';
+  return true;
+}
+
+}  // namespace
+
+bool ssl_crypto_policy_parse_file(const char *path, CryptoPolicyConfig *out) {
+  if (path == nullptr || out == nullptr) {
+    return false;
+  }
+
+  FILE *f = fopen(path, "r");
+  if (f == nullptr) {
+    return false;
+  }
+
+  char buf[8192];
+  while (fgets(buf, sizeof(buf), f) != nullptr) {
+    size_t len = strlen(buf);
+    bool had_newline = len > 0 && buf[len - 1] == '\n';
+    // Skip over-long lines: if the buffer filled without reaching a newline and
+    // we are not at end-of-file, consume the rest of the line and ignore it.
+    if (!had_newline && feof(f) == 0) {
+      int c;
+      while ((c = fgetc(f)) != EOF && c != '\n') {
+      }
+      continue;
+    }
+
+    // Trim leading whitespace so indented directives are recognized, then skip
+    // blank lines, comments, and section headers.
+    const char *line = buf;
+    while (*line == ' ' || *line == '\t') {
+      line++;
+    }
+    if (*line == '\0' || *line == '\n' || *line == '#' || *line == '[') {
+      continue;
+    }
+
+    const char *eq = strchr(line, '=');
+    if (eq == nullptr) {
+      continue;
+    }
+
+    // Trim whitespace off both sides of the key.
+    const char *key = line;
+    const char *key_end = eq;
+    while (key < key_end && IsAsciiWhitespace(*key)) {
+      key++;
+    }
+    while (key_end > key && IsAsciiWhitespace(key_end[-1])) {
+      key_end--;
+    }
+
+    // Trim whitespace off both sides of the value, then strip a single pair of
+    // surrounding quotes if present.
+    const char *val = eq + 1;
+    const char *val_end = line + strlen(line);
+    while (val < val_end && IsAsciiWhitespace(*val)) {
+      val++;
+    }
+    while (val_end > val && IsAsciiWhitespace(val_end[-1])) {
+      val_end--;
+    }
+    if (val_end - val >= 2 && (*val == '"' || *val == '\'') &&
+        *val == val_end[-1]) {
+      val++;
+      val_end--;
+    }
+
+    const size_t key_len = static_cast<size_t>(key_end - key);
+    const size_t val_len = static_cast<size_t>(val_end - val);
+
+    // KeyIs compares the trimmed key against a literal directive name.
+    auto key_is = [key, key_len](const char *name) {
+      return strlen(name) == key_len && OPENSSL_memcmp(key, name, key_len) == 0;
+    };
+
+    // Recognized directives; the last occurrence of a key wins. Unknown keys,
+    // and values too long to represent, are ignored.
+    if (key_is("CipherString")) {
+      CopyPolicyValue(out->cipher_string, sizeof(out->cipher_string), val,
+                      val_len);
+    } else if (key_is("Ciphersuites")) {
+      CopyPolicyValue(out->ciphersuites, sizeof(out->ciphersuites), val,
+                      val_len);
+    } else if (key_is("TLS.MinProtocol")) {
+      CopyPolicyValue(out->tls_min, sizeof(out->tls_min), val, val_len);
+    } else if (key_is("TLS.MaxProtocol")) {
+      CopyPolicyValue(out->tls_max, sizeof(out->tls_max), val, val_len);
+    } else if (key_is("DTLS.MinProtocol")) {
+      CopyPolicyValue(out->dtls_min, sizeof(out->dtls_min), val, val_len);
+    } else if (key_is("DTLS.MaxProtocol")) {
+      CopyPolicyValue(out->dtls_max, sizeof(out->dtls_max), val, val_len);
+    } else if (key_is("SignatureAlgorithms")) {
+      CopyPolicyValue(out->sigalgs, sizeof(out->sigalgs), val, val_len);
+    } else if (key_is("Groups")) {
+      CopyPolicyValue(out->groups, sizeof(out->groups), val, val_len);
+    }
+  }
+
+  fclose(f);
+  return true;
+}
+
+const char *ssl_crypto_policy_default_path(void) {
+  // The compile-time default is a root-owned file under /etc; the environment is
+  // not. Honoring the override in a set-uid or set-gid process would let an
+  // unprivileged caller choose the TLS policy that privileged process runs
+  // under, so the override is dropped across a privilege boundary.
+  //
+  // This compares the real and effective ids rather than using glibc's
+  // secure_getenv so that no libc feature detection is needed. It therefore does
+  // not catch the rarer AT_SECURE cases that leave the ids equal, such as file
+  // capabilities; a packager shipping such a binary should build with
+  // -DAWSLC_CRYPTO_POLICY_PATH and treat the compile-time path as the only one.
+#if !defined(OPENSSL_WINDOWS)
+  if (getuid() != geteuid() || getgid() != getegid()) {
+    return AWSLC_CRYPTO_POLICY_PATH;
+  }
+#endif
+  const char *env = getenv("AWSLC_CRYPTO_POLICY_FILE");
+  if (env != nullptr && env[0] != '\0') {
+    return env;
+  }
+  return AWSLC_CRYPTO_POLICY_PATH;
+}
+
+BSSL_NAMESPACE_END
+
+#endif  // AWSLC_CRYPTO_POLICIES

--- a/ssl/crypto_policy.cc
+++ b/ssl/crypto_policy.cc
@@ -155,17 +155,17 @@ const char *ssl_crypto_policy_default_path(void) {
   // secure_getenv so that no libc feature detection is needed. It therefore does
   // not catch the rarer AT_SECURE cases that leave the ids equal, such as file
   // capabilities; a packager shipping such a binary should build with
-  // -DAWSLC_CRYPTO_POLICY_PATH and treat the compile-time path as the only one.
+  // -DAWSLC_CRYPTO_POLICY_FILE and treat the compile-time path as the only one.
 #if !defined(OPENSSL_WINDOWS)
   if (getuid() != geteuid() || getgid() != getegid()) {
-    return AWSLC_CRYPTO_POLICY_PATH;
+    return AWSLC_CRYPTO_POLICY_DEFAULT_FILE;
   }
 #endif
   const char *env = getenv("AWSLC_CRYPTO_POLICY_FILE");
   if (env != nullptr && env[0] != '\0') {
     return env;
   }
-  return AWSLC_CRYPTO_POLICY_PATH;
+  return AWSLC_CRYPTO_POLICY_DEFAULT_FILE;
 }
 
 BSSL_NAMESPACE_END

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -3665,6 +3665,75 @@ void ssl_set_read_error(SSL *ssl);
 // set to false when the mutex in |SSL_CTX| has already been locked.
 void ssl_update_counter(SSL_CTX *ctx, SSL_STATS_COUNTER_TYPE &counter, bool lock);
 
+#if defined(AWSLC_CRYPTO_POLICIES)
+
+// System crypto-policies (opt-in via -DENABLE_CRYPTO_POLICIES). On Amazon Linux
+// 2023 and Fedora the system-wide crypto-policies framework renders an OpenSSL
+// back-end file describing the OS TLS posture. The declarations below locate and
+// read that file.
+
+// AWSLC_CRYPTO_POLICY_PATH is the compile-time default location of the
+// crypto-policies OpenSSL back-end file. Packagers may override it with
+// -DAWSLC_CRYPTO_POLICY_PATH=..., and it may be overridden at runtime with the
+// AWSLC_CRYPTO_POLICY_FILE environment variable (see
+// |ssl_crypto_policy_default_path|).
+#if !defined(AWSLC_CRYPTO_POLICY_PATH)
+#define AWSLC_CRYPTO_POLICY_PATH "/etc/crypto-policies/back-ends/opensslcnf.config"
+#endif
+
+// AWSLC_CRYPTO_POLICY_MAX_VALUE is the longest directive value, excluding the
+// NUL terminator, that AWS-LC will act on. The longest value the crypto-policies
+// framework emits is the LEGACY policy's CipherString, well under this bound.
+//
+// A longer value is treated as absent rather than truncated: half of a cipher
+// list or group list is not a weaker version of the operator's policy, it is a
+// different policy that nobody chose.
+#define AWSLC_CRYPTO_POLICY_MAX_VALUE 1023
+
+// AWSLC_CRYPTO_POLICY_MAX_TOKEN bounds the single-token protocol directives
+// ("TLSv1.2", "DTLSv1.2", and the like).
+#define AWSLC_CRYPTO_POLICY_MAX_TOKEN 31
+
+// CryptoPolicyConfig holds the recognized directives parsed from a
+// crypto-policies OpenSSL back-end file. Each field is a NUL-terminated string;
+// an absent directive is the empty string, so callers must zero-initialize
+// (|CryptoPolicyConfig cfg = {};|).
+//
+// These are fixed buffers rather than |std::string| because libssl on Linux may
+// not depend on the C++ runtime (see STYLE.md), a constraint
+// util/check_imported_libraries.go enforces. Fixed buffers also cannot throw out
+// of |SSL_CTX_new|, which is a C entry point.
+struct CryptoPolicyConfig {
+  // cipher_string is CipherString, which may still carry a leading @SECLEVEL.
+  char cipher_string[AWSLC_CRYPTO_POLICY_MAX_VALUE + 1];
+  char ciphersuites[AWSLC_CRYPTO_POLICY_MAX_VALUE + 1];  // Ciphersuites
+  char sigalgs[AWSLC_CRYPTO_POLICY_MAX_VALUE + 1];       // SignatureAlgorithms
+  char groups[AWSLC_CRYPTO_POLICY_MAX_VALUE + 1];        // Groups
+  char tls_min[AWSLC_CRYPTO_POLICY_MAX_TOKEN + 1];       // TLS.MinProtocol
+  char tls_max[AWSLC_CRYPTO_POLICY_MAX_TOKEN + 1];       // TLS.MaxProtocol
+  char dtls_min[AWSLC_CRYPTO_POLICY_MAX_TOKEN + 1];      // DTLS.MinProtocol
+  char dtls_max[AWSLC_CRYPTO_POLICY_MAX_TOKEN + 1];      // DTLS.MaxProtocol
+};
+
+// ssl_crypto_policy_parse_file reads |path| line-by-line and fills |out| with
+// the recognized directives. Blank lines, '#' comments, and '[section]' headers
+// are ignored, as are unrecognized keys; the last occurrence of a key wins. It
+// returns true if the file could be opened and read (even if no recognized keys
+// were present) and false only if the file could not be opened.
+bool ssl_crypto_policy_parse_file(const char *path, CryptoPolicyConfig *out);
+
+// ssl_crypto_policy_default_path returns the path of the crypto-policies OpenSSL
+// back-end file to read: the value of the AWSLC_CRYPTO_POLICY_FILE environment
+// variable if set and non-empty, otherwise the compile-time
+// |AWSLC_CRYPTO_POLICY_PATH| default. Mirrors the SSL_CERT_FILE override idiom.
+//
+// The environment override is ignored in processes running with elevated
+// privileges, where the environment sits on the far side of a privilege boundary
+// from the root-owned default path.
+const char *ssl_crypto_policy_default_path(void);
+
+#endif  // AWSLC_CRYPTO_POLICIES
+
 BSSL_NAMESPACE_END
 
 // ssl_x509_persist_peer_ca_names eagerly converts the peer CA names from

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -3720,8 +3720,9 @@ struct CryptoPolicyConfig {
 // ssl_crypto_policy_parse_file reads |path| line-by-line and fills |out| with
 // the recognized directives. Blank lines, '#' comments, and '[section]' headers
 // are ignored, as are unrecognized keys; the last occurrence of a key wins. It
-// returns true if the file could be opened and read (even if no recognized keys
-// were present) and false only if the file could not be opened.
+// returns true if the whole file was read (even if no recognized keys were
+// present), and false on invalid arguments or if the file could not be opened
+// or read to its end.
 bool ssl_crypto_policy_parse_file(const char *path, CryptoPolicyConfig *out);
 
 // ssl_crypto_policy_default_path returns the path of the crypto-policies OpenSSL

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -3672,13 +3672,15 @@ void ssl_update_counter(SSL_CTX *ctx, SSL_STATS_COUNTER_TYPE &counter, bool lock
 // back-end file describing the OS TLS posture. The declarations below locate and
 // read that file.
 
-// AWSLC_CRYPTO_POLICY_PATH is the compile-time default location of the
-// crypto-policies OpenSSL back-end file. Packagers may override it with
-// -DAWSLC_CRYPTO_POLICY_PATH=..., and it may be overridden at runtime with the
-// AWSLC_CRYPTO_POLICY_FILE environment variable (see
-// |ssl_crypto_policy_default_path|).
-#if !defined(AWSLC_CRYPTO_POLICY_PATH)
-#define AWSLC_CRYPTO_POLICY_PATH "/etc/crypto-policies/back-ends/opensslcnf.config"
+// AWSLC_CRYPTO_POLICY_DEFAULT_FILE is the compile-time default location of the
+// crypto-policies OpenSSL back-end file. Packagers set it with
+// -DAWSLC_CRYPTO_POLICY_FILE=..., which is also the name of the environment
+// variable that overrides it at run time (see |ssl_crypto_policy_default_path|).
+// The macro spells "DEFAULT" so the name a caller sets and the value it falls
+// back to are not the same identifier.
+#if !defined(AWSLC_CRYPTO_POLICY_DEFAULT_FILE)
+#define AWSLC_CRYPTO_POLICY_DEFAULT_FILE \
+  "/etc/crypto-policies/back-ends/opensslcnf.config"
 #endif
 
 // AWSLC_CRYPTO_POLICY_MAX_VALUE is the longest directive value, excluding the
@@ -3725,7 +3727,7 @@ bool ssl_crypto_policy_parse_file(const char *path, CryptoPolicyConfig *out);
 // ssl_crypto_policy_default_path returns the path of the crypto-policies OpenSSL
 // back-end file to read: the value of the AWSLC_CRYPTO_POLICY_FILE environment
 // variable if set and non-empty, otherwise the compile-time
-// |AWSLC_CRYPTO_POLICY_PATH| default. Mirrors the SSL_CERT_FILE override idiom.
+// |AWSLC_CRYPTO_POLICY_DEFAULT_FILE|. Mirrors the SSL_CERT_FILE override idiom.
 //
 // The environment override is ignored in processes running with elevated
 // privileges, where the environment sits on the far side of a privilege boundary

--- a/ssl/ssl_crypto_policy_test.cc
+++ b/ssl/ssl_crypto_policy_test.cc
@@ -1,0 +1,294 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+#include <gtest/gtest.h>
+
+// These tests cover the system crypto-policies reader implemented in
+// ssl/crypto_policy.cc. That code, and the internal declarations it relies on,
+// only exist when built with -DENABLE_CRYPTO_POLICIES, so the whole body is
+// guarded to keep this an (almost) empty translation unit otherwise.
+
+#if defined(AWSLC_CRYPTO_POLICIES)
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <string>
+
+#include <openssl/ssl.h>
+
+#include "../crypto/test/file_util.h"
+#include "internal.h"
+
+BSSL_NAMESPACE_BEGIN
+
+namespace {
+
+// The Amazon Linux 2023 / Fedora DEFAULT policy, copied as crypto-policies
+// writes it.
+const char kDefaultPolicy[] =
+    "# crypto-policies OpenSSL back-end (test fixture)\n"
+    "CipherString = @SECLEVEL=2:kEECDH:kRSA:kEDH:kPSK:kDHEPSK:kECDHEPSK:"
+    "kRSAPSK:-aDSS:-3DES:!DES:!RC4:!RC2:!IDEA:-SEED:!eNULL:!aNULL:!MD5:"
+    "-SHA384:-CAMELLIA:-ARIA:-AESCCM8\n"
+    "Ciphersuites = TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\n"
+    "TLS.MinProtocol = TLSv1.2\n"
+    "TLS.MaxProtocol = TLSv1.3\n"
+    "DTLS.MinProtocol = DTLSv1.2\n"
+    "DTLS.MaxProtocol = DTLSv1.2\n"
+    "SignatureAlgorithms = ECDSA+SHA256:ECDSA+SHA384:ECDSA+SHA512:ed25519:"
+    "ed448:rsa_pss_pss_sha256:rsa_pss_pss_sha384:rsa_pss_pss_sha512:"
+    "rsa_pss_rsae_sha256:rsa_pss_rsae_sha384:rsa_pss_rsae_sha512:RSA+SHA256:"
+    "RSA+SHA384:RSA+SHA512:ECDSA+SHA224:RSA+SHA224\n"
+    "Groups = X25519:secp256r1:X448:secp521r1:secp384r1:ffdhe2048:ffdhe3072:"
+    "ffdhe4096:ffdhe6144:ffdhe8192\n";
+
+// The expected parse of |kDefaultPolicy|, directive by directive.
+const char kDefaultCipherString[] =
+    "@SECLEVEL=2:kEECDH:kRSA:kEDH:kPSK:kDHEPSK:kECDHEPSK:kRSAPSK:-aDSS:-3DES:"
+    "!DES:!RC4:!RC2:!IDEA:-SEED:!eNULL:!aNULL:!MD5:-SHA384:-CAMELLIA:-ARIA:"
+    "-AESCCM8";
+const char kDefaultCiphersuites[] =
+    "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256";
+const char kDefaultSigalgs[] =
+    "ECDSA+SHA256:ECDSA+SHA384:ECDSA+SHA512:ed25519:ed448:rsa_pss_pss_sha256:"
+    "rsa_pss_pss_sha384:rsa_pss_pss_sha512:rsa_pss_rsae_sha256:"
+    "rsa_pss_rsae_sha384:rsa_pss_rsae_sha512:RSA+SHA256:RSA+SHA384:RSA+SHA512:"
+    "ECDSA+SHA224:RSA+SHA224";
+const char kDefaultGroups[] =
+    "X25519:secp256r1:X448:secp521r1:secp384r1:ffdhe2048:ffdhe3072:ffdhe4096:"
+    "ffdhe6144:ffdhe8192";
+
+// A path no policy file will ever occupy.
+const char kNoSuchPath[] = "/nonexistent/aws-lc/crypto-policy/does-not-exist";
+
+// WriteTempPolicy writes |content| to a fresh temporary file and returns it.
+// On platforms where temp files are unavailable the test is skipped.
+bool WriteTempPolicy(TemporaryFile *out, const std::string &content) {
+  if (SkipTempFileTests()) {
+    return false;
+  }
+  return out->Init(content);
+}
+
+// ScopedEnv saves an environment variable on construction and restores it (to
+// set-with-the-same-value or unset) on destruction, so a test can never leak
+// policy-path state into a later one.
+class ScopedEnv {
+ public:
+  explicit ScopedEnv(const char *name) : name_(name) {
+    const char *v = getenv(name);
+    had_ = v != nullptr;
+    if (had_) {
+      saved_ = v;
+    }
+  }
+  ~ScopedEnv() {
+    if (had_) {
+      setenv(name_, saved_.c_str(), /*overwrite=*/1);
+    } else {
+      unsetenv(name_);
+    }
+  }
+  ScopedEnv(const ScopedEnv &) = delete;
+  ScopedEnv &operator=(const ScopedEnv &) = delete;
+
+  void Set(const char *value) { setenv(name_, value, /*overwrite=*/1); }
+  void Unset() { unsetenv(name_); }
+
+ private:
+  const char *name_;
+  bool had_ = false;
+  std::string saved_;
+};
+
+}  // namespace
+
+TEST(CryptoPolicyParseTest, FullPolicy) {
+  TemporaryFile file;
+  if (!WriteTempPolicy(&file, kDefaultPolicy)) {
+    GTEST_SKIP() << "temporary files unavailable";
+  }
+
+  CryptoPolicyConfig cfg = {};
+  ASSERT_TRUE(ssl_crypto_policy_parse_file(file.path().c_str(), &cfg));
+
+  EXPECT_STREQ(kDefaultCipherString, cfg.cipher_string);
+  EXPECT_STREQ(kDefaultCiphersuites, cfg.ciphersuites);
+  EXPECT_STREQ(kDefaultSigalgs, cfg.sigalgs);
+  EXPECT_STREQ(kDefaultGroups, cfg.groups);
+  EXPECT_STREQ("TLSv1.2", cfg.tls_min);
+  EXPECT_STREQ("TLSv1.3", cfg.tls_max);
+  EXPECT_STREQ("DTLSv1.2", cfg.dtls_min);
+  EXPECT_STREQ("DTLSv1.2", cfg.dtls_max);
+}
+
+TEST(CryptoPolicyParseTest, MissingFileFails) {
+  CryptoPolicyConfig cfg = {};
+  EXPECT_FALSE(ssl_crypto_policy_parse_file(kNoSuchPath, &cfg));
+  EXPECT_STREQ("", cfg.cipher_string);
+}
+
+TEST(CryptoPolicyParseTest, NullArgumentsFail) {
+  CryptoPolicyConfig cfg = {};
+  EXPECT_FALSE(ssl_crypto_policy_parse_file(nullptr, &cfg));
+  EXPECT_FALSE(ssl_crypto_policy_parse_file(kNoSuchPath, nullptr));
+}
+
+TEST(CryptoPolicyParseTest, EmptyFileLeavesConfigEmpty) {
+  TemporaryFile file;
+  if (!WriteTempPolicy(&file, "")) {
+    GTEST_SKIP() << "temporary files unavailable";
+  }
+
+  CryptoPolicyConfig cfg = {};
+  ASSERT_TRUE(ssl_crypto_policy_parse_file(file.path().c_str(), &cfg));
+  EXPECT_STREQ("", cfg.cipher_string);
+  EXPECT_STREQ("", cfg.ciphersuites);
+  EXPECT_STREQ("", cfg.sigalgs);
+  EXPECT_STREQ("", cfg.groups);
+  EXPECT_STREQ("", cfg.tls_min);
+  EXPECT_STREQ("", cfg.tls_max);
+  EXPECT_STREQ("", cfg.dtls_min);
+  EXPECT_STREQ("", cfg.dtls_max);
+}
+
+// crypto-policies emits section headers and comments, and OpenSSL config files
+// carry keys from every back-end. None of it may derail the directives that
+// follow.
+TEST(CryptoPolicyParseTest, IgnoresCommentsSectionsAndUnknownKeys) {
+  TemporaryFile file;
+  if (!WriteTempPolicy(&file,
+                       "# a comment\n"
+                       "\n"
+                       "[openssl_init]\n"
+                       "providers = provider_sect\n"
+                       "MinProtocol = TLSv1.1\n"  // No TLS./DTLS. prefix.
+                       "ciphersuites = TLS_AES_128_CCM_SHA256\n"  // Wrong case.
+                       "TLS.MinProtocol = TLSv1.2\n"
+                       "no equals sign here\n"
+                       "= value with no key\n"
+                       "Groups = X25519\n")) {
+    GTEST_SKIP() << "temporary files unavailable";
+  }
+
+  CryptoPolicyConfig cfg = {};
+  ASSERT_TRUE(ssl_crypto_policy_parse_file(file.path().c_str(), &cfg));
+  EXPECT_STREQ("TLSv1.2", cfg.tls_min);
+  EXPECT_STREQ("X25519", cfg.groups);
+  EXPECT_STREQ("", cfg.ciphersuites);
+}
+
+TEST(CryptoPolicyParseTest, TrimsWhitespace) {
+  TemporaryFile file;
+  if (!WriteTempPolicy(&file,
+                       "   Groups\t =\t X25519   \n"
+                       "\tTLS.MinProtocol   =TLSv1.2\r\n"
+                       "Ciphersuites=TLS_AES_128_GCM_SHA256\n")) {
+    GTEST_SKIP() << "temporary files unavailable";
+  }
+
+  CryptoPolicyConfig cfg = {};
+  ASSERT_TRUE(ssl_crypto_policy_parse_file(file.path().c_str(), &cfg));
+  EXPECT_STREQ("X25519", cfg.groups);
+  EXPECT_STREQ("TLSv1.2", cfg.tls_min);
+  EXPECT_STREQ("TLS_AES_128_GCM_SHA256", cfg.ciphersuites);
+}
+
+TEST(CryptoPolicyParseTest, StripsOneLayerOfQuotes) {
+  TemporaryFile file;
+  if (!WriteTempPolicy(&file,
+                       "Groups = \"X25519\"\n"
+                       "TLS.MinProtocol = 'TLSv1.2'\n"
+                       "TLS.MaxProtocol = \"TLSv1.3\n"     // Unbalanced.
+                       "Ciphersuites = \"'quoted'\"\n")) {  // Only the outer pair.
+    GTEST_SKIP() << "temporary files unavailable";
+  }
+
+  CryptoPolicyConfig cfg = {};
+  ASSERT_TRUE(ssl_crypto_policy_parse_file(file.path().c_str(), &cfg));
+  EXPECT_STREQ("X25519", cfg.groups);
+  EXPECT_STREQ("TLSv1.2", cfg.tls_min);
+  EXPECT_STREQ("\"TLSv1.3", cfg.tls_max);
+  EXPECT_STREQ("'quoted'", cfg.ciphersuites);
+}
+
+TEST(CryptoPolicyParseTest, LastOccurrenceWins) {
+  TemporaryFile file;
+  if (!WriteTempPolicy(&file,
+                       "Groups = X25519\n"
+                       "Groups = secp384r1\n")) {
+    GTEST_SKIP() << "temporary files unavailable";
+  }
+
+  CryptoPolicyConfig cfg = {};
+  ASSERT_TRUE(ssl_crypto_policy_parse_file(file.path().c_str(), &cfg));
+  EXPECT_STREQ("secp384r1", cfg.groups);
+}
+
+// Half a group list is not a weaker version of the operator's policy, it is a
+// different policy nobody chose, so an over-long value is dropped whole and the
+// field left empty.
+TEST(CryptoPolicyParseTest, OverlongValueIsDroppedNotTruncated) {
+  std::string content = "Groups = ";
+  content.append(AWSLC_CRYPTO_POLICY_MAX_VALUE + 1, 'X');
+  content += "\nTLS.MinProtocol = TLSv1.2\n";
+
+  TemporaryFile file;
+  if (!WriteTempPolicy(&file, content)) {
+    GTEST_SKIP() << "temporary files unavailable";
+  }
+
+  CryptoPolicyConfig cfg = {};
+  ASSERT_TRUE(ssl_crypto_policy_parse_file(file.path().c_str(), &cfg));
+  EXPECT_STREQ("", cfg.groups);
+  // The rest of the file still parses.
+  EXPECT_STREQ("TLSv1.2", cfg.tls_min);
+}
+
+// A line longer than the read buffer is consumed to its newline rather than
+// split, so its tail cannot be mistaken for a directive of its own.
+TEST(CryptoPolicyParseTest, OverlongLineIsSkippedWhole) {
+  std::string content = "Ciphersuites = ";
+  content.append(9000, 'X');
+  content += ":TLS.MinProtocol = TLSv1.1\nTLS.MinProtocol = TLSv1.2\n";
+
+  TemporaryFile file;
+  if (!WriteTempPolicy(&file, content)) {
+    GTEST_SKIP() << "temporary files unavailable";
+  }
+
+  CryptoPolicyConfig cfg = {};
+  ASSERT_TRUE(ssl_crypto_policy_parse_file(file.path().c_str(), &cfg));
+  EXPECT_STREQ("", cfg.ciphersuites);
+  EXPECT_STREQ("TLSv1.2", cfg.tls_min);
+}
+
+// A file whose last line has no newline is still a complete line.
+TEST(CryptoPolicyParseTest, FinalLineWithoutNewline) {
+  TemporaryFile file;
+  if (!WriteTempPolicy(&file, "Groups = X25519")) {
+    GTEST_SKIP() << "temporary files unavailable";
+  }
+
+  CryptoPolicyConfig cfg = {};
+  ASSERT_TRUE(ssl_crypto_policy_parse_file(file.path().c_str(), &cfg));
+  EXPECT_STREQ("X25519", cfg.groups);
+}
+
+TEST(CryptoPolicyParseTest, DefaultPathHonorsEnvOverride) {
+  ScopedEnv env("AWSLC_CRYPTO_POLICY_FILE");
+
+  env.Set("/tmp/some-policy.config");
+  EXPECT_STREQ("/tmp/some-policy.config", ssl_crypto_policy_default_path());
+
+  // An unset or empty override falls back to the compile-time default.
+  env.Unset();
+  EXPECT_STREQ(AWSLC_CRYPTO_POLICY_PATH, ssl_crypto_policy_default_path());
+  env.Set("");
+  EXPECT_STREQ(AWSLC_CRYPTO_POLICY_PATH, ssl_crypto_policy_default_path());
+}
+
+BSSL_NAMESPACE_END
+
+#endif  // AWSLC_CRYPTO_POLICIES

--- a/ssl/ssl_crypto_policy_test.cc
+++ b/ssl/ssl_crypto_policy_test.cc
@@ -10,6 +10,7 @@
 
 #if defined(AWSLC_CRYPTO_POLICIES)
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -127,6 +128,20 @@ TEST(CryptoPolicyParseTest, MissingFileFails) {
   CryptoPolicyConfig cfg = {};
   EXPECT_FALSE(ssl_crypto_policy_parse_file(kNoSuchPath, &cfg));
   EXPECT_STREQ("", cfg.cipher_string);
+}
+
+// A file that errors part way through is not a policy that simply ended: the
+// directives read so far are half of somebody's policy. Opening a directory is
+// the portable way to make the read fail.
+TEST(CryptoPolicyParseTest, ReadErrorFails) {
+  FILE *dir = fopen("/tmp", "r");
+  if (dir == nullptr) {
+    GTEST_SKIP() << "cannot open a directory as a file";
+  }
+  fclose(dir);
+
+  CryptoPolicyConfig cfg = {};
+  EXPECT_FALSE(ssl_crypto_policy_parse_file("/tmp", &cfg));
 }
 
 TEST(CryptoPolicyParseTest, NullArgumentsFail) {

--- a/ssl/ssl_crypto_policy_test.cc
+++ b/ssl/ssl_crypto_policy_test.cc
@@ -284,9 +284,11 @@ TEST(CryptoPolicyParseTest, DefaultPathHonorsEnvOverride) {
 
   // An unset or empty override falls back to the compile-time default.
   env.Unset();
-  EXPECT_STREQ(AWSLC_CRYPTO_POLICY_PATH, ssl_crypto_policy_default_path());
+  EXPECT_STREQ(AWSLC_CRYPTO_POLICY_DEFAULT_FILE,
+               ssl_crypto_policy_default_path());
   env.Set("");
-  EXPECT_STREQ(AWSLC_CRYPTO_POLICY_PATH, ssl_crypto_policy_default_path());
+  EXPECT_STREQ(AWSLC_CRYPTO_POLICY_DEFAULT_FILE,
+               ssl_crypto_policy_default_path());
 }
 
 BSSL_NAMESPACE_END


### PR DESCRIPTION
Stack, split out of #3442, to merge bottom-up (#3501, the error-queue primitives, has landed):

1. **#3502 -- policy file reader (this PR)**
2. #3527 -- shared-build symbol export and CI
3. #3503 -- cipher lists and version bounds
4. #3504 -- groups and signature algorithms
5. #3505 -- post-quantum defaults

## Description

- Adds an off-by-default build flag, `-DENABLE_CRYPTO_POLICIES`, and a reader for the OpenSSL back-end file that Amazon Linux 2023 and Fedora render from the operator's chosen system policy.
- `AWSLC_CRYPTO_POLICY_FILE` relocates that file at build time and is declared in the CMake cache, so `cmake -L` and cmake-gui list it for a packager who is not reading the CMakeLists.
- Parses the directives AWS-LC could act on into a fixed-size config struct. Nothing consumes the result yet.
- Comments, section headers, and unknown keys are ignored, so the reader tolerates the rest of what the framework writes today and whatever it adds later. A value too long to represent is ignored the same way, even where an earlier line set the same key.
- The reader succeeds only if it read the whole file, so half a policy cannot pass for a shorter one.
- The policy path is fixed at build time and overridable at runtime, which is how the tests here and in the rest of the stack drive it. The override is dropped in a secure execution, where the environment sits on the far side of a privilege boundary from the root-owned default path.

## Testing / verification

- Parse tests cover a full stock policy, quoting, surrounding whitespace, a repeated key, and a final line with no trailing newline.
- An overlong value or line is dropped whole rather than truncated, and drops the value an earlier line gave the same key, so a policy larger than the reader's buffers cannot quietly become a different policy.
- A missing file, a read error, and null arguments all fail rather than yielding a half-filled config. The read-error case opens a directory, which fails on the first read rather than on the open.
- The runtime path override is exercised directly, since every later test in the stack rests on it.
- Checked the override drop against a real binary: honored as an ordinary process, ignored once that binary carries file capabilities, which leave the real and effective ids equal.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.




