### PR TITLE
Fix BN_CTX leak on allocation failure in `EC_GROUP_new_curve_GFp`

### DIFF
--- a/crypto/fipsmodule/ec/ec.c
+++ b/crypto/fipsmodule/ec/ec.c
@@ -251,7 +251,7 @@ EC_GROUP *EC_GROUP_new_curve_GFp(const BIGNUM *p, const BIGNUM *a,
 
   ret = OPENSSL_zalloc(sizeof(EC_GROUP));
   if (ret == NULL) {
-    return NULL;
+    goto err;
   }
   ret->mutable_ec_group = 1;
   ret->conv_form = POINT_CONVERSION_UNCOMPRESSED;


### PR DESCRIPTION
### Context and motivation

In `EC_GROUP_new_curve_GFp`, the `OPENSSL_zalloc` failure check sits after `BN_CTX_start(ctx)` but returns directly instead of jumping to the common cleanup label. On that path we leak the internally allocated `BN_CTX` (when the caller passed `ctx == NULL`) or leave a caller-supplied `BN_CTX` with an unbalanced `BN_CTX_start`/`BN_CTX_end` frame. This was spotted while reviewing tests that exercise this function; the bug is inherited from upstream and only reachable on malloc failure.

### Description of changes

One-line change: `return NULL;` -> `goto err;`. `ret` is already `NULL` at that point, so the `err:` path calls `BN_CTX_end(ctx)` and `BN_CTX_free(new_ctx)` and then returns `NULL` as before. No observable behavior change on the success path or any other failure path.

### Testing

No tests added. The bug is only reachable when `OPENSSL_zalloc` fails, which we don't have a mechanism to inject in `crypto_test`. Existing `ECTest.*` coverage (which exercises `EC_GROUP_new_curve_GFp` with both NULL and caller-supplied contexts) passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
