### PR TITLE
Stop building the test suite in the ABI diff image

### DIFF
--- a/.github/docker_images/abidiff/build.sh
+++ b/.github/docker_images/abidiff/build.sh
@@ -4,5 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
 set -ex
-cmake -S . -B build -GNinja -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+# abidiff only reads libcrypto.so and libssl.so, so skip the test targets and
+# the command-line tools. Both options already exist and default to ON, and
+# neither changes the libraries: BUILD_TESTING adds test subdirectories and
+# executables, and its one global side effect (-DBORINGSSL_HAVE_LIBUNWIND) is
+# consumed only by crypto/test/abi_test.cc. BUILD_LIBSSL is independent of both
+# and stays on, so libssl is still built.
+cmake -S . -B build -GNinja -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF
 cmake --build build


### PR DESCRIPTION
### Context and motivation

diff.sh builds aws-lc twice per job, and the four abidiff jobs together do eight full builds per PR push, roughly 30 minutes of GitHub-hosted runner time. Each build ran a bare `cmake --build build`, which builds all 720 targets: 442 test objects plus gtest, crypto_test_data, the test support libraries, and the bssl and openssl tools. abidiff only reads libcrypto.so and libssl.so. In a sampled run each side took 3m45s to build and abidiff itself took 3 seconds.
### Description of changes

Configure with BUILD_TESTING=OFF and BUILD_TOOL=OFF. Both options already exist and default to ON, and neither changes the libraries: BUILD_TESTING adds test subdirectories and executables, and its one global side effect (-DBORINGSSL_HAVE_LIBUNWIND) is consumed only by crypto/test/abi_test.cc. BUILD_LIBSSL is independent and stays on, so libssl is still built.

### Review considerations

Both sides of every "ABI diff" are configured identically, so this cannot skew a comparison. Release tags predating BUILD_TOOL will warn about an unused variable and continue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
