### PR TITLE
Fix tpm2-tss integration build without SM4

### DIFF
--- a/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
+++ b/tests/ci/integration/tpm2_tss_patch/aws-lc-tpm2-tss.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Support AWS-LC
 
 ---
  configure.ac                            | 6 ------
- src/tss2-esys/esys_crypto_ossl.c        | 2 +-
+ src/tss2-esys/esys_crypto_ossl.c        | 4 +++-
  src/tss2-fapi/ifapi_curl.c              | 6 +++---
  src/tss2-fapi/ifapi_verify_cert_chain.c | 2 +-
  test/unit/fapi-eventlog.c               | 2 +-
- 5 files changed, 6 insertions(+), 12 deletions(-)
+ 5 files changed, 8 insertions(+), 12 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
 index 9df86bce..d5f3bbe2 100644
@@ -32,7 +32,18 @@ diff --git a/src/tss2-esys/esys_crypto_ossl.c b/src/tss2-esys/esys_crypto_ossl.c
 index 50d00c4b..84b16347 100644
 --- a/src/tss2-esys/esys_crypto_ossl.c
 +++ b/src/tss2-esys/esys_crypto_ossl.c
-@@ -711,7 +711,7 @@ iesys_cryptossl_pk_encrypt(TPM2B_PUBLIC *pub_tpm_key,
+@@ -128,8 +128,10 @@ get_ossl_cipher(TPM2_ALG_ID tpm_sym_alg, UINT16 key_bits, TPM2_ALG_ID tpm_mode) {
+         default:
+             return NULL;
+         }
++#if HAVE_EVP_SM4_CFB && !defined(OPENSSL_NO_SM4)
+     case TPM2_ALG_SM4:
+         return key_bits == 128 ? EVP_sm4_cfb128() : NULL;
++#endif
+     default:
+         return NULL;
+     }
+@@ -711,7 +713,7 @@ iesys_cryptossl_pk_encrypt(TPM2B_PUBLIC *pub_tpm_key,
          goto_error(r, TSS2_ESYS_RC_MEMORY, "Could not duplicate OAEP label", cleanup);
      }
  


### PR DESCRIPTION
### Context and motivation

An [upstream tpm2-tss change](https://github.com/tpm2-software/tpm2-tss/commit/d32903d1b7b9da7a12020e303fec982449be69ed) added an unguarded `EVP_sm4_cfb128()` call, breaking our integration job because AWS-LC does not support SM4.

### Description of changes

Update the integration patch to guard the new SM4 case using the same capability checks already used elsewhere in tpm2-tss. This preserves AES support and keeps testing upstream HEAD without relaxing compiler warnings.

### Testing

Reproduced the original failure, then successfully ran the full TPM2 integration runner on Ubuntu 24.04 x86-64 with GCC 13.3. All 57 tpm2-tss and 26 tpm2-abrmd tests passed, tpm2-tools built successfully, and AWS-LC linkage checks passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.