### PR TITLE
Cache the CMake-from-source image layers in CMake compatibility CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,10 +33,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      # The image compiles CMake from source and depends only on matrix.cmake,
+      # so the four cells sharing a version build an identical copy. Cache the
+      # layers per version so it is compiled once, not by every cell every run.
       - name: Build Docker Image
-        working-directory: .github/docker_images/cmake_build_versions
-        run: |
-          docker build -t "cmake-${{ matrix.cmake.version }}" --build-arg CMAKE_VERSION=${{ matrix.cmake.version }} --build-arg CMAKE_DOWNLOAD_URL=${{ matrix.cmake.url }} --build-arg CMAKE_SHA256=${{ matrix.cmake.hash }} .
+        uses: docker/build-push-action@v7
+        with:
+          context: .github/docker_images/cmake_build_versions
+          load: true
+          provenance: false
+          tags: cmake-${{ matrix.cmake.version }}
+          build-args: |
+            CMAKE_VERSION=${{ matrix.cmake.version }}
+            CMAKE_DOWNLOAD_URL=${{ matrix.cmake.url }}
+            CMAKE_SHA256=${{ matrix.cmake.hash }}
+          cache-from: type=gha,scope=cmake-${{ matrix.cmake.version }}
+          cache-to: type=gha,mode=max,scope=cmake-${{ matrix.cmake.version }}
       - name: ${{ matrix.generator }} (Static)
         run: |
           docker run -v "${{ github.workspace }}:/awslc" "cmake-${{ matrix.cmake.version }}" -G "${{ matrix.generator }}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DFIPS=${{ matrix.fips }}


### PR DESCRIPTION
### Context and motivation

GitHub-hosted `ubuntu-latest` capacity is shared, and aws-lc draws roughly 1,130 minutes of it per PR push. About 40% of this workflow goes to rebuilding an identical Docker image.

### Description of changes

All 12 matrix cells built a Docker image that compiles CMake from source, a median of 9.7 minutes and 97.6 minutes in aggregate. The image depends only on `matrix.cmake`, not on the generator or the FIPS setting, so the four cells sharing a version each rebuilt a byte-identical copy. It is now built through buildx with a GitHub Actions layer cache scoped to the CMake version. The Dockerfile, build arguments and build context are unchanged.

### Testing

Measured on this PR. Run 1 is a cold cache, run 2 is warm:

| | image build (sum) | all cells (sum) | wall clock |
|---|---|---|---|
| baseline on main | 97.6m | 248m | ~25m |
| run 1, cold cache | 130.0m | 283.1m | 38.8m |
| run 2, warm cache | 10.1m | 174.4m | 15.3m |

Warm layer restore is a median of 0.8 minutes per cell, saving about 74 minutes of GitHub-hosted runner time per push and cutting wall clock from roughly 25 minutes to 15. All 12 cells passed in both runs.

### Review considerations

- The first run on `main` after merge will be cold: expect ~283 minutes and ~39 minutes wall clock before the cache is warm for later PRs.
- The 12 cells are required status checks listed by exact job name, so the `name:` template is deliberately unchanged. That is also why the matrix was not collapsed into one job per CMake version, which would otherwise be the obvious way to dedup the image build.
- CI configuration only. No public API or ABI impact.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
