### PR TITLE
ci: fix OpenSSH integration

### DIFF
--- a/tests/ci/integration/openssh_patch/aws-lc-openssh.patch
+++ b/tests/ci/integration/openssh_patch/aws-lc-openssh.patch
@@ -1,0 +1,6 @@
+diff --git a/regress/keygen-comment.sh b/regress/keygen-comment.sh
+--- a/regress/keygen-comment.sh
++++ b/regress/keygen-comment.sh
+@@ -33 +33 @@
+-		ssh-ed25519|*openssh.com) test -z "$oldfmt" || continue ;;
++		ssh-ed25519|ssh-mldsa44-ed25519|*openssh.com) test -z "$oldfmt" || continue ;;

--- a/tests/ci/integration/run_openssh_integration.sh
+++ b/tests/ci/integration/run_openssh_integration.sh
@@ -20,6 +20,7 @@ source tests/ci/common_posix_setup.sh
 #    - OPENSSH_INSTALL_FOLDER
 
 # Assumes script is executed from the root of aws-lc directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SCRATCH_FOLDER="${SYS_ROOT}/SCRATCH_AWSLC_OPENSSH_INTERN_TEST"
 AWS_LC_BUILD_FOLDER="${SCRATCH_FOLDER}/aws-lc-build"
 AWS_LC_INSTALL_FOLDER="${SCRATCH_FOLDER}/aws-lc-install"
@@ -50,6 +51,9 @@ function install_aws_lc() {
 
 function openssh_build() {
   pushd "${OPENSSH_WORKSPACE_FOLDER}"
+  if [ "${OPENSSH_REF}" == "master" ]; then
+    patch -p1 --quiet -i "${SCRIPT_DIR}/openssh_patch/aws-lc-openssh.patch"
+  fi
   autoreconf
 
   if [ "${OPENSSH_REF}" == "master" ] || [[ "${OPENSSH_REF}" == V_10_* ]]; then


### PR DESCRIPTION
 ### Context and motivation

OpenSSH master renamed its experimental MLDSA key type from an `@openssh.com` name to `ssh-mldsa44-ed25519`. Its `keygen-comment` regression test still recognizes only the old name as unsupported in PEM and PKCS8 formats.

The test therefore expects the comment to be missing, even though OpenSSH stores this key in its native format and retains the comment. This causes an unrelated OpenSSH master integration failure.

  ### Description of changes

Apply a small OpenSSH master-only patch that recognizes the renamed key type as unsupported in PEM and PKCS8 formats. This keeps keygen-comment running for supported  formats instead of skipping the entire test.

  ### Testing

  - Applied the patch to a fresh OpenSSH master checkout.
  - Ran git diff --check.
  - Ran bash -n tests/ci/integration/run_openssh_integration.sh

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
