### PR TITLE
Thin the compiler-tests config axis

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -443,11 +443,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # FIPS only; this range holds no family endpoints. clang18 is listed
-        # separately because its FIPS build is broken, so non-FIPS is the only
-        # coverage it has.
-        # TODO: fix the clang 18 FIPS build and fold it back into the list above.
-        clang_version: ["14", "15", "16", "17", "19"]
+        # FIPS only; this range holds no family endpoints. clang18 keeps its
+        # non-FIPS cell as a fallback while we re-test its FIPS build, which was
+        # excluded as broken in Sept 2025. x86-64 builds clang18 FIPS fine, so
+        # the failure was arm64-specific.
+        clang_version: ["14", "15", "16", "17", "18", "19"]
         fips: ["1"]
         include:
           - { clang_version: "18", fips: "0" }

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -361,8 +361,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # FIPS for every version; the family endpoints also get non-FIPS. Same
+        # reasoning as compiler-tests above.
         gcc_version: ["9", "10", "11", "12", "13", "14", "15", "16"]
-        fips: ["0", "1"]
+        fips: ["1"]
+        include:
+          - { gcc_version: "9", fips: "0" }
+          - { gcc_version: "16", fips: "0" }
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
@@ -400,6 +405,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # clang22 is a family endpoint, so it keeps both configs.
         clang_version: ["22"]
         fips: ["0", "1"]
     steps:
@@ -437,12 +443,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang_version: ["14", "15", "16", "17", "18", "19"]
-        fips: ["0", "1"]
-        exclude:
-          # TODO: Broken FIPS build w/ clang 18
-          - clang_version: "18"
-            fips: "1"
+        # FIPS only; this range holds no family endpoints. clang18 is listed
+        # separately because its FIPS build is broken, so non-FIPS is the only
+        # coverage it has.
+        # TODO: fix the clang 18 FIPS build and fold it back into the list above.
+        clang_version: ["14", "15", "16", "17", "19"]
+        fips: ["1"]
+        include:
+          - { clang_version: "18", fips: "0" }
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
@@ -479,8 +487,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # FIPS only; this range holds no family endpoints.
         clang_version: ["11", "12", "13"]
-        fips: ["0", "1"]
+        fips: ["1"]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
@@ -517,8 +526,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # FIPS for every version; clang7 is a family endpoint so it also gets
+        # non-FIPS.
         clang_version: ["7", "8", "9", "10"]
-        fips: ["0", "1"]
+        fips: ["1"]
+        include:
+          - { clang_version: "7", fips: "0" }
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -179,8 +179,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fips: [0, 1]
-        shared: [0, 1]
+        # Every compiler version gets the FIPS static build, the most
+        # compiler-sensitive configuration because delocate rewrites the
+        # compiler's own assembly output. The fips and shared axes exercise build
+        # plumbing rather than codegen, so crossing them with all 17 versions cost
+        # 68 cells and 688 minutes per push. The range endpoints of each compiler
+        # family keep the full grid, where a config-specific compiler bug is most
+        # likely to surface.
+        fips: [1]
+        shared: [0]
         compiler:
           - "gcc9"
           - "gcc10"
@@ -199,6 +206,19 @@ jobs:
           - "clang20"
           - "clang21"
           - "clang22"
+        include:
+          - { compiler: "gcc9", fips: 0, shared: 0 }
+          - { compiler: "gcc9", fips: 0, shared: 1 }
+          - { compiler: "gcc9", fips: 1, shared: 1 }
+          - { compiler: "gcc16", fips: 0, shared: 0 }
+          - { compiler: "gcc16", fips: 0, shared: 1 }
+          - { compiler: "gcc16", fips: 1, shared: 1 }
+          - { compiler: "clang14", fips: 0, shared: 0 }
+          - { compiler: "clang14", fips: 0, shared: 1 }
+          - { compiler: "clang14", fips: 1, shared: 1 }
+          - { compiler: "clang22", fips: 0, shared: 0 }
+          - { compiler: "clang22", fips: 0, shared: 1 }
+          - { compiler: "clang22", fips: 1, shared: 1 }
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mattkretz/cplusplus-ci/${{ matrix.compiler }}

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -443,14 +443,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # FIPS only; this range holds no family endpoints. clang18 keeps its
-        # non-FIPS cell as a fallback while we re-test its FIPS build, which was
-        # excluded as broken in Sept 2025. x86-64 builds clang18 FIPS fine, so
-        # the failure was arm64-specific.
+        # FIPS only; this range holds no family endpoints.
         clang_version: ["14", "15", "16", "17", "18", "19"]
         fips: ["1"]
-        include:
-          - { clang_version: "18", fips: "0" }
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6


### PR DESCRIPTION
### Context and motivation

The compiler matrices are the largest single item in our GitHub-hosted CI: `compiler-tests` produced 68 cells and 688 minutes per PR push (38% of our `ubuntu-latest` total), and the five arm64 compiler jobs produced 43 cells and roughly 426 minutes.

### Description of changes

`fips` and `shared` exercise build plumbing (delocate, symbol visibility, linkage); the compiler axis exercises codegen. Crossing them fully assumes compiler-specific bugs are also config-specific.

One policy on both architectures: every compiler version keeps the FIPS build, the most compiler-sensitive configuration because delocate rewrites the compiler's own assembly output. The range endpoints of each family keep the full config set, `gcc9`, `gcc16`, `clang14` and `clang22` on x86-64, and `gcc9`, `gcc16`, `clang7` and `clang22` on arm64.

arm64 stays as five jobs, and its endpoints gain fewer cells, because it sources clang from distro packages (the only route to arm64 and to clang7-13) and passes no `BUILD_SHARED_LIBS`, so every arm64 cell is static.

The last two commits deal with `arm64 - clang18 - FIPS`, excluded as broken in September 2025 and never revisited. It was re-enabled and **passed**, so the exclude was stale. clang18's non-FIPS fallback cell is then dropped, leaving it FIPS-only like its non-endpoint peers.

### Testing

| | before | after | measured saving |
|---|---|---|---|
| x86-64 `compiler-tests` | 68 cells, 688 min | 29 cells, 326 min | **-362 min** |
| arm64 (five jobs) | 43 cells, 426 min | 26 cells, ~304 min | **~-122 min** |

Measured on this PR: all 56 compiler cells green, zero failures. The arm64 figure is 311 min measured across 27 cells, less the 6.8 min `clang18 - non-FIPS` cell dropped in the final commit.

Per-cell medians rose (x86-64 9.9 to 11.7 min, arm64 7.6 to 12.5) because the cheaper non-FIPS and shared cells were the ones removed, not because anything got slower.

Matrix expansion was checked programmatically against the required status check list: 55 cells produced, 0 required checks left unproduced.

### Review considerations

- Required status checks are already updated, so no check goes unreported and no PR hangs.
- This is a coverage trade, not duplication removal: 13 x86-64 and 18 arm64 versions move from two or four configurations to one. Every version still builds and runs the test suite.
- Separately, 17 cells run without gating, including all four arm64 endpoints. Worth adding to the required list.
- CI configuration only. No library, API or ABI impact.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
