### PR TITLE
fix: declare FIPS service-indicator funcs in curve25519.c

### DIFF
--- a/crypto/fipsmodule/curve25519/curve25519.c
+++ b/crypto/fipsmodule/curve25519/curve25519.c
@@ -19,6 +19,7 @@
 
 #include "../../internal.h"
 #include "../cpucap/internal.h"
+#include "../service_indicator/internal.h"
 #include "internal.h"
 
 const uint8_t RFC8032_DOM2_PREFIX[DOM2_PREFIX_SIZE] = {


### PR DESCRIPTION
### Issues:
No GitHub issue. Root cause surfaced by the clang-tidy run on #3477 (RFC 8032 Duvet annotations), which added comment lines adjacent to these calls and re-triggered a pre-existing `implicit-function-declaration` warning. This PR fixes the underlying cause independently of that annotation work.

### Description of changes:
`crypto/fipsmodule/curve25519/curve25519.c` calls `FIPS_service_indicator_lock_state()` / `FIPS_service_indicator_unlock_state()` but does not include the header that declares them, `crypto/fipsmodule/service_indicator/internal.h`. Nothing in its existing include chain reaches that header (the public `<openssl/service_indicator.h>` does not declare the lock/unlock functions), so the calls rely on an implicit function declaration.

This change adds `#include "../service_indicator/internal.h"`, matching the 12 other fipsmodule translation units that use these functions (e.g. `hmac.c`, `ec_key.c`, `ecdh.c`, `e_aesccm.c`).

### Call-outs:
- No functional change today: in FIPS builds the module links as a unit and the real symbol resolves; the assumed `int f()` prototype vs. actual `void f(void)` is harmless for a no-arg call.
- The fix matters as latent correctness: implicit declarations are a hard error under C23 / newer clang, and in non-FIPS builds the missing include bypasses the intended `OPENSSL_INLINE` no-op definition.

### Testing:
No new tests. Covered by existing curve25519/Ed25519 suites; the change only makes an already-used declaration visible. Verified the include path matches sibling fipsmodule files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
