### PR TITLE
ci: enable shared libraries for clang-tidy provider build

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,6 +20,7 @@ jobs:
           install_commands: >-
             /github/workspace/util/build_compilation_database.sh
             -DBUILD_AWSLC_PROVIDER=ON
+            -DBUILD_SHARED_LIBS=ON
             -DAWSLC_PROVIDER_OPENSSL_ROOT=/usr
           config_file: '/github/workspace/.clang-tidy'
       - uses: ZedThree/clang-tidy-review/upload@v0.23.1


### PR DESCRIPTION
### Context and motivation

The clang-tidy workflow enables the AWS-LC provider when generating its compilation. The provider requires shared libraries, but the workflow did not set `BUILD_SHARED_LIBS=ON`. As a result, CMake fails before clang-tidy runs with:

`BUILD_AWSLC_PROVIDER requires BUILD_SHARED_LIBS.`

### Description of changes

Enable shared libraries for the clang-tidy workflow's provider build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
