### PR TITLE
ci: handle expired Bullseye repository in legacy GCC jobs

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -348,6 +348,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ">=1.18"
+      - name: Disable expired Bullseye security repository
+        if: fromJSON(matrix.gcc_version) <= 11
+        run: sed -i '/debian-security/d' /etc/apt/sources.list
       - name: Install build dependencies
         run: |
           apt-get update


### PR DESCRIPTION
### Context and motivation

The ARM64 GCC 9, 10, and 11 CI jobs use Bullseye-based GCC containers. Bullseye LTS ended on August 31, 2026, and its security repository metadata has expired, causing `apt-get update` to fail during dependency installation. GCC 12 and newer use supported Debian releases and are unaffected.

### Description of changes

Remove the defunct Bullseye security repository before installing dependencies in GCC 9, 10, and 11 jobs. This retains the legacy compiler coverage without disabling APT expiration checks for active repositories or affecting newer GCC jobs.

### Testing

- Ran the updated dependency installation commands in ARM64 `gcc:9`, `gcc:10`, and `gcc:11` containers on `ubuntu-2404-arm`; all completed successfully.
- Ran `git diff --check`.
- Verified the workflow has no editor YAML diagnostics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
