### PR TITLE
Run the macOS jobs on a single OS version

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -89,8 +89,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # One macOS version, matching macOS-x86 which already runs only
+        # macos-15-intel. macOS has the smallest GitHub-hosted concurrency
+        # ceiling and is the one pool a larger runner group cannot relieve,
+        # because that ceiling is shared between standard and larger runners.
         os:
-          - "macos-14"
           - "macos-15"
     steps:
       - uses: actions/checkout@v7
@@ -139,8 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-14"
-          - "macos-15"
+          - "macos-15" # one version, see macOS-ARM above
         clang:
           - 22
           - 0 # default

--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -94,7 +94,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-14 ]
+        # Path-with-spaces handling splits along POSIX vs Windows quoting, and
+        # macOS shares POSIX semantics with ubuntu-latest, which covers both
+        # ninja values. The macOS cells re-tested that on the tightest pool.
+        os: [ ubuntu-latest, windows-latest ]
         ninja: [ 0, 1 ]
     steps:
       - if: ${{ matrix.os == 'windows-latest' }}


### PR DESCRIPTION
### Context and motivation

macOS has the smallest concurrency ceiling of any GitHub-hosted runner pool, and it is the only one a dedicated larger-runner group cannot relieve, because that ceiling is shared between standard and larger runners. A single aws-lc PR push measured 619 macOS minutes and peaked at 13 simultaneous macOS jobs, so macOS is where our CI footprint is proportionally largest.

### Description of changes

Drop `macos-14` from three matrices, keeping `macos-15`:

- `macOS-ARM` and `macOS-ARM-FIPS` each ran over both versions. Both are arm64, and `macOS-x86` already runs a single version (`macos-15-intel`), so the second version on the ARM side looks like drift rather than intent.
- `path-has-spaces` ran a `macos-14` cell for each ninja value. Path-with-spaces handling splits along POSIX versus Windows quoting, and macOS shares POSIX semantics with `ubuntu-latest`, which already covers both values.

### Testing

Five macOS jobs are removed. Durations measured from a recent push:

| removed cell | |
|---|---|
| `macOS-ARM (macos-14)` | 80.3m |
| `macOS-ARM-FIPS (macos-14, 22)` | 68.3m |
| `macOS-ARM-FIPS (macos-14, 0)` | 61.6m |
| `path-has-spaces (macos-14, 0)` | 30.9m |
| `path-has-spaces (macos-14, 1)` | 24.4m |
| **total** | **265.5m of 619m, a 43% reduction** |

Coverage is unchanged in kind: arm64 under both Xcode clang and llvm@22 with FIPS, x86_64 via `macos-15-intel`, and path-with-spaces on both POSIX and Windows. The three matrices were expanded and diffed against the required status check list to confirm every remaining required cell is still produced.

### Review considerations

- The four `macos-14` entries have been removed from the `main` ruleset's required status checks, so no required check is left unreported. `macOS-ARM-FIPS (macos-14, 22)` was never required.
- Keeping `macos-15` over `macos-14`: newer image, and GitHub retires older macOS runners over time. The counter-argument is that the oldest supported OS catches accidental new-SDK dependencies. If that matters more, invert the choice.
- Dropping macOS from `path-has-spaces` assumes APFS case-insensitivity is out of scope for a path-quoting test. If it is in scope, that cell should stay.
- CI configuration only. No library, API or ABI impact.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
