### PR TITLE
ci: fix librelp integration test

### DIFF
--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -219,7 +219,7 @@ jobs:
             allow_failure: false
             run: ./tests/ci/integration/run_librelp_integration.sh v1.13
           # librelp (tracking upstream main - informational, allowed to fail)
-          - name: librelp-master
+          - name: librelp-main
             arch: x86_64
             size: small
             image: ubuntu:22.04

--- a/.github/workflows/integration_omnibus.yml
+++ b/.github/workflows/integration_omnibus.yml
@@ -218,14 +218,14 @@ jobs:
             compiler: gcc-12
             allow_failure: false
             run: ./tests/ci/integration/run_librelp_integration.sh v1.13
-          # librelp (tracking upstream master - informational, allowed to fail)
+          # librelp (tracking upstream main - informational, allowed to fail)
           - name: librelp-master
             arch: x86_64
             size: small
             image: ubuntu:22.04
             compiler: gcc-12
             allow_failure: true
-            run: ./tests/ci/integration/run_librelp_integration.sh master
+            run: ./tests/ci/integration/run_librelp_integration.sh main
 
           # HAProxy Integration Tests
           - name: haproxy


### PR DESCRIPTION

### Context and motivation

Librelp integration test is failing.

### Description of changes

[Librelp](https://github.com/rsyslog/librelp) changed its base branch name from "master" to "main." Modify the script to track "main" now.

### Testing:
Validated here: https://github.com/aws/aws-lc/actions/runs/34645792594/job/103417536431?pr=3517

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
