### PR TITLE
ci: fix mariadb integration

### DIFF
--- a/tests/ci/integration/run_mariadb_integration.sh
+++ b/tests/ci/integration/run_mariadb_integration.sh
@@ -63,6 +63,7 @@ main.mysql_upgrade_noengine : upgrade output order does not match the expected
 main.plugin_load : This test generates a warning in Codebuild. Skip over since this isn't relevant to AWS-LC.
 main.desc_index_min_max : This test is flaky and unrelated to aws-lc.
 main.socket_conflict : mariadbd refuses to run as root in CI container; not relevant to AWS-LC.
+main.start_slave_until : This test is flaky and unrelated to AWS-LC.
 "> skiplist
   # mtr's --retry defaults to 1, meaning no retries at all, so --retry-failure
   # (which only caps retries) does nothing on its own.


### PR DESCRIPTION
### Context and motivation

The `mariadb-aarch64` integration test job is intermittently failing in MariaDB's `main.start_slave_until` test.

MariaDB sometimes leaves replication settings behind from another test. That makes the test `start_slave_until` fail even though AWS-LC is not involved.

  ### Description of changes
Add `main.start_slave_until` to the existing MariaDB integration skip list.

### Testing
Validated here: https://github.com/aws/aws-lc/actions/runs/34646096597/job/103417133617?pr=3518

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
